### PR TITLE
Test against a given NIDM-Results version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ before_install:
  - git remote add nidm https://github.com/incf-nidash/nidm.git
  - git fetch nidm
  - git subtree add --prefix nidm nidm/master --squash
+ - git subtree add --prefix nidm_releases/1.0.0 nidm tags/NIDM-Results_1.0.0 --squash

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
  - git config --global user.name "TravisCI"
  - git config --global user.email "travis@dummy.com"
  # Create subtree nidm from main nidm repository
- - git remote add nidm https://github.com/incf-nidash/nidm.git
+ - git remote add nidm https://github.com/cmaumet/nidm.git
  - git fetch nidm
- - git subtree add --prefix nidm nidm/master --squash
+ - git subtree add --prefix nidm nidm/test_based_on_nidm_version --squash
  - git subtree add --prefix nidm_releases/1.0.0 nidm tags/NIDM-Results_1.0.0 --squash

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
  - git config --global user.name "TravisCI"
  - git config --global user.email "travis@dummy.com"
  # Create subtree nidm from main nidm repository
- - git remote add nidm https://github.com/cmaumet/nidm.git
+ - git remote add nidm https://github.com/incf-nidash/nidm.git
  - git fetch nidm
- - git subtree add --prefix nidm nidm/test_based_on_nidm_version --squash
+ - git subtree add --prefix nidm nidm/master --squash
  - git subtree add --prefix nidm_releases/1.0.0 nidm tags/NIDM-Results_1.0.0 --squash

--- a/TestSPMResultDataModel.py
+++ b/TestSPMResultDataModel.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 '''Test of NI-DM SPM export tool
 
-To run the test, copy the NIDM turtle file 'spm_nidm.ttl' obtained by exporting the 
-results of example001 (as specified in 'examples/spm/example001') in a directory named 
-spmexport' under 'test' and from the command line call:
+To run the test, copy the NIDM turtle file 'spm_nidm.ttl' obtained by exporting
+the results of example001 (as specified in 'examples/spm/example001') in a
+directory named spmexport' under 'test' and from the command line call:
 
-python test/TestSPMResultDataModel.py 
+python test/TestSPMResultDataModel.py
 
 @author: Camille Maumet <c.m.j.maumet@warwick.ac.uk>, Satrajit Ghosh
 @copyright: University of Warwick 2014
@@ -27,8 +27,8 @@ RELPATH = os.path.dirname(os.path.abspath(__file__))
 # Add nidm common testing code folder to python path
 NIDM_DIR = os.path.join(RELPATH, "nidm")
 
-# In TravisCI the nidm repository will be created as a subtree, however locally the nidm
-# directory will be accessed directly
+# In TravisCI the nidm repository will be created as a subtree, however locally
+# the nidm directory will be accessed directly
 logging.debug(NIDM_DIR)
 if not os.path.isdir(NIDM_DIR):
     NIDM_DIR = os.path.join(RELPATH, "..", "nidm")
@@ -41,66 +41,85 @@ from TestResultDataModel import TestResultDataModel
 from TestCommons import *
 from CheckConsistency import *
 
-# FIXME: Extend tests to more than one dataset (group analysis, ...)
-'''Tests based on the analysis of single-subject auditory data based on test01_spm_batch.m using SPM12b r5918.
-'''
+
 class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
+    # FIXME: Extend tests to more than one dataset (group analysis, ...)
+    '''Tests based on the analysis of single-subject auditory data based on
+    test01_spm_batch.m using SPM12b r5918.
+    '''
 
     def setUp(self):
         self.my_execption = ""
 
         # Display log messages in console
-        logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format='%(asctime)s - %(levelname)s - %(message)s')
 
         # Retreive owl file for NIDM-Results
         owl_file = os.path.join(NIDM_RESULTS_DIR, 'terms', 'nidm-results.owl')
         # Retreive imported owl files from NIDM-Results
-        owl_imports = glob.glob(os.path.join(os.path.dirname(owl_file),
+        owl_imports = glob.glob(os.path.join(
+            os.path.dirname(owl_file),
             os.pardir, os.pardir, "imports", '*.ttl'))
 
-        TestResultDataModel.setUp(self, owl_file, owl_imports) 
-        self.ground_truth_dir = os.path.join(self.ground_truth_dir, 'spm', 'example001')
+        TestResultDataModel.setUp(self, owl_file, owl_imports)
+        self.ground_truth_dir = os.path.join(
+            self.ground_truth_dir, 'spm', 'example001')
 
         # Current module directory is used as test directory
-        self.test_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'spmexport', 'example001')
-        
+        self.test_dir = os.path.join(os.path.dirname(
+            os.path.abspath(__file__)), 'spmexport', 'example001')
+
         # RDF obtained by the SPM export
         self.spmexport = Graph()
 
         #  Turtle file obtained with SPM NI-DM export tool
-        self.spm_export_ttl = os.path.join(self.test_dir, 'nidm.ttl');
+        self.spm_export_ttl = os.path.join(self.test_dir, 'nidm.ttl')
         # print "\n\nComparing: "+self.spm_export_ttl
         self.spmexport.parse(self.spm_export_ttl, format='turtle')
 
     def test01_class_consistency_with_owl(self):
-        my_exception = self.owl.check_class_names(self.spmexport, "SPM example001")
+        my_exception = self.owl.check_class_names(
+            self.spmexport, "SPM example001")
 
-        # FIXME (error message display should be simplified when only one example...)
+        # FIXME (error message display should be simplified when only one
+        # example...)
         if my_exception:
             error_msg = ""
             for unrecognised_class_name, examples in my_exception.items():
-                error_msg += unrecognised_class_name+" (from "+', '.join(examples)+")"
+                error_msg += unrecognised_class_name + \
+                    " (from " + ', '.join(examples) + ")"
             raise Exception(error_msg)
 
     def test02_attributes_consistency_with_owl(self):
-        my_exception = self.owl.check_attributes(self.spmexport, "SPM example001")
+        my_exception = self.owl.check_attributes(
+            self.spmexport, "SPM example001")
 
-        # FIXME (error message display should be simplified when only one example...)
+        # FIXME (error message display should be simplified when only one
+        # example...)
         error_msg = ""
         if my_exception[0]:
-            for unrecognised_attribute, example_names in my_exception[0].items():
-                error_msg += unrecognised_attribute+" (from "+', '.join(example_names)+")"
+            for unrecognised_attribute, example_names in \
+                    my_exception[0].items():
+                error_msg += unrecognised_attribute + \
+                    " (from " + ', '.join(example_names) + ")"
         if my_exception[1]:
             for unrecognised_range, example_names in my_exception[1].items():
-                error_msg += unrecognised_range+" (from "+', '.join(example_names)+")"
+                error_msg += unrecognised_range + \
+                    " (from " + ', '.join(example_names) + ")"
         if error_msg:
             raise Exception(error_msg)
 
-    '''Comparing that the ttl file generated by SPM and the expected ttl file (generated manually) are identical'''
-    # FIXME: If terms PR is accepted then these tests should be moved to TestResultDataModel.py
+    '''Comparing that the ttl file generated by SPM and the expected ttl file
+    (generated manually) are identical'''
+    # FIXME: If terms PR is accepted then these tests should be moved to
+    # TestResultDataModel.py
+
     def test03_ex1_auditory_singlesub_full_graph(self):
         #  Turtle file of ground truth (manually computed) RDF
-        ground_truth_provn = os.path.join(self.ground_truth_dir, 'example001_spm_results.provn');
+        ground_truth_provn = os.path.join(
+            self.ground_truth_dir, 'example001_spm_results.provn')
         ground_truth_ttl = ground_truth_provn.replace(".provn", ".ttl")
 
         # print "\n\nwith: "+ground_truth_ttl
@@ -117,13 +136,13 @@ class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
     # '''Test06: StatisticMap: existance and attributes'''
     # def test06_StatisticMap(self):
     #     prefixInfo = """
-    #     prefix prov: <http://www.w3.org/ns/prov#>
-    #     prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
+    # prefix prov: <http://www.w3.org/ns/prov#>
+    # prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
     #     prefix nidm: <http://nidm.nidash.org/>
 
     #     """
 
-    #     # Look for: instance of type StatisticMap
+    # Look for: instance of type StatisticMap
     #     query = prefixInfo+"""
     #     SELECT ?smapid WHERE {
     #     }
@@ -133,9 +152,9 @@ class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
 
     #     if not self.successful_retreive(res, 'StatisticMap'):
     #         raise Exception(self.my_execption)
-       
-    #     # If StatisticMap was found check that all the attributes are available for 
-    #     # each StatisticMap entity
+
+    # If StatisticMap was found check that all the attributes are available for
+    # each StatisticMap entity
     #     for idx, row in enumerate(res.bindings):
     #         rowfmt = []
     #         for key, val in sorted(row.items()):
@@ -144,27 +163,28 @@ class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
     #                 self.my_execption += "\nMissing: \t %s" % (key)
     #                 return False
 
-
-    # '''Test02: Test availability of attributes needed to perform a meta-analysis as specified in use-case *1* at: http://wiki.incf.org/mediawiki/index.php/Queries'''
+    # '''Test02: Test availability of attributes needed to perform a
+    # meta-analysis as specified in use-case *1* at:
+    # http://wiki.incf.org/mediawiki/index.php/Queries'''
     # def test02_metaanalysis_usecase1(self):
     #     prefixInfo = """
-    #     prefix prov: <http://www.w3.org/ns/prov#>
-    #     prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
+    # prefix prov: <http://www.w3.org/ns/prov#>
+    # prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
     #     prefix nidm: <http://nidm.nidash.org/>
 
     #     """
-    #     # Look for:
-    #     # - "location" of "Contrast map",
-    #     # - "location" of "Contrast variance map",
-    #     # - "prov:type" in "nidm" namespace of the analysis software.
+    # Look for:
+    # - "location" of "Contrast map",
+    # - "location" of "Contrast variance map",
+    # - "prov:type" in "nidm" namespace of the analysis software.
     #     query = prefixInfo+"""
     #     SELECT ?cfile ?efile ?stype WHERE {
     #      ?aid a spm:contrast ;
     #           prov:wasAssociatedWith ?sid.
     #      ?sid a prov:Agent;
     #           a prov:SoftwareAgent;
-    #           a ?stype . 
-    #      FILTER regex(str(?stype), "nidm") 
+    #           a ?stype .
+    #      FILTER regex(str(?stype), "nidm")
     #      ?cid a nidm:contrastMap ;
     #           prov:wasGeneratedBy ?aid ;
     #           prov:atLocation ?cfile .
@@ -174,50 +194,56 @@ class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
     #     }
     #     """
 
-        # if not self.successful_retreive(self.spmexport.query(query), 'ContrastMap and ContrastStandardErrorMap'):
+        # if not self.successful_retreive(self.spmexport.query(query),
+            # 'ContrastMap and ContrastStandardErrorMap'):
         #     raise Exception(self.my_execption)
 
-    # '''Test03: Test availability of attributes needed to perform a meta-analysis as specified in use-case *2* at: http://wiki.incf.org/mediawiki/index.php/Queries'''
+    # '''Test03: Test availability of attributes needed to perform a
+    # meta-analysis as specified in use-case *2* at:
+    # http://wiki.incf.org/mediawiki/index.php/Queries'''
     # def test03_metaanalysis_usecase2(self):
     #     prefixInfo = """
-    #     prefix prov: <http://www.w3.org/ns/prov#>
-    #     prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
+    # prefix prov: <http://www.w3.org/ns/prov#>
+    # prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
     #     prefix nidm: <http://nidm.nidash.org/>
 
     #     """
 
-    #     # Look for:
-    #     # - "location" of "Contrast map",
-    #     # - "prov:type" in "nidm" namespace of the analysis software.
+    # Look for:
+    # - "location" of "Contrast map",
+    # - "prov:type" in "nidm" namespace of the analysis software.
     #     query = prefixInfo+"""
     #     SELECT ?cfile ?efile ?stype WHERE {
     #      ?aid a spm:contrast ;
     #           prov:wasAssociatedWith ?sid.
     #      ?sid a prov:Agent;
     #           a prov:SoftwareAgent;
-    #           a ?stype . 
-    #      FILTER regex(str(?stype), "nidm") 
+    #           a ?stype .
+    #      FILTER regex(str(?stype), "nidm")
     #      ?cid a nidm:contrastMap ;
     #           prov:wasGeneratedBy ?aid ;
     #           prov:atLocation ?cfile .
     #     }
     #     """
 
-    #     if not self.successful_retreive(self.spmexport.query(query), 'ContrastMap and ContrastStandardErrorMap'):
+    #     if not self.successful_retreive(self.spmexport.query(query),
+        # 'ContrastMap and ContrastStandardErrorMap'):
     #         raise Exception(self.my_execption)
 
-    # '''Test04: Test availability of attributes needed to perform a meta-analysis as specified in use-case *3* at: http://wiki.incf.org/mediawiki/index.php/Queries'''
+    # '''Test04: Test availability of attributes needed to perform a
+    # meta-analysis as specified in use-case *3* at:
+    # http://wiki.incf.org/mediawiki/index.php/Queries'''
     # def test04_metaanalysis_usecase3(self):
     #     prefixInfo = """
-    #     prefix prov: <http://www.w3.org/ns/prov#>
-    #     prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
+    # prefix prov: <http://www.w3.org/ns/prov#>
+    # prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
     #     prefix nidm: <http://nidm.nidash.org/>
 
     #     """
 
-    #     # Look for:
-    #     # - "location" of "Statistic Map",
-    #     # - "nidm:errorDegreesOfFreedom" in "Statistic Map".
+    # Look for:
+    # - "location" of "Statistic Map",
+    # - "nidm:errorDegreesOfFreedom" in "Statistic Map".
     #     query = prefixInfo+"""
     #     SELECT ?sfile ?dof WHERE {
     #      ?sid a nidm:statisticalMap ;
@@ -226,22 +252,26 @@ class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
     #     }
     #     """
 
-    #     if not self.successful_retreive(self.spmexport.query(query), 'ContrastMap and ContrastStandardErrorMap'):
+    #     if not self.successful_retreive(self.spmexport.query(query),
+        # 'ContrastMap and ContrastStandardErrorMap'):
     #         raise Exception(self.my_execption)
 
-    # '''Test05: Test availability of attributes needed to perform a meta-analysis as specified in use-case *4* at: http://wiki.incf.org/mediawiki/index.php/Queries'''
+    # '''Test05: Test availability of attributes needed to perform a
+    # meta-analysis as specified in use-case *4* at:
+    # http://wiki.incf.org/mediawiki/index.php/Queries'''
     # def test05_metaanalysis_usecase4(self):
     #     prefixInfo = """
-    #     prefix prov: <http://www.w3.org/ns/prov#>
-    #     prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
+    # prefix prov: <http://www.w3.org/ns/prov#>
+    # prefix spm: <http://www.fil.ion.ucl.ac.uk/spm/ns/#>
     #     prefix nidm: <http://nidm.nidash.org/>
 
     #     """
 
-    #     # Look for:
-    #     # - For each "Peak" "equivZStat" and"coordinate1" (and optionally "coordinate2" and "coordinate3"),
-    #     # - "clusterSizeInVoxels" of "height threshold"
-    #     # - "value" of "extent threshold"
+    # Look for:
+    # - For each "Peak" "equivZStat" and"coordinate1"
+    # (and optionally "coordinate2" and "coordinate3"),
+    # - "clusterSizeInVoxels" of "height threshold"
+    # - "value" of "extent threshold"
     #     query = prefixInfo+"""
     #     SELECT ?equivz ?coord1 ?coord2 ?coord3 ?ethresh ?hthresh WHERE {
     #      ?pid a spm:peakStatistic ;
@@ -266,9 +296,9 @@ class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
     #     }
     #     """
 
-    #     if not self.successful_retreive(self.spmexport.query(query), 'ContrastMap and ContrastStandardErrorMap'):
+    #     if not self.successful_retreive(self.spmexport.query(query),
+        # 'ContrastMap and ContrastStandardErrorMap'):
     #         raise Exception(self.my_execption)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request implements the following updates:
 - Modify Travis configuration file to load NIDM-Results 1.0.0 tag (as well as NIDM-Results development version). (We will be able to load more versions in the future.)
 - For each example, find which version of NIDM-Results is implemented by looking at the value of the nidm:'software Version' attribute and compare against the appropriate version.