### PR TITLE
Travis config: test against main nidm repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ before_install:
  - git config --global user.name "TravisCI"
  - git config --global user.email "travis@dummy.com"
  # Create subtree nidm from main nidm repository
- # - git remote add nidm https://github.com/incf-nidash/nidm.git
- # - git fetch nidm
- # - git subtree add --prefix nidm nidm/master --squash
- - git remote add nidm https://github.com/cmaumet/nidm.git
+ - git remote add nidm https://github.com/incf-nidash/nidm.git
  - git fetch nidm
- - git subtree add --prefix nidm nidm/spm_gt --squash
+ - git subtree add --prefix nidm nidm/master --squash


### PR DESCRIPTION
Following the merge of incf-nidash/nidm#327, tests can now be computed against the master branch of the main nidm repository.