### PR TITLE
Test battery using nidmresults-examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 nidm/*
 
 debug.log
+
+# nidm export data
+*.nii.gz
+*.png
+*.csv
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,20 @@ Test for NIDM-Results export in SPM
 ================
 
 Testing procedures for SPM NIDM-Results export.
+
+Test data is available at https://github.com/incf-nidash/nidmresults-examples/, you will need a local copy of this repository:
+```
+git clone https://github.com/incf-nidash/nidmresults-examples.git
+```
+
+To run the test battery, follow those steps:
+ 1. Run the NIDM-Results export on your machine (within Matlab)
+```
+nidm_export_all('LOCAL_PATH_TO_NIDMRES_EX/nidmresults-examples/', 'LOCAL_PATH_TO_NIDMRES_SPM/nidm-results_spm/spmexport')
+``` 
+ 2. Push the updates ttl and provn file to GitHub:
+```
+    git add -u
+    git commit -m "description of updated feature"
+    git push origin master
+```

--- a/TestSPMResultDataModel.py
+++ b/TestSPMResultDataModel.py
@@ -68,8 +68,10 @@ class TestSPMResultsDataModel(unittest.TestCase, TestResultDataModel):
             os.path.dirname(owl_file),
             os.pardir, os.pardir, "imports", '*.ttl'))
 
+        gt_dir = os.path.join(TEST_DIR, 'spmexport', 'ground_truth')
+
         TestResultDataModel.setUp(self, owl_file, owl_imports, test_files,
-                                  TEST_DIR, NIDM_RESULTS_DIR)
+                                  TEST_DIR, gt_dir)
 
     @data(*test_files)
     def test_class_consistency_with_owl(self, ttl):

--- a/nidm_export.m
+++ b/nidm_export.m
@@ -1,0 +1,32 @@
+function nidm_export(path_to_script_folder)
+    cwd = pwd;
+    cd(path_to_script_folder)
+    % Remove previous nidm exports    
+    files = dir(path_to_script_folder);
+    subdirs = files([files.isdir]);
+    for i = 1:numel(subdirs)
+        dname = subdirs(i).name;
+        if strncmpi(dname,'nidm',4)
+            disp(['Removing ' dname])
+            rmdir(dname,'s')
+            delete([dname '.nidm.zip'])
+        end
+        
+        nidm_zips = cellstr(strvcat(spm_select('FPList', path_to_script_folder, '\.nidm\.zip$')));
+        for j = 1:numel(nidm_zips)
+            if ~isempty(nidm_zips{j})
+                disp(['Deleting ' nidm_zips{j}])
+                delete(nidm_zips{j})
+            end
+        end
+    end
+    
+    
+    run(fullfile(pwd, 'batch.m'))
+    result_batch = matlabbatch(end);
+    result_batch{1}.spm.stats.results.spmmat = {fullfile(pwd, 'SPM.mat')};
+    result_batch{1}.spm.stats.results.print = 'nidm';    
+    spm_jobman('run', result_batch)
+    
+    cd(cwd);
+end

--- a/nidm_export.m
+++ b/nidm_export.m
@@ -29,12 +29,37 @@ function nidm_export(path_to_script_folder, out_path)
     unzip('spm_0001.nidm.zip', 'nidm')
     
     if ~isempty(out_path)
-        target_dir = fullfile(out_path, ['ex_' spm_file(path_to_script_folder, 'basename')]);
+        test_name = spm_file(path_to_script_folder, 'basename');
+        
+        target_dir = fullfile(out_path, ['ex_' test_name]);
         if isdir(target_dir)
             disp(['Removing ' target_dir])
             rmdir(target_dir,'s')
         end
         movefile('nidm', target_dir)
+        json_file = fullfile(path_to_script_folder, 'config.json');
+        copyfile(json_file, ...
+                 fullfile(target_dir, 'config.json'));
+             
+        fname = json_file;
+        fid = fopen(fname);
+        raw = fread(fid,inf);
+        str = char(raw');
+        fclose(fid);
+
+        expression = '\[".*"\]';
+        gt = regexp(str,expression,'match'); 
+        gt = strrep(strrep(strrep(gt{1}, '[', ''), ']', ''), '"', '');
+        disp(gt)
+        gt_file = fullfile(path_to_script_folder, '..', 'ground_truth', gt);
+        
+        target_gt_dir = fullfile(out_path, 'ground_truth', spm_file(gt,'path'));
+        if isdir(target_gt_dir)
+            disp(['Removing ' target_gt_dir])
+            rmdir(target_gt_dir,'s')
+        end
+        mkdir(target_gt_dir)
+        copyfile(gt_file, target_gt_dir);
     end
     
     cd(cwd);

--- a/nidm_export.m
+++ b/nidm_export.m
@@ -20,11 +20,19 @@ function nidm_export(path_to_script_folder, out_path)
         end
     end
     
-    run(fullfile(pwd, 'batch.m'))
-    result_batch = matlabbatch(end);
-    result_batch{1}.spm.stats.results.spmmat = {fullfile(pwd, 'SPM.mat')};
-    result_batch{1}.spm.stats.results.print = 'nidm';    
-    spm_jobman('run', result_batch)
+    if strcmp(dname, 'spm_full_example001')
+        % For SPM full example 001 we use already exported peaks 
+        % and clusters list to get exactly the same graph
+        load(fullfile(path_to, dname, 'nidm_example001.mat'));
+        SPM.swd=pwd;
+        spm_results_nidm(SPM,xSPM,TabDat);
+    else    
+        run(fullfile(pwd, 'batch.m'))
+        result_batch = matlabbatch(end);
+        result_batch{1}.spm.stats.results.spmmat = {fullfile(pwd, 'SPM.mat')};
+        result_batch{1}.spm.stats.results.print = 'nidm';    
+        spm_jobman('run', result_batch)
+    end
     
     unzip('spm_0001.nidm.zip', 'nidm')
     

--- a/nidm_export.m
+++ b/nidm_export.m
@@ -1,4 +1,4 @@
-function nidm_export(path_to_script_folder)
+function nidm_export(path_to_script_folder, out_path)
     cwd = pwd;
     cd(path_to_script_folder)
     % Remove previous nidm exports    
@@ -20,7 +20,6 @@ function nidm_export(path_to_script_folder)
         end
     end
     
-    
     run(fullfile(pwd, 'batch.m'))
     result_batch = matlabbatch(end);
     result_batch{1}.spm.stats.results.spmmat = {fullfile(pwd, 'SPM.mat')};
@@ -28,6 +27,15 @@ function nidm_export(path_to_script_folder)
     spm_jobman('run', result_batch)
     
     unzip('spm_0001.nidm.zip', 'nidm')
+    
+    if ~isempty(out_path)
+        target_dir = fullfile(out_path, ['ex_' spm_file(path_to_script_folder, 'basename')]);
+        if isdir(target_dir)
+            disp(['Removing ' target_dir])
+            rmdir(target_dir,'s')
+        end
+        movefile('nidm', target_dir)
+    end
     
     cd(cwd);
 end

--- a/nidm_export.m
+++ b/nidm_export.m
@@ -9,7 +9,6 @@ function nidm_export(path_to_script_folder)
         if strncmpi(dname,'nidm',4)
             disp(['Removing ' dname])
             rmdir(dname,'s')
-            delete([dname '.nidm.zip'])
         end
         
         nidm_zips = cellstr(strvcat(spm_select('FPList', path_to_script_folder, '\.nidm\.zip$')));
@@ -27,6 +26,8 @@ function nidm_export(path_to_script_folder)
     result_batch{1}.spm.stats.results.spmmat = {fullfile(pwd, 'SPM.mat')};
     result_batch{1}.spm.stats.results.print = 'nidm';    
     spm_jobman('run', result_batch)
+    
+    unzip('spm_0001.nidm.zip', 'nidm')
     
     cd(cwd);
 end

--- a/nidm_export_all.m
+++ b/nidm_export_all.m
@@ -1,4 +1,8 @@
-function nidm_export_all(path_to)
+function nidm_export_all(path_to, out_path)
+    if ~isvarname('out_path')
+        out_path = '';
+    end
+
     spm('defaults','fmri');
     spm_jobman('initcfg');
 
@@ -18,12 +22,9 @@ function nidm_export_all(path_to)
                 if strncmpi(dname,'spm_',4)
                     if ~strcmp(dname, 'ground_truth')
                         disp(dname)
-                        nidm_export(fullfile(path_to, dname))
+                        nidm_export(fullfile(path_to, dname), out_path)
                     end
                 end
-            else
-                load('nidm_example001.mat')
-                spm_results_nidm(SPM,xSPM,TabDat)
             end
         end
     end

--- a/nidm_export_all.m
+++ b/nidm_export_all.m
@@ -11,19 +11,11 @@ function nidm_export_all(path_to, out_path)
     for i = 1:numel(subdirs)
         dname = subdirs(i).name;
         if ~strcmp(dname, 'spm_explicit_mask')
-            if strcmp(dname, 'spm_full_example001')
-                % For SPM full example 001 we use already exported peaks 
-                % and clusters list to get exactly the same graph
-                load(fullfile(path_to, dname, 'nidm_example001.mat'));
-                SPM.swd=pwd;
-                spm_results_nidm(SPM,xSPM,TabDat);
-            else
-                % TODO: read config.json instead to check for software used
-                if strncmpi(dname,'spm_',4)
-                    if ~strcmp(dname, 'ground_truth')
-                        disp(dname)
-                        nidm_export(fullfile(path_to, dname), out_path)
-                    end
+            % TODO: read config.json instead to check for software used
+            if strncmpi(dname,'spm_',4)
+                if ~strcmp(dname, 'ground_truth')
+                    disp(dname)
+                    nidm_export(fullfile(path_to, dname), out_path)
                 end
             end
         end

--- a/nidm_export_all.m
+++ b/nidm_export_all.m
@@ -1,0 +1,19 @@
+function nidm_export_all(path_to)
+    spm('defaults','fmri');
+    spm_jobman('initcfg');
+
+    files = dir(path_to);
+    subdirs = files([files.isdir]);
+    for i = 1:numel(subdirs)
+        dname = subdirs(i).name;
+        if ~strcmp(dname, 'spm_explicit_mask')
+        % TODO: read config.json instead        
+        if strncmpi(dname,'spm_',4)
+            if ~strcmp(dname, 'ground_truth')
+                disp(dname)
+                nidm_export(fullfile(path_to, dname))
+            end
+        end
+        end
+    end
+end

--- a/nidm_export_all.m
+++ b/nidm_export_all.m
@@ -7,13 +7,24 @@ function nidm_export_all(path_to)
     for i = 1:numel(subdirs)
         dname = subdirs(i).name;
         if ~strcmp(dname, 'spm_explicit_mask')
-        % TODO: read config.json instead        
-        if strncmpi(dname,'spm_',4)
-            if ~strcmp(dname, 'ground_truth')
-                disp(dname)
-                nidm_export(fullfile(path_to, dname))
+            if strcmp(dname, 'spm_full_example001')
+                % For SPM full example 001 we use already exported peaks 
+                % and clusters list to get exactly the same graph
+                load('nidm_example001.mat');
+                SPM.swd=pwd;
+                spm_results_nidm(SPM,xSPM,TabDat);
+            else
+                % TODO: read config.json instead to check for software used
+                if strncmpi(dname,'spm_',4)
+                    if ~strcmp(dname, 'ground_truth')
+                        disp(dname)
+                        nidm_export(fullfile(path_to, dname))
+                    end
+                end
+            else
+                load('nidm_example001.mat')
+                spm_results_nidm(SPM,xSPM,TabDat)
             end
-        end
         end
     end
 end

--- a/nidm_export_all.m
+++ b/nidm_export_all.m
@@ -14,7 +14,7 @@ function nidm_export_all(path_to, out_path)
             if strcmp(dname, 'spm_full_example001')
                 % For SPM full example 001 we use already exported peaks 
                 % and clusters list to get exactly the same graph
-                load('nidm_example001.mat');
+                load(fullfile(path_to, dname, 'nidm_example001.mat'));
                 SPM.swd=pwd;
                 spm_results_nidm(SPM,xSPM,TabDat);
             else

--- a/spmexport/ex_spm_FDR_p005/config.json
+++ b/spmexport/ex_spm_FDR_p005/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["voxel_FDR_p_05/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_FDR_p005/nidm.provn
+++ b/spmexport/ex_spm_FDR_p005/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:2f1427c5f800de0cb67679a5b90a4497,
+  entity(niiri:47a694786709fd5213c3221d185a7ff6,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:1cfb2c64c64d30e1e0e014fa1bbc072a,
+  agent(niiri:e9118aac641c910c106b40ebc1df2599,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:e0bc6e5e657729160f4c04a0942b2b20,
+  activity(niiri:d9b86f5beeeb7e68f17e8888f295d361,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:e0bc6e5e657729160f4c04a0942b2b20, niiri:1cfb2c64c64d30e1e0e014fa1bbc072a, -)
-  wasGeneratedBy(niiri:2f1427c5f800de0cb67679a5b90a4497, niiri:e0bc6e5e657729160f4c04a0942b2b20, 2016-01-11T10:31:51)
-  bundle niiri:2f1427c5f800de0cb67679a5b90a4497
+  wasAssociatedWith(niiri:d9b86f5beeeb7e68f17e8888f295d361, niiri:e9118aac641c910c106b40ebc1df2599, -)
+  wasGeneratedBy(niiri:47a694786709fd5213c3221d185a7ff6, niiri:d9b86f5beeeb7e68f17e8888f295d361, 2016-01-11T10:43:12)
+  bundle niiri:47a694786709fd5213c3221d185a7ff6
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:6890e6cf2e5b88847f9d6b37cc9435ee,
+    agent(niiri:659fe5297ce2e256c5ac2b9cf6969bf1,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:72972f83a8d00f66bb3d6155789c7305,
+    entity(niiri:f1ac7f84f58c8d485272df9ba0fc2534,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:8ad2b9c36e0ca8e9c2e7579be1c3e6da,
+    entity(niiri:fbd02be4e06b477b7131be2e8a66922f,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:50b26818a7c0ae3b7f2c50db0401da6b,
+    entity(niiri:b54d382fa234dd8137236332684182ee,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:b068d0824f197632cc995b100a6533df,
+    entity(niiri:d1c6d55eab3c3a73cd7360a10d68fd6a,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:450123099db1897cb95a7fde00399b39',
+        dc:description = 'niiri:6b092b221cf50df781d81bbb27d4241b',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:50b26818a7c0ae3b7f2c50db0401da6b',
+        nidm_hasDriftModel: = 'niiri:b54d382fa234dd8137236332684182ee',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:450123099db1897cb95a7fde00399b39,
+    entity(niiri:6b092b221cf50df781d81bbb27d4241b,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:e13323ea4fb7c71006a383232cdf52b7,
+    entity(niiri:488c20d8f76dd0382eab6e2fdb872903,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:ebb7e829d24d7f16822d6ab10dbc9358,
+    activity(niiri:5223f230d7a04ec38363c093be331069,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:ebb7e829d24d7f16822d6ab10dbc9358, niiri:6890e6cf2e5b88847f9d6b37cc9435ee, -)
-    used(niiri:ebb7e829d24d7f16822d6ab10dbc9358, niiri:b068d0824f197632cc995b100a6533df, -)
-    used(niiri:ebb7e829d24d7f16822d6ab10dbc9358, niiri:8ad2b9c36e0ca8e9c2e7579be1c3e6da, -)
-    used(niiri:ebb7e829d24d7f16822d6ab10dbc9358, niiri:e13323ea4fb7c71006a383232cdf52b7, -)
-    entity(niiri:e394d5fbfd251977c00b29594f0dcf96,
+    wasAssociatedWith(niiri:5223f230d7a04ec38363c093be331069, niiri:659fe5297ce2e256c5ac2b9cf6969bf1, -)
+    used(niiri:5223f230d7a04ec38363c093be331069, niiri:d1c6d55eab3c3a73cd7360a10d68fd6a, -)
+    used(niiri:5223f230d7a04ec38363c093be331069, niiri:fbd02be4e06b477b7131be2e8a66922f, -)
+    used(niiri:5223f230d7a04ec38363c093be331069, niiri:488c20d8f76dd0382eab6e2fdb872903, -)
+    entity(niiri:c396b5ce233bfe4d703d38713a288a50,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:157ac4d9c5793dff9f106ea6352d2aca,
+    entity(niiri:d50bc804979d5df3abc5bd0a753f9c28,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:e394d5fbfd251977c00b29594f0dcf96, niiri:157ac4d9c5793dff9f106ea6352d2aca, -, -, -)
-    wasGeneratedBy(niiri:e394d5fbfd251977c00b29594f0dcf96, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
-    entity(niiri:efd852153fcd5030d4ba060f13ee7ce3,
+    wasDerivedFrom(niiri:c396b5ce233bfe4d703d38713a288a50, niiri:d50bc804979d5df3abc5bd0a753f9c28, -, -, -)
+    wasGeneratedBy(niiri:c396b5ce233bfe4d703d38713a288a50, niiri:5223f230d7a04ec38363c093be331069, -)
+    entity(niiri:d144fd9155bfd51784d01fd2c392cf87,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:efd852153fcd5030d4ba060f13ee7ce3, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
-    entity(niiri:1d6f2fbb2b9802a2a599623a510930ee,
+    wasGeneratedBy(niiri:d144fd9155bfd51784d01fd2c392cf87, niiri:5223f230d7a04ec38363c093be331069, -)
+    entity(niiri:1fa4f6a110c9d70dd671edae9d77ef5f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305'])
-    entity(niiri:fc83f4f71ce6df65a62a742c2061511d,
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534'])
+    entity(niiri:cb026e1a1349c97ac6d8bc5933c24b69,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:1d6f2fbb2b9802a2a599623a510930ee, niiri:fc83f4f71ce6df65a62a742c2061511d, -, -, -)
-    wasGeneratedBy(niiri:1d6f2fbb2b9802a2a599623a510930ee, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
-    entity(niiri:370b10f7022979b9909b1f54e031a190,
+    wasDerivedFrom(niiri:1fa4f6a110c9d70dd671edae9d77ef5f, niiri:cb026e1a1349c97ac6d8bc5933c24b69, -, -, -)
+    wasGeneratedBy(niiri:1fa4f6a110c9d70dd671edae9d77ef5f, niiri:5223f230d7a04ec38363c093be331069, -)
+    entity(niiri:c9582cf7beebf684ea4a75cefb93f9d5,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305'])
-    entity(niiri:238d7f5fad63f3a09d06b50d4157ccab,
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534'])
+    entity(niiri:59239d01280a87902fb9705559c952e7,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:370b10f7022979b9909b1f54e031a190, niiri:238d7f5fad63f3a09d06b50d4157ccab, -, -, -)
-    wasGeneratedBy(niiri:370b10f7022979b9909b1f54e031a190, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
-    entity(niiri:501303c4526e36bacd33575de9e1c7e1,
+    wasDerivedFrom(niiri:c9582cf7beebf684ea4a75cefb93f9d5, niiri:59239d01280a87902fb9705559c952e7, -, -, -)
+    wasGeneratedBy(niiri:c9582cf7beebf684ea4a75cefb93f9d5, niiri:5223f230d7a04ec38363c093be331069, -)
+    entity(niiri:f9ec34325ec4e2ba2338ce621c42ca48,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305'])
-    entity(niiri:5900e46c07fe094206dbe5619373c843,
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534'])
+    entity(niiri:715eb8a35cfc28578e90a8aff21fc7e5,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:501303c4526e36bacd33575de9e1c7e1, niiri:5900e46c07fe094206dbe5619373c843, -, -, -)
-    wasGeneratedBy(niiri:501303c4526e36bacd33575de9e1c7e1, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
-    entity(niiri:b12062dbf6cf00ffdebbc055426df71f,
+    wasDerivedFrom(niiri:f9ec34325ec4e2ba2338ce621c42ca48, niiri:715eb8a35cfc28578e90a8aff21fc7e5, -, -, -)
+    wasGeneratedBy(niiri:f9ec34325ec4e2ba2338ce621c42ca48, niiri:5223f230d7a04ec38363c093be331069, -)
+    entity(niiri:9e17cdd0e6bd9cf96842abc6b61409a2,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:2346d8320f94832a873b7758ed41ad16,
+    entity(niiri:4bff30639b821c07c01117a776f7d6a5,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:b12062dbf6cf00ffdebbc055426df71f, niiri:2346d8320f94832a873b7758ed41ad16, -, -, -)
-    wasGeneratedBy(niiri:b12062dbf6cf00ffdebbc055426df71f, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
-    entity(niiri:9505f00ac6458db15a4ebb837091b83a,
+    wasDerivedFrom(niiri:9e17cdd0e6bd9cf96842abc6b61409a2, niiri:4bff30639b821c07c01117a776f7d6a5, -, -, -)
+    wasGeneratedBy(niiri:9e17cdd0e6bd9cf96842abc6b61409a2, niiri:5223f230d7a04ec38363c093be331069, -)
+    entity(niiri:9d1126ce16ebe38a616de6742d7e9d09,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:82a17d37d66e6643b4a8b753f9157424,
+    entity(niiri:185ee3d53c0827cbcf6d0d5da0c8a86d,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:9505f00ac6458db15a4ebb837091b83a, niiri:82a17d37d66e6643b4a8b753f9157424, -, -, -)
-    wasGeneratedBy(niiri:9505f00ac6458db15a4ebb837091b83a, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
-    entity(niiri:ae5fa7781aa268589bbc6e9989763317,
+    wasDerivedFrom(niiri:9d1126ce16ebe38a616de6742d7e9d09, niiri:185ee3d53c0827cbcf6d0d5da0c8a86d, -, -, -)
+    wasGeneratedBy(niiri:9d1126ce16ebe38a616de6742d7e9d09, niiri:5223f230d7a04ec38363c093be331069, -)
+    entity(niiri:1eb1e143c502eec939d94753797551a6,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:5035ddea2ab2479eebc28ff8a3237d7e,
+    activity(niiri:4de0f73985aada0bf6d5792109fe20c0,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:6890e6cf2e5b88847f9d6b37cc9435ee, -)
-    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:e394d5fbfd251977c00b29594f0dcf96, -)
-    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:b12062dbf6cf00ffdebbc055426df71f, -)
-    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:b068d0824f197632cc995b100a6533df, -)
-    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:ae5fa7781aa268589bbc6e9989763317, -)
-    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:1d6f2fbb2b9802a2a599623a510930ee, -)
-    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:370b10f7022979b9909b1f54e031a190, -)
-    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:501303c4526e36bacd33575de9e1c7e1, -)
-    entity(niiri:83f28ed5522edbc5cf106d016d973b6f,
+    wasAssociatedWith(niiri:4de0f73985aada0bf6d5792109fe20c0, niiri:659fe5297ce2e256c5ac2b9cf6969bf1, -)
+    used(niiri:4de0f73985aada0bf6d5792109fe20c0, niiri:c396b5ce233bfe4d703d38713a288a50, -)
+    used(niiri:4de0f73985aada0bf6d5792109fe20c0, niiri:9e17cdd0e6bd9cf96842abc6b61409a2, -)
+    used(niiri:4de0f73985aada0bf6d5792109fe20c0, niiri:d1c6d55eab3c3a73cd7360a10d68fd6a, -)
+    used(niiri:4de0f73985aada0bf6d5792109fe20c0, niiri:1eb1e143c502eec939d94753797551a6, -)
+    used(niiri:4de0f73985aada0bf6d5792109fe20c0, niiri:1fa4f6a110c9d70dd671edae9d77ef5f, -)
+    used(niiri:4de0f73985aada0bf6d5792109fe20c0, niiri:c9582cf7beebf684ea4a75cefb93f9d5, -)
+    used(niiri:4de0f73985aada0bf6d5792109fe20c0, niiri:f9ec34325ec4e2ba2338ce621c42ca48, -)
+    entity(niiri:0f79437bc56dc496cfcb40b63ec890d0,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:549d4a17964a1363568b8eb683ac6c21,
+    entity(niiri:eb0a7014614cc8bb3fc815fde5a79894,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:83f28ed5522edbc5cf106d016d973b6f, niiri:549d4a17964a1363568b8eb683ac6c21, -, -, -)
-    wasGeneratedBy(niiri:83f28ed5522edbc5cf106d016d973b6f, niiri:5035ddea2ab2479eebc28ff8a3237d7e, -)
-    entity(niiri:3567246fbbb1bfbdfa50fd84beba45a1,
+    wasDerivedFrom(niiri:0f79437bc56dc496cfcb40b63ec890d0, niiri:eb0a7014614cc8bb3fc815fde5a79894, -, -, -)
+    wasGeneratedBy(niiri:0f79437bc56dc496cfcb40b63ec890d0, niiri:4de0f73985aada0bf6d5792109fe20c0, -)
+    entity(niiri:fc7d9cf6a2d1aaad7f7c1ffed419a445,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:8dc4aa119c0aa747c979c4d43790afcb,
+    entity(niiri:5d1c0efeba6da141daf22be47fbb0668,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:3567246fbbb1bfbdfa50fd84beba45a1, niiri:8dc4aa119c0aa747c979c4d43790afcb, -, -, -)
-    wasGeneratedBy(niiri:3567246fbbb1bfbdfa50fd84beba45a1, niiri:5035ddea2ab2479eebc28ff8a3237d7e, -)
-    entity(niiri:b7524d4fe2fbaa284684ae0f7c31bf0b,
+    wasDerivedFrom(niiri:fc7d9cf6a2d1aaad7f7c1ffed419a445, niiri:5d1c0efeba6da141daf22be47fbb0668, -, -, -)
+    wasGeneratedBy(niiri:fc7d9cf6a2d1aaad7f7c1ffed419a445, niiri:4de0f73985aada0bf6d5792109fe20c0, -)
+    entity(niiri:54bec7e32e1fba760ba0240edc0dd7d3,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:b7524d4fe2fbaa284684ae0f7c31bf0b, niiri:5035ddea2ab2479eebc28ff8a3237d7e, -)
-    entity(niiri:4611b9195510d367480bac820aa29d7c,
+    wasGeneratedBy(niiri:54bec7e32e1fba760ba0240edc0dd7d3, niiri:4de0f73985aada0bf6d5792109fe20c0, -)
+    entity(niiri:c986ca761eb7e01b3aae8125f1a05ca4,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "Inf" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:916032106111f7bfbb885dfe74f72d38',
-        nidm_equivalentThreshold: = 'niiri:99f606153159dc7a5186d27cf2db5898'])
-    entity(niiri:916032106111f7bfbb885dfe74f72d38,
+        nidm_equivalentThreshold: = 'niiri:9b220f4ea7c1ca34b6032b98ff861072',
+        nidm_equivalentThreshold: = 'niiri:e8ae70de6a583659d6e06eab530951d8'])
+    entity(niiri:9b220f4ea7c1ca34b6032b98ff861072,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.44089209850063e-16" %% xsd:float])
-    entity(niiri:99f606153159dc7a5186d27cf2db5898,
+    entity(niiri:e8ae70de6a583659d6e06eab530951d8,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0" %% xsd:float])
-    entity(niiri:0d32149a72934b58ee4cc33bcc696ab3,
+    entity(niiri:71ddc580885caa4465936bc2dab86615,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:be64c5f01f788362a2ea440a4c8a484b',
-        nidm_equivalentThreshold: = 'niiri:16a1b31778199aafa88f5e498a6104a0'])
-    entity(niiri:be64c5f01f788362a2ea440a4c8a484b,
+        nidm_equivalentThreshold: = 'niiri:5a43685fcf804a0ddab9a67f176f0595',
+        nidm_equivalentThreshold: = 'niiri:3116e164406bc59374c5a6d01d38cc23'])
+    entity(niiri:5a43685fcf804a0ddab9a67f176f0595,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:16a1b31778199aafa88f5e498a6104a0,
+    entity(niiri:3116e164406bc59374c5a6d01d38cc23,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:342d94b15ee3dac31586a642959f9fea,
+    entity(niiri:8db27febe98891391cfe822b83547cf5,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:4c716b188abb1bd482f4f753790d0e54,
+    entity(niiri:de48125bddcaf5cc5407a52ac4568b2a,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:cca11d9f63848f52a66313d39c6eebf8,
+    activity(niiri:83b99721bb1fee2ad0d390f27cd9b250,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:6890e6cf2e5b88847f9d6b37cc9435ee, -)
-    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:4611b9195510d367480bac820aa29d7c, -)
-    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:0d32149a72934b58ee4cc33bcc696ab3, -)
-    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:83f28ed5522edbc5cf106d016d973b6f, -)
-    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:9505f00ac6458db15a4ebb837091b83a, -)
-    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:e394d5fbfd251977c00b29594f0dcf96, -)
-    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:342d94b15ee3dac31586a642959f9fea, -)
-    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:4c716b188abb1bd482f4f753790d0e54, -)
-    entity(niiri:7d5c95222d51279f7d81ce2411009c27,
+    wasAssociatedWith(niiri:83b99721bb1fee2ad0d390f27cd9b250, niiri:659fe5297ce2e256c5ac2b9cf6969bf1, -)
+    used(niiri:83b99721bb1fee2ad0d390f27cd9b250, niiri:c986ca761eb7e01b3aae8125f1a05ca4, -)
+    used(niiri:83b99721bb1fee2ad0d390f27cd9b250, niiri:71ddc580885caa4465936bc2dab86615, -)
+    used(niiri:83b99721bb1fee2ad0d390f27cd9b250, niiri:0f79437bc56dc496cfcb40b63ec890d0, -)
+    used(niiri:83b99721bb1fee2ad0d390f27cd9b250, niiri:9d1126ce16ebe38a616de6742d7e9d09, -)
+    used(niiri:83b99721bb1fee2ad0d390f27cd9b250, niiri:c396b5ce233bfe4d703d38713a288a50, -)
+    used(niiri:83b99721bb1fee2ad0d390f27cd9b250, niiri:8db27febe98891391cfe822b83547cf5, -)
+    used(niiri:83b99721bb1fee2ad0d390f27cd9b250, niiri:de48125bddcaf5cc5407a52ac4568b2a, -)
+    entity(niiri:d3682ea3d26b44d8e50b3459be4339ed,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:7d5c95222d51279f7d81ce2411009c27, niiri:cca11d9f63848f52a66313d39c6eebf8, -)
-    entity(niiri:a32366d24af7805e745ddd7dea48f2ed,
+    wasGeneratedBy(niiri:d3682ea3d26b44d8e50b3459be4339ed, niiri:83b99721bb1fee2ad0d390f27cd9b250, -)
+    entity(niiri:5fb83f625b3645998fd297c85f9b90f6,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:c6c7962c875a2418e1de18c9ccedb38a',
-        nidm_hasMaximumIntensityProjection: = 'niiri:cb80b59a64cb33f2390d64694103cb19',
-        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
+        nidm_hasClusterLabelsMap: = 'niiri:df78d8f9820095bea3904f6bb24c0074',
+        nidm_hasMaximumIntensityProjection: = 'niiri:508268df7f20283c787e397b0a0847c4',
+        nidm_inCoordinateSpace: = 'niiri:f1ac7f84f58c8d485272df9ba0fc2534',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:c6c7962c875a2418e1de18c9ccedb38a,
+    entity(niiri:df78d8f9820095bea3904f6bb24c0074,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:cb80b59a64cb33f2390d64694103cb19,
+    entity(niiri:508268df7f20283c787e397b0a0847c4,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:a32366d24af7805e745ddd7dea48f2ed, niiri:cca11d9f63848f52a66313d39c6eebf8, -)
+    wasGeneratedBy(niiri:5fb83f625b3645998fd297c85f9b90f6, niiri:83b99721bb1fee2ad0d390f27cd9b250, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_FDR_p005/nidm.provn
+++ b/spmexport/ex_spm_FDR_p005/nidm.provn
@@ -1,0 +1,429 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:bc69a1ac57705467805587f33ef4be40,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:85abba3318e1f613a6c08f6776d98654,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:81d7145c2e911eca2556999a7bdfdb1a,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:81d7145c2e911eca2556999a7bdfdb1a, niiri:85abba3318e1f613a6c08f6776d98654, -)
+  wasGeneratedBy(niiri:bc69a1ac57705467805587f33ef4be40, niiri:81d7145c2e911eca2556999a7bdfdb1a, 2016-01-11T10:10:29)
+  bundle niiri:bc69a1ac57705467805587f33ef4be40
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+
+    agent(niiri:fc3f44ad32e225d48140d371082295b7,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:1296df377e4b3e17f0d439a04c2e1636,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:d6895de6f20332f03064080eb61a41f4,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:1350c014ebc82fe774f7d9eedcaaf26e,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:974a30c09e6ff2768ac64c1c0a35017b,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:08f4d2fd1d03353254ce9aea7c04ebd5',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:1350c014ebc82fe774f7d9eedcaaf26e',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:08f4d2fd1d03353254ce9aea7c04ebd5,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:513a96deec8aaa6157a38b65af9585b9,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:5087a65e60fa718315c6b087af5bd5fe,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:5087a65e60fa718315c6b087af5bd5fe, niiri:fc3f44ad32e225d48140d371082295b7, -)
+    used(niiri:5087a65e60fa718315c6b087af5bd5fe, niiri:974a30c09e6ff2768ac64c1c0a35017b, -)
+    used(niiri:5087a65e60fa718315c6b087af5bd5fe, niiri:d6895de6f20332f03064080eb61a41f4, -)
+    used(niiri:5087a65e60fa718315c6b087af5bd5fe, niiri:513a96deec8aaa6157a38b65af9585b9, -)
+    entity(niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    entity(niiri:221da0fa52e9e0567709645f7e780029,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
+    wasDerivedFrom(niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08, niiri:221da0fa52e9e0567709645f7e780029, -, -, -)
+    wasGeneratedBy(niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
+    entity(niiri:634450dee06194bfcfc9f0137d7c4e3e,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "121.744659423828" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
+    wasGeneratedBy(niiri:634450dee06194bfcfc9f0137d7c4e3e, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
+    entity(niiri:1286f7d2a33ec76e5a3bf677b4716a41,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636'])
+    entity(niiri:8797fb1368e40029241c25dd93aa02ef,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
+    wasDerivedFrom(niiri:1286f7d2a33ec76e5a3bf677b4716a41, niiri:8797fb1368e40029241c25dd93aa02ef, -, -, -)
+    wasGeneratedBy(niiri:1286f7d2a33ec76e5a3bf677b4716a41, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
+    entity(niiri:6d3972348b560017e101dc8e8eefa8fe,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636'])
+    entity(niiri:70f9dad6c2b7832f6225539ddfad35f9,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
+    wasDerivedFrom(niiri:6d3972348b560017e101dc8e8eefa8fe, niiri:70f9dad6c2b7832f6225539ddfad35f9, -, -, -)
+    wasGeneratedBy(niiri:6d3972348b560017e101dc8e8eefa8fe, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
+    entity(niiri:924c7d4d7309ff00193af75400143ff3,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636'])
+    entity(niiri:6d9ac5382dc49cb90381d57166c4ed2f,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
+    wasDerivedFrom(niiri:924c7d4d7309ff00193af75400143ff3, niiri:6d9ac5382dc49cb90381d57166c4ed2f, -, -, -)
+    wasGeneratedBy(niiri:924c7d4d7309ff00193af75400143ff3, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
+    entity(niiri:c4e8879f799272253a6da18f1386fc4f,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
+    entity(niiri:7baed57d876853c4a67110bb56bd18c7,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
+    wasDerivedFrom(niiri:c4e8879f799272253a6da18f1386fc4f, niiri:7baed57d876853c4a67110bb56bd18c7, -, -, -)
+    wasGeneratedBy(niiri:c4e8879f799272253a6da18f1386fc4f, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
+    entity(niiri:71e9f5d599435c0b1579a85bbcf0258f,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
+    entity(niiri:e238214fa3cbbcdf14e5b5071440c444,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
+    wasDerivedFrom(niiri:71e9f5d599435c0b1579a85bbcf0258f, niiri:e238214fa3cbbcdf14e5b5071440c444, -, -, -)
+    wasGeneratedBy(niiri:71e9f5d599435c0b1579a85bbcf0258f, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
+    entity(niiri:9061bdf6ef6cca5a54b93f3935d31ed5,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        prov:label = "Contrast: pos vs neg" %% xsd:string,
+        prov:value = "[1, -1, 0]" %% xsd:string])
+    activity(niiri:c61baa01f732a9bdeca50d93f9083e04,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:fc3f44ad32e225d48140d371082295b7, -)
+    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08, -)
+    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:c4e8879f799272253a6da18f1386fc4f, -)
+    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:974a30c09e6ff2768ac64c1c0a35017b, -)
+    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:9061bdf6ef6cca5a54b93f3935d31ed5, -)
+    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:1286f7d2a33ec76e5a3bf677b4716a41, -)
+    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:6d3972348b560017e101dc8e8eefa8fe, -)
+    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:924c7d4d7309ff00193af75400143ff3, -)
+    entity(niiri:0815851b8e0dca6a14ef64c00390b0db,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: pos vs neg" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
+    entity(niiri:fafb571ca9c00072e2b1a90417ae17c2,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
+    wasDerivedFrom(niiri:0815851b8e0dca6a14ef64c00390b0db, niiri:fafb571ca9c00072e2b1a90417ae17c2, -, -, -)
+    wasGeneratedBy(niiri:0815851b8e0dca6a14ef64c00390b0db, niiri:c61baa01f732a9bdeca50d93f9083e04, -)
+    entity(niiri:ec6ddf0c2d630bb6973c7df03d2c71b8,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: pos vs neg" %% xsd:string,
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
+    entity(niiri:da4100e5e0922728b8f0ef95f7ed83f3,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
+    wasDerivedFrom(niiri:ec6ddf0c2d630bb6973c7df03d2c71b8, niiri:da4100e5e0922728b8f0ef95f7ed83f3, -, -, -)
+    wasGeneratedBy(niiri:ec6ddf0c2d630bb6973c7df03d2c71b8, niiri:c61baa01f732a9bdeca50d93f9083e04, -)
+    entity(niiri:df95e156ad51e1587db4326d44cae8d6,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
+    wasGeneratedBy(niiri:df95e156ad51e1587db4326d44cae8d6, niiri:c61baa01f732a9bdeca50d93f9083e04, -)
+    entity(niiri:318d8aac2941f252174fce7ff51d31b9,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "Inf" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:3b723894f74c64c5e06df4a66ca537ac',
+        nidm_equivalentThreshold: = 'niiri:4fe4a146aa90dc2a73c28311fc5c0534'])
+    entity(niiri:3b723894f74c64c5e06df4a66ca537ac,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "4.44089209850063e-16" %% xsd:float])
+    entity(niiri:4fe4a146aa90dc2a73c28311fc5c0534,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0" %% xsd:float])
+    entity(niiri:270519a254ff149fa79d1a95ee5beec1,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:2db2aacebb91598178340495413bb165',
+        nidm_equivalentThreshold: = 'niiri:60ab3f03d8b8f172c413b65fe6744469'])
+    entity(niiri:2db2aacebb91598178340495413bb165,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:60ab3f03d8b8f172c413b65fe6744469,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:1e9b6b09f5ad34e15eb32ce5f89689ac,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:2d95847a8fda744d8fcdfbde4f662f4d,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:03ce6ccb6754d10712833f321cfe3f8e,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:fc3f44ad32e225d48140d371082295b7, -)
+    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:318d8aac2941f252174fce7ff51d31b9, -)
+    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:270519a254ff149fa79d1a95ee5beec1, -)
+    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:0815851b8e0dca6a14ef64c00390b0db, -)
+    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:71e9f5d599435c0b1579a85bbcf0258f, -)
+    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08, -)
+    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:1e9b6b09f5ad34e15eb32ce5f89689ac, -)
+    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:2d95847a8fda744d8fcdfbde4f662f4d, -)
+    entity(niiri:545e1a3189a64de9abd3df8c7afc0d8e,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
+        nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
+        nidm_searchVolumeInResels: = "2650.12011223711" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.01704921884936, 4.07618247398105, 4.38831339907177]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.03409843769872, 8.1523649479621, 8.77662679814353]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "71.8552337008045" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "7.92955854811053e-13" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.05094049746367" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    wasGeneratedBy(niiri:545e1a3189a64de9abd3df8c7afc0d8e, niiri:03ce6ccb6754d10712833f321cfe3f8e, -)
+    entity(niiri:f70092ed17b7a2d95c289d1ab32f428c,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
+        nidm_pValue: = "NaN" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:313ef7865165e4270bdf861a58ffc21d',
+        nidm_hasMaximumIntensityProjection: = 'niiri:f88f3043328411e4cf3090cf7031ce1c',
+        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
+    entity(niiri:313ef7865165e4270bdf861a58ffc21d,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:f88f3043328411e4cf3090cf7031ce1c,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:f70092ed17b7a2d95c289d1ab32f428c, niiri:03ce6ccb6754d10712833f321cfe3f8e, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_FDR_p005/nidm.provn
+++ b/spmexport/ex_spm_FDR_p005/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:bc69a1ac57705467805587f33ef4be40,
+  entity(niiri:2f1427c5f800de0cb67679a5b90a4497,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:85abba3318e1f613a6c08f6776d98654,
+  agent(niiri:1cfb2c64c64d30e1e0e014fa1bbc072a,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:81d7145c2e911eca2556999a7bdfdb1a,
+  activity(niiri:e0bc6e5e657729160f4c04a0942b2b20,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:81d7145c2e911eca2556999a7bdfdb1a, niiri:85abba3318e1f613a6c08f6776d98654, -)
-  wasGeneratedBy(niiri:bc69a1ac57705467805587f33ef4be40, niiri:81d7145c2e911eca2556999a7bdfdb1a, 2016-01-11T10:10:29)
-  bundle niiri:bc69a1ac57705467805587f33ef4be40
+  wasAssociatedWith(niiri:e0bc6e5e657729160f4c04a0942b2b20, niiri:1cfb2c64c64d30e1e0e014fa1bbc072a, -)
+  wasGeneratedBy(niiri:2f1427c5f800de0cb67679a5b90a4497, niiri:e0bc6e5e657729160f4c04a0942b2b20, 2016-01-11T10:31:51)
+  bundle niiri:2f1427c5f800de0cb67679a5b90a4497
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:fc3f44ad32e225d48140d371082295b7,
+    agent(niiri:6890e6cf2e5b88847f9d6b37cc9435ee,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:1296df377e4b3e17f0d439a04c2e1636,
+    entity(niiri:72972f83a8d00f66bb3d6155789c7305,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:d6895de6f20332f03064080eb61a41f4,
+    entity(niiri:8ad2b9c36e0ca8e9c2e7579be1c3e6da,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:1350c014ebc82fe774f7d9eedcaaf26e,
+    entity(niiri:50b26818a7c0ae3b7f2c50db0401da6b,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:974a30c09e6ff2768ac64c1c0a35017b,
+    entity(niiri:b068d0824f197632cc995b100a6533df,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:08f4d2fd1d03353254ce9aea7c04ebd5',
+        dc:description = 'niiri:450123099db1897cb95a7fde00399b39',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:1350c014ebc82fe774f7d9eedcaaf26e',
+        nidm_hasDriftModel: = 'niiri:50b26818a7c0ae3b7f2c50db0401da6b',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:08f4d2fd1d03353254ce9aea7c04ebd5,
+    entity(niiri:450123099db1897cb95a7fde00399b39,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:513a96deec8aaa6157a38b65af9585b9,
+    entity(niiri:e13323ea4fb7c71006a383232cdf52b7,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:5087a65e60fa718315c6b087af5bd5fe,
+    activity(niiri:ebb7e829d24d7f16822d6ab10dbc9358,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:5087a65e60fa718315c6b087af5bd5fe, niiri:fc3f44ad32e225d48140d371082295b7, -)
-    used(niiri:5087a65e60fa718315c6b087af5bd5fe, niiri:974a30c09e6ff2768ac64c1c0a35017b, -)
-    used(niiri:5087a65e60fa718315c6b087af5bd5fe, niiri:d6895de6f20332f03064080eb61a41f4, -)
-    used(niiri:5087a65e60fa718315c6b087af5bd5fe, niiri:513a96deec8aaa6157a38b65af9585b9, -)
-    entity(niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08,
+    wasAssociatedWith(niiri:ebb7e829d24d7f16822d6ab10dbc9358, niiri:6890e6cf2e5b88847f9d6b37cc9435ee, -)
+    used(niiri:ebb7e829d24d7f16822d6ab10dbc9358, niiri:b068d0824f197632cc995b100a6533df, -)
+    used(niiri:ebb7e829d24d7f16822d6ab10dbc9358, niiri:8ad2b9c36e0ca8e9c2e7579be1c3e6da, -)
+    used(niiri:ebb7e829d24d7f16822d6ab10dbc9358, niiri:e13323ea4fb7c71006a383232cdf52b7, -)
+    entity(niiri:e394d5fbfd251977c00b29594f0dcf96,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:221da0fa52e9e0567709645f7e780029,
+    entity(niiri:157ac4d9c5793dff9f106ea6352d2aca,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08, niiri:221da0fa52e9e0567709645f7e780029, -, -, -)
-    wasGeneratedBy(niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
-    entity(niiri:634450dee06194bfcfc9f0137d7c4e3e,
+    wasDerivedFrom(niiri:e394d5fbfd251977c00b29594f0dcf96, niiri:157ac4d9c5793dff9f106ea6352d2aca, -, -, -)
+    wasGeneratedBy(niiri:e394d5fbfd251977c00b29594f0dcf96, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
+    entity(niiri:efd852153fcd5030d4ba060f13ee7ce3,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:634450dee06194bfcfc9f0137d7c4e3e, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
-    entity(niiri:1286f7d2a33ec76e5a3bf677b4716a41,
+    wasGeneratedBy(niiri:efd852153fcd5030d4ba060f13ee7ce3, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
+    entity(niiri:1d6f2fbb2b9802a2a599623a510930ee,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636'])
-    entity(niiri:8797fb1368e40029241c25dd93aa02ef,
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305'])
+    entity(niiri:fc83f4f71ce6df65a62a742c2061511d,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:1286f7d2a33ec76e5a3bf677b4716a41, niiri:8797fb1368e40029241c25dd93aa02ef, -, -, -)
-    wasGeneratedBy(niiri:1286f7d2a33ec76e5a3bf677b4716a41, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
-    entity(niiri:6d3972348b560017e101dc8e8eefa8fe,
+    wasDerivedFrom(niiri:1d6f2fbb2b9802a2a599623a510930ee, niiri:fc83f4f71ce6df65a62a742c2061511d, -, -, -)
+    wasGeneratedBy(niiri:1d6f2fbb2b9802a2a599623a510930ee, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
+    entity(niiri:370b10f7022979b9909b1f54e031a190,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636'])
-    entity(niiri:70f9dad6c2b7832f6225539ddfad35f9,
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305'])
+    entity(niiri:238d7f5fad63f3a09d06b50d4157ccab,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:6d3972348b560017e101dc8e8eefa8fe, niiri:70f9dad6c2b7832f6225539ddfad35f9, -, -, -)
-    wasGeneratedBy(niiri:6d3972348b560017e101dc8e8eefa8fe, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
-    entity(niiri:924c7d4d7309ff00193af75400143ff3,
+    wasDerivedFrom(niiri:370b10f7022979b9909b1f54e031a190, niiri:238d7f5fad63f3a09d06b50d4157ccab, -, -, -)
+    wasGeneratedBy(niiri:370b10f7022979b9909b1f54e031a190, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
+    entity(niiri:501303c4526e36bacd33575de9e1c7e1,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636'])
-    entity(niiri:6d9ac5382dc49cb90381d57166c4ed2f,
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305'])
+    entity(niiri:5900e46c07fe094206dbe5619373c843,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:924c7d4d7309ff00193af75400143ff3, niiri:6d9ac5382dc49cb90381d57166c4ed2f, -, -, -)
-    wasGeneratedBy(niiri:924c7d4d7309ff00193af75400143ff3, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
-    entity(niiri:c4e8879f799272253a6da18f1386fc4f,
+    wasDerivedFrom(niiri:501303c4526e36bacd33575de9e1c7e1, niiri:5900e46c07fe094206dbe5619373c843, -, -, -)
+    wasGeneratedBy(niiri:501303c4526e36bacd33575de9e1c7e1, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
+    entity(niiri:b12062dbf6cf00ffdebbc055426df71f,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:7baed57d876853c4a67110bb56bd18c7,
+    entity(niiri:2346d8320f94832a873b7758ed41ad16,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:c4e8879f799272253a6da18f1386fc4f, niiri:7baed57d876853c4a67110bb56bd18c7, -, -, -)
-    wasGeneratedBy(niiri:c4e8879f799272253a6da18f1386fc4f, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
-    entity(niiri:71e9f5d599435c0b1579a85bbcf0258f,
+    wasDerivedFrom(niiri:b12062dbf6cf00ffdebbc055426df71f, niiri:2346d8320f94832a873b7758ed41ad16, -, -, -)
+    wasGeneratedBy(niiri:b12062dbf6cf00ffdebbc055426df71f, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
+    entity(niiri:9505f00ac6458db15a4ebb837091b83a,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:e238214fa3cbbcdf14e5b5071440c444,
+    entity(niiri:82a17d37d66e6643b4a8b753f9157424,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:71e9f5d599435c0b1579a85bbcf0258f, niiri:e238214fa3cbbcdf14e5b5071440c444, -, -, -)
-    wasGeneratedBy(niiri:71e9f5d599435c0b1579a85bbcf0258f, niiri:5087a65e60fa718315c6b087af5bd5fe, -)
-    entity(niiri:9061bdf6ef6cca5a54b93f3935d31ed5,
+    wasDerivedFrom(niiri:9505f00ac6458db15a4ebb837091b83a, niiri:82a17d37d66e6643b4a8b753f9157424, -, -, -)
+    wasGeneratedBy(niiri:9505f00ac6458db15a4ebb837091b83a, niiri:ebb7e829d24d7f16822d6ab10dbc9358, -)
+    entity(niiri:ae5fa7781aa268589bbc6e9989763317,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:c61baa01f732a9bdeca50d93f9083e04,
+    activity(niiri:5035ddea2ab2479eebc28ff8a3237d7e,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:fc3f44ad32e225d48140d371082295b7, -)
-    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08, -)
-    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:c4e8879f799272253a6da18f1386fc4f, -)
-    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:974a30c09e6ff2768ac64c1c0a35017b, -)
-    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:9061bdf6ef6cca5a54b93f3935d31ed5, -)
-    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:1286f7d2a33ec76e5a3bf677b4716a41, -)
-    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:6d3972348b560017e101dc8e8eefa8fe, -)
-    used(niiri:c61baa01f732a9bdeca50d93f9083e04, niiri:924c7d4d7309ff00193af75400143ff3, -)
-    entity(niiri:0815851b8e0dca6a14ef64c00390b0db,
+    wasAssociatedWith(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:6890e6cf2e5b88847f9d6b37cc9435ee, -)
+    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:e394d5fbfd251977c00b29594f0dcf96, -)
+    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:b12062dbf6cf00ffdebbc055426df71f, -)
+    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:b068d0824f197632cc995b100a6533df, -)
+    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:ae5fa7781aa268589bbc6e9989763317, -)
+    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:1d6f2fbb2b9802a2a599623a510930ee, -)
+    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:370b10f7022979b9909b1f54e031a190, -)
+    used(niiri:5035ddea2ab2479eebc28ff8a3237d7e, niiri:501303c4526e36bacd33575de9e1c7e1, -)
+    entity(niiri:83f28ed5522edbc5cf106d016d973b6f,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:fafb571ca9c00072e2b1a90417ae17c2,
+    entity(niiri:549d4a17964a1363568b8eb683ac6c21,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:0815851b8e0dca6a14ef64c00390b0db, niiri:fafb571ca9c00072e2b1a90417ae17c2, -, -, -)
-    wasGeneratedBy(niiri:0815851b8e0dca6a14ef64c00390b0db, niiri:c61baa01f732a9bdeca50d93f9083e04, -)
-    entity(niiri:ec6ddf0c2d630bb6973c7df03d2c71b8,
+    wasDerivedFrom(niiri:83f28ed5522edbc5cf106d016d973b6f, niiri:549d4a17964a1363568b8eb683ac6c21, -, -, -)
+    wasGeneratedBy(niiri:83f28ed5522edbc5cf106d016d973b6f, niiri:5035ddea2ab2479eebc28ff8a3237d7e, -)
+    entity(niiri:3567246fbbb1bfbdfa50fd84beba45a1,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:da4100e5e0922728b8f0ef95f7ed83f3,
+    entity(niiri:8dc4aa119c0aa747c979c4d43790afcb,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:ec6ddf0c2d630bb6973c7df03d2c71b8, niiri:da4100e5e0922728b8f0ef95f7ed83f3, -, -, -)
-    wasGeneratedBy(niiri:ec6ddf0c2d630bb6973c7df03d2c71b8, niiri:c61baa01f732a9bdeca50d93f9083e04, -)
-    entity(niiri:df95e156ad51e1587db4326d44cae8d6,
+    wasDerivedFrom(niiri:3567246fbbb1bfbdfa50fd84beba45a1, niiri:8dc4aa119c0aa747c979c4d43790afcb, -, -, -)
+    wasGeneratedBy(niiri:3567246fbbb1bfbdfa50fd84beba45a1, niiri:5035ddea2ab2479eebc28ff8a3237d7e, -)
+    entity(niiri:b7524d4fe2fbaa284684ae0f7c31bf0b,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:df95e156ad51e1587db4326d44cae8d6, niiri:c61baa01f732a9bdeca50d93f9083e04, -)
-    entity(niiri:318d8aac2941f252174fce7ff51d31b9,
+    wasGeneratedBy(niiri:b7524d4fe2fbaa284684ae0f7c31bf0b, niiri:5035ddea2ab2479eebc28ff8a3237d7e, -)
+    entity(niiri:4611b9195510d367480bac820aa29d7c,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "Inf" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:3b723894f74c64c5e06df4a66ca537ac',
-        nidm_equivalentThreshold: = 'niiri:4fe4a146aa90dc2a73c28311fc5c0534'])
-    entity(niiri:3b723894f74c64c5e06df4a66ca537ac,
+        nidm_equivalentThreshold: = 'niiri:916032106111f7bfbb885dfe74f72d38',
+        nidm_equivalentThreshold: = 'niiri:99f606153159dc7a5186d27cf2db5898'])
+    entity(niiri:916032106111f7bfbb885dfe74f72d38,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.44089209850063e-16" %% xsd:float])
-    entity(niiri:4fe4a146aa90dc2a73c28311fc5c0534,
+    entity(niiri:99f606153159dc7a5186d27cf2db5898,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0" %% xsd:float])
-    entity(niiri:270519a254ff149fa79d1a95ee5beec1,
+    entity(niiri:0d32149a72934b58ee4cc33bcc696ab3,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:2db2aacebb91598178340495413bb165',
-        nidm_equivalentThreshold: = 'niiri:60ab3f03d8b8f172c413b65fe6744469'])
-    entity(niiri:2db2aacebb91598178340495413bb165,
+        nidm_equivalentThreshold: = 'niiri:be64c5f01f788362a2ea440a4c8a484b',
+        nidm_equivalentThreshold: = 'niiri:16a1b31778199aafa88f5e498a6104a0'])
+    entity(niiri:be64c5f01f788362a2ea440a4c8a484b,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:60ab3f03d8b8f172c413b65fe6744469,
+    entity(niiri:16a1b31778199aafa88f5e498a6104a0,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:1e9b6b09f5ad34e15eb32ce5f89689ac,
+    entity(niiri:342d94b15ee3dac31586a642959f9fea,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:2d95847a8fda744d8fcdfbde4f662f4d,
+    entity(niiri:4c716b188abb1bd482f4f753790d0e54,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:03ce6ccb6754d10712833f321cfe3f8e,
+    activity(niiri:cca11d9f63848f52a66313d39c6eebf8,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:fc3f44ad32e225d48140d371082295b7, -)
-    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:318d8aac2941f252174fce7ff51d31b9, -)
-    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:270519a254ff149fa79d1a95ee5beec1, -)
-    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:0815851b8e0dca6a14ef64c00390b0db, -)
-    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:71e9f5d599435c0b1579a85bbcf0258f, -)
-    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08, -)
-    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:1e9b6b09f5ad34e15eb32ce5f89689ac, -)
-    used(niiri:03ce6ccb6754d10712833f321cfe3f8e, niiri:2d95847a8fda744d8fcdfbde4f662f4d, -)
-    entity(niiri:545e1a3189a64de9abd3df8c7afc0d8e,
+    wasAssociatedWith(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:6890e6cf2e5b88847f9d6b37cc9435ee, -)
+    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:4611b9195510d367480bac820aa29d7c, -)
+    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:0d32149a72934b58ee4cc33bcc696ab3, -)
+    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:83f28ed5522edbc5cf106d016d973b6f, -)
+    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:9505f00ac6458db15a4ebb837091b83a, -)
+    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:e394d5fbfd251977c00b29594f0dcf96, -)
+    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:342d94b15ee3dac31586a642959f9fea, -)
+    used(niiri:cca11d9f63848f52a66313d39c6eebf8, niiri:4c716b188abb1bd482f4f753790d0e54, -)
+    entity(niiri:7d5c95222d51279f7d81ce2411009c27,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:545e1a3189a64de9abd3df8c7afc0d8e, niiri:03ce6ccb6754d10712833f321cfe3f8e, -)
-    entity(niiri:f70092ed17b7a2d95c289d1ab32f428c,
+    wasGeneratedBy(niiri:7d5c95222d51279f7d81ce2411009c27, niiri:cca11d9f63848f52a66313d39c6eebf8, -)
+    entity(niiri:a32366d24af7805e745ddd7dea48f2ed,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:313ef7865165e4270bdf861a58ffc21d',
-        nidm_hasMaximumIntensityProjection: = 'niiri:f88f3043328411e4cf3090cf7031ce1c',
-        nidm_inCoordinateSpace: = 'niiri:1296df377e4b3e17f0d439a04c2e1636',
+        nidm_hasClusterLabelsMap: = 'niiri:c6c7962c875a2418e1de18c9ccedb38a',
+        nidm_hasMaximumIntensityProjection: = 'niiri:cb80b59a64cb33f2390d64694103cb19',
+        nidm_inCoordinateSpace: = 'niiri:72972f83a8d00f66bb3d6155789c7305',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:313ef7865165e4270bdf861a58ffc21d,
+    entity(niiri:c6c7962c875a2418e1de18c9ccedb38a,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:f88f3043328411e4cf3090cf7031ce1c,
+    entity(niiri:cb80b59a64cb33f2390d64694103cb19,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:f70092ed17b7a2d95c289d1ab32f428c, niiri:03ce6ccb6754d10712833f321cfe3f8e, -)
+    wasGeneratedBy(niiri:a32366d24af7805e745ddd7dea48f2ed, niiri:cca11d9f63848f52a66313d39c6eebf8, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_FDR_p005/nidm.ttl
+++ b/spmexport/ex_spm_FDR_p005/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:bc69a1ac57705467805587f33ef4be40
+niiri:2f1427c5f800de0cb67679a5b90a4497
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:85abba3318e1f613a6c08f6776d98654
+niiri:1cfb2c64c64d30e1e0e014fa1bbc072a
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:81d7145c2e911eca2556999a7bdfdb1a
+niiri:e0bc6e5e657729160f4c04a0942b2b20
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:81d7145c2e911eca2556999a7bdfdb1a prov:wasAssociatedWith niiri:85abba3318e1f613a6c08f6776d98654 .
+niiri:e0bc6e5e657729160f4c04a0942b2b20 prov:wasAssociatedWith niiri:1cfb2c64c64d30e1e0e014fa1bbc072a .
 
 _:blank5 a prov:Generation .
 
-niiri:bc69a1ac57705467805587f33ef4be40 prov:qualifiedGeneration _:blank5 .
+niiri:2f1427c5f800de0cb67679a5b90a4497 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:10:29"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:31:51"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:10:29"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:fc3f44ad32e225d48140d371082295b7
+niiri:6890e6cf2e5b88847f9d6b37cc9435ee
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:1296df377e4b3e17f0d439a04c2e1636
+niiri:72972f83a8d00f66bb3d6155789c7305
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:1296df377e4b3e17f0d439a04c2e1636
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:d6895de6f20332f03064080eb61a41f4
+niiri:8ad2b9c36e0ca8e9c2e7579be1c3e6da
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:1350c014ebc82fe774f7d9eedcaaf26e
+niiri:50b26818a7c0ae3b7f2c50db0401da6b
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:974a30c09e6ff2768ac64c1c0a35017b
+niiri:b068d0824f197632cc995b100a6533df
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:08f4d2fd1d03353254ce9aea7c04ebd5 ;
+    dc:description niiri:450123099db1897cb95a7fde00399b39 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:1350c014ebc82fe774f7d9eedcaaf26e ;
+    nidm_hasDriftModel: niiri:50b26818a7c0ae3b7f2c50db0401da6b ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:08f4d2fd1d03353254ce9aea7c04ebd5
+niiri:450123099db1897cb95a7fde00399b39
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:513a96deec8aaa6157a38b65af9585b9
+niiri:e13323ea4fb7c71006a383232cdf52b7
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:513a96deec8aaa6157a38b65af9585b9
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:5087a65e60fa718315c6b087af5bd5fe
+niiri:ebb7e829d24d7f16822d6ab10dbc9358
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:5087a65e60fa718315c6b087af5bd5fe prov:wasAssociatedWith niiri:fc3f44ad32e225d48140d371082295b7 .
+niiri:ebb7e829d24d7f16822d6ab10dbc9358 prov:wasAssociatedWith niiri:6890e6cf2e5b88847f9d6b37cc9435ee .
 
-niiri:5087a65e60fa718315c6b087af5bd5fe prov:used niiri:974a30c09e6ff2768ac64c1c0a35017b .
+niiri:ebb7e829d24d7f16822d6ab10dbc9358 prov:used niiri:b068d0824f197632cc995b100a6533df .
 
-niiri:5087a65e60fa718315c6b087af5bd5fe prov:used niiri:d6895de6f20332f03064080eb61a41f4 .
+niiri:ebb7e829d24d7f16822d6ab10dbc9358 prov:used niiri:8ad2b9c36e0ca8e9c2e7579be1c3e6da .
 
-niiri:5087a65e60fa718315c6b087af5bd5fe prov:used niiri:513a96deec8aaa6157a38b65af9585b9 .
+niiri:ebb7e829d24d7f16822d6ab10dbc9358 prov:used niiri:e13323ea4fb7c71006a383232cdf52b7 .
 
-niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08
+niiri:e394d5fbfd251977c00b29594f0dcf96
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:221da0fa52e9e0567709645f7e780029
+niiri:157ac4d9c5793dff9f106ea6352d2aca
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08 prov:wasDerivedFrom niiri:221da0fa52e9e0567709645f7e780029 .
+niiri:e394d5fbfd251977c00b29594f0dcf96 prov:wasDerivedFrom niiri:157ac4d9c5793dff9f106ea6352d2aca .
 
-niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08 prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+niiri:e394d5fbfd251977c00b29594f0dcf96 prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
 
-niiri:634450dee06194bfcfc9f0137d7c4e3e
+niiri:efd852153fcd5030d4ba060f13ee7ce3
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:634450dee06194bfcfc9f0137d7c4e3e prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+niiri:efd852153fcd5030d4ba060f13ee7ce3 prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
 
-niiri:1286f7d2a33ec76e5a3bf677b4716a41
+niiri:1d6f2fbb2b9802a2a599623a510930ee
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 .
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 .
 
-niiri:8797fb1368e40029241c25dd93aa02ef
+niiri:fc83f4f71ce6df65a62a742c2061511d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:1286f7d2a33ec76e5a3bf677b4716a41 prov:wasDerivedFrom niiri:8797fb1368e40029241c25dd93aa02ef .
+niiri:1d6f2fbb2b9802a2a599623a510930ee prov:wasDerivedFrom niiri:fc83f4f71ce6df65a62a742c2061511d .
 
-niiri:1286f7d2a33ec76e5a3bf677b4716a41 prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+niiri:1d6f2fbb2b9802a2a599623a510930ee prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
 
-niiri:6d3972348b560017e101dc8e8eefa8fe
+niiri:370b10f7022979b9909b1f54e031a190
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 .
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 .
 
-niiri:70f9dad6c2b7832f6225539ddfad35f9
+niiri:238d7f5fad63f3a09d06b50d4157ccab
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:6d3972348b560017e101dc8e8eefa8fe prov:wasDerivedFrom niiri:70f9dad6c2b7832f6225539ddfad35f9 .
+niiri:370b10f7022979b9909b1f54e031a190 prov:wasDerivedFrom niiri:238d7f5fad63f3a09d06b50d4157ccab .
 
-niiri:6d3972348b560017e101dc8e8eefa8fe prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+niiri:370b10f7022979b9909b1f54e031a190 prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
 
-niiri:924c7d4d7309ff00193af75400143ff3
+niiri:501303c4526e36bacd33575de9e1c7e1
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 .
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 .
 
-niiri:6d9ac5382dc49cb90381d57166c4ed2f
+niiri:5900e46c07fe094206dbe5619373c843
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:924c7d4d7309ff00193af75400143ff3 prov:wasDerivedFrom niiri:6d9ac5382dc49cb90381d57166c4ed2f .
+niiri:501303c4526e36bacd33575de9e1c7e1 prov:wasDerivedFrom niiri:5900e46c07fe094206dbe5619373c843 .
 
-niiri:924c7d4d7309ff00193af75400143ff3 prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+niiri:501303c4526e36bacd33575de9e1c7e1 prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
 
-niiri:c4e8879f799272253a6da18f1386fc4f
+niiri:b12062dbf6cf00ffdebbc055426df71f
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:7baed57d876853c4a67110bb56bd18c7
+niiri:2346d8320f94832a873b7758ed41ad16
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:c4e8879f799272253a6da18f1386fc4f prov:wasDerivedFrom niiri:7baed57d876853c4a67110bb56bd18c7 .
+niiri:b12062dbf6cf00ffdebbc055426df71f prov:wasDerivedFrom niiri:2346d8320f94832a873b7758ed41ad16 .
 
-niiri:c4e8879f799272253a6da18f1386fc4f prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+niiri:b12062dbf6cf00ffdebbc055426df71f prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
 
-niiri:71e9f5d599435c0b1579a85bbcf0258f
+niiri:9505f00ac6458db15a4ebb837091b83a
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:e238214fa3cbbcdf14e5b5071440c444
+niiri:82a17d37d66e6643b4a8b753f9157424
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:71e9f5d599435c0b1579a85bbcf0258f prov:wasDerivedFrom niiri:e238214fa3cbbcdf14e5b5071440c444 .
+niiri:9505f00ac6458db15a4ebb837091b83a prov:wasDerivedFrom niiri:82a17d37d66e6643b4a8b753f9157424 .
 
-niiri:71e9f5d599435c0b1579a85bbcf0258f prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+niiri:9505f00ac6458db15a4ebb837091b83a prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
 
-niiri:9061bdf6ef6cca5a54b93f3935d31ed5
+niiri:ae5fa7781aa268589bbc6e9989763317
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04
+niiri:5035ddea2ab2479eebc28ff8a3237d7e
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04 prov:wasAssociatedWith niiri:fc3f44ad32e225d48140d371082295b7 .
+niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:wasAssociatedWith niiri:6890e6cf2e5b88847f9d6b37cc9435ee .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08 .
+niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:e394d5fbfd251977c00b29594f0dcf96 .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:c4e8879f799272253a6da18f1386fc4f .
+niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:b12062dbf6cf00ffdebbc055426df71f .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:974a30c09e6ff2768ac64c1c0a35017b .
+niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:b068d0824f197632cc995b100a6533df .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:9061bdf6ef6cca5a54b93f3935d31ed5 .
+niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:ae5fa7781aa268589bbc6e9989763317 .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:1286f7d2a33ec76e5a3bf677b4716a41 .
+niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:1d6f2fbb2b9802a2a599623a510930ee .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:6d3972348b560017e101dc8e8eefa8fe .
+niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:370b10f7022979b9909b1f54e031a190 .
 
-niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:924c7d4d7309ff00193af75400143ff3 .
+niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:501303c4526e36bacd33575de9e1c7e1 .
 
-niiri:0815851b8e0dca6a14ef64c00390b0db
+niiri:83f28ed5522edbc5cf106d016d973b6f
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:0815851b8e0dca6a14ef64c00390b0db
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:fafb571ca9c00072e2b1a90417ae17c2
+niiri:549d4a17964a1363568b8eb683ac6c21
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:0815851b8e0dca6a14ef64c00390b0db prov:wasDerivedFrom niiri:fafb571ca9c00072e2b1a90417ae17c2 .
+niiri:83f28ed5522edbc5cf106d016d973b6f prov:wasDerivedFrom niiri:549d4a17964a1363568b8eb683ac6c21 .
 
-niiri:0815851b8e0dca6a14ef64c00390b0db prov:wasGeneratedBy niiri:c61baa01f732a9bdeca50d93f9083e04 .
+niiri:83f28ed5522edbc5cf106d016d973b6f prov:wasGeneratedBy niiri:5035ddea2ab2479eebc28ff8a3237d7e .
 
-niiri:ec6ddf0c2d630bb6973c7df03d2c71b8
+niiri:3567246fbbb1bfbdfa50fd84beba45a1
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:da4100e5e0922728b8f0ef95f7ed83f3
+niiri:8dc4aa119c0aa747c979c4d43790afcb
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:ec6ddf0c2d630bb6973c7df03d2c71b8 prov:wasDerivedFrom niiri:da4100e5e0922728b8f0ef95f7ed83f3 .
+niiri:3567246fbbb1bfbdfa50fd84beba45a1 prov:wasDerivedFrom niiri:8dc4aa119c0aa747c979c4d43790afcb .
 
-niiri:ec6ddf0c2d630bb6973c7df03d2c71b8 prov:wasGeneratedBy niiri:c61baa01f732a9bdeca50d93f9083e04 .
+niiri:3567246fbbb1bfbdfa50fd84beba45a1 prov:wasGeneratedBy niiri:5035ddea2ab2479eebc28ff8a3237d7e .
 
-niiri:df95e156ad51e1587db4326d44cae8d6
+niiri:b7524d4fe2fbaa284684ae0f7c31bf0b
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:df95e156ad51e1587db4326d44cae8d6 prov:wasGeneratedBy niiri:c61baa01f732a9bdeca50d93f9083e04 .
+niiri:b7524d4fe2fbaa284684ae0f7c31bf0b prov:wasGeneratedBy niiri:5035ddea2ab2479eebc28ff8a3237d7e .
 
-niiri:318d8aac2941f252174fce7ff51d31b9
+niiri:4611b9195510d367480bac820aa29d7c
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "Inf"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:3b723894f74c64c5e06df4a66ca537ac ;
-    nidm_equivalentThreshold: niiri:4fe4a146aa90dc2a73c28311fc5c0534 .
+    nidm_equivalentThreshold: niiri:916032106111f7bfbb885dfe74f72d38 ;
+    nidm_equivalentThreshold: niiri:99f606153159dc7a5186d27cf2db5898 .
 
-niiri:3b723894f74c64c5e06df4a66ca537ac
+niiri:916032106111f7bfbb885dfe74f72d38
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.44089209850063e-16"^^xsd:float .
 
-niiri:4fe4a146aa90dc2a73c28311fc5c0534
+niiri:99f606153159dc7a5186d27cf2db5898
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0"^^xsd:float .
 
-niiri:270519a254ff149fa79d1a95ee5beec1
+niiri:0d32149a72934b58ee4cc33bcc696ab3
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:2db2aacebb91598178340495413bb165 ;
-    nidm_equivalentThreshold: niiri:60ab3f03d8b8f172c413b65fe6744469 .
+    nidm_equivalentThreshold: niiri:be64c5f01f788362a2ea440a4c8a484b ;
+    nidm_equivalentThreshold: niiri:16a1b31778199aafa88f5e498a6104a0 .
 
-niiri:2db2aacebb91598178340495413bb165
+niiri:be64c5f01f788362a2ea440a4c8a484b
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:60ab3f03d8b8f172c413b65fe6744469
+niiri:16a1b31778199aafa88f5e498a6104a0
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:1e9b6b09f5ad34e15eb32ce5f89689ac
+niiri:342d94b15ee3dac31586a642959f9fea
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:2d95847a8fda744d8fcdfbde4f662f4d
+niiri:4c716b188abb1bd482f4f753790d0e54
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e
+niiri:cca11d9f63848f52a66313d39c6eebf8
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e prov:wasAssociatedWith niiri:fc3f44ad32e225d48140d371082295b7 .
+niiri:cca11d9f63848f52a66313d39c6eebf8 prov:wasAssociatedWith niiri:6890e6cf2e5b88847f9d6b37cc9435ee .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:318d8aac2941f252174fce7ff51d31b9 .
+niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:4611b9195510d367480bac820aa29d7c .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:270519a254ff149fa79d1a95ee5beec1 .
+niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:0d32149a72934b58ee4cc33bcc696ab3 .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:0815851b8e0dca6a14ef64c00390b0db .
+niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:83f28ed5522edbc5cf106d016d973b6f .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:71e9f5d599435c0b1579a85bbcf0258f .
+niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:9505f00ac6458db15a4ebb837091b83a .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08 .
+niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:e394d5fbfd251977c00b29594f0dcf96 .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:1e9b6b09f5ad34e15eb32ce5f89689ac .
+niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:342d94b15ee3dac31586a642959f9fea .
 
-niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:2d95847a8fda744d8fcdfbde4f662f4d .
+niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:4c716b188abb1bd482f4f753790d0e54 .
 
-niiri:545e1a3189a64de9abd3df8c7afc0d8e
+niiri:7d5c95222d51279f7d81ce2411009c27
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:545e1a3189a64de9abd3df8c7afc0d8e
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:545e1a3189a64de9abd3df8c7afc0d8e prov:wasGeneratedBy niiri:03ce6ccb6754d10712833f321cfe3f8e .
+niiri:7d5c95222d51279f7d81ce2411009c27 prov:wasGeneratedBy niiri:cca11d9f63848f52a66313d39c6eebf8 .
 
-niiri:f70092ed17b7a2d95c289d1ab32f428c
+niiri:a32366d24af7805e745ddd7dea48f2ed
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:f70092ed17b7a2d95c289d1ab32f428c
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:313ef7865165e4270bdf861a58ffc21d ;
-    nidm_hasMaximumIntensityProjection: niiri:f88f3043328411e4cf3090cf7031ce1c ;
-    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_hasClusterLabelsMap: niiri:c6c7962c875a2418e1de18c9ccedb38a ;
+    nidm_hasMaximumIntensityProjection: niiri:cb80b59a64cb33f2390d64694103cb19 ;
+    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:313ef7865165e4270bdf861a58ffc21d
+niiri:c6c7962c875a2418e1de18c9ccedb38a
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:f88f3043328411e4cf3090cf7031ce1c
+niiri:cb80b59a64cb33f2390d64694103cb19
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:f70092ed17b7a2d95c289d1ab32f428c prov:wasGeneratedBy niiri:03ce6ccb6754d10712833f321cfe3f8e .
+niiri:a32366d24af7805e745ddd7dea48f2ed prov:wasGeneratedBy niiri:cca11d9f63848f52a66313d39c6eebf8 .
 

--- a/spmexport/ex_spm_FDR_p005/nidm.ttl
+++ b/spmexport/ex_spm_FDR_p005/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:2f1427c5f800de0cb67679a5b90a4497
+niiri:47a694786709fd5213c3221d185a7ff6
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:1cfb2c64c64d30e1e0e014fa1bbc072a
+niiri:e9118aac641c910c106b40ebc1df2599
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:e0bc6e5e657729160f4c04a0942b2b20
+niiri:d9b86f5beeeb7e68f17e8888f295d361
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:e0bc6e5e657729160f4c04a0942b2b20 prov:wasAssociatedWith niiri:1cfb2c64c64d30e1e0e014fa1bbc072a .
+niiri:d9b86f5beeeb7e68f17e8888f295d361 prov:wasAssociatedWith niiri:e9118aac641c910c106b40ebc1df2599 .
 
 _:blank5 a prov:Generation .
 
-niiri:2f1427c5f800de0cb67679a5b90a4497 prov:qualifiedGeneration _:blank5 .
+niiri:47a694786709fd5213c3221d185a7ff6 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:31:51"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:43:12"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:31:51"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:6890e6cf2e5b88847f9d6b37cc9435ee
+niiri:659fe5297ce2e256c5ac2b9cf6969bf1
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:72972f83a8d00f66bb3d6155789c7305
+niiri:f1ac7f84f58c8d485272df9ba0fc2534
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:72972f83a8d00f66bb3d6155789c7305
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:8ad2b9c36e0ca8e9c2e7579be1c3e6da
+niiri:fbd02be4e06b477b7131be2e8a66922f
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:50b26818a7c0ae3b7f2c50db0401da6b
+niiri:b54d382fa234dd8137236332684182ee
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:b068d0824f197632cc995b100a6533df
+niiri:d1c6d55eab3c3a73cd7360a10d68fd6a
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:450123099db1897cb95a7fde00399b39 ;
+    dc:description niiri:6b092b221cf50df781d81bbb27d4241b ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:50b26818a7c0ae3b7f2c50db0401da6b ;
+    nidm_hasDriftModel: niiri:b54d382fa234dd8137236332684182ee ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:450123099db1897cb95a7fde00399b39
+niiri:6b092b221cf50df781d81bbb27d4241b
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:e13323ea4fb7c71006a383232cdf52b7
+niiri:488c20d8f76dd0382eab6e2fdb872903
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:e13323ea4fb7c71006a383232cdf52b7
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:ebb7e829d24d7f16822d6ab10dbc9358
+niiri:5223f230d7a04ec38363c093be331069
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:ebb7e829d24d7f16822d6ab10dbc9358 prov:wasAssociatedWith niiri:6890e6cf2e5b88847f9d6b37cc9435ee .
+niiri:5223f230d7a04ec38363c093be331069 prov:wasAssociatedWith niiri:659fe5297ce2e256c5ac2b9cf6969bf1 .
 
-niiri:ebb7e829d24d7f16822d6ab10dbc9358 prov:used niiri:b068d0824f197632cc995b100a6533df .
+niiri:5223f230d7a04ec38363c093be331069 prov:used niiri:d1c6d55eab3c3a73cd7360a10d68fd6a .
 
-niiri:ebb7e829d24d7f16822d6ab10dbc9358 prov:used niiri:8ad2b9c36e0ca8e9c2e7579be1c3e6da .
+niiri:5223f230d7a04ec38363c093be331069 prov:used niiri:fbd02be4e06b477b7131be2e8a66922f .
 
-niiri:ebb7e829d24d7f16822d6ab10dbc9358 prov:used niiri:e13323ea4fb7c71006a383232cdf52b7 .
+niiri:5223f230d7a04ec38363c093be331069 prov:used niiri:488c20d8f76dd0382eab6e2fdb872903 .
 
-niiri:e394d5fbfd251977c00b29594f0dcf96
+niiri:c396b5ce233bfe4d703d38713a288a50
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:157ac4d9c5793dff9f106ea6352d2aca
+niiri:d50bc804979d5df3abc5bd0a753f9c28
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:e394d5fbfd251977c00b29594f0dcf96 prov:wasDerivedFrom niiri:157ac4d9c5793dff9f106ea6352d2aca .
+niiri:c396b5ce233bfe4d703d38713a288a50 prov:wasDerivedFrom niiri:d50bc804979d5df3abc5bd0a753f9c28 .
 
-niiri:e394d5fbfd251977c00b29594f0dcf96 prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
+niiri:c396b5ce233bfe4d703d38713a288a50 prov:wasGeneratedBy niiri:5223f230d7a04ec38363c093be331069 .
 
-niiri:efd852153fcd5030d4ba060f13ee7ce3
+niiri:d144fd9155bfd51784d01fd2c392cf87
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:efd852153fcd5030d4ba060f13ee7ce3 prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
+niiri:d144fd9155bfd51784d01fd2c392cf87 prov:wasGeneratedBy niiri:5223f230d7a04ec38363c093be331069 .
 
-niiri:1d6f2fbb2b9802a2a599623a510930ee
+niiri:1fa4f6a110c9d70dd671edae9d77ef5f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 .
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 .
 
-niiri:fc83f4f71ce6df65a62a742c2061511d
+niiri:cb026e1a1349c97ac6d8bc5933c24b69
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:1d6f2fbb2b9802a2a599623a510930ee prov:wasDerivedFrom niiri:fc83f4f71ce6df65a62a742c2061511d .
+niiri:1fa4f6a110c9d70dd671edae9d77ef5f prov:wasDerivedFrom niiri:cb026e1a1349c97ac6d8bc5933c24b69 .
 
-niiri:1d6f2fbb2b9802a2a599623a510930ee prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
+niiri:1fa4f6a110c9d70dd671edae9d77ef5f prov:wasGeneratedBy niiri:5223f230d7a04ec38363c093be331069 .
 
-niiri:370b10f7022979b9909b1f54e031a190
+niiri:c9582cf7beebf684ea4a75cefb93f9d5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 .
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 .
 
-niiri:238d7f5fad63f3a09d06b50d4157ccab
+niiri:59239d01280a87902fb9705559c952e7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:370b10f7022979b9909b1f54e031a190 prov:wasDerivedFrom niiri:238d7f5fad63f3a09d06b50d4157ccab .
+niiri:c9582cf7beebf684ea4a75cefb93f9d5 prov:wasDerivedFrom niiri:59239d01280a87902fb9705559c952e7 .
 
-niiri:370b10f7022979b9909b1f54e031a190 prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
+niiri:c9582cf7beebf684ea4a75cefb93f9d5 prov:wasGeneratedBy niiri:5223f230d7a04ec38363c093be331069 .
 
-niiri:501303c4526e36bacd33575de9e1c7e1
+niiri:f9ec34325ec4e2ba2338ce621c42ca48
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 .
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 .
 
-niiri:5900e46c07fe094206dbe5619373c843
+niiri:715eb8a35cfc28578e90a8aff21fc7e5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:501303c4526e36bacd33575de9e1c7e1 prov:wasDerivedFrom niiri:5900e46c07fe094206dbe5619373c843 .
+niiri:f9ec34325ec4e2ba2338ce621c42ca48 prov:wasDerivedFrom niiri:715eb8a35cfc28578e90a8aff21fc7e5 .
 
-niiri:501303c4526e36bacd33575de9e1c7e1 prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
+niiri:f9ec34325ec4e2ba2338ce621c42ca48 prov:wasGeneratedBy niiri:5223f230d7a04ec38363c093be331069 .
 
-niiri:b12062dbf6cf00ffdebbc055426df71f
+niiri:9e17cdd0e6bd9cf96842abc6b61409a2
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:2346d8320f94832a873b7758ed41ad16
+niiri:4bff30639b821c07c01117a776f7d6a5
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:b12062dbf6cf00ffdebbc055426df71f prov:wasDerivedFrom niiri:2346d8320f94832a873b7758ed41ad16 .
+niiri:9e17cdd0e6bd9cf96842abc6b61409a2 prov:wasDerivedFrom niiri:4bff30639b821c07c01117a776f7d6a5 .
 
-niiri:b12062dbf6cf00ffdebbc055426df71f prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
+niiri:9e17cdd0e6bd9cf96842abc6b61409a2 prov:wasGeneratedBy niiri:5223f230d7a04ec38363c093be331069 .
 
-niiri:9505f00ac6458db15a4ebb837091b83a
+niiri:9d1126ce16ebe38a616de6742d7e9d09
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:82a17d37d66e6643b4a8b753f9157424
+niiri:185ee3d53c0827cbcf6d0d5da0c8a86d
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:9505f00ac6458db15a4ebb837091b83a prov:wasDerivedFrom niiri:82a17d37d66e6643b4a8b753f9157424 .
+niiri:9d1126ce16ebe38a616de6742d7e9d09 prov:wasDerivedFrom niiri:185ee3d53c0827cbcf6d0d5da0c8a86d .
 
-niiri:9505f00ac6458db15a4ebb837091b83a prov:wasGeneratedBy niiri:ebb7e829d24d7f16822d6ab10dbc9358 .
+niiri:9d1126ce16ebe38a616de6742d7e9d09 prov:wasGeneratedBy niiri:5223f230d7a04ec38363c093be331069 .
 
-niiri:ae5fa7781aa268589bbc6e9989763317
+niiri:1eb1e143c502eec939d94753797551a6
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e
+niiri:4de0f73985aada0bf6d5792109fe20c0
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:wasAssociatedWith niiri:6890e6cf2e5b88847f9d6b37cc9435ee .
+niiri:4de0f73985aada0bf6d5792109fe20c0 prov:wasAssociatedWith niiri:659fe5297ce2e256c5ac2b9cf6969bf1 .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:e394d5fbfd251977c00b29594f0dcf96 .
+niiri:4de0f73985aada0bf6d5792109fe20c0 prov:used niiri:c396b5ce233bfe4d703d38713a288a50 .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:b12062dbf6cf00ffdebbc055426df71f .
+niiri:4de0f73985aada0bf6d5792109fe20c0 prov:used niiri:9e17cdd0e6bd9cf96842abc6b61409a2 .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:b068d0824f197632cc995b100a6533df .
+niiri:4de0f73985aada0bf6d5792109fe20c0 prov:used niiri:d1c6d55eab3c3a73cd7360a10d68fd6a .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:ae5fa7781aa268589bbc6e9989763317 .
+niiri:4de0f73985aada0bf6d5792109fe20c0 prov:used niiri:1eb1e143c502eec939d94753797551a6 .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:1d6f2fbb2b9802a2a599623a510930ee .
+niiri:4de0f73985aada0bf6d5792109fe20c0 prov:used niiri:1fa4f6a110c9d70dd671edae9d77ef5f .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:370b10f7022979b9909b1f54e031a190 .
+niiri:4de0f73985aada0bf6d5792109fe20c0 prov:used niiri:c9582cf7beebf684ea4a75cefb93f9d5 .
 
-niiri:5035ddea2ab2479eebc28ff8a3237d7e prov:used niiri:501303c4526e36bacd33575de9e1c7e1 .
+niiri:4de0f73985aada0bf6d5792109fe20c0 prov:used niiri:f9ec34325ec4e2ba2338ce621c42ca48 .
 
-niiri:83f28ed5522edbc5cf106d016d973b6f
+niiri:0f79437bc56dc496cfcb40b63ec890d0
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:83f28ed5522edbc5cf106d016d973b6f
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:549d4a17964a1363568b8eb683ac6c21
+niiri:eb0a7014614cc8bb3fc815fde5a79894
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:83f28ed5522edbc5cf106d016d973b6f prov:wasDerivedFrom niiri:549d4a17964a1363568b8eb683ac6c21 .
+niiri:0f79437bc56dc496cfcb40b63ec890d0 prov:wasDerivedFrom niiri:eb0a7014614cc8bb3fc815fde5a79894 .
 
-niiri:83f28ed5522edbc5cf106d016d973b6f prov:wasGeneratedBy niiri:5035ddea2ab2479eebc28ff8a3237d7e .
+niiri:0f79437bc56dc496cfcb40b63ec890d0 prov:wasGeneratedBy niiri:4de0f73985aada0bf6d5792109fe20c0 .
 
-niiri:3567246fbbb1bfbdfa50fd84beba45a1
+niiri:fc7d9cf6a2d1aaad7f7c1ffed419a445
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:8dc4aa119c0aa747c979c4d43790afcb
+niiri:5d1c0efeba6da141daf22be47fbb0668
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:3567246fbbb1bfbdfa50fd84beba45a1 prov:wasDerivedFrom niiri:8dc4aa119c0aa747c979c4d43790afcb .
+niiri:fc7d9cf6a2d1aaad7f7c1ffed419a445 prov:wasDerivedFrom niiri:5d1c0efeba6da141daf22be47fbb0668 .
 
-niiri:3567246fbbb1bfbdfa50fd84beba45a1 prov:wasGeneratedBy niiri:5035ddea2ab2479eebc28ff8a3237d7e .
+niiri:fc7d9cf6a2d1aaad7f7c1ffed419a445 prov:wasGeneratedBy niiri:4de0f73985aada0bf6d5792109fe20c0 .
 
-niiri:b7524d4fe2fbaa284684ae0f7c31bf0b
+niiri:54bec7e32e1fba760ba0240edc0dd7d3
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:b7524d4fe2fbaa284684ae0f7c31bf0b prov:wasGeneratedBy niiri:5035ddea2ab2479eebc28ff8a3237d7e .
+niiri:54bec7e32e1fba760ba0240edc0dd7d3 prov:wasGeneratedBy niiri:4de0f73985aada0bf6d5792109fe20c0 .
 
-niiri:4611b9195510d367480bac820aa29d7c
+niiri:c986ca761eb7e01b3aae8125f1a05ca4
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "Inf"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:916032106111f7bfbb885dfe74f72d38 ;
-    nidm_equivalentThreshold: niiri:99f606153159dc7a5186d27cf2db5898 .
+    nidm_equivalentThreshold: niiri:9b220f4ea7c1ca34b6032b98ff861072 ;
+    nidm_equivalentThreshold: niiri:e8ae70de6a583659d6e06eab530951d8 .
 
-niiri:916032106111f7bfbb885dfe74f72d38
+niiri:9b220f4ea7c1ca34b6032b98ff861072
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.44089209850063e-16"^^xsd:float .
 
-niiri:99f606153159dc7a5186d27cf2db5898
+niiri:e8ae70de6a583659d6e06eab530951d8
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0"^^xsd:float .
 
-niiri:0d32149a72934b58ee4cc33bcc696ab3
+niiri:71ddc580885caa4465936bc2dab86615
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:be64c5f01f788362a2ea440a4c8a484b ;
-    nidm_equivalentThreshold: niiri:16a1b31778199aafa88f5e498a6104a0 .
+    nidm_equivalentThreshold: niiri:5a43685fcf804a0ddab9a67f176f0595 ;
+    nidm_equivalentThreshold: niiri:3116e164406bc59374c5a6d01d38cc23 .
 
-niiri:be64c5f01f788362a2ea440a4c8a484b
+niiri:5a43685fcf804a0ddab9a67f176f0595
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:16a1b31778199aafa88f5e498a6104a0
+niiri:3116e164406bc59374c5a6d01d38cc23
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:342d94b15ee3dac31586a642959f9fea
+niiri:8db27febe98891391cfe822b83547cf5
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:4c716b188abb1bd482f4f753790d0e54
+niiri:de48125bddcaf5cc5407a52ac4568b2a
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8
+niiri:83b99721bb1fee2ad0d390f27cd9b250
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8 prov:wasAssociatedWith niiri:6890e6cf2e5b88847f9d6b37cc9435ee .
+niiri:83b99721bb1fee2ad0d390f27cd9b250 prov:wasAssociatedWith niiri:659fe5297ce2e256c5ac2b9cf6969bf1 .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:4611b9195510d367480bac820aa29d7c .
+niiri:83b99721bb1fee2ad0d390f27cd9b250 prov:used niiri:c986ca761eb7e01b3aae8125f1a05ca4 .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:0d32149a72934b58ee4cc33bcc696ab3 .
+niiri:83b99721bb1fee2ad0d390f27cd9b250 prov:used niiri:71ddc580885caa4465936bc2dab86615 .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:83f28ed5522edbc5cf106d016d973b6f .
+niiri:83b99721bb1fee2ad0d390f27cd9b250 prov:used niiri:0f79437bc56dc496cfcb40b63ec890d0 .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:9505f00ac6458db15a4ebb837091b83a .
+niiri:83b99721bb1fee2ad0d390f27cd9b250 prov:used niiri:9d1126ce16ebe38a616de6742d7e9d09 .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:e394d5fbfd251977c00b29594f0dcf96 .
+niiri:83b99721bb1fee2ad0d390f27cd9b250 prov:used niiri:c396b5ce233bfe4d703d38713a288a50 .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:342d94b15ee3dac31586a642959f9fea .
+niiri:83b99721bb1fee2ad0d390f27cd9b250 prov:used niiri:8db27febe98891391cfe822b83547cf5 .
 
-niiri:cca11d9f63848f52a66313d39c6eebf8 prov:used niiri:4c716b188abb1bd482f4f753790d0e54 .
+niiri:83b99721bb1fee2ad0d390f27cd9b250 prov:used niiri:de48125bddcaf5cc5407a52ac4568b2a .
 
-niiri:7d5c95222d51279f7d81ce2411009c27
+niiri:d3682ea3d26b44d8e50b3459be4339ed
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:7d5c95222d51279f7d81ce2411009c27
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:7d5c95222d51279f7d81ce2411009c27 prov:wasGeneratedBy niiri:cca11d9f63848f52a66313d39c6eebf8 .
+niiri:d3682ea3d26b44d8e50b3459be4339ed prov:wasGeneratedBy niiri:83b99721bb1fee2ad0d390f27cd9b250 .
 
-niiri:a32366d24af7805e745ddd7dea48f2ed
+niiri:5fb83f625b3645998fd297c85f9b90f6
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:a32366d24af7805e745ddd7dea48f2ed
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:c6c7962c875a2418e1de18c9ccedb38a ;
-    nidm_hasMaximumIntensityProjection: niiri:cb80b59a64cb33f2390d64694103cb19 ;
-    nidm_inCoordinateSpace: niiri:72972f83a8d00f66bb3d6155789c7305 ;
+    nidm_hasClusterLabelsMap: niiri:df78d8f9820095bea3904f6bb24c0074 ;
+    nidm_hasMaximumIntensityProjection: niiri:508268df7f20283c787e397b0a0847c4 ;
+    nidm_inCoordinateSpace: niiri:f1ac7f84f58c8d485272df9ba0fc2534 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:c6c7962c875a2418e1de18c9ccedb38a
+niiri:df78d8f9820095bea3904f6bb24c0074
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:cb80b59a64cb33f2390d64694103cb19
+niiri:508268df7f20283c787e397b0a0847c4
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:a32366d24af7805e745ddd7dea48f2ed prov:wasGeneratedBy niiri:cca11d9f63848f52a66313d39c6eebf8 .
+niiri:5fb83f625b3645998fd297c85f9b90f6 prov:wasGeneratedBy niiri:83b99721bb1fee2ad0d390f27cd9b250 .
 

--- a/spmexport/ex_spm_FDR_p005/nidm.ttl
+++ b/spmexport/ex_spm_FDR_p005/nidm.ttl
@@ -1,0 +1,510 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:bc69a1ac57705467805587f33ef4be40
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:85abba3318e1f613a6c08f6776d98654
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:81d7145c2e911eca2556999a7bdfdb1a
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:81d7145c2e911eca2556999a7bdfdb1a prov:wasAssociatedWith niiri:85abba3318e1f613a6c08f6776d98654 .
+
+_:blank5 a prov:Generation .
+
+niiri:bc69a1ac57705467805587f33ef4be40 prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:10:29"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+
+niiri:fc3f44ad32e225d48140d371082295b7
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:1296df377e4b3e17f0d439a04c2e1636
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:d6895de6f20332f03064080eb61a41f4
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:1350c014ebc82fe774f7d9eedcaaf26e
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:974a30c09e6ff2768ac64c1c0a35017b
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:08f4d2fd1d03353254ce9aea7c04ebd5 ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:1350c014ebc82fe774f7d9eedcaaf26e ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:08f4d2fd1d03353254ce9aea7c04ebd5
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:513a96deec8aaa6157a38b65af9585b9
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:5087a65e60fa718315c6b087af5bd5fe
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:5087a65e60fa718315c6b087af5bd5fe prov:wasAssociatedWith niiri:fc3f44ad32e225d48140d371082295b7 .
+
+niiri:5087a65e60fa718315c6b087af5bd5fe prov:used niiri:974a30c09e6ff2768ac64c1c0a35017b .
+
+niiri:5087a65e60fa718315c6b087af5bd5fe prov:used niiri:d6895de6f20332f03064080eb61a41f4 .
+
+niiri:5087a65e60fa718315c6b087af5bd5fe prov:used niiri:513a96deec8aaa6157a38b65af9585b9 .
+
+niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:221da0fa52e9e0567709645f7e780029
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
+
+niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08 prov:wasDerivedFrom niiri:221da0fa52e9e0567709645f7e780029 .
+
+niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08 prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+
+niiri:634450dee06194bfcfc9f0137d7c4e3e
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "121.744659423828"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
+
+niiri:634450dee06194bfcfc9f0137d7c4e3e prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+
+niiri:1286f7d2a33ec76e5a3bf677b4716a41
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 .
+
+niiri:8797fb1368e40029241c25dd93aa02ef
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
+
+niiri:1286f7d2a33ec76e5a3bf677b4716a41 prov:wasDerivedFrom niiri:8797fb1368e40029241c25dd93aa02ef .
+
+niiri:1286f7d2a33ec76e5a3bf677b4716a41 prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+
+niiri:6d3972348b560017e101dc8e8eefa8fe
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 .
+
+niiri:70f9dad6c2b7832f6225539ddfad35f9
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
+
+niiri:6d3972348b560017e101dc8e8eefa8fe prov:wasDerivedFrom niiri:70f9dad6c2b7832f6225539ddfad35f9 .
+
+niiri:6d3972348b560017e101dc8e8eefa8fe prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+
+niiri:924c7d4d7309ff00193af75400143ff3
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 .
+
+niiri:6d9ac5382dc49cb90381d57166c4ed2f
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
+
+niiri:924c7d4d7309ff00193af75400143ff3 prov:wasDerivedFrom niiri:6d9ac5382dc49cb90381d57166c4ed2f .
+
+niiri:924c7d4d7309ff00193af75400143ff3 prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+
+niiri:c4e8879f799272253a6da18f1386fc4f
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
+
+niiri:7baed57d876853c4a67110bb56bd18c7
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
+
+niiri:c4e8879f799272253a6da18f1386fc4f prov:wasDerivedFrom niiri:7baed57d876853c4a67110bb56bd18c7 .
+
+niiri:c4e8879f799272253a6da18f1386fc4f prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+
+niiri:71e9f5d599435c0b1579a85bbcf0258f
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
+
+niiri:e238214fa3cbbcdf14e5b5071440c444
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
+
+niiri:71e9f5d599435c0b1579a85bbcf0258f prov:wasDerivedFrom niiri:e238214fa3cbbcdf14e5b5071440c444 .
+
+niiri:71e9f5d599435c0b1579a85bbcf0258f prov:wasGeneratedBy niiri:5087a65e60fa718315c6b087af5bd5fe .
+
+niiri:9061bdf6ef6cca5a54b93f3935d31ed5
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    rdfs:label "Contrast: pos vs neg" ;
+    prov:value "[1, -1, 0]"^^xsd:string .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04 prov:wasAssociatedWith niiri:fc3f44ad32e225d48140d371082295b7 .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08 .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:c4e8879f799272253a6da18f1386fc4f .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:974a30c09e6ff2768ac64c1c0a35017b .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:9061bdf6ef6cca5a54b93f3935d31ed5 .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:1286f7d2a33ec76e5a3bf677b4716a41 .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:6d3972348b560017e101dc8e8eefa8fe .
+
+niiri:c61baa01f732a9bdeca50d93f9083e04 prov:used niiri:924c7d4d7309ff00193af75400143ff3 .
+
+niiri:0815851b8e0dca6a14ef64c00390b0db
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: pos vs neg" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
+
+niiri:fafb571ca9c00072e2b1a90417ae17c2
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
+
+niiri:0815851b8e0dca6a14ef64c00390b0db prov:wasDerivedFrom niiri:fafb571ca9c00072e2b1a90417ae17c2 .
+
+niiri:0815851b8e0dca6a14ef64c00390b0db prov:wasGeneratedBy niiri:c61baa01f732a9bdeca50d93f9083e04 .
+
+niiri:ec6ddf0c2d630bb6973c7df03d2c71b8
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: pos vs neg" ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
+
+niiri:da4100e5e0922728b8f0ef95f7ed83f3
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
+
+niiri:ec6ddf0c2d630bb6973c7df03d2c71b8 prov:wasDerivedFrom niiri:da4100e5e0922728b8f0ef95f7ed83f3 .
+
+niiri:ec6ddf0c2d630bb6973c7df03d2c71b8 prov:wasGeneratedBy niiri:c61baa01f732a9bdeca50d93f9083e04 .
+
+niiri:df95e156ad51e1587db4326d44cae8d6
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
+
+niiri:df95e156ad51e1587db4326d44cae8d6 prov:wasGeneratedBy niiri:c61baa01f732a9bdeca50d93f9083e04 .
+
+niiri:318d8aac2941f252174fce7ff51d31b9
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "Inf"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:3b723894f74c64c5e06df4a66ca537ac ;
+    nidm_equivalentThreshold: niiri:4fe4a146aa90dc2a73c28311fc5c0534 .
+
+niiri:3b723894f74c64c5e06df4a66ca537ac
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "4.44089209850063e-16"^^xsd:float .
+
+niiri:4fe4a146aa90dc2a73c28311fc5c0534
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0"^^xsd:float .
+
+niiri:270519a254ff149fa79d1a95ee5beec1
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:2db2aacebb91598178340495413bb165 ;
+    nidm_equivalentThreshold: niiri:60ab3f03d8b8f172c413b65fe6744469 .
+
+niiri:2db2aacebb91598178340495413bb165
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:60ab3f03d8b8f172c413b65fe6744469
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:1e9b6b09f5ad34e15eb32ce5f89689ac
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:2d95847a8fda744d8fcdfbde4f662f4d
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e prov:wasAssociatedWith niiri:fc3f44ad32e225d48140d371082295b7 .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:318d8aac2941f252174fce7ff51d31b9 .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:270519a254ff149fa79d1a95ee5beec1 .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:0815851b8e0dca6a14ef64c00390b0db .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:71e9f5d599435c0b1579a85bbcf0258f .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:0a1e3bd7ec1c78d82ed38103ff4e3f08 .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:1e9b6b09f5ad34e15eb32ce5f89689ac .
+
+niiri:03ce6ccb6754d10712833f321cfe3f8e prov:used niiri:2d95847a8fda744d8fcdfbde4f662f4d .
+
+niiri:545e1a3189a64de9abd3df8c7afc0d8e
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
+    nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
+    nidm_searchVolumeInResels: "2650.12011223711"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.01704921884936, 4.07618247398105, 4.38831339907177]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.03409843769872, 8.1523649479621, 8.77662679814353]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "71.8552337008045"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "7.92955854811053e-13"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.05094049746367"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:545e1a3189a64de9abd3df8c7afc0d8e prov:wasGeneratedBy niiri:03ce6ccb6754d10712833f321cfe3f8e .
+
+niiri:f70092ed17b7a2d95c289d1ab32f428c
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
+    nidm_pValue: "NaN"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:313ef7865165e4270bdf861a58ffc21d ;
+    nidm_hasMaximumIntensityProjection: niiri:f88f3043328411e4cf3090cf7031ce1c ;
+    nidm_inCoordinateSpace: niiri:1296df377e4b3e17f0d439a04c2e1636 ;
+    crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
+
+niiri:313ef7865165e4270bdf861a58ffc21d
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:f88f3043328411e4cf3090cf7031ce1c
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:f70092ed17b7a2d95c289d1ab32f428c prov:wasGeneratedBy niiri:03ce6ccb6754d10712833f321cfe3f8e .
+

--- a/spmexport/ex_spm_FWE_p005/config.json
+++ b/spmexport/ex_spm_FWE_p005/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["voxel_FWE_p_05/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_FWE_p005/nidm.provn
+++ b/spmexport/ex_spm_FWE_p005/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:91b735cc90a2466539fb7db728892dae,
+  entity(niiri:9f198b1c51df5b656422af3d83108487,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:acd7c73b151ffdbfcffcfb99df7e29b5,
+  agent(niiri:2226f1e20a7a0f8366ae882fccfb5510,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:cb500330e513da865bf3f2c61f60eb24,
+  activity(niiri:ac8e76f4e75ad143f4e5fba87f3aa5a9,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:cb500330e513da865bf3f2c61f60eb24, niiri:acd7c73b151ffdbfcffcfb99df7e29b5, -)
-  wasGeneratedBy(niiri:91b735cc90a2466539fb7db728892dae, niiri:cb500330e513da865bf3f2c61f60eb24, 2016-01-11T10:31:56)
-  bundle niiri:91b735cc90a2466539fb7db728892dae
+  wasAssociatedWith(niiri:ac8e76f4e75ad143f4e5fba87f3aa5a9, niiri:2226f1e20a7a0f8366ae882fccfb5510, -)
+  wasGeneratedBy(niiri:9f198b1c51df5b656422af3d83108487, niiri:ac8e76f4e75ad143f4e5fba87f3aa5a9, 2016-01-11T10:43:16)
+  bundle niiri:9f198b1c51df5b656422af3d83108487
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:71c8456a05efd329a3f63e78a4cfe15d,
+    agent(niiri:b6950ee7f74c4f69e0ff57a2fd3f53ee,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:e1dc7971dcc9f1d319fffccd663141d5,
+    entity(niiri:9c886b3994cffee0dbf1b02f290dafc8,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:fdd94370bd26f6fe18b987145dfe9c6e,
+    entity(niiri:d80eb643fae41db986da24ea2070f99b,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:89ae73e417c8181c1a14f21b56840bb2,
+    entity(niiri:a1cc95af1537334b30bf3b688433d9d4,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:c6b57742e6455dc33b60216ed0099120,
+    entity(niiri:10b0d179f32bdfb717ce80e748ede8fd,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:8bcf3b39ec247d37c26ff1fad29e23ff',
+        dc:description = 'niiri:a0a50832f5426c9bf3be1a30962d4c37',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:89ae73e417c8181c1a14f21b56840bb2',
+        nidm_hasDriftModel: = 'niiri:a1cc95af1537334b30bf3b688433d9d4',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:8bcf3b39ec247d37c26ff1fad29e23ff,
+    entity(niiri:a0a50832f5426c9bf3be1a30962d4c37,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:261b784a230bade72faa605b2eb720bb,
+    entity(niiri:556b7a14cfe5d283f4990dbb5bcbfce0,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:a20d6bca7e84f7bc034a6bdb9f920c50,
+    activity(niiri:f12dd57c185818e6c545a983df605807,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:a20d6bca7e84f7bc034a6bdb9f920c50, niiri:71c8456a05efd329a3f63e78a4cfe15d, -)
-    used(niiri:a20d6bca7e84f7bc034a6bdb9f920c50, niiri:c6b57742e6455dc33b60216ed0099120, -)
-    used(niiri:a20d6bca7e84f7bc034a6bdb9f920c50, niiri:fdd94370bd26f6fe18b987145dfe9c6e, -)
-    used(niiri:a20d6bca7e84f7bc034a6bdb9f920c50, niiri:261b784a230bade72faa605b2eb720bb, -)
-    entity(niiri:89ebb0606f4e26391c8e3f64d942e3ca,
+    wasAssociatedWith(niiri:f12dd57c185818e6c545a983df605807, niiri:b6950ee7f74c4f69e0ff57a2fd3f53ee, -)
+    used(niiri:f12dd57c185818e6c545a983df605807, niiri:10b0d179f32bdfb717ce80e748ede8fd, -)
+    used(niiri:f12dd57c185818e6c545a983df605807, niiri:d80eb643fae41db986da24ea2070f99b, -)
+    used(niiri:f12dd57c185818e6c545a983df605807, niiri:556b7a14cfe5d283f4990dbb5bcbfce0, -)
+    entity(niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:a318421b76ae92f36eba383569fc0651,
+    entity(niiri:354e5c0abea91177d0f8f72c6e0ca648,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:89ebb0606f4e26391c8e3f64d942e3ca, niiri:a318421b76ae92f36eba383569fc0651, -, -, -)
-    wasGeneratedBy(niiri:89ebb0606f4e26391c8e3f64d942e3ca, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
-    entity(niiri:d56a4a2ac4b9f9da1d2d044bbe246fb1,
+    wasDerivedFrom(niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba, niiri:354e5c0abea91177d0f8f72c6e0ca648, -, -, -)
+    wasGeneratedBy(niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba, niiri:f12dd57c185818e6c545a983df605807, -)
+    entity(niiri:39b2f6258c15bb182aadac3b6eb2239d,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:d56a4a2ac4b9f9da1d2d044bbe246fb1, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
-    entity(niiri:858886e9108f4b75e9aa045d5860b95e,
+    wasGeneratedBy(niiri:39b2f6258c15bb182aadac3b6eb2239d, niiri:f12dd57c185818e6c545a983df605807, -)
+    entity(niiri:5d97e9bba8154f20a32ccb6edf6ba66a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5'])
-    entity(niiri:6f1544cee8087d8545f26ec090532eb5,
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8'])
+    entity(niiri:66ab507fcffe5a0b687f0fdbe4f65a55,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:858886e9108f4b75e9aa045d5860b95e, niiri:6f1544cee8087d8545f26ec090532eb5, -, -, -)
-    wasGeneratedBy(niiri:858886e9108f4b75e9aa045d5860b95e, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
-    entity(niiri:12a3b092d8cc5d60a211293739b5874b,
+    wasDerivedFrom(niiri:5d97e9bba8154f20a32ccb6edf6ba66a, niiri:66ab507fcffe5a0b687f0fdbe4f65a55, -, -, -)
+    wasGeneratedBy(niiri:5d97e9bba8154f20a32ccb6edf6ba66a, niiri:f12dd57c185818e6c545a983df605807, -)
+    entity(niiri:9bb43173e4e1d22c63b22a309eb4b2e4,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5'])
-    entity(niiri:05dbb9b2eba40ae1f33513c211fc6e61,
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8'])
+    entity(niiri:389a44850477178c17cbd77f56161399,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:12a3b092d8cc5d60a211293739b5874b, niiri:05dbb9b2eba40ae1f33513c211fc6e61, -, -, -)
-    wasGeneratedBy(niiri:12a3b092d8cc5d60a211293739b5874b, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
-    entity(niiri:9a9ded36fbab97d79c125db666700993,
+    wasDerivedFrom(niiri:9bb43173e4e1d22c63b22a309eb4b2e4, niiri:389a44850477178c17cbd77f56161399, -, -, -)
+    wasGeneratedBy(niiri:9bb43173e4e1d22c63b22a309eb4b2e4, niiri:f12dd57c185818e6c545a983df605807, -)
+    entity(niiri:6950eefa80a142b8ddc915fe6b9c091c,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5'])
-    entity(niiri:0395c198284a51b99b1513beebc37662,
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8'])
+    entity(niiri:3ac89ba503b2268d612701672cabf739,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:9a9ded36fbab97d79c125db666700993, niiri:0395c198284a51b99b1513beebc37662, -, -, -)
-    wasGeneratedBy(niiri:9a9ded36fbab97d79c125db666700993, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
-    entity(niiri:c0acfe714a899e541a50bcd463b59a45,
+    wasDerivedFrom(niiri:6950eefa80a142b8ddc915fe6b9c091c, niiri:3ac89ba503b2268d612701672cabf739, -, -, -)
+    wasGeneratedBy(niiri:6950eefa80a142b8ddc915fe6b9c091c, niiri:f12dd57c185818e6c545a983df605807, -)
+    entity(niiri:e077ed12825ccc6bdf24a062c83b89cf,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:db8b50ff414b852849744b24a03eec19,
+    entity(niiri:d78f886719107f5ff13b05419473dff1,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:c0acfe714a899e541a50bcd463b59a45, niiri:db8b50ff414b852849744b24a03eec19, -, -, -)
-    wasGeneratedBy(niiri:c0acfe714a899e541a50bcd463b59a45, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
-    entity(niiri:972f4ebf3d02c5b4931d8424c67b2482,
+    wasDerivedFrom(niiri:e077ed12825ccc6bdf24a062c83b89cf, niiri:d78f886719107f5ff13b05419473dff1, -, -, -)
+    wasGeneratedBy(niiri:e077ed12825ccc6bdf24a062c83b89cf, niiri:f12dd57c185818e6c545a983df605807, -)
+    entity(niiri:ac46b2be553e75b3f83c2b15ad03803d,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:c0c5c25437e6e0070570a680c0387235,
+    entity(niiri:af8f06988df9fbf5bacda0f9a163c637,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:972f4ebf3d02c5b4931d8424c67b2482, niiri:c0c5c25437e6e0070570a680c0387235, -, -, -)
-    wasGeneratedBy(niiri:972f4ebf3d02c5b4931d8424c67b2482, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
-    entity(niiri:311a6b7aa5fceec0e88b50a8da2d07e0,
+    wasDerivedFrom(niiri:ac46b2be553e75b3f83c2b15ad03803d, niiri:af8f06988df9fbf5bacda0f9a163c637, -, -, -)
+    wasGeneratedBy(niiri:ac46b2be553e75b3f83c2b15ad03803d, niiri:f12dd57c185818e6c545a983df605807, -)
+    entity(niiri:79890a18bdd7fbb149f795a64051e496,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:1351ea345e931572fac6dec43f3c32df,
+    activity(niiri:05d2fc600186fd9a34e7e6a946dc1579,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:1351ea345e931572fac6dec43f3c32df, niiri:71c8456a05efd329a3f63e78a4cfe15d, -)
-    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:89ebb0606f4e26391c8e3f64d942e3ca, -)
-    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:c0acfe714a899e541a50bcd463b59a45, -)
-    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:c6b57742e6455dc33b60216ed0099120, -)
-    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:311a6b7aa5fceec0e88b50a8da2d07e0, -)
-    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:858886e9108f4b75e9aa045d5860b95e, -)
-    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:12a3b092d8cc5d60a211293739b5874b, -)
-    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:9a9ded36fbab97d79c125db666700993, -)
-    entity(niiri:d11e36fd29880f3b973fc6dc402ee917,
+    wasAssociatedWith(niiri:05d2fc600186fd9a34e7e6a946dc1579, niiri:b6950ee7f74c4f69e0ff57a2fd3f53ee, -)
+    used(niiri:05d2fc600186fd9a34e7e6a946dc1579, niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba, -)
+    used(niiri:05d2fc600186fd9a34e7e6a946dc1579, niiri:e077ed12825ccc6bdf24a062c83b89cf, -)
+    used(niiri:05d2fc600186fd9a34e7e6a946dc1579, niiri:10b0d179f32bdfb717ce80e748ede8fd, -)
+    used(niiri:05d2fc600186fd9a34e7e6a946dc1579, niiri:79890a18bdd7fbb149f795a64051e496, -)
+    used(niiri:05d2fc600186fd9a34e7e6a946dc1579, niiri:5d97e9bba8154f20a32ccb6edf6ba66a, -)
+    used(niiri:05d2fc600186fd9a34e7e6a946dc1579, niiri:9bb43173e4e1d22c63b22a309eb4b2e4, -)
+    used(niiri:05d2fc600186fd9a34e7e6a946dc1579, niiri:6950eefa80a142b8ddc915fe6b9c091c, -)
+    entity(niiri:861f0db5ce96d3b39a2739927a320eea,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:63c1c1fa04b3ee61d4366341364ec42f,
+    entity(niiri:b68ef9888a2f772a4ccc8fd1ef364af2,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:d11e36fd29880f3b973fc6dc402ee917, niiri:63c1c1fa04b3ee61d4366341364ec42f, -, -, -)
-    wasGeneratedBy(niiri:d11e36fd29880f3b973fc6dc402ee917, niiri:1351ea345e931572fac6dec43f3c32df, -)
-    entity(niiri:e6dd75975fb2edab3963b35e1f1cf333,
+    wasDerivedFrom(niiri:861f0db5ce96d3b39a2739927a320eea, niiri:b68ef9888a2f772a4ccc8fd1ef364af2, -, -, -)
+    wasGeneratedBy(niiri:861f0db5ce96d3b39a2739927a320eea, niiri:05d2fc600186fd9a34e7e6a946dc1579, -)
+    entity(niiri:7088ff0d24af6168d504f0e5e49c13f5,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:fe26dfec8012d45708b7a001deb923e3,
+    entity(niiri:8d704e4dcbbbfcee7e981c21e7c8ecf0,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:e6dd75975fb2edab3963b35e1f1cf333, niiri:fe26dfec8012d45708b7a001deb923e3, -, -, -)
-    wasGeneratedBy(niiri:e6dd75975fb2edab3963b35e1f1cf333, niiri:1351ea345e931572fac6dec43f3c32df, -)
-    entity(niiri:d68866f79a2ab5e237bf9de20baa11c9,
+    wasDerivedFrom(niiri:7088ff0d24af6168d504f0e5e49c13f5, niiri:8d704e4dcbbbfcee7e981c21e7c8ecf0, -, -, -)
+    wasGeneratedBy(niiri:7088ff0d24af6168d504f0e5e49c13f5, niiri:05d2fc600186fd9a34e7e6a946dc1579, -)
+    entity(niiri:7d3867de5a9e1793815a88621dcf40f4,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:d68866f79a2ab5e237bf9de20baa11c9, niiri:1351ea345e931572fac6dec43f3c32df, -)
-    entity(niiri:82447ee0736a585fc01ee527763ff332,
+    wasGeneratedBy(niiri:7d3867de5a9e1793815a88621dcf40f4, niiri:05d2fc600186fd9a34e7e6a946dc1579, -)
+    entity(niiri:413a8cf1fac2929e086a90df81feebe0,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold: p<0.050000 (FWE)" %% xsd:string,
         prov:value = "0.0499999999999963" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:ad6d05a8935310f99fb2330332b10aea',
-        nidm_equivalentThreshold: = 'niiri:d4d9aa77117d02d0a5ab9d82eb6fe6ae'])
-    entity(niiri:ad6d05a8935310f99fb2330332b10aea,
+        nidm_equivalentThreshold: = 'niiri:1dec6aa975b9babd09d23703a934592e',
+        nidm_equivalentThreshold: = 'niiri:f37710c0e7a49ddf892f3cfec10d0714'])
+    entity(niiri:1dec6aa975b9babd09d23703a934592e,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "5.05094049746367" %% xsd:float])
-    entity(niiri:d4d9aa77117d02d0a5ab9d82eb6fe6ae,
+    entity(niiri:f37710c0e7a49ddf892f3cfec10d0714,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.68626416449958e-07" %% xsd:float])
-    entity(niiri:99ea5bf7127e81401121a328684412a8,
+    entity(niiri:27d079bf777bd75e1a4974f4b0013b7f,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:16fd025609b05423820da8183b0d74a5',
-        nidm_equivalentThreshold: = 'niiri:e4bd6debecfc4aa96fa940f6c1c9c0f7'])
-    entity(niiri:16fd025609b05423820da8183b0d74a5,
+        nidm_equivalentThreshold: = 'niiri:11beb704b9e563b684353ca133b2298e',
+        nidm_equivalentThreshold: = 'niiri:ee8303369803e640e024cf02aa772adc'])
+    entity(niiri:11beb704b9e563b684353ca133b2298e,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:e4bd6debecfc4aa96fa940f6c1c9c0f7,
+    entity(niiri:ee8303369803e640e024cf02aa772adc,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:f288d45ed0a5c665d83ae5e37141fd7e,
+    entity(niiri:4c83027a5fe9dd03529c28369366cd98,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:83c828dca525f3197249395f62b3277f,
+    entity(niiri:180649d8d2b2ec25c0ef5d85d12315bd,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:a6cee5f6a69ae317ea647be432a49ee8,
+    activity(niiri:a3b418065894185edf4b4173f5658f32,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:71c8456a05efd329a3f63e78a4cfe15d, -)
-    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:82447ee0736a585fc01ee527763ff332, -)
-    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:99ea5bf7127e81401121a328684412a8, -)
-    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:d11e36fd29880f3b973fc6dc402ee917, -)
-    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:972f4ebf3d02c5b4931d8424c67b2482, -)
-    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:89ebb0606f4e26391c8e3f64d942e3ca, -)
-    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:f288d45ed0a5c665d83ae5e37141fd7e, -)
-    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:83c828dca525f3197249395f62b3277f, -)
-    entity(niiri:4109b12b91085e2edad74bbe6d4f57ec,
+    wasAssociatedWith(niiri:a3b418065894185edf4b4173f5658f32, niiri:b6950ee7f74c4f69e0ff57a2fd3f53ee, -)
+    used(niiri:a3b418065894185edf4b4173f5658f32, niiri:413a8cf1fac2929e086a90df81feebe0, -)
+    used(niiri:a3b418065894185edf4b4173f5658f32, niiri:27d079bf777bd75e1a4974f4b0013b7f, -)
+    used(niiri:a3b418065894185edf4b4173f5658f32, niiri:861f0db5ce96d3b39a2739927a320eea, -)
+    used(niiri:a3b418065894185edf4b4173f5658f32, niiri:ac46b2be553e75b3f83c2b15ad03803d, -)
+    used(niiri:a3b418065894185edf4b4173f5658f32, niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba, -)
+    used(niiri:a3b418065894185edf4b4173f5658f32, niiri:4c83027a5fe9dd03529c28369366cd98, -)
+    used(niiri:a3b418065894185edf4b4173f5658f32, niiri:180649d8d2b2ec25c0ef5d85d12315bd, -)
+    entity(niiri:86d37c54684c6bce0fd10dc7dee77f88,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:4109b12b91085e2edad74bbe6d4f57ec, niiri:a6cee5f6a69ae317ea647be432a49ee8, -)
-    entity(niiri:c0731091f26b72d4d15acc1d2b6c174c,
+    wasGeneratedBy(niiri:86d37c54684c6bce0fd10dc7dee77f88, niiri:a3b418065894185edf4b4173f5658f32, -)
+    entity(niiri:2ddfdf7b057ce16048ead3e615b6e866,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:9df92be29cc6f877bacdeace910f275c',
-        nidm_hasMaximumIntensityProjection: = 'niiri:dc7e5d0895131b04509e9ce3075df927',
-        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
+        nidm_hasClusterLabelsMap: = 'niiri:2ecc6807ec67cff3091ef5da23d43d04',
+        nidm_hasMaximumIntensityProjection: = 'niiri:63250d6d0fd797369d0e3e66c7b702d2',
+        nidm_inCoordinateSpace: = 'niiri:9c886b3994cffee0dbf1b02f290dafc8',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:9df92be29cc6f877bacdeace910f275c,
+    entity(niiri:2ecc6807ec67cff3091ef5da23d43d04,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:dc7e5d0895131b04509e9ce3075df927,
+    entity(niiri:63250d6d0fd797369d0e3e66c7b702d2,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:c0731091f26b72d4d15acc1d2b6c174c, niiri:a6cee5f6a69ae317ea647be432a49ee8, -)
+    wasGeneratedBy(niiri:2ddfdf7b057ce16048ead3e615b6e866, niiri:a3b418065894185edf4b4173f5658f32, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_FWE_p005/nidm.provn
+++ b/spmexport/ex_spm_FWE_p005/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:d9de61d3916a81c2f7cb096f42ab4b72,
+  entity(niiri:91b735cc90a2466539fb7db728892dae,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:8d8ba223a9d656a5b8520269ade7e047,
+  agent(niiri:acd7c73b151ffdbfcffcfb99df7e29b5,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:a31eb8912e4a92d5c03ca364d719dcc9,
+  activity(niiri:cb500330e513da865bf3f2c61f60eb24,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:a31eb8912e4a92d5c03ca364d719dcc9, niiri:8d8ba223a9d656a5b8520269ade7e047, -)
-  wasGeneratedBy(niiri:d9de61d3916a81c2f7cb096f42ab4b72, niiri:a31eb8912e4a92d5c03ca364d719dcc9, 2016-01-11T10:10:34)
-  bundle niiri:d9de61d3916a81c2f7cb096f42ab4b72
+  wasAssociatedWith(niiri:cb500330e513da865bf3f2c61f60eb24, niiri:acd7c73b151ffdbfcffcfb99df7e29b5, -)
+  wasGeneratedBy(niiri:91b735cc90a2466539fb7db728892dae, niiri:cb500330e513da865bf3f2c61f60eb24, 2016-01-11T10:31:56)
+  bundle niiri:91b735cc90a2466539fb7db728892dae
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:e0d5b4ac9482578d83619fbe3feae527,
+    agent(niiri:71c8456a05efd329a3f63e78a4cfe15d,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:14edd4a5900bf231a2960f7ff2750926,
+    entity(niiri:e1dc7971dcc9f1d319fffccd663141d5,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:5e308681974dd8c906327b02a544de35,
+    entity(niiri:fdd94370bd26f6fe18b987145dfe9c6e,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:a331cc8ba1b743022f8cb34554cee1a4,
+    entity(niiri:89ae73e417c8181c1a14f21b56840bb2,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:fe507a67cbacb261defcf15d946ed9df,
+    entity(niiri:c6b57742e6455dc33b60216ed0099120,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:aec501eb129bec593f22f87e3a0f6a47',
+        dc:description = 'niiri:8bcf3b39ec247d37c26ff1fad29e23ff',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:a331cc8ba1b743022f8cb34554cee1a4',
+        nidm_hasDriftModel: = 'niiri:89ae73e417c8181c1a14f21b56840bb2',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:aec501eb129bec593f22f87e3a0f6a47,
+    entity(niiri:8bcf3b39ec247d37c26ff1fad29e23ff,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:4e99ef4c03d343296bde2da88ac53c7a,
+    entity(niiri:261b784a230bade72faa605b2eb720bb,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:83554b391c8b59930adf37f7be8454dc,
+    activity(niiri:a20d6bca7e84f7bc034a6bdb9f920c50,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:83554b391c8b59930adf37f7be8454dc, niiri:e0d5b4ac9482578d83619fbe3feae527, -)
-    used(niiri:83554b391c8b59930adf37f7be8454dc, niiri:fe507a67cbacb261defcf15d946ed9df, -)
-    used(niiri:83554b391c8b59930adf37f7be8454dc, niiri:5e308681974dd8c906327b02a544de35, -)
-    used(niiri:83554b391c8b59930adf37f7be8454dc, niiri:4e99ef4c03d343296bde2da88ac53c7a, -)
-    entity(niiri:15b06a0d061ae28a2c52bb9c26fe9f3a,
+    wasAssociatedWith(niiri:a20d6bca7e84f7bc034a6bdb9f920c50, niiri:71c8456a05efd329a3f63e78a4cfe15d, -)
+    used(niiri:a20d6bca7e84f7bc034a6bdb9f920c50, niiri:c6b57742e6455dc33b60216ed0099120, -)
+    used(niiri:a20d6bca7e84f7bc034a6bdb9f920c50, niiri:fdd94370bd26f6fe18b987145dfe9c6e, -)
+    used(niiri:a20d6bca7e84f7bc034a6bdb9f920c50, niiri:261b784a230bade72faa605b2eb720bb, -)
+    entity(niiri:89ebb0606f4e26391c8e3f64d942e3ca,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:31f490c36fc99785fe05bd7d094f3d8f,
+    entity(niiri:a318421b76ae92f36eba383569fc0651,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:15b06a0d061ae28a2c52bb9c26fe9f3a, niiri:31f490c36fc99785fe05bd7d094f3d8f, -, -, -)
-    wasGeneratedBy(niiri:15b06a0d061ae28a2c52bb9c26fe9f3a, niiri:83554b391c8b59930adf37f7be8454dc, -)
-    entity(niiri:14f96ff0133fff298d386e931522de24,
+    wasDerivedFrom(niiri:89ebb0606f4e26391c8e3f64d942e3ca, niiri:a318421b76ae92f36eba383569fc0651, -, -, -)
+    wasGeneratedBy(niiri:89ebb0606f4e26391c8e3f64d942e3ca, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
+    entity(niiri:d56a4a2ac4b9f9da1d2d044bbe246fb1,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:14f96ff0133fff298d386e931522de24, niiri:83554b391c8b59930adf37f7be8454dc, -)
-    entity(niiri:358dc2520f89aff47246f1db72ab5925,
+    wasGeneratedBy(niiri:d56a4a2ac4b9f9da1d2d044bbe246fb1, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
+    entity(niiri:858886e9108f4b75e9aa045d5860b95e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926'])
-    entity(niiri:a3fd975a8a55e667bc273ef9f784f888,
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5'])
+    entity(niiri:6f1544cee8087d8545f26ec090532eb5,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:358dc2520f89aff47246f1db72ab5925, niiri:a3fd975a8a55e667bc273ef9f784f888, -, -, -)
-    wasGeneratedBy(niiri:358dc2520f89aff47246f1db72ab5925, niiri:83554b391c8b59930adf37f7be8454dc, -)
-    entity(niiri:78307e7d5b33bdca6bd3bbb8ebf545cd,
+    wasDerivedFrom(niiri:858886e9108f4b75e9aa045d5860b95e, niiri:6f1544cee8087d8545f26ec090532eb5, -, -, -)
+    wasGeneratedBy(niiri:858886e9108f4b75e9aa045d5860b95e, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
+    entity(niiri:12a3b092d8cc5d60a211293739b5874b,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926'])
-    entity(niiri:e4a40c5a8ce81c8c690700d50d87c5ec,
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5'])
+    entity(niiri:05dbb9b2eba40ae1f33513c211fc6e61,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:78307e7d5b33bdca6bd3bbb8ebf545cd, niiri:e4a40c5a8ce81c8c690700d50d87c5ec, -, -, -)
-    wasGeneratedBy(niiri:78307e7d5b33bdca6bd3bbb8ebf545cd, niiri:83554b391c8b59930adf37f7be8454dc, -)
-    entity(niiri:2f9cac92a9b509411f714e12cdf6f2ee,
+    wasDerivedFrom(niiri:12a3b092d8cc5d60a211293739b5874b, niiri:05dbb9b2eba40ae1f33513c211fc6e61, -, -, -)
+    wasGeneratedBy(niiri:12a3b092d8cc5d60a211293739b5874b, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
+    entity(niiri:9a9ded36fbab97d79c125db666700993,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926'])
-    entity(niiri:dd060a83065aafc85ec3711a2a812c84,
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5'])
+    entity(niiri:0395c198284a51b99b1513beebc37662,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:2f9cac92a9b509411f714e12cdf6f2ee, niiri:dd060a83065aafc85ec3711a2a812c84, -, -, -)
-    wasGeneratedBy(niiri:2f9cac92a9b509411f714e12cdf6f2ee, niiri:83554b391c8b59930adf37f7be8454dc, -)
-    entity(niiri:f61eef5baa649bda63fa775b463ca078,
+    wasDerivedFrom(niiri:9a9ded36fbab97d79c125db666700993, niiri:0395c198284a51b99b1513beebc37662, -, -, -)
+    wasGeneratedBy(niiri:9a9ded36fbab97d79c125db666700993, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
+    entity(niiri:c0acfe714a899e541a50bcd463b59a45,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:db740e221640f9a1869c57620036d8ae,
+    entity(niiri:db8b50ff414b852849744b24a03eec19,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:f61eef5baa649bda63fa775b463ca078, niiri:db740e221640f9a1869c57620036d8ae, -, -, -)
-    wasGeneratedBy(niiri:f61eef5baa649bda63fa775b463ca078, niiri:83554b391c8b59930adf37f7be8454dc, -)
-    entity(niiri:ad6393a696d5aa1d7fab0a01cc3704a0,
+    wasDerivedFrom(niiri:c0acfe714a899e541a50bcd463b59a45, niiri:db8b50ff414b852849744b24a03eec19, -, -, -)
+    wasGeneratedBy(niiri:c0acfe714a899e541a50bcd463b59a45, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
+    entity(niiri:972f4ebf3d02c5b4931d8424c67b2482,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:92c86ff8a0141d839725edf7b7954c13,
+    entity(niiri:c0c5c25437e6e0070570a680c0387235,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:ad6393a696d5aa1d7fab0a01cc3704a0, niiri:92c86ff8a0141d839725edf7b7954c13, -, -, -)
-    wasGeneratedBy(niiri:ad6393a696d5aa1d7fab0a01cc3704a0, niiri:83554b391c8b59930adf37f7be8454dc, -)
-    entity(niiri:e44ce829afafab2dda577663b1c69b01,
+    wasDerivedFrom(niiri:972f4ebf3d02c5b4931d8424c67b2482, niiri:c0c5c25437e6e0070570a680c0387235, -, -, -)
+    wasGeneratedBy(niiri:972f4ebf3d02c5b4931d8424c67b2482, niiri:a20d6bca7e84f7bc034a6bdb9f920c50, -)
+    entity(niiri:311a6b7aa5fceec0e88b50a8da2d07e0,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:46171bad4d1d4c5b109ad525d9c516a4,
+    activity(niiri:1351ea345e931572fac6dec43f3c32df,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:e0d5b4ac9482578d83619fbe3feae527, -)
-    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:15b06a0d061ae28a2c52bb9c26fe9f3a, -)
-    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:f61eef5baa649bda63fa775b463ca078, -)
-    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:fe507a67cbacb261defcf15d946ed9df, -)
-    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:e44ce829afafab2dda577663b1c69b01, -)
-    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:358dc2520f89aff47246f1db72ab5925, -)
-    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:78307e7d5b33bdca6bd3bbb8ebf545cd, -)
-    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:2f9cac92a9b509411f714e12cdf6f2ee, -)
-    entity(niiri:90aec8ea8f469d8229fe877cb4ea5ee7,
+    wasAssociatedWith(niiri:1351ea345e931572fac6dec43f3c32df, niiri:71c8456a05efd329a3f63e78a4cfe15d, -)
+    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:89ebb0606f4e26391c8e3f64d942e3ca, -)
+    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:c0acfe714a899e541a50bcd463b59a45, -)
+    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:c6b57742e6455dc33b60216ed0099120, -)
+    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:311a6b7aa5fceec0e88b50a8da2d07e0, -)
+    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:858886e9108f4b75e9aa045d5860b95e, -)
+    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:12a3b092d8cc5d60a211293739b5874b, -)
+    used(niiri:1351ea345e931572fac6dec43f3c32df, niiri:9a9ded36fbab97d79c125db666700993, -)
+    entity(niiri:d11e36fd29880f3b973fc6dc402ee917,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:dd58316f1e4d9c7ed5aca9ab23fef8e7,
+    entity(niiri:63c1c1fa04b3ee61d4366341364ec42f,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:90aec8ea8f469d8229fe877cb4ea5ee7, niiri:dd58316f1e4d9c7ed5aca9ab23fef8e7, -, -, -)
-    wasGeneratedBy(niiri:90aec8ea8f469d8229fe877cb4ea5ee7, niiri:46171bad4d1d4c5b109ad525d9c516a4, -)
-    entity(niiri:9426c4b0d85d753bd1e3b25b75121365,
+    wasDerivedFrom(niiri:d11e36fd29880f3b973fc6dc402ee917, niiri:63c1c1fa04b3ee61d4366341364ec42f, -, -, -)
+    wasGeneratedBy(niiri:d11e36fd29880f3b973fc6dc402ee917, niiri:1351ea345e931572fac6dec43f3c32df, -)
+    entity(niiri:e6dd75975fb2edab3963b35e1f1cf333,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:893cc06b0a25ab2917c4a0081b3f2a0c,
+    entity(niiri:fe26dfec8012d45708b7a001deb923e3,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:9426c4b0d85d753bd1e3b25b75121365, niiri:893cc06b0a25ab2917c4a0081b3f2a0c, -, -, -)
-    wasGeneratedBy(niiri:9426c4b0d85d753bd1e3b25b75121365, niiri:46171bad4d1d4c5b109ad525d9c516a4, -)
-    entity(niiri:98d9a9a6ec9c249d5d0d51a6c67e5dfc,
+    wasDerivedFrom(niiri:e6dd75975fb2edab3963b35e1f1cf333, niiri:fe26dfec8012d45708b7a001deb923e3, -, -, -)
+    wasGeneratedBy(niiri:e6dd75975fb2edab3963b35e1f1cf333, niiri:1351ea345e931572fac6dec43f3c32df, -)
+    entity(niiri:d68866f79a2ab5e237bf9de20baa11c9,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:98d9a9a6ec9c249d5d0d51a6c67e5dfc, niiri:46171bad4d1d4c5b109ad525d9c516a4, -)
-    entity(niiri:51edeaa8fd32895c4cb13e5eb778c252,
+    wasGeneratedBy(niiri:d68866f79a2ab5e237bf9de20baa11c9, niiri:1351ea345e931572fac6dec43f3c32df, -)
+    entity(niiri:82447ee0736a585fc01ee527763ff332,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold: p<0.050000 (FWE)" %% xsd:string,
         prov:value = "0.0499999999999963" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:6c823818fb2f80f96876a22dc0536bf0',
-        nidm_equivalentThreshold: = 'niiri:0e22a266d8be4e6b5425fefacabfd54c'])
-    entity(niiri:6c823818fb2f80f96876a22dc0536bf0,
+        nidm_equivalentThreshold: = 'niiri:ad6d05a8935310f99fb2330332b10aea',
+        nidm_equivalentThreshold: = 'niiri:d4d9aa77117d02d0a5ab9d82eb6fe6ae'])
+    entity(niiri:ad6d05a8935310f99fb2330332b10aea,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "5.05094049746367" %% xsd:float])
-    entity(niiri:0e22a266d8be4e6b5425fefacabfd54c,
+    entity(niiri:d4d9aa77117d02d0a5ab9d82eb6fe6ae,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.68626416449958e-07" %% xsd:float])
-    entity(niiri:08e5645cf3ce4571bab5625cfb8066b3,
+    entity(niiri:99ea5bf7127e81401121a328684412a8,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:3c1cc25625cd2f1c5b6aaf2a315ca2ab',
-        nidm_equivalentThreshold: = 'niiri:f11d0230d31b703344f61ca5d47ec998'])
-    entity(niiri:3c1cc25625cd2f1c5b6aaf2a315ca2ab,
+        nidm_equivalentThreshold: = 'niiri:16fd025609b05423820da8183b0d74a5',
+        nidm_equivalentThreshold: = 'niiri:e4bd6debecfc4aa96fa940f6c1c9c0f7'])
+    entity(niiri:16fd025609b05423820da8183b0d74a5,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:f11d0230d31b703344f61ca5d47ec998,
+    entity(niiri:e4bd6debecfc4aa96fa940f6c1c9c0f7,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:b0837eddee352bb496077c3968246fe2,
+    entity(niiri:f288d45ed0a5c665d83ae5e37141fd7e,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:7a0372c5cb2cd1b39e9118215879ac17,
+    entity(niiri:83c828dca525f3197249395f62b3277f,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:7a541f989712cab79ace2f7c3c5e57f1,
+    activity(niiri:a6cee5f6a69ae317ea647be432a49ee8,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:e0d5b4ac9482578d83619fbe3feae527, -)
-    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:51edeaa8fd32895c4cb13e5eb778c252, -)
-    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:08e5645cf3ce4571bab5625cfb8066b3, -)
-    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:90aec8ea8f469d8229fe877cb4ea5ee7, -)
-    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:ad6393a696d5aa1d7fab0a01cc3704a0, -)
-    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:15b06a0d061ae28a2c52bb9c26fe9f3a, -)
-    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:b0837eddee352bb496077c3968246fe2, -)
-    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:7a0372c5cb2cd1b39e9118215879ac17, -)
-    entity(niiri:976f853e0e60d580f3ee2265db6db908,
+    wasAssociatedWith(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:71c8456a05efd329a3f63e78a4cfe15d, -)
+    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:82447ee0736a585fc01ee527763ff332, -)
+    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:99ea5bf7127e81401121a328684412a8, -)
+    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:d11e36fd29880f3b973fc6dc402ee917, -)
+    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:972f4ebf3d02c5b4931d8424c67b2482, -)
+    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:89ebb0606f4e26391c8e3f64d942e3ca, -)
+    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:f288d45ed0a5c665d83ae5e37141fd7e, -)
+    used(niiri:a6cee5f6a69ae317ea647be432a49ee8, niiri:83c828dca525f3197249395f62b3277f, -)
+    entity(niiri:4109b12b91085e2edad74bbe6d4f57ec,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:976f853e0e60d580f3ee2265db6db908, niiri:7a541f989712cab79ace2f7c3c5e57f1, -)
-    entity(niiri:679bd504c707d487180455319641dbcb,
+    wasGeneratedBy(niiri:4109b12b91085e2edad74bbe6d4f57ec, niiri:a6cee5f6a69ae317ea647be432a49ee8, -)
+    entity(niiri:c0731091f26b72d4d15acc1d2b6c174c,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:c8306e9d21c619dac3ced7835592bcb4',
-        nidm_hasMaximumIntensityProjection: = 'niiri:3176ddc10bc191279e478bfc850003a5',
-        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_hasClusterLabelsMap: = 'niiri:9df92be29cc6f877bacdeace910f275c',
+        nidm_hasMaximumIntensityProjection: = 'niiri:dc7e5d0895131b04509e9ce3075df927',
+        nidm_inCoordinateSpace: = 'niiri:e1dc7971dcc9f1d319fffccd663141d5',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:c8306e9d21c619dac3ced7835592bcb4,
+    entity(niiri:9df92be29cc6f877bacdeace910f275c,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:3176ddc10bc191279e478bfc850003a5,
+    entity(niiri:dc7e5d0895131b04509e9ce3075df927,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:679bd504c707d487180455319641dbcb, niiri:7a541f989712cab79ace2f7c3c5e57f1, -)
+    wasGeneratedBy(niiri:c0731091f26b72d4d15acc1d2b6c174c, niiri:a6cee5f6a69ae317ea647be432a49ee8, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_FWE_p005/nidm.provn
+++ b/spmexport/ex_spm_FWE_p005/nidm.provn
@@ -1,0 +1,429 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:d9de61d3916a81c2f7cb096f42ab4b72,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:8d8ba223a9d656a5b8520269ade7e047,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:a31eb8912e4a92d5c03ca364d719dcc9,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:a31eb8912e4a92d5c03ca364d719dcc9, niiri:8d8ba223a9d656a5b8520269ade7e047, -)
+  wasGeneratedBy(niiri:d9de61d3916a81c2f7cb096f42ab4b72, niiri:a31eb8912e4a92d5c03ca364d719dcc9, 2016-01-11T10:10:34)
+  bundle niiri:d9de61d3916a81c2f7cb096f42ab4b72
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+
+    agent(niiri:e0d5b4ac9482578d83619fbe3feae527,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:14edd4a5900bf231a2960f7ff2750926,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:5e308681974dd8c906327b02a544de35,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:a331cc8ba1b743022f8cb34554cee1a4,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:fe507a67cbacb261defcf15d946ed9df,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:aec501eb129bec593f22f87e3a0f6a47',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:a331cc8ba1b743022f8cb34554cee1a4',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:aec501eb129bec593f22f87e3a0f6a47,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:4e99ef4c03d343296bde2da88ac53c7a,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:83554b391c8b59930adf37f7be8454dc,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:83554b391c8b59930adf37f7be8454dc, niiri:e0d5b4ac9482578d83619fbe3feae527, -)
+    used(niiri:83554b391c8b59930adf37f7be8454dc, niiri:fe507a67cbacb261defcf15d946ed9df, -)
+    used(niiri:83554b391c8b59930adf37f7be8454dc, niiri:5e308681974dd8c906327b02a544de35, -)
+    used(niiri:83554b391c8b59930adf37f7be8454dc, niiri:4e99ef4c03d343296bde2da88ac53c7a, -)
+    entity(niiri:15b06a0d061ae28a2c52bb9c26fe9f3a,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    entity(niiri:31f490c36fc99785fe05bd7d094f3d8f,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
+    wasDerivedFrom(niiri:15b06a0d061ae28a2c52bb9c26fe9f3a, niiri:31f490c36fc99785fe05bd7d094f3d8f, -, -, -)
+    wasGeneratedBy(niiri:15b06a0d061ae28a2c52bb9c26fe9f3a, niiri:83554b391c8b59930adf37f7be8454dc, -)
+    entity(niiri:14f96ff0133fff298d386e931522de24,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "121.744659423828" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
+    wasGeneratedBy(niiri:14f96ff0133fff298d386e931522de24, niiri:83554b391c8b59930adf37f7be8454dc, -)
+    entity(niiri:358dc2520f89aff47246f1db72ab5925,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926'])
+    entity(niiri:a3fd975a8a55e667bc273ef9f784f888,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
+    wasDerivedFrom(niiri:358dc2520f89aff47246f1db72ab5925, niiri:a3fd975a8a55e667bc273ef9f784f888, -, -, -)
+    wasGeneratedBy(niiri:358dc2520f89aff47246f1db72ab5925, niiri:83554b391c8b59930adf37f7be8454dc, -)
+    entity(niiri:78307e7d5b33bdca6bd3bbb8ebf545cd,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926'])
+    entity(niiri:e4a40c5a8ce81c8c690700d50d87c5ec,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
+    wasDerivedFrom(niiri:78307e7d5b33bdca6bd3bbb8ebf545cd, niiri:e4a40c5a8ce81c8c690700d50d87c5ec, -, -, -)
+    wasGeneratedBy(niiri:78307e7d5b33bdca6bd3bbb8ebf545cd, niiri:83554b391c8b59930adf37f7be8454dc, -)
+    entity(niiri:2f9cac92a9b509411f714e12cdf6f2ee,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926'])
+    entity(niiri:dd060a83065aafc85ec3711a2a812c84,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
+    wasDerivedFrom(niiri:2f9cac92a9b509411f714e12cdf6f2ee, niiri:dd060a83065aafc85ec3711a2a812c84, -, -, -)
+    wasGeneratedBy(niiri:2f9cac92a9b509411f714e12cdf6f2ee, niiri:83554b391c8b59930adf37f7be8454dc, -)
+    entity(niiri:f61eef5baa649bda63fa775b463ca078,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
+    entity(niiri:db740e221640f9a1869c57620036d8ae,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
+    wasDerivedFrom(niiri:f61eef5baa649bda63fa775b463ca078, niiri:db740e221640f9a1869c57620036d8ae, -, -, -)
+    wasGeneratedBy(niiri:f61eef5baa649bda63fa775b463ca078, niiri:83554b391c8b59930adf37f7be8454dc, -)
+    entity(niiri:ad6393a696d5aa1d7fab0a01cc3704a0,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
+    entity(niiri:92c86ff8a0141d839725edf7b7954c13,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
+    wasDerivedFrom(niiri:ad6393a696d5aa1d7fab0a01cc3704a0, niiri:92c86ff8a0141d839725edf7b7954c13, -, -, -)
+    wasGeneratedBy(niiri:ad6393a696d5aa1d7fab0a01cc3704a0, niiri:83554b391c8b59930adf37f7be8454dc, -)
+    entity(niiri:e44ce829afafab2dda577663b1c69b01,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        prov:label = "Contrast: pos vs neg" %% xsd:string,
+        prov:value = "[1, -1, 0]" %% xsd:string])
+    activity(niiri:46171bad4d1d4c5b109ad525d9c516a4,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:e0d5b4ac9482578d83619fbe3feae527, -)
+    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:15b06a0d061ae28a2c52bb9c26fe9f3a, -)
+    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:f61eef5baa649bda63fa775b463ca078, -)
+    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:fe507a67cbacb261defcf15d946ed9df, -)
+    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:e44ce829afafab2dda577663b1c69b01, -)
+    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:358dc2520f89aff47246f1db72ab5925, -)
+    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:78307e7d5b33bdca6bd3bbb8ebf545cd, -)
+    used(niiri:46171bad4d1d4c5b109ad525d9c516a4, niiri:2f9cac92a9b509411f714e12cdf6f2ee, -)
+    entity(niiri:90aec8ea8f469d8229fe877cb4ea5ee7,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: pos vs neg" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
+    entity(niiri:dd58316f1e4d9c7ed5aca9ab23fef8e7,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
+    wasDerivedFrom(niiri:90aec8ea8f469d8229fe877cb4ea5ee7, niiri:dd58316f1e4d9c7ed5aca9ab23fef8e7, -, -, -)
+    wasGeneratedBy(niiri:90aec8ea8f469d8229fe877cb4ea5ee7, niiri:46171bad4d1d4c5b109ad525d9c516a4, -)
+    entity(niiri:9426c4b0d85d753bd1e3b25b75121365,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: pos vs neg" %% xsd:string,
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
+    entity(niiri:893cc06b0a25ab2917c4a0081b3f2a0c,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
+    wasDerivedFrom(niiri:9426c4b0d85d753bd1e3b25b75121365, niiri:893cc06b0a25ab2917c4a0081b3f2a0c, -, -, -)
+    wasGeneratedBy(niiri:9426c4b0d85d753bd1e3b25b75121365, niiri:46171bad4d1d4c5b109ad525d9c516a4, -)
+    entity(niiri:98d9a9a6ec9c249d5d0d51a6c67e5dfc,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
+    wasGeneratedBy(niiri:98d9a9a6ec9c249d5d0d51a6c67e5dfc, niiri:46171bad4d1d4c5b109ad525d9c516a4, -)
+    entity(niiri:51edeaa8fd32895c4cb13e5eb778c252,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold: p<0.050000 (FWE)" %% xsd:string,
+        prov:value = "0.0499999999999963" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:6c823818fb2f80f96876a22dc0536bf0',
+        nidm_equivalentThreshold: = 'niiri:0e22a266d8be4e6b5425fefacabfd54c'])
+    entity(niiri:6c823818fb2f80f96876a22dc0536bf0,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "5.05094049746367" %% xsd:float])
+    entity(niiri:0e22a266d8be4e6b5425fefacabfd54c,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "4.68626416449958e-07" %% xsd:float])
+    entity(niiri:08e5645cf3ce4571bab5625cfb8066b3,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:3c1cc25625cd2f1c5b6aaf2a315ca2ab',
+        nidm_equivalentThreshold: = 'niiri:f11d0230d31b703344f61ca5d47ec998'])
+    entity(niiri:3c1cc25625cd2f1c5b6aaf2a315ca2ab,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:f11d0230d31b703344f61ca5d47ec998,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:b0837eddee352bb496077c3968246fe2,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:7a0372c5cb2cd1b39e9118215879ac17,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:7a541f989712cab79ace2f7c3c5e57f1,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:e0d5b4ac9482578d83619fbe3feae527, -)
+    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:51edeaa8fd32895c4cb13e5eb778c252, -)
+    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:08e5645cf3ce4571bab5625cfb8066b3, -)
+    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:90aec8ea8f469d8229fe877cb4ea5ee7, -)
+    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:ad6393a696d5aa1d7fab0a01cc3704a0, -)
+    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:15b06a0d061ae28a2c52bb9c26fe9f3a, -)
+    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:b0837eddee352bb496077c3968246fe2, -)
+    used(niiri:7a541f989712cab79ace2f7c3c5e57f1, niiri:7a0372c5cb2cd1b39e9118215879ac17, -)
+    entity(niiri:976f853e0e60d580f3ee2265db6db908,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
+        nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
+        nidm_searchVolumeInResels: = "2650.12011223711" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.01704921884936, 4.07618247398105, 4.38831339907177]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.03409843769872, 8.1523649479621, 8.77662679814353]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "1.91762007396833" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "0.0512932943875464" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.05094049746367" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    wasGeneratedBy(niiri:976f853e0e60d580f3ee2265db6db908, niiri:7a541f989712cab79ace2f7c3c5e57f1, -)
+    entity(niiri:679bd504c707d487180455319641dbcb,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
+        nidm_pValue: = "NaN" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:c8306e9d21c619dac3ced7835592bcb4',
+        nidm_hasMaximumIntensityProjection: = 'niiri:3176ddc10bc191279e478bfc850003a5',
+        nidm_inCoordinateSpace: = 'niiri:14edd4a5900bf231a2960f7ff2750926',
+        crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
+    entity(niiri:c8306e9d21c619dac3ced7835592bcb4,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:3176ddc10bc191279e478bfc850003a5,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:679bd504c707d487180455319641dbcb, niiri:7a541f989712cab79ace2f7c3c5e57f1, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_FWE_p005/nidm.ttl
+++ b/spmexport/ex_spm_FWE_p005/nidm.ttl
@@ -1,0 +1,510 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:d9de61d3916a81c2f7cb096f42ab4b72
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:8d8ba223a9d656a5b8520269ade7e047
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:a31eb8912e4a92d5c03ca364d719dcc9
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:a31eb8912e4a92d5c03ca364d719dcc9 prov:wasAssociatedWith niiri:8d8ba223a9d656a5b8520269ade7e047 .
+
+_:blank5 a prov:Generation .
+
+niiri:d9de61d3916a81c2f7cb096f42ab4b72 prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:10:34"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+
+niiri:e0d5b4ac9482578d83619fbe3feae527
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:14edd4a5900bf231a2960f7ff2750926
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:5e308681974dd8c906327b02a544de35
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:a331cc8ba1b743022f8cb34554cee1a4
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:fe507a67cbacb261defcf15d946ed9df
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:aec501eb129bec593f22f87e3a0f6a47 ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:a331cc8ba1b743022f8cb34554cee1a4 ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:aec501eb129bec593f22f87e3a0f6a47
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:4e99ef4c03d343296bde2da88ac53c7a
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:83554b391c8b59930adf37f7be8454dc
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:83554b391c8b59930adf37f7be8454dc prov:wasAssociatedWith niiri:e0d5b4ac9482578d83619fbe3feae527 .
+
+niiri:83554b391c8b59930adf37f7be8454dc prov:used niiri:fe507a67cbacb261defcf15d946ed9df .
+
+niiri:83554b391c8b59930adf37f7be8454dc prov:used niiri:5e308681974dd8c906327b02a544de35 .
+
+niiri:83554b391c8b59930adf37f7be8454dc prov:used niiri:4e99ef4c03d343296bde2da88ac53c7a .
+
+niiri:15b06a0d061ae28a2c52bb9c26fe9f3a
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:31f490c36fc99785fe05bd7d094f3d8f
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
+
+niiri:15b06a0d061ae28a2c52bb9c26fe9f3a prov:wasDerivedFrom niiri:31f490c36fc99785fe05bd7d094f3d8f .
+
+niiri:15b06a0d061ae28a2c52bb9c26fe9f3a prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+
+niiri:14f96ff0133fff298d386e931522de24
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "121.744659423828"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
+
+niiri:14f96ff0133fff298d386e931522de24 prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+
+niiri:358dc2520f89aff47246f1db72ab5925
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 .
+
+niiri:a3fd975a8a55e667bc273ef9f784f888
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
+
+niiri:358dc2520f89aff47246f1db72ab5925 prov:wasDerivedFrom niiri:a3fd975a8a55e667bc273ef9f784f888 .
+
+niiri:358dc2520f89aff47246f1db72ab5925 prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+
+niiri:78307e7d5b33bdca6bd3bbb8ebf545cd
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 .
+
+niiri:e4a40c5a8ce81c8c690700d50d87c5ec
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
+
+niiri:78307e7d5b33bdca6bd3bbb8ebf545cd prov:wasDerivedFrom niiri:e4a40c5a8ce81c8c690700d50d87c5ec .
+
+niiri:78307e7d5b33bdca6bd3bbb8ebf545cd prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+
+niiri:2f9cac92a9b509411f714e12cdf6f2ee
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 .
+
+niiri:dd060a83065aafc85ec3711a2a812c84
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
+
+niiri:2f9cac92a9b509411f714e12cdf6f2ee prov:wasDerivedFrom niiri:dd060a83065aafc85ec3711a2a812c84 .
+
+niiri:2f9cac92a9b509411f714e12cdf6f2ee prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+
+niiri:f61eef5baa649bda63fa775b463ca078
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
+
+niiri:db740e221640f9a1869c57620036d8ae
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
+
+niiri:f61eef5baa649bda63fa775b463ca078 prov:wasDerivedFrom niiri:db740e221640f9a1869c57620036d8ae .
+
+niiri:f61eef5baa649bda63fa775b463ca078 prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+
+niiri:ad6393a696d5aa1d7fab0a01cc3704a0
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
+
+niiri:92c86ff8a0141d839725edf7b7954c13
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
+
+niiri:ad6393a696d5aa1d7fab0a01cc3704a0 prov:wasDerivedFrom niiri:92c86ff8a0141d839725edf7b7954c13 .
+
+niiri:ad6393a696d5aa1d7fab0a01cc3704a0 prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+
+niiri:e44ce829afafab2dda577663b1c69b01
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    rdfs:label "Contrast: pos vs neg" ;
+    prov:value "[1, -1, 0]"^^xsd:string .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:wasAssociatedWith niiri:e0d5b4ac9482578d83619fbe3feae527 .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:15b06a0d061ae28a2c52bb9c26fe9f3a .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:f61eef5baa649bda63fa775b463ca078 .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:fe507a67cbacb261defcf15d946ed9df .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:e44ce829afafab2dda577663b1c69b01 .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:358dc2520f89aff47246f1db72ab5925 .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:78307e7d5b33bdca6bd3bbb8ebf545cd .
+
+niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:2f9cac92a9b509411f714e12cdf6f2ee .
+
+niiri:90aec8ea8f469d8229fe877cb4ea5ee7
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: pos vs neg" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
+
+niiri:dd58316f1e4d9c7ed5aca9ab23fef8e7
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
+
+niiri:90aec8ea8f469d8229fe877cb4ea5ee7 prov:wasDerivedFrom niiri:dd58316f1e4d9c7ed5aca9ab23fef8e7 .
+
+niiri:90aec8ea8f469d8229fe877cb4ea5ee7 prov:wasGeneratedBy niiri:46171bad4d1d4c5b109ad525d9c516a4 .
+
+niiri:9426c4b0d85d753bd1e3b25b75121365
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: pos vs neg" ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
+
+niiri:893cc06b0a25ab2917c4a0081b3f2a0c
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
+
+niiri:9426c4b0d85d753bd1e3b25b75121365 prov:wasDerivedFrom niiri:893cc06b0a25ab2917c4a0081b3f2a0c .
+
+niiri:9426c4b0d85d753bd1e3b25b75121365 prov:wasGeneratedBy niiri:46171bad4d1d4c5b109ad525d9c516a4 .
+
+niiri:98d9a9a6ec9c249d5d0d51a6c67e5dfc
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
+
+niiri:98d9a9a6ec9c249d5d0d51a6c67e5dfc prov:wasGeneratedBy niiri:46171bad4d1d4c5b109ad525d9c516a4 .
+
+niiri:51edeaa8fd32895c4cb13e5eb778c252
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold: p<0.050000 (FWE)" ;
+    prov:value "0.0499999999999963"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:6c823818fb2f80f96876a22dc0536bf0 ;
+    nidm_equivalentThreshold: niiri:0e22a266d8be4e6b5425fefacabfd54c .
+
+niiri:6c823818fb2f80f96876a22dc0536bf0
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "5.05094049746367"^^xsd:float .
+
+niiri:0e22a266d8be4e6b5425fefacabfd54c
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "4.68626416449958e-07"^^xsd:float .
+
+niiri:08e5645cf3ce4571bab5625cfb8066b3
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:3c1cc25625cd2f1c5b6aaf2a315ca2ab ;
+    nidm_equivalentThreshold: niiri:f11d0230d31b703344f61ca5d47ec998 .
+
+niiri:3c1cc25625cd2f1c5b6aaf2a315ca2ab
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:f11d0230d31b703344f61ca5d47ec998
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:b0837eddee352bb496077c3968246fe2
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:7a0372c5cb2cd1b39e9118215879ac17
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:wasAssociatedWith niiri:e0d5b4ac9482578d83619fbe3feae527 .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:51edeaa8fd32895c4cb13e5eb778c252 .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:08e5645cf3ce4571bab5625cfb8066b3 .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:90aec8ea8f469d8229fe877cb4ea5ee7 .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:ad6393a696d5aa1d7fab0a01cc3704a0 .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:15b06a0d061ae28a2c52bb9c26fe9f3a .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:b0837eddee352bb496077c3968246fe2 .
+
+niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:7a0372c5cb2cd1b39e9118215879ac17 .
+
+niiri:976f853e0e60d580f3ee2265db6db908
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
+    nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
+    nidm_searchVolumeInResels: "2650.12011223711"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.01704921884936, 4.07618247398105, 4.38831339907177]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.03409843769872, 8.1523649479621, 8.77662679814353]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "1.91762007396833"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "0.0512932943875464"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.05094049746367"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:976f853e0e60d580f3ee2265db6db908 prov:wasGeneratedBy niiri:7a541f989712cab79ace2f7c3c5e57f1 .
+
+niiri:679bd504c707d487180455319641dbcb
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
+    nidm_pValue: "NaN"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:c8306e9d21c619dac3ced7835592bcb4 ;
+    nidm_hasMaximumIntensityProjection: niiri:3176ddc10bc191279e478bfc850003a5 ;
+    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
+
+niiri:c8306e9d21c619dac3ced7835592bcb4
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:3176ddc10bc191279e478bfc850003a5
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:679bd504c707d487180455319641dbcb prov:wasGeneratedBy niiri:7a541f989712cab79ace2f7c3c5e57f1 .
+

--- a/spmexport/ex_spm_FWE_p005/nidm.ttl
+++ b/spmexport/ex_spm_FWE_p005/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:d9de61d3916a81c2f7cb096f42ab4b72
+niiri:91b735cc90a2466539fb7db728892dae
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:8d8ba223a9d656a5b8520269ade7e047
+niiri:acd7c73b151ffdbfcffcfb99df7e29b5
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:a31eb8912e4a92d5c03ca364d719dcc9
+niiri:cb500330e513da865bf3f2c61f60eb24
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:a31eb8912e4a92d5c03ca364d719dcc9 prov:wasAssociatedWith niiri:8d8ba223a9d656a5b8520269ade7e047 .
+niiri:cb500330e513da865bf3f2c61f60eb24 prov:wasAssociatedWith niiri:acd7c73b151ffdbfcffcfb99df7e29b5 .
 
 _:blank5 a prov:Generation .
 
-niiri:d9de61d3916a81c2f7cb096f42ab4b72 prov:qualifiedGeneration _:blank5 .
+niiri:91b735cc90a2466539fb7db728892dae prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:10:34"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:31:56"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:10:34"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:e0d5b4ac9482578d83619fbe3feae527
+niiri:71c8456a05efd329a3f63e78a4cfe15d
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:14edd4a5900bf231a2960f7ff2750926
+niiri:e1dc7971dcc9f1d319fffccd663141d5
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:14edd4a5900bf231a2960f7ff2750926
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:5e308681974dd8c906327b02a544de35
+niiri:fdd94370bd26f6fe18b987145dfe9c6e
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:a331cc8ba1b743022f8cb34554cee1a4
+niiri:89ae73e417c8181c1a14f21b56840bb2
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:fe507a67cbacb261defcf15d946ed9df
+niiri:c6b57742e6455dc33b60216ed0099120
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:aec501eb129bec593f22f87e3a0f6a47 ;
+    dc:description niiri:8bcf3b39ec247d37c26ff1fad29e23ff ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:a331cc8ba1b743022f8cb34554cee1a4 ;
+    nidm_hasDriftModel: niiri:89ae73e417c8181c1a14f21b56840bb2 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:aec501eb129bec593f22f87e3a0f6a47
+niiri:8bcf3b39ec247d37c26ff1fad29e23ff
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:4e99ef4c03d343296bde2da88ac53c7a
+niiri:261b784a230bade72faa605b2eb720bb
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:4e99ef4c03d343296bde2da88ac53c7a
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:83554b391c8b59930adf37f7be8454dc
+niiri:a20d6bca7e84f7bc034a6bdb9f920c50
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:83554b391c8b59930adf37f7be8454dc prov:wasAssociatedWith niiri:e0d5b4ac9482578d83619fbe3feae527 .
+niiri:a20d6bca7e84f7bc034a6bdb9f920c50 prov:wasAssociatedWith niiri:71c8456a05efd329a3f63e78a4cfe15d .
 
-niiri:83554b391c8b59930adf37f7be8454dc prov:used niiri:fe507a67cbacb261defcf15d946ed9df .
+niiri:a20d6bca7e84f7bc034a6bdb9f920c50 prov:used niiri:c6b57742e6455dc33b60216ed0099120 .
 
-niiri:83554b391c8b59930adf37f7be8454dc prov:used niiri:5e308681974dd8c906327b02a544de35 .
+niiri:a20d6bca7e84f7bc034a6bdb9f920c50 prov:used niiri:fdd94370bd26f6fe18b987145dfe9c6e .
 
-niiri:83554b391c8b59930adf37f7be8454dc prov:used niiri:4e99ef4c03d343296bde2da88ac53c7a .
+niiri:a20d6bca7e84f7bc034a6bdb9f920c50 prov:used niiri:261b784a230bade72faa605b2eb720bb .
 
-niiri:15b06a0d061ae28a2c52bb9c26fe9f3a
+niiri:89ebb0606f4e26391c8e3f64d942e3ca
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:31f490c36fc99785fe05bd7d094f3d8f
+niiri:a318421b76ae92f36eba383569fc0651
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:15b06a0d061ae28a2c52bb9c26fe9f3a prov:wasDerivedFrom niiri:31f490c36fc99785fe05bd7d094f3d8f .
+niiri:89ebb0606f4e26391c8e3f64d942e3ca prov:wasDerivedFrom niiri:a318421b76ae92f36eba383569fc0651 .
 
-niiri:15b06a0d061ae28a2c52bb9c26fe9f3a prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+niiri:89ebb0606f4e26391c8e3f64d942e3ca prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
 
-niiri:14f96ff0133fff298d386e931522de24
+niiri:d56a4a2ac4b9f9da1d2d044bbe246fb1
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:14f96ff0133fff298d386e931522de24 prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+niiri:d56a4a2ac4b9f9da1d2d044bbe246fb1 prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
 
-niiri:358dc2520f89aff47246f1db72ab5925
+niiri:858886e9108f4b75e9aa045d5860b95e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 .
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 .
 
-niiri:a3fd975a8a55e667bc273ef9f784f888
+niiri:6f1544cee8087d8545f26ec090532eb5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:358dc2520f89aff47246f1db72ab5925 prov:wasDerivedFrom niiri:a3fd975a8a55e667bc273ef9f784f888 .
+niiri:858886e9108f4b75e9aa045d5860b95e prov:wasDerivedFrom niiri:6f1544cee8087d8545f26ec090532eb5 .
 
-niiri:358dc2520f89aff47246f1db72ab5925 prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+niiri:858886e9108f4b75e9aa045d5860b95e prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
 
-niiri:78307e7d5b33bdca6bd3bbb8ebf545cd
+niiri:12a3b092d8cc5d60a211293739b5874b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 .
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 .
 
-niiri:e4a40c5a8ce81c8c690700d50d87c5ec
+niiri:05dbb9b2eba40ae1f33513c211fc6e61
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:78307e7d5b33bdca6bd3bbb8ebf545cd prov:wasDerivedFrom niiri:e4a40c5a8ce81c8c690700d50d87c5ec .
+niiri:12a3b092d8cc5d60a211293739b5874b prov:wasDerivedFrom niiri:05dbb9b2eba40ae1f33513c211fc6e61 .
 
-niiri:78307e7d5b33bdca6bd3bbb8ebf545cd prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+niiri:12a3b092d8cc5d60a211293739b5874b prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
 
-niiri:2f9cac92a9b509411f714e12cdf6f2ee
+niiri:9a9ded36fbab97d79c125db666700993
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 .
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 .
 
-niiri:dd060a83065aafc85ec3711a2a812c84
+niiri:0395c198284a51b99b1513beebc37662
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:2f9cac92a9b509411f714e12cdf6f2ee prov:wasDerivedFrom niiri:dd060a83065aafc85ec3711a2a812c84 .
+niiri:9a9ded36fbab97d79c125db666700993 prov:wasDerivedFrom niiri:0395c198284a51b99b1513beebc37662 .
 
-niiri:2f9cac92a9b509411f714e12cdf6f2ee prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+niiri:9a9ded36fbab97d79c125db666700993 prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
 
-niiri:f61eef5baa649bda63fa775b463ca078
+niiri:c0acfe714a899e541a50bcd463b59a45
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:db740e221640f9a1869c57620036d8ae
+niiri:db8b50ff414b852849744b24a03eec19
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:f61eef5baa649bda63fa775b463ca078 prov:wasDerivedFrom niiri:db740e221640f9a1869c57620036d8ae .
+niiri:c0acfe714a899e541a50bcd463b59a45 prov:wasDerivedFrom niiri:db8b50ff414b852849744b24a03eec19 .
 
-niiri:f61eef5baa649bda63fa775b463ca078 prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+niiri:c0acfe714a899e541a50bcd463b59a45 prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
 
-niiri:ad6393a696d5aa1d7fab0a01cc3704a0
+niiri:972f4ebf3d02c5b4931d8424c67b2482
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:92c86ff8a0141d839725edf7b7954c13
+niiri:c0c5c25437e6e0070570a680c0387235
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:ad6393a696d5aa1d7fab0a01cc3704a0 prov:wasDerivedFrom niiri:92c86ff8a0141d839725edf7b7954c13 .
+niiri:972f4ebf3d02c5b4931d8424c67b2482 prov:wasDerivedFrom niiri:c0c5c25437e6e0070570a680c0387235 .
 
-niiri:ad6393a696d5aa1d7fab0a01cc3704a0 prov:wasGeneratedBy niiri:83554b391c8b59930adf37f7be8454dc .
+niiri:972f4ebf3d02c5b4931d8424c67b2482 prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
 
-niiri:e44ce829afafab2dda577663b1c69b01
+niiri:311a6b7aa5fceec0e88b50a8da2d07e0
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4
+niiri:1351ea345e931572fac6dec43f3c32df
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:wasAssociatedWith niiri:e0d5b4ac9482578d83619fbe3feae527 .
+niiri:1351ea345e931572fac6dec43f3c32df prov:wasAssociatedWith niiri:71c8456a05efd329a3f63e78a4cfe15d .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:15b06a0d061ae28a2c52bb9c26fe9f3a .
+niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:89ebb0606f4e26391c8e3f64d942e3ca .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:f61eef5baa649bda63fa775b463ca078 .
+niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:c0acfe714a899e541a50bcd463b59a45 .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:fe507a67cbacb261defcf15d946ed9df .
+niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:c6b57742e6455dc33b60216ed0099120 .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:e44ce829afafab2dda577663b1c69b01 .
+niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:311a6b7aa5fceec0e88b50a8da2d07e0 .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:358dc2520f89aff47246f1db72ab5925 .
+niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:858886e9108f4b75e9aa045d5860b95e .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:78307e7d5b33bdca6bd3bbb8ebf545cd .
+niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:12a3b092d8cc5d60a211293739b5874b .
 
-niiri:46171bad4d1d4c5b109ad525d9c516a4 prov:used niiri:2f9cac92a9b509411f714e12cdf6f2ee .
+niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:9a9ded36fbab97d79c125db666700993 .
 
-niiri:90aec8ea8f469d8229fe877cb4ea5ee7
+niiri:d11e36fd29880f3b973fc6dc402ee917
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:90aec8ea8f469d8229fe877cb4ea5ee7
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:dd58316f1e4d9c7ed5aca9ab23fef8e7
+niiri:63c1c1fa04b3ee61d4366341364ec42f
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:90aec8ea8f469d8229fe877cb4ea5ee7 prov:wasDerivedFrom niiri:dd58316f1e4d9c7ed5aca9ab23fef8e7 .
+niiri:d11e36fd29880f3b973fc6dc402ee917 prov:wasDerivedFrom niiri:63c1c1fa04b3ee61d4366341364ec42f .
 
-niiri:90aec8ea8f469d8229fe877cb4ea5ee7 prov:wasGeneratedBy niiri:46171bad4d1d4c5b109ad525d9c516a4 .
+niiri:d11e36fd29880f3b973fc6dc402ee917 prov:wasGeneratedBy niiri:1351ea345e931572fac6dec43f3c32df .
 
-niiri:9426c4b0d85d753bd1e3b25b75121365
+niiri:e6dd75975fb2edab3963b35e1f1cf333
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:893cc06b0a25ab2917c4a0081b3f2a0c
+niiri:fe26dfec8012d45708b7a001deb923e3
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:9426c4b0d85d753bd1e3b25b75121365 prov:wasDerivedFrom niiri:893cc06b0a25ab2917c4a0081b3f2a0c .
+niiri:e6dd75975fb2edab3963b35e1f1cf333 prov:wasDerivedFrom niiri:fe26dfec8012d45708b7a001deb923e3 .
 
-niiri:9426c4b0d85d753bd1e3b25b75121365 prov:wasGeneratedBy niiri:46171bad4d1d4c5b109ad525d9c516a4 .
+niiri:e6dd75975fb2edab3963b35e1f1cf333 prov:wasGeneratedBy niiri:1351ea345e931572fac6dec43f3c32df .
 
-niiri:98d9a9a6ec9c249d5d0d51a6c67e5dfc
+niiri:d68866f79a2ab5e237bf9de20baa11c9
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:98d9a9a6ec9c249d5d0d51a6c67e5dfc prov:wasGeneratedBy niiri:46171bad4d1d4c5b109ad525d9c516a4 .
+niiri:d68866f79a2ab5e237bf9de20baa11c9 prov:wasGeneratedBy niiri:1351ea345e931572fac6dec43f3c32df .
 
-niiri:51edeaa8fd32895c4cb13e5eb778c252
+niiri:82447ee0736a585fc01ee527763ff332
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold: p<0.050000 (FWE)" ;
     prov:value "0.0499999999999963"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:6c823818fb2f80f96876a22dc0536bf0 ;
-    nidm_equivalentThreshold: niiri:0e22a266d8be4e6b5425fefacabfd54c .
+    nidm_equivalentThreshold: niiri:ad6d05a8935310f99fb2330332b10aea ;
+    nidm_equivalentThreshold: niiri:d4d9aa77117d02d0a5ab9d82eb6fe6ae .
 
-niiri:6c823818fb2f80f96876a22dc0536bf0
+niiri:ad6d05a8935310f99fb2330332b10aea
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "5.05094049746367"^^xsd:float .
 
-niiri:0e22a266d8be4e6b5425fefacabfd54c
+niiri:d4d9aa77117d02d0a5ab9d82eb6fe6ae
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.68626416449958e-07"^^xsd:float .
 
-niiri:08e5645cf3ce4571bab5625cfb8066b3
+niiri:99ea5bf7127e81401121a328684412a8
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:3c1cc25625cd2f1c5b6aaf2a315ca2ab ;
-    nidm_equivalentThreshold: niiri:f11d0230d31b703344f61ca5d47ec998 .
+    nidm_equivalentThreshold: niiri:16fd025609b05423820da8183b0d74a5 ;
+    nidm_equivalentThreshold: niiri:e4bd6debecfc4aa96fa940f6c1c9c0f7 .
 
-niiri:3c1cc25625cd2f1c5b6aaf2a315ca2ab
+niiri:16fd025609b05423820da8183b0d74a5
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:f11d0230d31b703344f61ca5d47ec998
+niiri:e4bd6debecfc4aa96fa940f6c1c9c0f7
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:b0837eddee352bb496077c3968246fe2
+niiri:f288d45ed0a5c665d83ae5e37141fd7e
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:7a0372c5cb2cd1b39e9118215879ac17
+niiri:83c828dca525f3197249395f62b3277f
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1
+niiri:a6cee5f6a69ae317ea647be432a49ee8
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:wasAssociatedWith niiri:e0d5b4ac9482578d83619fbe3feae527 .
+niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:wasAssociatedWith niiri:71c8456a05efd329a3f63e78a4cfe15d .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:51edeaa8fd32895c4cb13e5eb778c252 .
+niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:82447ee0736a585fc01ee527763ff332 .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:08e5645cf3ce4571bab5625cfb8066b3 .
+niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:99ea5bf7127e81401121a328684412a8 .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:90aec8ea8f469d8229fe877cb4ea5ee7 .
+niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:d11e36fd29880f3b973fc6dc402ee917 .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:ad6393a696d5aa1d7fab0a01cc3704a0 .
+niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:972f4ebf3d02c5b4931d8424c67b2482 .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:15b06a0d061ae28a2c52bb9c26fe9f3a .
+niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:89ebb0606f4e26391c8e3f64d942e3ca .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:b0837eddee352bb496077c3968246fe2 .
+niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:f288d45ed0a5c665d83ae5e37141fd7e .
 
-niiri:7a541f989712cab79ace2f7c3c5e57f1 prov:used niiri:7a0372c5cb2cd1b39e9118215879ac17 .
+niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:83c828dca525f3197249395f62b3277f .
 
-niiri:976f853e0e60d580f3ee2265db6db908
+niiri:4109b12b91085e2edad74bbe6d4f57ec
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:976f853e0e60d580f3ee2265db6db908
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:976f853e0e60d580f3ee2265db6db908 prov:wasGeneratedBy niiri:7a541f989712cab79ace2f7c3c5e57f1 .
+niiri:4109b12b91085e2edad74bbe6d4f57ec prov:wasGeneratedBy niiri:a6cee5f6a69ae317ea647be432a49ee8 .
 
-niiri:679bd504c707d487180455319641dbcb
+niiri:c0731091f26b72d4d15acc1d2b6c174c
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:679bd504c707d487180455319641dbcb
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:c8306e9d21c619dac3ced7835592bcb4 ;
-    nidm_hasMaximumIntensityProjection: niiri:3176ddc10bc191279e478bfc850003a5 ;
-    nidm_inCoordinateSpace: niiri:14edd4a5900bf231a2960f7ff2750926 ;
+    nidm_hasClusterLabelsMap: niiri:9df92be29cc6f877bacdeace910f275c ;
+    nidm_hasMaximumIntensityProjection: niiri:dc7e5d0895131b04509e9ce3075df927 ;
+    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:c8306e9d21c619dac3ced7835592bcb4
+niiri:9df92be29cc6f877bacdeace910f275c
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:3176ddc10bc191279e478bfc850003a5
+niiri:dc7e5d0895131b04509e9ce3075df927
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:679bd504c707d487180455319641dbcb prov:wasGeneratedBy niiri:7a541f989712cab79ace2f7c3c5e57f1 .
+niiri:c0731091f26b72d4d15acc1d2b6c174c prov:wasGeneratedBy niiri:a6cee5f6a69ae317ea647be432a49ee8 .
 

--- a/spmexport/ex_spm_FWE_p005/nidm.ttl
+++ b/spmexport/ex_spm_FWE_p005/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:91b735cc90a2466539fb7db728892dae
+niiri:9f198b1c51df5b656422af3d83108487
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:acd7c73b151ffdbfcffcfb99df7e29b5
+niiri:2226f1e20a7a0f8366ae882fccfb5510
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:cb500330e513da865bf3f2c61f60eb24
+niiri:ac8e76f4e75ad143f4e5fba87f3aa5a9
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:cb500330e513da865bf3f2c61f60eb24 prov:wasAssociatedWith niiri:acd7c73b151ffdbfcffcfb99df7e29b5 .
+niiri:ac8e76f4e75ad143f4e5fba87f3aa5a9 prov:wasAssociatedWith niiri:2226f1e20a7a0f8366ae882fccfb5510 .
 
 _:blank5 a prov:Generation .
 
-niiri:91b735cc90a2466539fb7db728892dae prov:qualifiedGeneration _:blank5 .
+niiri:9f198b1c51df5b656422af3d83108487 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:31:56"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:43:16"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:31:56"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:71c8456a05efd329a3f63e78a4cfe15d
+niiri:b6950ee7f74c4f69e0ff57a2fd3f53ee
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:e1dc7971dcc9f1d319fffccd663141d5
+niiri:9c886b3994cffee0dbf1b02f290dafc8
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:e1dc7971dcc9f1d319fffccd663141d5
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:fdd94370bd26f6fe18b987145dfe9c6e
+niiri:d80eb643fae41db986da24ea2070f99b
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:89ae73e417c8181c1a14f21b56840bb2
+niiri:a1cc95af1537334b30bf3b688433d9d4
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:c6b57742e6455dc33b60216ed0099120
+niiri:10b0d179f32bdfb717ce80e748ede8fd
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:8bcf3b39ec247d37c26ff1fad29e23ff ;
+    dc:description niiri:a0a50832f5426c9bf3be1a30962d4c37 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:89ae73e417c8181c1a14f21b56840bb2 ;
+    nidm_hasDriftModel: niiri:a1cc95af1537334b30bf3b688433d9d4 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:8bcf3b39ec247d37c26ff1fad29e23ff
+niiri:a0a50832f5426c9bf3be1a30962d4c37
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:261b784a230bade72faa605b2eb720bb
+niiri:556b7a14cfe5d283f4990dbb5bcbfce0
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:261b784a230bade72faa605b2eb720bb
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:a20d6bca7e84f7bc034a6bdb9f920c50
+niiri:f12dd57c185818e6c545a983df605807
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:a20d6bca7e84f7bc034a6bdb9f920c50 prov:wasAssociatedWith niiri:71c8456a05efd329a3f63e78a4cfe15d .
+niiri:f12dd57c185818e6c545a983df605807 prov:wasAssociatedWith niiri:b6950ee7f74c4f69e0ff57a2fd3f53ee .
 
-niiri:a20d6bca7e84f7bc034a6bdb9f920c50 prov:used niiri:c6b57742e6455dc33b60216ed0099120 .
+niiri:f12dd57c185818e6c545a983df605807 prov:used niiri:10b0d179f32bdfb717ce80e748ede8fd .
 
-niiri:a20d6bca7e84f7bc034a6bdb9f920c50 prov:used niiri:fdd94370bd26f6fe18b987145dfe9c6e .
+niiri:f12dd57c185818e6c545a983df605807 prov:used niiri:d80eb643fae41db986da24ea2070f99b .
 
-niiri:a20d6bca7e84f7bc034a6bdb9f920c50 prov:used niiri:261b784a230bade72faa605b2eb720bb .
+niiri:f12dd57c185818e6c545a983df605807 prov:used niiri:556b7a14cfe5d283f4990dbb5bcbfce0 .
 
-niiri:89ebb0606f4e26391c8e3f64d942e3ca
+niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:a318421b76ae92f36eba383569fc0651
+niiri:354e5c0abea91177d0f8f72c6e0ca648
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:89ebb0606f4e26391c8e3f64d942e3ca prov:wasDerivedFrom niiri:a318421b76ae92f36eba383569fc0651 .
+niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba prov:wasDerivedFrom niiri:354e5c0abea91177d0f8f72c6e0ca648 .
 
-niiri:89ebb0606f4e26391c8e3f64d942e3ca prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
+niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba prov:wasGeneratedBy niiri:f12dd57c185818e6c545a983df605807 .
 
-niiri:d56a4a2ac4b9f9da1d2d044bbe246fb1
+niiri:39b2f6258c15bb182aadac3b6eb2239d
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:d56a4a2ac4b9f9da1d2d044bbe246fb1 prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
+niiri:39b2f6258c15bb182aadac3b6eb2239d prov:wasGeneratedBy niiri:f12dd57c185818e6c545a983df605807 .
 
-niiri:858886e9108f4b75e9aa045d5860b95e
+niiri:5d97e9bba8154f20a32ccb6edf6ba66a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 .
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 .
 
-niiri:6f1544cee8087d8545f26ec090532eb5
+niiri:66ab507fcffe5a0b687f0fdbe4f65a55
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:858886e9108f4b75e9aa045d5860b95e prov:wasDerivedFrom niiri:6f1544cee8087d8545f26ec090532eb5 .
+niiri:5d97e9bba8154f20a32ccb6edf6ba66a prov:wasDerivedFrom niiri:66ab507fcffe5a0b687f0fdbe4f65a55 .
 
-niiri:858886e9108f4b75e9aa045d5860b95e prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
+niiri:5d97e9bba8154f20a32ccb6edf6ba66a prov:wasGeneratedBy niiri:f12dd57c185818e6c545a983df605807 .
 
-niiri:12a3b092d8cc5d60a211293739b5874b
+niiri:9bb43173e4e1d22c63b22a309eb4b2e4
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 .
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 .
 
-niiri:05dbb9b2eba40ae1f33513c211fc6e61
+niiri:389a44850477178c17cbd77f56161399
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:12a3b092d8cc5d60a211293739b5874b prov:wasDerivedFrom niiri:05dbb9b2eba40ae1f33513c211fc6e61 .
+niiri:9bb43173e4e1d22c63b22a309eb4b2e4 prov:wasDerivedFrom niiri:389a44850477178c17cbd77f56161399 .
 
-niiri:12a3b092d8cc5d60a211293739b5874b prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
+niiri:9bb43173e4e1d22c63b22a309eb4b2e4 prov:wasGeneratedBy niiri:f12dd57c185818e6c545a983df605807 .
 
-niiri:9a9ded36fbab97d79c125db666700993
+niiri:6950eefa80a142b8ddc915fe6b9c091c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 .
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 .
 
-niiri:0395c198284a51b99b1513beebc37662
+niiri:3ac89ba503b2268d612701672cabf739
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:9a9ded36fbab97d79c125db666700993 prov:wasDerivedFrom niiri:0395c198284a51b99b1513beebc37662 .
+niiri:6950eefa80a142b8ddc915fe6b9c091c prov:wasDerivedFrom niiri:3ac89ba503b2268d612701672cabf739 .
 
-niiri:9a9ded36fbab97d79c125db666700993 prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
+niiri:6950eefa80a142b8ddc915fe6b9c091c prov:wasGeneratedBy niiri:f12dd57c185818e6c545a983df605807 .
 
-niiri:c0acfe714a899e541a50bcd463b59a45
+niiri:e077ed12825ccc6bdf24a062c83b89cf
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:db8b50ff414b852849744b24a03eec19
+niiri:d78f886719107f5ff13b05419473dff1
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:c0acfe714a899e541a50bcd463b59a45 prov:wasDerivedFrom niiri:db8b50ff414b852849744b24a03eec19 .
+niiri:e077ed12825ccc6bdf24a062c83b89cf prov:wasDerivedFrom niiri:d78f886719107f5ff13b05419473dff1 .
 
-niiri:c0acfe714a899e541a50bcd463b59a45 prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
+niiri:e077ed12825ccc6bdf24a062c83b89cf prov:wasGeneratedBy niiri:f12dd57c185818e6c545a983df605807 .
 
-niiri:972f4ebf3d02c5b4931d8424c67b2482
+niiri:ac46b2be553e75b3f83c2b15ad03803d
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:c0c5c25437e6e0070570a680c0387235
+niiri:af8f06988df9fbf5bacda0f9a163c637
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:972f4ebf3d02c5b4931d8424c67b2482 prov:wasDerivedFrom niiri:c0c5c25437e6e0070570a680c0387235 .
+niiri:ac46b2be553e75b3f83c2b15ad03803d prov:wasDerivedFrom niiri:af8f06988df9fbf5bacda0f9a163c637 .
 
-niiri:972f4ebf3d02c5b4931d8424c67b2482 prov:wasGeneratedBy niiri:a20d6bca7e84f7bc034a6bdb9f920c50 .
+niiri:ac46b2be553e75b3f83c2b15ad03803d prov:wasGeneratedBy niiri:f12dd57c185818e6c545a983df605807 .
 
-niiri:311a6b7aa5fceec0e88b50a8da2d07e0
+niiri:79890a18bdd7fbb149f795a64051e496
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:1351ea345e931572fac6dec43f3c32df
+niiri:05d2fc600186fd9a34e7e6a946dc1579
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:1351ea345e931572fac6dec43f3c32df prov:wasAssociatedWith niiri:71c8456a05efd329a3f63e78a4cfe15d .
+niiri:05d2fc600186fd9a34e7e6a946dc1579 prov:wasAssociatedWith niiri:b6950ee7f74c4f69e0ff57a2fd3f53ee .
 
-niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:89ebb0606f4e26391c8e3f64d942e3ca .
+niiri:05d2fc600186fd9a34e7e6a946dc1579 prov:used niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba .
 
-niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:c0acfe714a899e541a50bcd463b59a45 .
+niiri:05d2fc600186fd9a34e7e6a946dc1579 prov:used niiri:e077ed12825ccc6bdf24a062c83b89cf .
 
-niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:c6b57742e6455dc33b60216ed0099120 .
+niiri:05d2fc600186fd9a34e7e6a946dc1579 prov:used niiri:10b0d179f32bdfb717ce80e748ede8fd .
 
-niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:311a6b7aa5fceec0e88b50a8da2d07e0 .
+niiri:05d2fc600186fd9a34e7e6a946dc1579 prov:used niiri:79890a18bdd7fbb149f795a64051e496 .
 
-niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:858886e9108f4b75e9aa045d5860b95e .
+niiri:05d2fc600186fd9a34e7e6a946dc1579 prov:used niiri:5d97e9bba8154f20a32ccb6edf6ba66a .
 
-niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:12a3b092d8cc5d60a211293739b5874b .
+niiri:05d2fc600186fd9a34e7e6a946dc1579 prov:used niiri:9bb43173e4e1d22c63b22a309eb4b2e4 .
 
-niiri:1351ea345e931572fac6dec43f3c32df prov:used niiri:9a9ded36fbab97d79c125db666700993 .
+niiri:05d2fc600186fd9a34e7e6a946dc1579 prov:used niiri:6950eefa80a142b8ddc915fe6b9c091c .
 
-niiri:d11e36fd29880f3b973fc6dc402ee917
+niiri:861f0db5ce96d3b39a2739927a320eea
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:d11e36fd29880f3b973fc6dc402ee917
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:63c1c1fa04b3ee61d4366341364ec42f
+niiri:b68ef9888a2f772a4ccc8fd1ef364af2
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:d11e36fd29880f3b973fc6dc402ee917 prov:wasDerivedFrom niiri:63c1c1fa04b3ee61d4366341364ec42f .
+niiri:861f0db5ce96d3b39a2739927a320eea prov:wasDerivedFrom niiri:b68ef9888a2f772a4ccc8fd1ef364af2 .
 
-niiri:d11e36fd29880f3b973fc6dc402ee917 prov:wasGeneratedBy niiri:1351ea345e931572fac6dec43f3c32df .
+niiri:861f0db5ce96d3b39a2739927a320eea prov:wasGeneratedBy niiri:05d2fc600186fd9a34e7e6a946dc1579 .
 
-niiri:e6dd75975fb2edab3963b35e1f1cf333
+niiri:7088ff0d24af6168d504f0e5e49c13f5
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:fe26dfec8012d45708b7a001deb923e3
+niiri:8d704e4dcbbbfcee7e981c21e7c8ecf0
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:e6dd75975fb2edab3963b35e1f1cf333 prov:wasDerivedFrom niiri:fe26dfec8012d45708b7a001deb923e3 .
+niiri:7088ff0d24af6168d504f0e5e49c13f5 prov:wasDerivedFrom niiri:8d704e4dcbbbfcee7e981c21e7c8ecf0 .
 
-niiri:e6dd75975fb2edab3963b35e1f1cf333 prov:wasGeneratedBy niiri:1351ea345e931572fac6dec43f3c32df .
+niiri:7088ff0d24af6168d504f0e5e49c13f5 prov:wasGeneratedBy niiri:05d2fc600186fd9a34e7e6a946dc1579 .
 
-niiri:d68866f79a2ab5e237bf9de20baa11c9
+niiri:7d3867de5a9e1793815a88621dcf40f4
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:d68866f79a2ab5e237bf9de20baa11c9 prov:wasGeneratedBy niiri:1351ea345e931572fac6dec43f3c32df .
+niiri:7d3867de5a9e1793815a88621dcf40f4 prov:wasGeneratedBy niiri:05d2fc600186fd9a34e7e6a946dc1579 .
 
-niiri:82447ee0736a585fc01ee527763ff332
+niiri:413a8cf1fac2929e086a90df81feebe0
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold: p<0.050000 (FWE)" ;
     prov:value "0.0499999999999963"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:ad6d05a8935310f99fb2330332b10aea ;
-    nidm_equivalentThreshold: niiri:d4d9aa77117d02d0a5ab9d82eb6fe6ae .
+    nidm_equivalentThreshold: niiri:1dec6aa975b9babd09d23703a934592e ;
+    nidm_equivalentThreshold: niiri:f37710c0e7a49ddf892f3cfec10d0714 .
 
-niiri:ad6d05a8935310f99fb2330332b10aea
+niiri:1dec6aa975b9babd09d23703a934592e
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "5.05094049746367"^^xsd:float .
 
-niiri:d4d9aa77117d02d0a5ab9d82eb6fe6ae
+niiri:f37710c0e7a49ddf892f3cfec10d0714
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.68626416449958e-07"^^xsd:float .
 
-niiri:99ea5bf7127e81401121a328684412a8
+niiri:27d079bf777bd75e1a4974f4b0013b7f
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:16fd025609b05423820da8183b0d74a5 ;
-    nidm_equivalentThreshold: niiri:e4bd6debecfc4aa96fa940f6c1c9c0f7 .
+    nidm_equivalentThreshold: niiri:11beb704b9e563b684353ca133b2298e ;
+    nidm_equivalentThreshold: niiri:ee8303369803e640e024cf02aa772adc .
 
-niiri:16fd025609b05423820da8183b0d74a5
+niiri:11beb704b9e563b684353ca133b2298e
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:e4bd6debecfc4aa96fa940f6c1c9c0f7
+niiri:ee8303369803e640e024cf02aa772adc
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:f288d45ed0a5c665d83ae5e37141fd7e
+niiri:4c83027a5fe9dd03529c28369366cd98
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:83c828dca525f3197249395f62b3277f
+niiri:180649d8d2b2ec25c0ef5d85d12315bd
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8
+niiri:a3b418065894185edf4b4173f5658f32
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:wasAssociatedWith niiri:71c8456a05efd329a3f63e78a4cfe15d .
+niiri:a3b418065894185edf4b4173f5658f32 prov:wasAssociatedWith niiri:b6950ee7f74c4f69e0ff57a2fd3f53ee .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:82447ee0736a585fc01ee527763ff332 .
+niiri:a3b418065894185edf4b4173f5658f32 prov:used niiri:413a8cf1fac2929e086a90df81feebe0 .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:99ea5bf7127e81401121a328684412a8 .
+niiri:a3b418065894185edf4b4173f5658f32 prov:used niiri:27d079bf777bd75e1a4974f4b0013b7f .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:d11e36fd29880f3b973fc6dc402ee917 .
+niiri:a3b418065894185edf4b4173f5658f32 prov:used niiri:861f0db5ce96d3b39a2739927a320eea .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:972f4ebf3d02c5b4931d8424c67b2482 .
+niiri:a3b418065894185edf4b4173f5658f32 prov:used niiri:ac46b2be553e75b3f83c2b15ad03803d .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:89ebb0606f4e26391c8e3f64d942e3ca .
+niiri:a3b418065894185edf4b4173f5658f32 prov:used niiri:9c9928a50cb5e5c3ee6d5f68c0f03cba .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:f288d45ed0a5c665d83ae5e37141fd7e .
+niiri:a3b418065894185edf4b4173f5658f32 prov:used niiri:4c83027a5fe9dd03529c28369366cd98 .
 
-niiri:a6cee5f6a69ae317ea647be432a49ee8 prov:used niiri:83c828dca525f3197249395f62b3277f .
+niiri:a3b418065894185edf4b4173f5658f32 prov:used niiri:180649d8d2b2ec25c0ef5d85d12315bd .
 
-niiri:4109b12b91085e2edad74bbe6d4f57ec
+niiri:86d37c54684c6bce0fd10dc7dee77f88
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:4109b12b91085e2edad74bbe6d4f57ec
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:4109b12b91085e2edad74bbe6d4f57ec prov:wasGeneratedBy niiri:a6cee5f6a69ae317ea647be432a49ee8 .
+niiri:86d37c54684c6bce0fd10dc7dee77f88 prov:wasGeneratedBy niiri:a3b418065894185edf4b4173f5658f32 .
 
-niiri:c0731091f26b72d4d15acc1d2b6c174c
+niiri:2ddfdf7b057ce16048ead3e615b6e866
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:c0731091f26b72d4d15acc1d2b6c174c
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:9df92be29cc6f877bacdeace910f275c ;
-    nidm_hasMaximumIntensityProjection: niiri:dc7e5d0895131b04509e9ce3075df927 ;
-    nidm_inCoordinateSpace: niiri:e1dc7971dcc9f1d319fffccd663141d5 ;
+    nidm_hasClusterLabelsMap: niiri:2ecc6807ec67cff3091ef5da23d43d04 ;
+    nidm_hasMaximumIntensityProjection: niiri:63250d6d0fd797369d0e3e66c7b702d2 ;
+    nidm_inCoordinateSpace: niiri:9c886b3994cffee0dbf1b02f290dafc8 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:9df92be29cc6f877bacdeace910f275c
+niiri:2ecc6807ec67cff3091ef5da23d43d04
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:dc7e5d0895131b04509e9ce3075df927
+niiri:63250d6d0fd797369d0e3e66c7b702d2
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:c0731091f26b72d4d15acc1d2b6c174c prov:wasGeneratedBy niiri:a6cee5f6a69ae317ea647be432a49ee8 .
+niiri:2ddfdf7b057ce16048ead3e615b6e866 prov:wasGeneratedBy niiri:a3b418065894185edf4b4173f5658f32 .
 

--- a/spmexport/ex_spm_HRF_informed_basis/config.json
+++ b/spmexport/ex_spm_HRF_informed_basis/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["HRF_informed_basis/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.provn
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:c855a42b9fd2a67825eb0eddad715ed5,
+  entity(niiri:eaf3e7315ea214768c764372ad90fbba,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:6742968a097360dc90801b311279b0d4,
+  agent(niiri:733e6cf34d59395e1785a046d38726a3,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:5dff151e4c0a26653cff2770db2c33fd,
+  activity(niiri:975599572d4b5dfbda5590e0e33f1a1c,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:5dff151e4c0a26653cff2770db2c33fd, niiri:6742968a097360dc90801b311279b0d4, -)
-  wasGeneratedBy(niiri:c855a42b9fd2a67825eb0eddad715ed5, niiri:5dff151e4c0a26653cff2770db2c33fd, 2016-01-11T10:32:00)
-  bundle niiri:c855a42b9fd2a67825eb0eddad715ed5
+  wasAssociatedWith(niiri:975599572d4b5dfbda5590e0e33f1a1c, niiri:733e6cf34d59395e1785a046d38726a3, -)
+  wasGeneratedBy(niiri:eaf3e7315ea214768c764372ad90fbba, niiri:975599572d4b5dfbda5590e0e33f1a1c, 2016-01-11T10:43:21)
+  bundle niiri:eaf3e7315ea214768c764372ad90fbba
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -121,12 +121,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:821b1a9b55ebe0032b859ca5150035ba,
+    agent(niiri:cc60b02c514e8cfe2e50b30d6bc67c94,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:ad7c74aa0e194b1d0e6a1fe1c514c722,
+    entity(niiri:31dd9a37443e169f0f7297a3dfb8a1d8,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -135,203 +135,203 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:5272f74dd7c9a2ab61942dd0f79ccf4e,
+    entity(niiri:81dcf34f2e3bdd084d5134a0e0d76ba9,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:9799d5818262bf28a045fe452798ac27,
+    entity(niiri:6fea47562615cda5d73c61606a93228e,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:c586c126a0dc3b44d055a5a4988d7fea,
+    entity(niiri:166c2e158b227993faf5795de3ce5ecb,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:d46159933e55bc459a8eda437a7d8dba',
+        dc:description = 'niiri:462d8289aca89ea1948735a20e43858f',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) positive feedback\ntask001 co*bf(3)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(3)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:9799d5818262bf28a045fe452798ac27',
+        nidm_hasDriftModel: = 'niiri:6fea47562615cda5d73c61606a93228e',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:',
         nidm_hasHRFBasis: = 'spm_SPMsTemporalDerivative:',
         nidm_hasHRFBasis: = 'spm_SPMsDispersionDerivative:'])
-    entity(niiri:d46159933e55bc459a8eda437a7d8dba,
+    entity(niiri:462d8289aca89ea1948735a20e43858f,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:207f859d84e7b611b8afcd2c433d7a99,
+    entity(niiri:e55ec0a33fd8cdf226d541902de8bf7f,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:e67c851046927dbfcf08886d4e18e257,
+    activity(niiri:6117be626763f1e26e2965325107479b,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:e67c851046927dbfcf08886d4e18e257, niiri:821b1a9b55ebe0032b859ca5150035ba, -)
-    used(niiri:e67c851046927dbfcf08886d4e18e257, niiri:c586c126a0dc3b44d055a5a4988d7fea, -)
-    used(niiri:e67c851046927dbfcf08886d4e18e257, niiri:5272f74dd7c9a2ab61942dd0f79ccf4e, -)
-    used(niiri:e67c851046927dbfcf08886d4e18e257, niiri:207f859d84e7b611b8afcd2c433d7a99, -)
-    entity(niiri:0725082be9bac12c7029d6178bc32234,
+    wasAssociatedWith(niiri:6117be626763f1e26e2965325107479b, niiri:cc60b02c514e8cfe2e50b30d6bc67c94, -)
+    used(niiri:6117be626763f1e26e2965325107479b, niiri:166c2e158b227993faf5795de3ce5ecb, -)
+    used(niiri:6117be626763f1e26e2965325107479b, niiri:81dcf34f2e3bdd084d5134a0e0d76ba9, -)
+    used(niiri:6117be626763f1e26e2965325107479b, niiri:e55ec0a33fd8cdf226d541902de8bf7f, -)
+    entity(niiri:55ee3044c6cea1caf6e83ad9beb57124,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:ba6b6df78ba4f8c1ecf50fd9cc7402c6,
+    entity(niiri:2ea496bd8f5d9c784ab7644dcd4e3012,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:0725082be9bac12c7029d6178bc32234, niiri:ba6b6df78ba4f8c1ecf50fd9cc7402c6, -, -, -)
-    wasGeneratedBy(niiri:0725082be9bac12c7029d6178bc32234, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:393592a4a2b55eadb7908e667437e023,
+    wasDerivedFrom(niiri:55ee3044c6cea1caf6e83ad9beb57124, niiri:2ea496bd8f5d9c784ab7644dcd4e3012, -, -, -)
+    wasGeneratedBy(niiri:55ee3044c6cea1caf6e83ad9beb57124, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:ad6c6c985fb5ab75855fad08474687c3,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.035133361816" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         crypto:sha512 = "9cfeeeacd33286a145a42ac9e011a2cdc19a57aa70e2abfe71114ec159be45b10fc5fb995b21bb253624732dc52d9d34cfa34b774edf3fcb1efceb98db468de1" %% xsd:string])
-    wasGeneratedBy(niiri:393592a4a2b55eadb7908e667437e023, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:513180f96afa3f5d3d4823e976a35799,
+    wasGeneratedBy(niiri:ad6c6c985fb5ab75855fad08474687c3, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:a8172b84431abcdda1fe59d67b915f4f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
-    entity(niiri:795ad2bb84b798c73c49be9153d72a0c,
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8'])
+    entity(niiri:2e1b05283c5d3b1334ab150084bc75db,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "05720970946f70a45079d6f6e993cfadfcfd7f2feaa3e1d2478a4b7f2d8508122250847bbebb9f63e10cfc83a8101bc031164e69a4b720ae19d0ed237edc4153" %% xsd:string])
-    wasDerivedFrom(niiri:513180f96afa3f5d3d4823e976a35799, niiri:795ad2bb84b798c73c49be9153d72a0c, -, -, -)
-    wasGeneratedBy(niiri:513180f96afa3f5d3d4823e976a35799, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:93a61b8edfa7ff506cb5da35ed98d4be,
+    wasDerivedFrom(niiri:a8172b84431abcdda1fe59d67b915f4f, niiri:2e1b05283c5d3b1334ab150084bc75db, -, -, -)
+    wasGeneratedBy(niiri:a8172b84431abcdda1fe59d67b915f4f, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:ac40b39a203b625b2a7ca16d3aa1fa67,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
-    entity(niiri:a5f9b5d659bbc028878bf7d5bf78a788,
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8'])
+    entity(niiri:83ccd49808a62fc365bb77c82b93dfbd,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "7dfb234cef66f41020d9840fa271a63501a32a27d11f6ea831b79c314b7f68243bffc1dfaf789eca3e1ce384b55cf7f4c351c76ed21c15b1bfad448cb5718533" %% xsd:string])
-    wasDerivedFrom(niiri:93a61b8edfa7ff506cb5da35ed98d4be, niiri:a5f9b5d659bbc028878bf7d5bf78a788, -, -, -)
-    wasGeneratedBy(niiri:93a61b8edfa7ff506cb5da35ed98d4be, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:3df80df10c40ad826b1b1e9ea7e7e6c7,
+    wasDerivedFrom(niiri:ac40b39a203b625b2a7ca16d3aa1fa67, niiri:83ccd49808a62fc365bb77c82b93dfbd, -, -, -)
+    wasGeneratedBy(niiri:ac40b39a203b625b2a7ca16d3aa1fa67, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:051c054940176d08952216f41f9cc0e2,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
-    entity(niiri:a7d6b54fe900046a9188ebd7c94f026e,
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8'])
+    entity(niiri:1a8d96bad9310f17ed6e635894ed7a00,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "663dc1415b03fdf028c1664564ab6291bcb3ad6d0490820f5b22566245799297c4780d000158d93d7ffaae4bb2eb267a1acd8871b99d15d0d0c4cd4bdb5d9e68" %% xsd:string])
-    wasDerivedFrom(niiri:3df80df10c40ad826b1b1e9ea7e7e6c7, niiri:a7d6b54fe900046a9188ebd7c94f026e, -, -, -)
-    wasGeneratedBy(niiri:3df80df10c40ad826b1b1e9ea7e7e6c7, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:40a2f864e7e24137f9a06a85483d9b32,
+    wasDerivedFrom(niiri:051c054940176d08952216f41f9cc0e2, niiri:1a8d96bad9310f17ed6e635894ed7a00, -, -, -)
+    wasGeneratedBy(niiri:051c054940176d08952216f41f9cc0e2, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:4873a07b988c7e284f8083a5b392bf40,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
-    entity(niiri:52f862349d1a76a394430446694f64d7,
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8'])
+    entity(niiri:553274370fbeabdb86a876a3e178557f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "03416c893a6bd36d720ab1953be4b0f47180f3aa1c2d22fbe74aa1070f97804a275e1f5ee2bec9a395485337986b7592e6284676ed3bddc39bf649d6c48c91de" %% xsd:string])
-    wasDerivedFrom(niiri:40a2f864e7e24137f9a06a85483d9b32, niiri:52f862349d1a76a394430446694f64d7, -, -, -)
-    wasGeneratedBy(niiri:40a2f864e7e24137f9a06a85483d9b32, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:8f5dd25bd7a034b14da4eaea22677e06,
+    wasDerivedFrom(niiri:4873a07b988c7e284f8083a5b392bf40, niiri:553274370fbeabdb86a876a3e178557f, -, -, -)
+    wasGeneratedBy(niiri:4873a07b988c7e284f8083a5b392bf40, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:4e7b6e1841cfb3a47594d13b9c8c605b,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
-    entity(niiri:23db4e685c42ed93a8b0bb0f3d56b135,
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8'])
+    entity(niiri:4b57d416fea6bc6ca307c3147be54e3a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "27acde5836e2523829c5674edec7a5f66b1080c86ab827a84fa0eb267a95db1e7bcaaa026c6b37df921eaae895c2ed019332fda17800aeaf5863238990b7ca9c" %% xsd:string])
-    wasDerivedFrom(niiri:8f5dd25bd7a034b14da4eaea22677e06, niiri:23db4e685c42ed93a8b0bb0f3d56b135, -, -, -)
-    wasGeneratedBy(niiri:8f5dd25bd7a034b14da4eaea22677e06, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:008976bbb934e0cd52493ee0c22a6e4a,
+    wasDerivedFrom(niiri:4e7b6e1841cfb3a47594d13b9c8c605b, niiri:4b57d416fea6bc6ca307c3147be54e3a, -, -, -)
+    wasGeneratedBy(niiri:4e7b6e1841cfb3a47594d13b9c8c605b, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:eb1bef092548083ab62c77a579dbd79f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 6" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
-    entity(niiri:a50d8358acedd8004571c40f28c9cec5,
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8'])
+    entity(niiri:844db2931c6fa205571914ac64bda513,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0006.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "591a8b7d598a0840aefab5c1305400550852acd74f2256bbe815a51de82bd5e8d56969fbe3d925e9165605ad777a9a1df5e7d8e5552d99e0f8d7c505216fdf42" %% xsd:string])
-    wasDerivedFrom(niiri:008976bbb934e0cd52493ee0c22a6e4a, niiri:a50d8358acedd8004571c40f28c9cec5, -, -, -)
-    wasGeneratedBy(niiri:008976bbb934e0cd52493ee0c22a6e4a, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:c69576112591b8fcb20504248cd4a060,
+    wasDerivedFrom(niiri:eb1bef092548083ab62c77a579dbd79f, niiri:844db2931c6fa205571914ac64bda513, -, -, -)
+    wasGeneratedBy(niiri:eb1bef092548083ab62c77a579dbd79f, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:5d81b1fd59e507510f7f8154f159c83e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 7" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
-    entity(niiri:edff09e8ce1f95b3106740677d664a09,
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8'])
+    entity(niiri:d08eb65fb3d8f29c19aab3b5fe51d7e9,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0007.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b4442e57fdbbe43c7374152d776957e9525ba67958ddca2e879f063a43b79317a228120a338c86a410e7faedc80738c7ac91afcead568bbeaf2980e913b7370a" %% xsd:string])
-    wasDerivedFrom(niiri:c69576112591b8fcb20504248cd4a060, niiri:edff09e8ce1f95b3106740677d664a09, -, -, -)
-    wasGeneratedBy(niiri:c69576112591b8fcb20504248cd4a060, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:9b219b0f4f4b15e459d933cb1a0f9b3a,
+    wasDerivedFrom(niiri:5d81b1fd59e507510f7f8154f159c83e, niiri:d08eb65fb3d8f29c19aab3b5fe51d7e9, -, -, -)
+    wasGeneratedBy(niiri:5d81b1fd59e507510f7f8154f159c83e, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:519f88373d207a69ac4fd07f59cdf6d9,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         crypto:sha512 = "e55dbb4bcee078ef7f7cffb3a618fe4900cc54aa2d4482f39b220812891dac5729209d7d84f387d3eac601ae9b0f64b16b6e23eea6f83f23429197dc25975aaf" %% xsd:string])
-    entity(niiri:b41bd286d1412a95a30af890f595c9a2,
+    entity(niiri:a902535b9ac7f254d63de84c7bd914a0,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "2d5bbdabc64950a9e8b9f7e9db623cebbff2cd835a3228e6c3f8249fed6f7d681b30b37254d070279984ce6c9e0600e944671ff5a7c68312d647dc3b6eb4330e" %% xsd:string])
-    wasDerivedFrom(niiri:9b219b0f4f4b15e459d933cb1a0f9b3a, niiri:b41bd286d1412a95a30af890f595c9a2, -, -, -)
-    wasGeneratedBy(niiri:9b219b0f4f4b15e459d933cb1a0f9b3a, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:cdc151b697c0cb04cbe5c7540f511e3b,
+    wasDerivedFrom(niiri:519f88373d207a69ac4fd07f59cdf6d9, niiri:a902535b9ac7f254d63de84c7bd914a0, -, -, -)
+    wasGeneratedBy(niiri:519f88373d207a69ac4fd07f59cdf6d9, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:d716e6c0dfd3a28f17fee84ebd1cb8d0,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         crypto:sha512 = "80e17a085bd95aaddf708f772f29ca49b44fd1a3a621b55b1c73687e66aba3d4d5ca5d463b38adf7ddfdfb9435f090d31911fc9277418c9a8eced4ef2b88d4dc" %% xsd:string])
-    entity(niiri:aba5ca187a48c5cd49d94ac923660ed3,
+    entity(niiri:bfe21fcb1d6145ba7a78de96479edf1f,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "4e0032db2fac38eb7ef64e9c6e2348af2bfdab0c05e04dea32b885b6c5f2519bf2e93fa4f7fb9d48292036b950446b841d73fbb92e15a969126e16d093193cee" %% xsd:string])
-    wasDerivedFrom(niiri:cdc151b697c0cb04cbe5c7540f511e3b, niiri:aba5ca187a48c5cd49d94ac923660ed3, -, -, -)
-    wasGeneratedBy(niiri:cdc151b697c0cb04cbe5c7540f511e3b, niiri:e67c851046927dbfcf08886d4e18e257, -)
-    entity(niiri:dda506529adbd8dadb3b3a795151fbb3,
+    wasDerivedFrom(niiri:d716e6c0dfd3a28f17fee84ebd1cb8d0, niiri:bfe21fcb1d6145ba7a78de96479edf1f, -, -, -)
+    wasGeneratedBy(niiri:d716e6c0dfd3a28f17fee84ebd1cb8d0, niiri:6117be626763f1e26e2965325107479b, -)
+    entity(niiri:81770f7b401a1767b47e8bdb1e1bc8f4,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, 0, 0, -1, 0, 0, 0]" %% xsd:string])
-    activity(niiri:e3eb926753b05559987938d0c0b54b29,
+    activity(niiri:465008558a2d203c1fbd8dd41c5be218,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:e3eb926753b05559987938d0c0b54b29, niiri:821b1a9b55ebe0032b859ca5150035ba, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:0725082be9bac12c7029d6178bc32234, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:9b219b0f4f4b15e459d933cb1a0f9b3a, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:c586c126a0dc3b44d055a5a4988d7fea, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:dda506529adbd8dadb3b3a795151fbb3, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:513180f96afa3f5d3d4823e976a35799, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:93a61b8edfa7ff506cb5da35ed98d4be, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:3df80df10c40ad826b1b1e9ea7e7e6c7, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:40a2f864e7e24137f9a06a85483d9b32, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:8f5dd25bd7a034b14da4eaea22677e06, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:008976bbb934e0cd52493ee0c22a6e4a, -)
-    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:c69576112591b8fcb20504248cd4a060, -)
-    entity(niiri:9cd280f9a6bb55ac54967cdba205b396,
+    wasAssociatedWith(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:cc60b02c514e8cfe2e50b30d6bc67c94, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:55ee3044c6cea1caf6e83ad9beb57124, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:519f88373d207a69ac4fd07f59cdf6d9, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:166c2e158b227993faf5795de3ce5ecb, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:81770f7b401a1767b47e8bdb1e1bc8f4, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:a8172b84431abcdda1fe59d67b915f4f, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:ac40b39a203b625b2a7ca16d3aa1fa67, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:051c054940176d08952216f41f9cc0e2, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:4873a07b988c7e284f8083a5b392bf40, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:4e7b6e1841cfb3a47594d13b9c8c605b, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:eb1bef092548083ab62c77a579dbd79f, -)
+    used(niiri:465008558a2d203c1fbd8dd41c5be218, niiri:5d81b1fd59e507510f7f8154f159c83e, -)
+    entity(niiri:36ed7a761df547c262491683cdaa3821,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -341,103 +341,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "210.999999999887" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         crypto:sha512 = "861f189848ac564804db8d7d7d6a9970a77ba0c0ffb158a758286519a0f03587e0ca9212a3e324139de312ee530d0b4922a68f8d63141ae762ae109abd9cd0f7" %% xsd:string])
-    entity(niiri:45f730ecf126ce9ea7d1fa843be720ed,
+    entity(niiri:d96008ee20e47968fa3a57617b30c11c,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "957b56d667b0101f7737111353cf7027bd3a5250b64386a416e7dbff994334124bc217c1123f1565ade6e2de13adb18951063665f5a483eee01f6cf4a3ef46aa" %% xsd:string])
-    wasDerivedFrom(niiri:9cd280f9a6bb55ac54967cdba205b396, niiri:45f730ecf126ce9ea7d1fa843be720ed, -, -, -)
-    wasGeneratedBy(niiri:9cd280f9a6bb55ac54967cdba205b396, niiri:e3eb926753b05559987938d0c0b54b29, -)
-    entity(niiri:5f6bfd1e7738d6ee402e8db9bf849c12,
+    wasDerivedFrom(niiri:36ed7a761df547c262491683cdaa3821, niiri:d96008ee20e47968fa3a57617b30c11c, -, -, -)
+    wasGeneratedBy(niiri:36ed7a761df547c262491683cdaa3821, niiri:465008558a2d203c1fbd8dd41c5be218, -)
+    entity(niiri:3f46bd67634e5e0b974d2279a69e6964,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         crypto:sha512 = "1b77b11d0ed5eb5364a39bf470d0f2a60530adb3b565ca4d58c5834663570035081dced5ae63a1036f67784fa0d4eb92c202eacfa1c68a761dc92d4c2fdcb635" %% xsd:string])
-    entity(niiri:05c8f26e316907f21f72409226929af0,
+    entity(niiri:950e30ad5ae44d45c36f7b84a2901bc6,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "ed1d9e50bb64b4de72f01f25fc46258c5ff16d5a3d68d40ea557bbba27034b3e58fed559f43140846dfc4326ab88693925e57a7ad459534f78200e11e9ae0fc2" %% xsd:string])
-    wasDerivedFrom(niiri:5f6bfd1e7738d6ee402e8db9bf849c12, niiri:05c8f26e316907f21f72409226929af0, -, -, -)
-    wasGeneratedBy(niiri:5f6bfd1e7738d6ee402e8db9bf849c12, niiri:e3eb926753b05559987938d0c0b54b29, -)
-    entity(niiri:6771530b3685dd3dff795116450da5b7,
+    wasDerivedFrom(niiri:3f46bd67634e5e0b974d2279a69e6964, niiri:950e30ad5ae44d45c36f7b84a2901bc6, -, -, -)
+    wasGeneratedBy(niiri:3f46bd67634e5e0b974d2279a69e6964, niiri:465008558a2d203c1fbd8dd41c5be218, -)
+    entity(niiri:5d613a71be1458890bbdedd18a17b2b8,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         crypto:sha512 = "c82dd92dc43589a48ea05591e3513b0b09d5e196227d549cd8dfe2d6697080f39b3054d1f4b2da18681b3f7d6f9959ed437674a90da99ca27742a7358d832643" %% xsd:string])
-    wasGeneratedBy(niiri:6771530b3685dd3dff795116450da5b7, niiri:e3eb926753b05559987938d0c0b54b29, -)
-    entity(niiri:b3d5c88c4c85d76ff21932c996a538d6,
+    wasGeneratedBy(niiri:5d613a71be1458890bbdedd18a17b2b8, niiri:465008558a2d203c1fbd8dd41c5be218, -)
+    entity(niiri:7c8f8f9040477fa4d39fd6c75981cd74,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500109473139" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:7e8b4bd3d47ee964dad44627502a8644',
-        nidm_equivalentThreshold: = 'niiri:4b7d70536ac114ad01c0e9b4498d3c07'])
-    entity(niiri:7e8b4bd3d47ee964dad44627502a8644,
+        nidm_equivalentThreshold: = 'niiri:e5bf19ba0c7ae13110a0782d0229a75f',
+        nidm_equivalentThreshold: = 'niiri:2b15aebc51312739924ed32729590ac2'])
+    entity(niiri:e5bf19ba0c7ae13110a0782d0229a75f,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12930472090591" %% xsd:float])
-    entity(niiri:4b7d70536ac114ad01c0e9b4498d3c07,
+    entity(niiri:2b15aebc51312739924ed32729590ac2,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999999071" %% xsd:float])
-    entity(niiri:198ec9f3a18190099c85925ab436b938,
+    entity(niiri:4f14b6fcb9279174a126cccf9dd611a1,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:bdacc0bac46096d14f3b3dbb41e9fc80',
-        nidm_equivalentThreshold: = 'niiri:c68ed99893979c9afe5b40cf03e4138c'])
-    entity(niiri:bdacc0bac46096d14f3b3dbb41e9fc80,
+        nidm_equivalentThreshold: = 'niiri:7f6bec15c9d8baa79c90c821551088d6',
+        nidm_equivalentThreshold: = 'niiri:fbfbd0fbf80788bf1a91569a5be10ef7'])
+    entity(niiri:7f6bec15c9d8baa79c90c821551088d6,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:c68ed99893979c9afe5b40cf03e4138c,
+    entity(niiri:fbfbd0fbf80788bf1a91569a5be10ef7,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:92946954f5b6da81dea8e9ac72e36531,
+    entity(niiri:141ea0417394588800010fc7717c287c,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:74614276020f94983328fde22a285866,
+    entity(niiri:4599dcab1df4a55cb237c0ac9ffabeae,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:f9272534debf5f02f91fdae4134c2588,
+    activity(niiri:5c52d135d7ccce64ed39f6e95c4a7360,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:f9272534debf5f02f91fdae4134c2588, niiri:821b1a9b55ebe0032b859ca5150035ba, -)
-    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:b3d5c88c4c85d76ff21932c996a538d6, -)
-    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:198ec9f3a18190099c85925ab436b938, -)
-    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:9cd280f9a6bb55ac54967cdba205b396, -)
-    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:cdc151b697c0cb04cbe5c7540f511e3b, -)
-    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:0725082be9bac12c7029d6178bc32234, -)
-    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:92946954f5b6da81dea8e9ac72e36531, -)
-    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:74614276020f94983328fde22a285866, -)
-    entity(niiri:465c676752e1251c0ebaef3853a92d44,
+    wasAssociatedWith(niiri:5c52d135d7ccce64ed39f6e95c4a7360, niiri:cc60b02c514e8cfe2e50b30d6bc67c94, -)
+    used(niiri:5c52d135d7ccce64ed39f6e95c4a7360, niiri:7c8f8f9040477fa4d39fd6c75981cd74, -)
+    used(niiri:5c52d135d7ccce64ed39f6e95c4a7360, niiri:4f14b6fcb9279174a126cccf9dd611a1, -)
+    used(niiri:5c52d135d7ccce64ed39f6e95c4a7360, niiri:36ed7a761df547c262491683cdaa3821, -)
+    used(niiri:5c52d135d7ccce64ed39f6e95c4a7360, niiri:d716e6c0dfd3a28f17fee84ebd1cb8d0, -)
+    used(niiri:5c52d135d7ccce64ed39f6e95c4a7360, niiri:55ee3044c6cea1caf6e83ad9beb57124, -)
+    used(niiri:5c52d135d7ccce64ed39f6e95c4a7360, niiri:141ea0417394588800010fc7717c287c, -)
+    used(niiri:5c52d135d7ccce64ed39f6e95c4a7360, niiri:4599dcab1df4a55cb237c0ac9ffabeae, -)
+    entity(niiri:884e2eba2c39dc777e612acf6012ee12,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "70.7136543802373" %% xsd:float,
@@ -453,8 +453,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:465c676752e1251c0ebaef3853a92d44, niiri:f9272534debf5f02f91fdae4134c2588, -)
-    entity(niiri:dbc3b401b4cc8fc84857cec6f78458b3,
+    wasGeneratedBy(niiri:884e2eba2c39dc777e612acf6012ee12, niiri:5c52d135d7ccce64ed39f6e95c4a7360, -)
+    entity(niiri:74482e945645949e91b2950e49c2026c,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -462,20 +462,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:04196d57e8d71d662d0ca3a62551db9d',
-        nidm_hasMaximumIntensityProjection: = 'niiri:210b7648621d83f3b498261707462aa6',
-        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
+        nidm_hasClusterLabelsMap: = 'niiri:49260fa7415b415130049110469bb055',
+        nidm_hasMaximumIntensityProjection: = 'niiri:ec756d1c48c0536f53dfa594031fd560',
+        nidm_inCoordinateSpace: = 'niiri:31dd9a37443e169f0f7297a3dfb8a1d8',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:04196d57e8d71d662d0ca3a62551db9d,
+    entity(niiri:49260fa7415b415130049110469bb055,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:210b7648621d83f3b498261707462aa6,
+    entity(niiri:ec756d1c48c0536f53dfa594031fd560,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:dbc3b401b4cc8fc84857cec6f78458b3, niiri:f9272534debf5f02f91fdae4134c2588, -)
+    wasGeneratedBy(niiri:74482e945645949e91b2950e49c2026c, niiri:5c52d135d7ccce64ed39f6e95c4a7360, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.provn
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.provn
@@ -1,0 +1,481 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:1f3972d440e0662ae30f95394c472c4b,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:4aea73471fd7ac02b19849bf1514b0dc,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:a8918a8d18ab7b5bda372d8835183a06,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:a8918a8d18ab7b5bda372d8835183a06, niiri:4aea73471fd7ac02b19849bf1514b0dc, -)
+  wasGeneratedBy(niiri:1f3972d440e0662ae30f95394c472c4b, niiri:a8918a8d18ab7b5bda372d8835183a06, 2016-01-11T10:10:39)
+  bundle niiri:1f3972d440e0662ae30f95394c472c4b
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix spm_SPMsTemporalDerivative <http://purl.org/nidash/spm#SPM_0000006>
+    prefix spm_SPMsDispersionDerivative <http://purl.org/nidash/spm#SPM_0000003>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+
+    agent(niiri:327a9ff3946f2ec4986e86c53e18fe08,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:dd9e45ff2bfada42c45b025ad5bbb149,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:e77033de47473eb122f2a499a902fd95,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:f0469999987415c033878a3cd80b6440,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:3b2d1088cc3b6cf7a1a53c6096b3f855,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:f84773591fde4d99c2c8b7683309e6c7',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) positive feedback\ntask001 co*bf(3)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(3)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:f0469999987415c033878a3cd80b6440',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:',
+        nidm_hasHRFBasis: = 'spm_SPMsTemporalDerivative:',
+        nidm_hasHRFBasis: = 'spm_SPMsDispersionDerivative:'])
+    entity(niiri:f84773591fde4d99c2c8b7683309e6c7,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:27647d7272bcc27c18636264b8b7b214,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:646802f08fa4125c11708667c0a5c56f,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:646802f08fa4125c11708667c0a5c56f, niiri:327a9ff3946f2ec4986e86c53e18fe08, -)
+    used(niiri:646802f08fa4125c11708667c0a5c56f, niiri:3b2d1088cc3b6cf7a1a53c6096b3f855, -)
+    used(niiri:646802f08fa4125c11708667c0a5c56f, niiri:e77033de47473eb122f2a499a902fd95, -)
+    used(niiri:646802f08fa4125c11708667c0a5c56f, niiri:27647d7272bcc27c18636264b8b7b214, -)
+    entity(niiri:004943b083f15c69d419d7bf95a9a882,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    entity(niiri:53ea54fabcf9cc3042fa0121e09641e4,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
+    wasDerivedFrom(niiri:004943b083f15c69d419d7bf95a9a882, niiri:53ea54fabcf9cc3042fa0121e09641e4, -, -, -)
+    wasGeneratedBy(niiri:004943b083f15c69d419d7bf95a9a882, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:06d798c010c8dd98bb5dfc11e39816a5,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "121.035133361816" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        crypto:sha512 = "9cfeeeacd33286a145a42ac9e011a2cdc19a57aa70e2abfe71114ec159be45b10fc5fb995b21bb253624732dc52d9d34cfa34b774edf3fcb1efceb98db468de1" %% xsd:string])
+    wasGeneratedBy(niiri:06d798c010c8dd98bb5dfc11e39816a5, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:76a8e1ecb96d47328c84ded1e8c9fcce,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
+    entity(niiri:1c1c45d6750b11a734fe2d0d3d04524b,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "05720970946f70a45079d6f6e993cfadfcfd7f2feaa3e1d2478a4b7f2d8508122250847bbebb9f63e10cfc83a8101bc031164e69a4b720ae19d0ed237edc4153" %% xsd:string])
+    wasDerivedFrom(niiri:76a8e1ecb96d47328c84ded1e8c9fcce, niiri:1c1c45d6750b11a734fe2d0d3d04524b, -, -, -)
+    wasGeneratedBy(niiri:76a8e1ecb96d47328c84ded1e8c9fcce, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:a81b51f7714cfacea14292d4ce12cbf0,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
+    entity(niiri:e341723ff93635384bb667caa931aac3,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "7dfb234cef66f41020d9840fa271a63501a32a27d11f6ea831b79c314b7f68243bffc1dfaf789eca3e1ce384b55cf7f4c351c76ed21c15b1bfad448cb5718533" %% xsd:string])
+    wasDerivedFrom(niiri:a81b51f7714cfacea14292d4ce12cbf0, niiri:e341723ff93635384bb667caa931aac3, -, -, -)
+    wasGeneratedBy(niiri:a81b51f7714cfacea14292d4ce12cbf0, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:f924a4b144030137570a5f4ec3bdd383,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
+    entity(niiri:4659d0e70e9587adefe084a2e56740c6,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "663dc1415b03fdf028c1664564ab6291bcb3ad6d0490820f5b22566245799297c4780d000158d93d7ffaae4bb2eb267a1acd8871b99d15d0d0c4cd4bdb5d9e68" %% xsd:string])
+    wasDerivedFrom(niiri:f924a4b144030137570a5f4ec3bdd383, niiri:4659d0e70e9587adefe084a2e56740c6, -, -, -)
+    wasGeneratedBy(niiri:f924a4b144030137570a5f4ec3bdd383, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:e13bd961e1ab6c34ce552b7e2cf3def2,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 4" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
+    entity(niiri:ba6b830f0e3883fbfd2edd369325478e,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0004.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "03416c893a6bd36d720ab1953be4b0f47180f3aa1c2d22fbe74aa1070f97804a275e1f5ee2bec9a395485337986b7592e6284676ed3bddc39bf649d6c48c91de" %% xsd:string])
+    wasDerivedFrom(niiri:e13bd961e1ab6c34ce552b7e2cf3def2, niiri:ba6b830f0e3883fbfd2edd369325478e, -, -, -)
+    wasGeneratedBy(niiri:e13bd961e1ab6c34ce552b7e2cf3def2, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:6907c49ae94c1c59885dff7ba73b6ad2,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 5" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
+    entity(niiri:b53565d569027fb62e62b8a8fcd63f2d,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0005.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "27acde5836e2523829c5674edec7a5f66b1080c86ab827a84fa0eb267a95db1e7bcaaa026c6b37df921eaae895c2ed019332fda17800aeaf5863238990b7ca9c" %% xsd:string])
+    wasDerivedFrom(niiri:6907c49ae94c1c59885dff7ba73b6ad2, niiri:b53565d569027fb62e62b8a8fcd63f2d, -, -, -)
+    wasGeneratedBy(niiri:6907c49ae94c1c59885dff7ba73b6ad2, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:3e47abc4258d401bfcd12c1c17335fa9,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 6" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
+    entity(niiri:51f8e9ed2e8e64c7361c7f7a2502b9e9,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0006.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "591a8b7d598a0840aefab5c1305400550852acd74f2256bbe815a51de82bd5e8d56969fbe3d925e9165605ad777a9a1df5e7d8e5552d99e0f8d7c505216fdf42" %% xsd:string])
+    wasDerivedFrom(niiri:3e47abc4258d401bfcd12c1c17335fa9, niiri:51f8e9ed2e8e64c7361c7f7a2502b9e9, -, -, -)
+    wasGeneratedBy(niiri:3e47abc4258d401bfcd12c1c17335fa9, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:05f7c6a5d3f20dacc4c00e1767077eb2,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 7" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
+    entity(niiri:e25a10393592506fe41e9eff6aa4bb0f,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0007.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b4442e57fdbbe43c7374152d776957e9525ba67958ddca2e879f063a43b79317a228120a338c86a410e7faedc80738c7ac91afcead568bbeaf2980e913b7370a" %% xsd:string])
+    wasDerivedFrom(niiri:05f7c6a5d3f20dacc4c00e1767077eb2, niiri:e25a10393592506fe41e9eff6aa4bb0f, -, -, -)
+    wasGeneratedBy(niiri:05f7c6a5d3f20dacc4c00e1767077eb2, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:89cdd5a0418dc30cb86718044231b9fb,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        crypto:sha512 = "e55dbb4bcee078ef7f7cffb3a618fe4900cc54aa2d4482f39b220812891dac5729209d7d84f387d3eac601ae9b0f64b16b6e23eea6f83f23429197dc25975aaf" %% xsd:string])
+    entity(niiri:87c25e6525ec7ca193b9e43fc70db585,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "2d5bbdabc64950a9e8b9f7e9db623cebbff2cd835a3228e6c3f8249fed6f7d681b30b37254d070279984ce6c9e0600e944671ff5a7c68312d647dc3b6eb4330e" %% xsd:string])
+    wasDerivedFrom(niiri:89cdd5a0418dc30cb86718044231b9fb, niiri:87c25e6525ec7ca193b9e43fc70db585, -, -, -)
+    wasGeneratedBy(niiri:89cdd5a0418dc30cb86718044231b9fb, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:14e90513cadd14ec08d1982515a57568,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        crypto:sha512 = "80e17a085bd95aaddf708f772f29ca49b44fd1a3a621b55b1c73687e66aba3d4d5ca5d463b38adf7ddfdfb9435f090d31911fc9277418c9a8eced4ef2b88d4dc" %% xsd:string])
+    entity(niiri:4bff0c6abe7073e4e149a8ef4871bf59,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "4e0032db2fac38eb7ef64e9c6e2348af2bfdab0c05e04dea32b885b6c5f2519bf2e93fa4f7fb9d48292036b950446b841d73fbb92e15a969126e16d093193cee" %% xsd:string])
+    wasDerivedFrom(niiri:14e90513cadd14ec08d1982515a57568, niiri:4bff0c6abe7073e4e149a8ef4871bf59, -, -, -)
+    wasGeneratedBy(niiri:14e90513cadd14ec08d1982515a57568, niiri:646802f08fa4125c11708667c0a5c56f, -)
+    entity(niiri:3184176bcf5c4d11386c89ec66785dc5,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        prov:label = "Contrast: pos vs neg" %% xsd:string,
+        prov:value = "[1, 0, 0, -1, 0, 0, 0]" %% xsd:string])
+    activity(niiri:0949319d2ef4c6c93abc59fd5ab36c60,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:327a9ff3946f2ec4986e86c53e18fe08, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:004943b083f15c69d419d7bf95a9a882, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:89cdd5a0418dc30cb86718044231b9fb, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:3b2d1088cc3b6cf7a1a53c6096b3f855, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:3184176bcf5c4d11386c89ec66785dc5, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:76a8e1ecb96d47328c84ded1e8c9fcce, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:a81b51f7714cfacea14292d4ce12cbf0, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:f924a4b144030137570a5f4ec3bdd383, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:e13bd961e1ab6c34ce552b7e2cf3def2, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:6907c49ae94c1c59885dff7ba73b6ad2, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:3e47abc4258d401bfcd12c1c17335fa9, -)
+    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:05f7c6a5d3f20dacc4c00e1767077eb2, -)
+    entity(niiri:36547963b0180bf5445943624ff36ab5,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: pos vs neg" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "210.999999999887" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        crypto:sha512 = "861f189848ac564804db8d7d7d6a9970a77ba0c0ffb158a758286519a0f03587e0ca9212a3e324139de312ee530d0b4922a68f8d63141ae762ae109abd9cd0f7" %% xsd:string])
+    entity(niiri:6f69458ac8e2905970d1867b3a690ea7,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "957b56d667b0101f7737111353cf7027bd3a5250b64386a416e7dbff994334124bc217c1123f1565ade6e2de13adb18951063665f5a483eee01f6cf4a3ef46aa" %% xsd:string])
+    wasDerivedFrom(niiri:36547963b0180bf5445943624ff36ab5, niiri:6f69458ac8e2905970d1867b3a690ea7, -, -, -)
+    wasGeneratedBy(niiri:36547963b0180bf5445943624ff36ab5, niiri:0949319d2ef4c6c93abc59fd5ab36c60, -)
+    entity(niiri:1b782d30ef88b5dec50d781f0f8c7b90,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: pos vs neg" %% xsd:string,
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        crypto:sha512 = "1b77b11d0ed5eb5364a39bf470d0f2a60530adb3b565ca4d58c5834663570035081dced5ae63a1036f67784fa0d4eb92c202eacfa1c68a761dc92d4c2fdcb635" %% xsd:string])
+    entity(niiri:3e41323291957893cacf579dfe6cd678,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "ed1d9e50bb64b4de72f01f25fc46258c5ff16d5a3d68d40ea557bbba27034b3e58fed559f43140846dfc4326ab88693925e57a7ad459534f78200e11e9ae0fc2" %% xsd:string])
+    wasDerivedFrom(niiri:1b782d30ef88b5dec50d781f0f8c7b90, niiri:3e41323291957893cacf579dfe6cd678, -, -, -)
+    wasGeneratedBy(niiri:1b782d30ef88b5dec50d781f0f8c7b90, niiri:0949319d2ef4c6c93abc59fd5ab36c60, -)
+    entity(niiri:35e15769c5844a4c220e3f2a8ee4db98,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        crypto:sha512 = "c82dd92dc43589a48ea05591e3513b0b09d5e196227d549cd8dfe2d6697080f39b3054d1f4b2da18681b3f7d6f9959ed437674a90da99ca27742a7358d832643" %% xsd:string])
+    wasGeneratedBy(niiri:35e15769c5844a4c220e3f2a8ee4db98, niiri:0949319d2ef4c6c93abc59fd5ab36c60, -)
+    entity(niiri:7030cadfaa88d7036ca8f29a016c65f8,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
+        prov:value = "0.000999500109473139" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:0dbe0ae4e935c37d15660dce41a4a626',
+        nidm_equivalentThreshold: = 'niiri:043660ac38a59f66f758bacb56c24168'])
+    entity(niiri:0dbe0ae4e935c37d15660dce41a4a626,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "3.12930472090591" %% xsd:float])
+    entity(niiri:043660ac38a59f66f758bacb56c24168,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.999999999999071" %% xsd:float])
+    entity(niiri:da875b2e8e05e4785db8390ac9ca6bea,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:b9c8421cbde2dda368e334ee41445213',
+        nidm_equivalentThreshold: = 'niiri:4a5a24bbf6fc3ef6377e86dca3ad0aee'])
+    entity(niiri:b9c8421cbde2dda368e334ee41445213,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:4a5a24bbf6fc3ef6377e86dca3ad0aee,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:ce2709f7d21f37e6c1b4b649ea2d0e63,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:2a1941c7407f83aa18a742051141d0e3,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:18a70c6743d2ee3291ef9fe8ddc693aa,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:327a9ff3946f2ec4986e86c53e18fe08, -)
+    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:7030cadfaa88d7036ca8f29a016c65f8, -)
+    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:da875b2e8e05e4785db8390ac9ca6bea, -)
+    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:36547963b0180bf5445943624ff36ab5, -)
+    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:14e90513cadd14ec08d1982515a57568, -)
+    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:004943b083f15c69d419d7bf95a9a882, -)
+    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:ce2709f7d21f37e6c1b4b649ea2d0e63, -)
+    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:2a1941c7407f83aa18a742051141d0e3, -)
+    entity(niiri:20b1f3fc5f789afa8b55e495a2fb2fe8,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
+        nidm_reselSizeInVoxels: = "70.7136543802373" %% xsd:float,
+        nidm_searchVolumeInResels: = "2692.90282999741" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[3, 68.9594164134199, 858.533812023484, 2692.90282999741]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[3.99462540569425, 4.05658931798885, 4.36381347533009]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[7.98925081138849, 8.11317863597769, 8.72762695066017]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "8.09886000027364" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "27.7043233277657" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.05796155312953" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    wasGeneratedBy(niiri:20b1f3fc5f789afa8b55e495a2fb2fe8, niiri:18a70c6743d2ee3291ef9fe8ddc693aa, -)
+    entity(niiri:0bd3c23f663f5db458405c9f8f024e0e,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
+        nidm_pValue: = "NaN" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:2a0ad393b6ba67c913ca2734dad76d72',
+        nidm_hasMaximumIntensityProjection: = 'niiri:cff9ff1e3ab6021801484e5a4ecd68eb',
+        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
+    entity(niiri:2a0ad393b6ba67c913ca2734dad76d72,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:cff9ff1e3ab6021801484e5a4ecd68eb,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:0bd3c23f663f5db458405c9f8f024e0e, niiri:18a70c6743d2ee3291ef9fe8ddc693aa, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.provn
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:1f3972d440e0662ae30f95394c472c4b,
+  entity(niiri:c855a42b9fd2a67825eb0eddad715ed5,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:4aea73471fd7ac02b19849bf1514b0dc,
+  agent(niiri:6742968a097360dc90801b311279b0d4,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:a8918a8d18ab7b5bda372d8835183a06,
+  activity(niiri:5dff151e4c0a26653cff2770db2c33fd,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:a8918a8d18ab7b5bda372d8835183a06, niiri:4aea73471fd7ac02b19849bf1514b0dc, -)
-  wasGeneratedBy(niiri:1f3972d440e0662ae30f95394c472c4b, niiri:a8918a8d18ab7b5bda372d8835183a06, 2016-01-11T10:10:39)
-  bundle niiri:1f3972d440e0662ae30f95394c472c4b
+  wasAssociatedWith(niiri:5dff151e4c0a26653cff2770db2c33fd, niiri:6742968a097360dc90801b311279b0d4, -)
+  wasGeneratedBy(niiri:c855a42b9fd2a67825eb0eddad715ed5, niiri:5dff151e4c0a26653cff2770db2c33fd, 2016-01-11T10:32:00)
+  bundle niiri:c855a42b9fd2a67825eb0eddad715ed5
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -121,12 +121,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:327a9ff3946f2ec4986e86c53e18fe08,
+    agent(niiri:821b1a9b55ebe0032b859ca5150035ba,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:dd9e45ff2bfada42c45b025ad5bbb149,
+    entity(niiri:ad7c74aa0e194b1d0e6a1fe1c514c722,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -135,203 +135,203 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:e77033de47473eb122f2a499a902fd95,
+    entity(niiri:5272f74dd7c9a2ab61942dd0f79ccf4e,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:f0469999987415c033878a3cd80b6440,
+    entity(niiri:9799d5818262bf28a045fe452798ac27,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:3b2d1088cc3b6cf7a1a53c6096b3f855,
+    entity(niiri:c586c126a0dc3b44d055a5a4988d7fea,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:f84773591fde4d99c2c8b7683309e6c7',
+        dc:description = 'niiri:d46159933e55bc459a8eda437a7d8dba',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) positive feedback\ntask001 co*bf(3)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(3)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:f0469999987415c033878a3cd80b6440',
+        nidm_hasDriftModel: = 'niiri:9799d5818262bf28a045fe452798ac27',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:',
         nidm_hasHRFBasis: = 'spm_SPMsTemporalDerivative:',
         nidm_hasHRFBasis: = 'spm_SPMsDispersionDerivative:'])
-    entity(niiri:f84773591fde4d99c2c8b7683309e6c7,
+    entity(niiri:d46159933e55bc459a8eda437a7d8dba,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:27647d7272bcc27c18636264b8b7b214,
+    entity(niiri:207f859d84e7b611b8afcd2c433d7a99,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:646802f08fa4125c11708667c0a5c56f,
+    activity(niiri:e67c851046927dbfcf08886d4e18e257,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:646802f08fa4125c11708667c0a5c56f, niiri:327a9ff3946f2ec4986e86c53e18fe08, -)
-    used(niiri:646802f08fa4125c11708667c0a5c56f, niiri:3b2d1088cc3b6cf7a1a53c6096b3f855, -)
-    used(niiri:646802f08fa4125c11708667c0a5c56f, niiri:e77033de47473eb122f2a499a902fd95, -)
-    used(niiri:646802f08fa4125c11708667c0a5c56f, niiri:27647d7272bcc27c18636264b8b7b214, -)
-    entity(niiri:004943b083f15c69d419d7bf95a9a882,
+    wasAssociatedWith(niiri:e67c851046927dbfcf08886d4e18e257, niiri:821b1a9b55ebe0032b859ca5150035ba, -)
+    used(niiri:e67c851046927dbfcf08886d4e18e257, niiri:c586c126a0dc3b44d055a5a4988d7fea, -)
+    used(niiri:e67c851046927dbfcf08886d4e18e257, niiri:5272f74dd7c9a2ab61942dd0f79ccf4e, -)
+    used(niiri:e67c851046927dbfcf08886d4e18e257, niiri:207f859d84e7b611b8afcd2c433d7a99, -)
+    entity(niiri:0725082be9bac12c7029d6178bc32234,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:53ea54fabcf9cc3042fa0121e09641e4,
+    entity(niiri:ba6b6df78ba4f8c1ecf50fd9cc7402c6,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:004943b083f15c69d419d7bf95a9a882, niiri:53ea54fabcf9cc3042fa0121e09641e4, -, -, -)
-    wasGeneratedBy(niiri:004943b083f15c69d419d7bf95a9a882, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:06d798c010c8dd98bb5dfc11e39816a5,
+    wasDerivedFrom(niiri:0725082be9bac12c7029d6178bc32234, niiri:ba6b6df78ba4f8c1ecf50fd9cc7402c6, -, -, -)
+    wasGeneratedBy(niiri:0725082be9bac12c7029d6178bc32234, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:393592a4a2b55eadb7908e667437e023,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.035133361816" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         crypto:sha512 = "9cfeeeacd33286a145a42ac9e011a2cdc19a57aa70e2abfe71114ec159be45b10fc5fb995b21bb253624732dc52d9d34cfa34b774edf3fcb1efceb98db468de1" %% xsd:string])
-    wasGeneratedBy(niiri:06d798c010c8dd98bb5dfc11e39816a5, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:76a8e1ecb96d47328c84ded1e8c9fcce,
+    wasGeneratedBy(niiri:393592a4a2b55eadb7908e667437e023, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:513180f96afa3f5d3d4823e976a35799,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
-    entity(niiri:1c1c45d6750b11a734fe2d0d3d04524b,
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
+    entity(niiri:795ad2bb84b798c73c49be9153d72a0c,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "05720970946f70a45079d6f6e993cfadfcfd7f2feaa3e1d2478a4b7f2d8508122250847bbebb9f63e10cfc83a8101bc031164e69a4b720ae19d0ed237edc4153" %% xsd:string])
-    wasDerivedFrom(niiri:76a8e1ecb96d47328c84ded1e8c9fcce, niiri:1c1c45d6750b11a734fe2d0d3d04524b, -, -, -)
-    wasGeneratedBy(niiri:76a8e1ecb96d47328c84ded1e8c9fcce, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:a81b51f7714cfacea14292d4ce12cbf0,
+    wasDerivedFrom(niiri:513180f96afa3f5d3d4823e976a35799, niiri:795ad2bb84b798c73c49be9153d72a0c, -, -, -)
+    wasGeneratedBy(niiri:513180f96afa3f5d3d4823e976a35799, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:93a61b8edfa7ff506cb5da35ed98d4be,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
-    entity(niiri:e341723ff93635384bb667caa931aac3,
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
+    entity(niiri:a5f9b5d659bbc028878bf7d5bf78a788,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "7dfb234cef66f41020d9840fa271a63501a32a27d11f6ea831b79c314b7f68243bffc1dfaf789eca3e1ce384b55cf7f4c351c76ed21c15b1bfad448cb5718533" %% xsd:string])
-    wasDerivedFrom(niiri:a81b51f7714cfacea14292d4ce12cbf0, niiri:e341723ff93635384bb667caa931aac3, -, -, -)
-    wasGeneratedBy(niiri:a81b51f7714cfacea14292d4ce12cbf0, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:f924a4b144030137570a5f4ec3bdd383,
+    wasDerivedFrom(niiri:93a61b8edfa7ff506cb5da35ed98d4be, niiri:a5f9b5d659bbc028878bf7d5bf78a788, -, -, -)
+    wasGeneratedBy(niiri:93a61b8edfa7ff506cb5da35ed98d4be, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:3df80df10c40ad826b1b1e9ea7e7e6c7,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
-    entity(niiri:4659d0e70e9587adefe084a2e56740c6,
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
+    entity(niiri:a7d6b54fe900046a9188ebd7c94f026e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "663dc1415b03fdf028c1664564ab6291bcb3ad6d0490820f5b22566245799297c4780d000158d93d7ffaae4bb2eb267a1acd8871b99d15d0d0c4cd4bdb5d9e68" %% xsd:string])
-    wasDerivedFrom(niiri:f924a4b144030137570a5f4ec3bdd383, niiri:4659d0e70e9587adefe084a2e56740c6, -, -, -)
-    wasGeneratedBy(niiri:f924a4b144030137570a5f4ec3bdd383, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:e13bd961e1ab6c34ce552b7e2cf3def2,
+    wasDerivedFrom(niiri:3df80df10c40ad826b1b1e9ea7e7e6c7, niiri:a7d6b54fe900046a9188ebd7c94f026e, -, -, -)
+    wasGeneratedBy(niiri:3df80df10c40ad826b1b1e9ea7e7e6c7, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:40a2f864e7e24137f9a06a85483d9b32,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
-    entity(niiri:ba6b830f0e3883fbfd2edd369325478e,
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
+    entity(niiri:52f862349d1a76a394430446694f64d7,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "03416c893a6bd36d720ab1953be4b0f47180f3aa1c2d22fbe74aa1070f97804a275e1f5ee2bec9a395485337986b7592e6284676ed3bddc39bf649d6c48c91de" %% xsd:string])
-    wasDerivedFrom(niiri:e13bd961e1ab6c34ce552b7e2cf3def2, niiri:ba6b830f0e3883fbfd2edd369325478e, -, -, -)
-    wasGeneratedBy(niiri:e13bd961e1ab6c34ce552b7e2cf3def2, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:6907c49ae94c1c59885dff7ba73b6ad2,
+    wasDerivedFrom(niiri:40a2f864e7e24137f9a06a85483d9b32, niiri:52f862349d1a76a394430446694f64d7, -, -, -)
+    wasGeneratedBy(niiri:40a2f864e7e24137f9a06a85483d9b32, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:8f5dd25bd7a034b14da4eaea22677e06,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
-    entity(niiri:b53565d569027fb62e62b8a8fcd63f2d,
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
+    entity(niiri:23db4e685c42ed93a8b0bb0f3d56b135,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "27acde5836e2523829c5674edec7a5f66b1080c86ab827a84fa0eb267a95db1e7bcaaa026c6b37df921eaae895c2ed019332fda17800aeaf5863238990b7ca9c" %% xsd:string])
-    wasDerivedFrom(niiri:6907c49ae94c1c59885dff7ba73b6ad2, niiri:b53565d569027fb62e62b8a8fcd63f2d, -, -, -)
-    wasGeneratedBy(niiri:6907c49ae94c1c59885dff7ba73b6ad2, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:3e47abc4258d401bfcd12c1c17335fa9,
+    wasDerivedFrom(niiri:8f5dd25bd7a034b14da4eaea22677e06, niiri:23db4e685c42ed93a8b0bb0f3d56b135, -, -, -)
+    wasGeneratedBy(niiri:8f5dd25bd7a034b14da4eaea22677e06, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:008976bbb934e0cd52493ee0c22a6e4a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 6" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
-    entity(niiri:51f8e9ed2e8e64c7361c7f7a2502b9e9,
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
+    entity(niiri:a50d8358acedd8004571c40f28c9cec5,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0006.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "591a8b7d598a0840aefab5c1305400550852acd74f2256bbe815a51de82bd5e8d56969fbe3d925e9165605ad777a9a1df5e7d8e5552d99e0f8d7c505216fdf42" %% xsd:string])
-    wasDerivedFrom(niiri:3e47abc4258d401bfcd12c1c17335fa9, niiri:51f8e9ed2e8e64c7361c7f7a2502b9e9, -, -, -)
-    wasGeneratedBy(niiri:3e47abc4258d401bfcd12c1c17335fa9, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:05f7c6a5d3f20dacc4c00e1767077eb2,
+    wasDerivedFrom(niiri:008976bbb934e0cd52493ee0c22a6e4a, niiri:a50d8358acedd8004571c40f28c9cec5, -, -, -)
+    wasGeneratedBy(niiri:008976bbb934e0cd52493ee0c22a6e4a, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:c69576112591b8fcb20504248cd4a060,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 7" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149'])
-    entity(niiri:e25a10393592506fe41e9eff6aa4bb0f,
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722'])
+    entity(niiri:edff09e8ce1f95b3106740677d664a09,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0007.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b4442e57fdbbe43c7374152d776957e9525ba67958ddca2e879f063a43b79317a228120a338c86a410e7faedc80738c7ac91afcead568bbeaf2980e913b7370a" %% xsd:string])
-    wasDerivedFrom(niiri:05f7c6a5d3f20dacc4c00e1767077eb2, niiri:e25a10393592506fe41e9eff6aa4bb0f, -, -, -)
-    wasGeneratedBy(niiri:05f7c6a5d3f20dacc4c00e1767077eb2, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:89cdd5a0418dc30cb86718044231b9fb,
+    wasDerivedFrom(niiri:c69576112591b8fcb20504248cd4a060, niiri:edff09e8ce1f95b3106740677d664a09, -, -, -)
+    wasGeneratedBy(niiri:c69576112591b8fcb20504248cd4a060, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:9b219b0f4f4b15e459d933cb1a0f9b3a,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         crypto:sha512 = "e55dbb4bcee078ef7f7cffb3a618fe4900cc54aa2d4482f39b220812891dac5729209d7d84f387d3eac601ae9b0f64b16b6e23eea6f83f23429197dc25975aaf" %% xsd:string])
-    entity(niiri:87c25e6525ec7ca193b9e43fc70db585,
+    entity(niiri:b41bd286d1412a95a30af890f595c9a2,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "2d5bbdabc64950a9e8b9f7e9db623cebbff2cd835a3228e6c3f8249fed6f7d681b30b37254d070279984ce6c9e0600e944671ff5a7c68312d647dc3b6eb4330e" %% xsd:string])
-    wasDerivedFrom(niiri:89cdd5a0418dc30cb86718044231b9fb, niiri:87c25e6525ec7ca193b9e43fc70db585, -, -, -)
-    wasGeneratedBy(niiri:89cdd5a0418dc30cb86718044231b9fb, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:14e90513cadd14ec08d1982515a57568,
+    wasDerivedFrom(niiri:9b219b0f4f4b15e459d933cb1a0f9b3a, niiri:b41bd286d1412a95a30af890f595c9a2, -, -, -)
+    wasGeneratedBy(niiri:9b219b0f4f4b15e459d933cb1a0f9b3a, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:cdc151b697c0cb04cbe5c7540f511e3b,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         crypto:sha512 = "80e17a085bd95aaddf708f772f29ca49b44fd1a3a621b55b1c73687e66aba3d4d5ca5d463b38adf7ddfdfb9435f090d31911fc9277418c9a8eced4ef2b88d4dc" %% xsd:string])
-    entity(niiri:4bff0c6abe7073e4e149a8ef4871bf59,
+    entity(niiri:aba5ca187a48c5cd49d94ac923660ed3,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "4e0032db2fac38eb7ef64e9c6e2348af2bfdab0c05e04dea32b885b6c5f2519bf2e93fa4f7fb9d48292036b950446b841d73fbb92e15a969126e16d093193cee" %% xsd:string])
-    wasDerivedFrom(niiri:14e90513cadd14ec08d1982515a57568, niiri:4bff0c6abe7073e4e149a8ef4871bf59, -, -, -)
-    wasGeneratedBy(niiri:14e90513cadd14ec08d1982515a57568, niiri:646802f08fa4125c11708667c0a5c56f, -)
-    entity(niiri:3184176bcf5c4d11386c89ec66785dc5,
+    wasDerivedFrom(niiri:cdc151b697c0cb04cbe5c7540f511e3b, niiri:aba5ca187a48c5cd49d94ac923660ed3, -, -, -)
+    wasGeneratedBy(niiri:cdc151b697c0cb04cbe5c7540f511e3b, niiri:e67c851046927dbfcf08886d4e18e257, -)
+    entity(niiri:dda506529adbd8dadb3b3a795151fbb3,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, 0, 0, -1, 0, 0, 0]" %% xsd:string])
-    activity(niiri:0949319d2ef4c6c93abc59fd5ab36c60,
+    activity(niiri:e3eb926753b05559987938d0c0b54b29,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:327a9ff3946f2ec4986e86c53e18fe08, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:004943b083f15c69d419d7bf95a9a882, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:89cdd5a0418dc30cb86718044231b9fb, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:3b2d1088cc3b6cf7a1a53c6096b3f855, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:3184176bcf5c4d11386c89ec66785dc5, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:76a8e1ecb96d47328c84ded1e8c9fcce, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:a81b51f7714cfacea14292d4ce12cbf0, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:f924a4b144030137570a5f4ec3bdd383, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:e13bd961e1ab6c34ce552b7e2cf3def2, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:6907c49ae94c1c59885dff7ba73b6ad2, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:3e47abc4258d401bfcd12c1c17335fa9, -)
-    used(niiri:0949319d2ef4c6c93abc59fd5ab36c60, niiri:05f7c6a5d3f20dacc4c00e1767077eb2, -)
-    entity(niiri:36547963b0180bf5445943624ff36ab5,
+    wasAssociatedWith(niiri:e3eb926753b05559987938d0c0b54b29, niiri:821b1a9b55ebe0032b859ca5150035ba, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:0725082be9bac12c7029d6178bc32234, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:9b219b0f4f4b15e459d933cb1a0f9b3a, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:c586c126a0dc3b44d055a5a4988d7fea, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:dda506529adbd8dadb3b3a795151fbb3, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:513180f96afa3f5d3d4823e976a35799, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:93a61b8edfa7ff506cb5da35ed98d4be, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:3df80df10c40ad826b1b1e9ea7e7e6c7, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:40a2f864e7e24137f9a06a85483d9b32, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:8f5dd25bd7a034b14da4eaea22677e06, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:008976bbb934e0cd52493ee0c22a6e4a, -)
+    used(niiri:e3eb926753b05559987938d0c0b54b29, niiri:c69576112591b8fcb20504248cd4a060, -)
+    entity(niiri:9cd280f9a6bb55ac54967cdba205b396,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -341,103 +341,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "210.999999999887" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         crypto:sha512 = "861f189848ac564804db8d7d7d6a9970a77ba0c0ffb158a758286519a0f03587e0ca9212a3e324139de312ee530d0b4922a68f8d63141ae762ae109abd9cd0f7" %% xsd:string])
-    entity(niiri:6f69458ac8e2905970d1867b3a690ea7,
+    entity(niiri:45f730ecf126ce9ea7d1fa843be720ed,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "957b56d667b0101f7737111353cf7027bd3a5250b64386a416e7dbff994334124bc217c1123f1565ade6e2de13adb18951063665f5a483eee01f6cf4a3ef46aa" %% xsd:string])
-    wasDerivedFrom(niiri:36547963b0180bf5445943624ff36ab5, niiri:6f69458ac8e2905970d1867b3a690ea7, -, -, -)
-    wasGeneratedBy(niiri:36547963b0180bf5445943624ff36ab5, niiri:0949319d2ef4c6c93abc59fd5ab36c60, -)
-    entity(niiri:1b782d30ef88b5dec50d781f0f8c7b90,
+    wasDerivedFrom(niiri:9cd280f9a6bb55ac54967cdba205b396, niiri:45f730ecf126ce9ea7d1fa843be720ed, -, -, -)
+    wasGeneratedBy(niiri:9cd280f9a6bb55ac54967cdba205b396, niiri:e3eb926753b05559987938d0c0b54b29, -)
+    entity(niiri:5f6bfd1e7738d6ee402e8db9bf849c12,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         crypto:sha512 = "1b77b11d0ed5eb5364a39bf470d0f2a60530adb3b565ca4d58c5834663570035081dced5ae63a1036f67784fa0d4eb92c202eacfa1c68a761dc92d4c2fdcb635" %% xsd:string])
-    entity(niiri:3e41323291957893cacf579dfe6cd678,
+    entity(niiri:05c8f26e316907f21f72409226929af0,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "ed1d9e50bb64b4de72f01f25fc46258c5ff16d5a3d68d40ea557bbba27034b3e58fed559f43140846dfc4326ab88693925e57a7ad459534f78200e11e9ae0fc2" %% xsd:string])
-    wasDerivedFrom(niiri:1b782d30ef88b5dec50d781f0f8c7b90, niiri:3e41323291957893cacf579dfe6cd678, -, -, -)
-    wasGeneratedBy(niiri:1b782d30ef88b5dec50d781f0f8c7b90, niiri:0949319d2ef4c6c93abc59fd5ab36c60, -)
-    entity(niiri:35e15769c5844a4c220e3f2a8ee4db98,
+    wasDerivedFrom(niiri:5f6bfd1e7738d6ee402e8db9bf849c12, niiri:05c8f26e316907f21f72409226929af0, -, -, -)
+    wasGeneratedBy(niiri:5f6bfd1e7738d6ee402e8db9bf849c12, niiri:e3eb926753b05559987938d0c0b54b29, -)
+    entity(niiri:6771530b3685dd3dff795116450da5b7,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         crypto:sha512 = "c82dd92dc43589a48ea05591e3513b0b09d5e196227d549cd8dfe2d6697080f39b3054d1f4b2da18681b3f7d6f9959ed437674a90da99ca27742a7358d832643" %% xsd:string])
-    wasGeneratedBy(niiri:35e15769c5844a4c220e3f2a8ee4db98, niiri:0949319d2ef4c6c93abc59fd5ab36c60, -)
-    entity(niiri:7030cadfaa88d7036ca8f29a016c65f8,
+    wasGeneratedBy(niiri:6771530b3685dd3dff795116450da5b7, niiri:e3eb926753b05559987938d0c0b54b29, -)
+    entity(niiri:b3d5c88c4c85d76ff21932c996a538d6,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500109473139" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:0dbe0ae4e935c37d15660dce41a4a626',
-        nidm_equivalentThreshold: = 'niiri:043660ac38a59f66f758bacb56c24168'])
-    entity(niiri:0dbe0ae4e935c37d15660dce41a4a626,
+        nidm_equivalentThreshold: = 'niiri:7e8b4bd3d47ee964dad44627502a8644',
+        nidm_equivalentThreshold: = 'niiri:4b7d70536ac114ad01c0e9b4498d3c07'])
+    entity(niiri:7e8b4bd3d47ee964dad44627502a8644,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12930472090591" %% xsd:float])
-    entity(niiri:043660ac38a59f66f758bacb56c24168,
+    entity(niiri:4b7d70536ac114ad01c0e9b4498d3c07,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999999071" %% xsd:float])
-    entity(niiri:da875b2e8e05e4785db8390ac9ca6bea,
+    entity(niiri:198ec9f3a18190099c85925ab436b938,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:b9c8421cbde2dda368e334ee41445213',
-        nidm_equivalentThreshold: = 'niiri:4a5a24bbf6fc3ef6377e86dca3ad0aee'])
-    entity(niiri:b9c8421cbde2dda368e334ee41445213,
+        nidm_equivalentThreshold: = 'niiri:bdacc0bac46096d14f3b3dbb41e9fc80',
+        nidm_equivalentThreshold: = 'niiri:c68ed99893979c9afe5b40cf03e4138c'])
+    entity(niiri:bdacc0bac46096d14f3b3dbb41e9fc80,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:4a5a24bbf6fc3ef6377e86dca3ad0aee,
+    entity(niiri:c68ed99893979c9afe5b40cf03e4138c,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:ce2709f7d21f37e6c1b4b649ea2d0e63,
+    entity(niiri:92946954f5b6da81dea8e9ac72e36531,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:2a1941c7407f83aa18a742051141d0e3,
+    entity(niiri:74614276020f94983328fde22a285866,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:18a70c6743d2ee3291ef9fe8ddc693aa,
+    activity(niiri:f9272534debf5f02f91fdae4134c2588,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:327a9ff3946f2ec4986e86c53e18fe08, -)
-    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:7030cadfaa88d7036ca8f29a016c65f8, -)
-    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:da875b2e8e05e4785db8390ac9ca6bea, -)
-    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:36547963b0180bf5445943624ff36ab5, -)
-    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:14e90513cadd14ec08d1982515a57568, -)
-    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:004943b083f15c69d419d7bf95a9a882, -)
-    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:ce2709f7d21f37e6c1b4b649ea2d0e63, -)
-    used(niiri:18a70c6743d2ee3291ef9fe8ddc693aa, niiri:2a1941c7407f83aa18a742051141d0e3, -)
-    entity(niiri:20b1f3fc5f789afa8b55e495a2fb2fe8,
+    wasAssociatedWith(niiri:f9272534debf5f02f91fdae4134c2588, niiri:821b1a9b55ebe0032b859ca5150035ba, -)
+    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:b3d5c88c4c85d76ff21932c996a538d6, -)
+    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:198ec9f3a18190099c85925ab436b938, -)
+    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:9cd280f9a6bb55ac54967cdba205b396, -)
+    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:cdc151b697c0cb04cbe5c7540f511e3b, -)
+    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:0725082be9bac12c7029d6178bc32234, -)
+    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:92946954f5b6da81dea8e9ac72e36531, -)
+    used(niiri:f9272534debf5f02f91fdae4134c2588, niiri:74614276020f94983328fde22a285866, -)
+    entity(niiri:465c676752e1251c0ebaef3853a92d44,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "70.7136543802373" %% xsd:float,
@@ -453,8 +453,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:20b1f3fc5f789afa8b55e495a2fb2fe8, niiri:18a70c6743d2ee3291ef9fe8ddc693aa, -)
-    entity(niiri:0bd3c23f663f5db458405c9f8f024e0e,
+    wasGeneratedBy(niiri:465c676752e1251c0ebaef3853a92d44, niiri:f9272534debf5f02f91fdae4134c2588, -)
+    entity(niiri:dbc3b401b4cc8fc84857cec6f78458b3,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -462,20 +462,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:2a0ad393b6ba67c913ca2734dad76d72',
-        nidm_hasMaximumIntensityProjection: = 'niiri:cff9ff1e3ab6021801484e5a4ecd68eb',
-        nidm_inCoordinateSpace: = 'niiri:dd9e45ff2bfada42c45b025ad5bbb149',
+        nidm_hasClusterLabelsMap: = 'niiri:04196d57e8d71d662d0ca3a62551db9d',
+        nidm_hasMaximumIntensityProjection: = 'niiri:210b7648621d83f3b498261707462aa6',
+        nidm_inCoordinateSpace: = 'niiri:ad7c74aa0e194b1d0e6a1fe1c514c722',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:2a0ad393b6ba67c913ca2734dad76d72,
+    entity(niiri:04196d57e8d71d662d0ca3a62551db9d,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:cff9ff1e3ab6021801484e5a4ecd68eb,
+    entity(niiri:210b7648621d83f3b498261707462aa6,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:0bd3c23f663f5db458405c9f8f024e0e, niiri:18a70c6743d2ee3291ef9fe8ddc693aa, -)
+    wasGeneratedBy(niiri:dbc3b401b4cc8fc84857cec6f78458b3, niiri:f9272534debf5f02f91fdae4134c2588, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.ttl
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:c855a42b9fd2a67825eb0eddad715ed5
+niiri:eaf3e7315ea214768c764372ad90fbba
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:6742968a097360dc90801b311279b0d4
+niiri:733e6cf34d59395e1785a046d38726a3
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:5dff151e4c0a26653cff2770db2c33fd
+niiri:975599572d4b5dfbda5590e0e33f1a1c
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:5dff151e4c0a26653cff2770db2c33fd prov:wasAssociatedWith niiri:6742968a097360dc90801b311279b0d4 .
+niiri:975599572d4b5dfbda5590e0e33f1a1c prov:wasAssociatedWith niiri:733e6cf34d59395e1785a046d38726a3 .
 
 _:blank5 a prov:Generation .
 
-niiri:c855a42b9fd2a67825eb0eddad715ed5 prov:qualifiedGeneration _:blank5 .
+niiri:eaf3e7315ea214768c764372ad90fbba prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:32:00"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:43:21"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -131,12 +131,12 @@ _:blank5 prov:atTime "2016-01-11T10:32:00"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:821b1a9b55ebe0032b859ca5150035ba
+niiri:cc60b02c514e8cfe2e50b30d6bc67c94
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:ad7c74aa0e194b1d0e6a1fe1c514c722
+niiri:31dd9a37443e169f0f7297a3dfb8a1d8
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -146,37 +146,37 @@ niiri:ad7c74aa0e194b1d0e6a1fe1c514c722
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:5272f74dd7c9a2ab61942dd0f79ccf4e
+niiri:81dcf34f2e3bdd084d5134a0e0d76ba9
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:9799d5818262bf28a045fe452798ac27
+niiri:6fea47562615cda5d73c61606a93228e
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:c586c126a0dc3b44d055a5a4988d7fea
+niiri:166c2e158b227993faf5795de3ce5ecb
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:d46159933e55bc459a8eda437a7d8dba ;
+    dc:description niiri:462d8289aca89ea1948735a20e43858f ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) positive feedback\ntask001 co*bf(3)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(3)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:9799d5818262bf28a045fe452798ac27 ;
+    nidm_hasDriftModel: niiri:6fea47562615cda5d73c61606a93228e ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
     nidm_hasHRFBasis: spm_SPMsTemporalDerivative: ;
     nidm_hasHRFBasis: spm_SPMsDispersionDerivative: .
 
-niiri:d46159933e55bc459a8eda437a7d8dba
+niiri:462d8289aca89ea1948735a20e43858f
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:207f859d84e7b611b8afcd2c433d7a99
+niiri:e55ec0a33fd8cdf226d541902de8bf7f
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -184,230 +184,230 @@ niiri:207f859d84e7b611b8afcd2c433d7a99
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:e67c851046927dbfcf08886d4e18e257
+niiri:6117be626763f1e26e2965325107479b
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:e67c851046927dbfcf08886d4e18e257 prov:wasAssociatedWith niiri:821b1a9b55ebe0032b859ca5150035ba .
+niiri:6117be626763f1e26e2965325107479b prov:wasAssociatedWith niiri:cc60b02c514e8cfe2e50b30d6bc67c94 .
 
-niiri:e67c851046927dbfcf08886d4e18e257 prov:used niiri:c586c126a0dc3b44d055a5a4988d7fea .
+niiri:6117be626763f1e26e2965325107479b prov:used niiri:166c2e158b227993faf5795de3ce5ecb .
 
-niiri:e67c851046927dbfcf08886d4e18e257 prov:used niiri:5272f74dd7c9a2ab61942dd0f79ccf4e .
+niiri:6117be626763f1e26e2965325107479b prov:used niiri:81dcf34f2e3bdd084d5134a0e0d76ba9 .
 
-niiri:e67c851046927dbfcf08886d4e18e257 prov:used niiri:207f859d84e7b611b8afcd2c433d7a99 .
+niiri:6117be626763f1e26e2965325107479b prov:used niiri:e55ec0a33fd8cdf226d541902de8bf7f .
 
-niiri:0725082be9bac12c7029d6178bc32234
+niiri:55ee3044c6cea1caf6e83ad9beb57124
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:ba6b6df78ba4f8c1ecf50fd9cc7402c6
+niiri:2ea496bd8f5d9c784ab7644dcd4e3012
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:0725082be9bac12c7029d6178bc32234 prov:wasDerivedFrom niiri:ba6b6df78ba4f8c1ecf50fd9cc7402c6 .
+niiri:55ee3044c6cea1caf6e83ad9beb57124 prov:wasDerivedFrom niiri:2ea496bd8f5d9c784ab7644dcd4e3012 .
 
-niiri:0725082be9bac12c7029d6178bc32234 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:55ee3044c6cea1caf6e83ad9beb57124 prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:393592a4a2b55eadb7908e667437e023
+niiri:ad6c6c985fb5ab75855fad08474687c3
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.035133361816"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     crypto:sha512 "9cfeeeacd33286a145a42ac9e011a2cdc19a57aa70e2abfe71114ec159be45b10fc5fb995b21bb253624732dc52d9d34cfa34b774edf3fcb1efceb98db468de1"^^xsd:string .
 
-niiri:393592a4a2b55eadb7908e667437e023 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:ad6c6c985fb5ab75855fad08474687c3 prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:513180f96afa3f5d3d4823e976a35799
+niiri:a8172b84431abcdda1fe59d67b915f4f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 .
 
-niiri:795ad2bb84b798c73c49be9153d72a0c
+niiri:2e1b05283c5d3b1334ab150084bc75db
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "05720970946f70a45079d6f6e993cfadfcfd7f2feaa3e1d2478a4b7f2d8508122250847bbebb9f63e10cfc83a8101bc031164e69a4b720ae19d0ed237edc4153"^^xsd:string .
 
-niiri:513180f96afa3f5d3d4823e976a35799 prov:wasDerivedFrom niiri:795ad2bb84b798c73c49be9153d72a0c .
+niiri:a8172b84431abcdda1fe59d67b915f4f prov:wasDerivedFrom niiri:2e1b05283c5d3b1334ab150084bc75db .
 
-niiri:513180f96afa3f5d3d4823e976a35799 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:a8172b84431abcdda1fe59d67b915f4f prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:93a61b8edfa7ff506cb5da35ed98d4be
+niiri:ac40b39a203b625b2a7ca16d3aa1fa67
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 .
 
-niiri:a5f9b5d659bbc028878bf7d5bf78a788
+niiri:83ccd49808a62fc365bb77c82b93dfbd
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "7dfb234cef66f41020d9840fa271a63501a32a27d11f6ea831b79c314b7f68243bffc1dfaf789eca3e1ce384b55cf7f4c351c76ed21c15b1bfad448cb5718533"^^xsd:string .
 
-niiri:93a61b8edfa7ff506cb5da35ed98d4be prov:wasDerivedFrom niiri:a5f9b5d659bbc028878bf7d5bf78a788 .
+niiri:ac40b39a203b625b2a7ca16d3aa1fa67 prov:wasDerivedFrom niiri:83ccd49808a62fc365bb77c82b93dfbd .
 
-niiri:93a61b8edfa7ff506cb5da35ed98d4be prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:ac40b39a203b625b2a7ca16d3aa1fa67 prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:3df80df10c40ad826b1b1e9ea7e7e6c7
+niiri:051c054940176d08952216f41f9cc0e2
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 .
 
-niiri:a7d6b54fe900046a9188ebd7c94f026e
+niiri:1a8d96bad9310f17ed6e635894ed7a00
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "663dc1415b03fdf028c1664564ab6291bcb3ad6d0490820f5b22566245799297c4780d000158d93d7ffaae4bb2eb267a1acd8871b99d15d0d0c4cd4bdb5d9e68"^^xsd:string .
 
-niiri:3df80df10c40ad826b1b1e9ea7e7e6c7 prov:wasDerivedFrom niiri:a7d6b54fe900046a9188ebd7c94f026e .
+niiri:051c054940176d08952216f41f9cc0e2 prov:wasDerivedFrom niiri:1a8d96bad9310f17ed6e635894ed7a00 .
 
-niiri:3df80df10c40ad826b1b1e9ea7e7e6c7 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:051c054940176d08952216f41f9cc0e2 prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:40a2f864e7e24137f9a06a85483d9b32
+niiri:4873a07b988c7e284f8083a5b392bf40
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 .
 
-niiri:52f862349d1a76a394430446694f64d7
+niiri:553274370fbeabdb86a876a3e178557f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "03416c893a6bd36d720ab1953be4b0f47180f3aa1c2d22fbe74aa1070f97804a275e1f5ee2bec9a395485337986b7592e6284676ed3bddc39bf649d6c48c91de"^^xsd:string .
 
-niiri:40a2f864e7e24137f9a06a85483d9b32 prov:wasDerivedFrom niiri:52f862349d1a76a394430446694f64d7 .
+niiri:4873a07b988c7e284f8083a5b392bf40 prov:wasDerivedFrom niiri:553274370fbeabdb86a876a3e178557f .
 
-niiri:40a2f864e7e24137f9a06a85483d9b32 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:4873a07b988c7e284f8083a5b392bf40 prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:8f5dd25bd7a034b14da4eaea22677e06
+niiri:4e7b6e1841cfb3a47594d13b9c8c605b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 .
 
-niiri:23db4e685c42ed93a8b0bb0f3d56b135
+niiri:4b57d416fea6bc6ca307c3147be54e3a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "27acde5836e2523829c5674edec7a5f66b1080c86ab827a84fa0eb267a95db1e7bcaaa026c6b37df921eaae895c2ed019332fda17800aeaf5863238990b7ca9c"^^xsd:string .
 
-niiri:8f5dd25bd7a034b14da4eaea22677e06 prov:wasDerivedFrom niiri:23db4e685c42ed93a8b0bb0f3d56b135 .
+niiri:4e7b6e1841cfb3a47594d13b9c8c605b prov:wasDerivedFrom niiri:4b57d416fea6bc6ca307c3147be54e3a .
 
-niiri:8f5dd25bd7a034b14da4eaea22677e06 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:4e7b6e1841cfb3a47594d13b9c8c605b prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:008976bbb934e0cd52493ee0c22a6e4a
+niiri:eb1bef092548083ab62c77a579dbd79f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 6" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 .
 
-niiri:a50d8358acedd8004571c40f28c9cec5
+niiri:844db2931c6fa205571914ac64bda513
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "591a8b7d598a0840aefab5c1305400550852acd74f2256bbe815a51de82bd5e8d56969fbe3d925e9165605ad777a9a1df5e7d8e5552d99e0f8d7c505216fdf42"^^xsd:string .
 
-niiri:008976bbb934e0cd52493ee0c22a6e4a prov:wasDerivedFrom niiri:a50d8358acedd8004571c40f28c9cec5 .
+niiri:eb1bef092548083ab62c77a579dbd79f prov:wasDerivedFrom niiri:844db2931c6fa205571914ac64bda513 .
 
-niiri:008976bbb934e0cd52493ee0c22a6e4a prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:eb1bef092548083ab62c77a579dbd79f prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:c69576112591b8fcb20504248cd4a060
+niiri:5d81b1fd59e507510f7f8154f159c83e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 7" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 .
 
-niiri:edff09e8ce1f95b3106740677d664a09
+niiri:d08eb65fb3d8f29c19aab3b5fe51d7e9
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0007.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b4442e57fdbbe43c7374152d776957e9525ba67958ddca2e879f063a43b79317a228120a338c86a410e7faedc80738c7ac91afcead568bbeaf2980e913b7370a"^^xsd:string .
 
-niiri:c69576112591b8fcb20504248cd4a060 prov:wasDerivedFrom niiri:edff09e8ce1f95b3106740677d664a09 .
+niiri:5d81b1fd59e507510f7f8154f159c83e prov:wasDerivedFrom niiri:d08eb65fb3d8f29c19aab3b5fe51d7e9 .
 
-niiri:c69576112591b8fcb20504248cd4a060 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:5d81b1fd59e507510f7f8154f159c83e prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:9b219b0f4f4b15e459d933cb1a0f9b3a
+niiri:519f88373d207a69ac4fd07f59cdf6d9
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     crypto:sha512 "e55dbb4bcee078ef7f7cffb3a618fe4900cc54aa2d4482f39b220812891dac5729209d7d84f387d3eac601ae9b0f64b16b6e23eea6f83f23429197dc25975aaf"^^xsd:string .
 
-niiri:b41bd286d1412a95a30af890f595c9a2
+niiri:a902535b9ac7f254d63de84c7bd914a0
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "2d5bbdabc64950a9e8b9f7e9db623cebbff2cd835a3228e6c3f8249fed6f7d681b30b37254d070279984ce6c9e0600e944671ff5a7c68312d647dc3b6eb4330e"^^xsd:string .
 
-niiri:9b219b0f4f4b15e459d933cb1a0f9b3a prov:wasDerivedFrom niiri:b41bd286d1412a95a30af890f595c9a2 .
+niiri:519f88373d207a69ac4fd07f59cdf6d9 prov:wasDerivedFrom niiri:a902535b9ac7f254d63de84c7bd914a0 .
 
-niiri:9b219b0f4f4b15e459d933cb1a0f9b3a prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:519f88373d207a69ac4fd07f59cdf6d9 prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:cdc151b697c0cb04cbe5c7540f511e3b
+niiri:d716e6c0dfd3a28f17fee84ebd1cb8d0
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     crypto:sha512 "80e17a085bd95aaddf708f772f29ca49b44fd1a3a621b55b1c73687e66aba3d4d5ca5d463b38adf7ddfdfb9435f090d31911fc9277418c9a8eced4ef2b88d4dc"^^xsd:string .
 
-niiri:aba5ca187a48c5cd49d94ac923660ed3
+niiri:bfe21fcb1d6145ba7a78de96479edf1f
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4e0032db2fac38eb7ef64e9c6e2348af2bfdab0c05e04dea32b885b6c5f2519bf2e93fa4f7fb9d48292036b950446b841d73fbb92e15a969126e16d093193cee"^^xsd:string .
 
-niiri:cdc151b697c0cb04cbe5c7540f511e3b prov:wasDerivedFrom niiri:aba5ca187a48c5cd49d94ac923660ed3 .
+niiri:d716e6c0dfd3a28f17fee84ebd1cb8d0 prov:wasDerivedFrom niiri:bfe21fcb1d6145ba7a78de96479edf1f .
 
-niiri:cdc151b697c0cb04cbe5c7540f511e3b prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
+niiri:d716e6c0dfd3a28f17fee84ebd1cb8d0 prov:wasGeneratedBy niiri:6117be626763f1e26e2965325107479b .
 
-niiri:dda506529adbd8dadb3b3a795151fbb3
+niiri:81770f7b401a1767b47e8bdb1e1bc8f4
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, 0, 0, -1, 0, 0, 0]"^^xsd:string .
 
-niiri:e3eb926753b05559987938d0c0b54b29
+niiri:465008558a2d203c1fbd8dd41c5be218
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:wasAssociatedWith niiri:821b1a9b55ebe0032b859ca5150035ba .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:wasAssociatedWith niiri:cc60b02c514e8cfe2e50b30d6bc67c94 .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:0725082be9bac12c7029d6178bc32234 .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:55ee3044c6cea1caf6e83ad9beb57124 .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:9b219b0f4f4b15e459d933cb1a0f9b3a .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:519f88373d207a69ac4fd07f59cdf6d9 .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:c586c126a0dc3b44d055a5a4988d7fea .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:166c2e158b227993faf5795de3ce5ecb .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:dda506529adbd8dadb3b3a795151fbb3 .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:81770f7b401a1767b47e8bdb1e1bc8f4 .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:513180f96afa3f5d3d4823e976a35799 .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:a8172b84431abcdda1fe59d67b915f4f .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:93a61b8edfa7ff506cb5da35ed98d4be .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:ac40b39a203b625b2a7ca16d3aa1fa67 .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:3df80df10c40ad826b1b1e9ea7e7e6c7 .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:051c054940176d08952216f41f9cc0e2 .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:40a2f864e7e24137f9a06a85483d9b32 .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:4873a07b988c7e284f8083a5b392bf40 .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:8f5dd25bd7a034b14da4eaea22677e06 .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:4e7b6e1841cfb3a47594d13b9c8c605b .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:008976bbb934e0cd52493ee0c22a6e4a .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:eb1bef092548083ab62c77a579dbd79f .
 
-niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:c69576112591b8fcb20504248cd4a060 .
+niiri:465008558a2d203c1fbd8dd41c5be218 prov:used niiri:5d81b1fd59e507510f7f8154f159c83e .
 
-niiri:9cd280f9a6bb55ac54967cdba205b396
+niiri:36ed7a761df547c262491683cdaa3821
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -417,124 +417,124 @@ niiri:9cd280f9a6bb55ac54967cdba205b396
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "210.999999999887"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     crypto:sha512 "861f189848ac564804db8d7d7d6a9970a77ba0c0ffb158a758286519a0f03587e0ca9212a3e324139de312ee530d0b4922a68f8d63141ae762ae109abd9cd0f7"^^xsd:string .
 
-niiri:45f730ecf126ce9ea7d1fa843be720ed
+niiri:d96008ee20e47968fa3a57617b30c11c
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "957b56d667b0101f7737111353cf7027bd3a5250b64386a416e7dbff994334124bc217c1123f1565ade6e2de13adb18951063665f5a483eee01f6cf4a3ef46aa"^^xsd:string .
 
-niiri:9cd280f9a6bb55ac54967cdba205b396 prov:wasDerivedFrom niiri:45f730ecf126ce9ea7d1fa843be720ed .
+niiri:36ed7a761df547c262491683cdaa3821 prov:wasDerivedFrom niiri:d96008ee20e47968fa3a57617b30c11c .
 
-niiri:9cd280f9a6bb55ac54967cdba205b396 prov:wasGeneratedBy niiri:e3eb926753b05559987938d0c0b54b29 .
+niiri:36ed7a761df547c262491683cdaa3821 prov:wasGeneratedBy niiri:465008558a2d203c1fbd8dd41c5be218 .
 
-niiri:5f6bfd1e7738d6ee402e8db9bf849c12
+niiri:3f46bd67634e5e0b974d2279a69e6964
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     crypto:sha512 "1b77b11d0ed5eb5364a39bf470d0f2a60530adb3b565ca4d58c5834663570035081dced5ae63a1036f67784fa0d4eb92c202eacfa1c68a761dc92d4c2fdcb635"^^xsd:string .
 
-niiri:05c8f26e316907f21f72409226929af0
+niiri:950e30ad5ae44d45c36f7b84a2901bc6
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "ed1d9e50bb64b4de72f01f25fc46258c5ff16d5a3d68d40ea557bbba27034b3e58fed559f43140846dfc4326ab88693925e57a7ad459534f78200e11e9ae0fc2"^^xsd:string .
 
-niiri:5f6bfd1e7738d6ee402e8db9bf849c12 prov:wasDerivedFrom niiri:05c8f26e316907f21f72409226929af0 .
+niiri:3f46bd67634e5e0b974d2279a69e6964 prov:wasDerivedFrom niiri:950e30ad5ae44d45c36f7b84a2901bc6 .
 
-niiri:5f6bfd1e7738d6ee402e8db9bf849c12 prov:wasGeneratedBy niiri:e3eb926753b05559987938d0c0b54b29 .
+niiri:3f46bd67634e5e0b974d2279a69e6964 prov:wasGeneratedBy niiri:465008558a2d203c1fbd8dd41c5be218 .
 
-niiri:6771530b3685dd3dff795116450da5b7
+niiri:5d613a71be1458890bbdedd18a17b2b8
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     crypto:sha512 "c82dd92dc43589a48ea05591e3513b0b09d5e196227d549cd8dfe2d6697080f39b3054d1f4b2da18681b3f7d6f9959ed437674a90da99ca27742a7358d832643"^^xsd:string .
 
-niiri:6771530b3685dd3dff795116450da5b7 prov:wasGeneratedBy niiri:e3eb926753b05559987938d0c0b54b29 .
+niiri:5d613a71be1458890bbdedd18a17b2b8 prov:wasGeneratedBy niiri:465008558a2d203c1fbd8dd41c5be218 .
 
-niiri:b3d5c88c4c85d76ff21932c996a538d6
+niiri:7c8f8f9040477fa4d39fd6c75981cd74
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500109473139"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:7e8b4bd3d47ee964dad44627502a8644 ;
-    nidm_equivalentThreshold: niiri:4b7d70536ac114ad01c0e9b4498d3c07 .
+    nidm_equivalentThreshold: niiri:e5bf19ba0c7ae13110a0782d0229a75f ;
+    nidm_equivalentThreshold: niiri:2b15aebc51312739924ed32729590ac2 .
 
-niiri:7e8b4bd3d47ee964dad44627502a8644
+niiri:e5bf19ba0c7ae13110a0782d0229a75f
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12930472090591"^^xsd:float .
 
-niiri:4b7d70536ac114ad01c0e9b4498d3c07
+niiri:2b15aebc51312739924ed32729590ac2
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999999071"^^xsd:float .
 
-niiri:198ec9f3a18190099c85925ab436b938
+niiri:4f14b6fcb9279174a126cccf9dd611a1
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:bdacc0bac46096d14f3b3dbb41e9fc80 ;
-    nidm_equivalentThreshold: niiri:c68ed99893979c9afe5b40cf03e4138c .
+    nidm_equivalentThreshold: niiri:7f6bec15c9d8baa79c90c821551088d6 ;
+    nidm_equivalentThreshold: niiri:fbfbd0fbf80788bf1a91569a5be10ef7 .
 
-niiri:bdacc0bac46096d14f3b3dbb41e9fc80
+niiri:7f6bec15c9d8baa79c90c821551088d6
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:c68ed99893979c9afe5b40cf03e4138c
+niiri:fbfbd0fbf80788bf1a91569a5be10ef7
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:92946954f5b6da81dea8e9ac72e36531
+niiri:141ea0417394588800010fc7717c287c
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:74614276020f94983328fde22a285866
+niiri:4599dcab1df4a55cb237c0ac9ffabeae
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:f9272534debf5f02f91fdae4134c2588
+niiri:5c52d135d7ccce64ed39f6e95c4a7360
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:f9272534debf5f02f91fdae4134c2588 prov:wasAssociatedWith niiri:821b1a9b55ebe0032b859ca5150035ba .
+niiri:5c52d135d7ccce64ed39f6e95c4a7360 prov:wasAssociatedWith niiri:cc60b02c514e8cfe2e50b30d6bc67c94 .
 
-niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:b3d5c88c4c85d76ff21932c996a538d6 .
+niiri:5c52d135d7ccce64ed39f6e95c4a7360 prov:used niiri:7c8f8f9040477fa4d39fd6c75981cd74 .
 
-niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:198ec9f3a18190099c85925ab436b938 .
+niiri:5c52d135d7ccce64ed39f6e95c4a7360 prov:used niiri:4f14b6fcb9279174a126cccf9dd611a1 .
 
-niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:9cd280f9a6bb55ac54967cdba205b396 .
+niiri:5c52d135d7ccce64ed39f6e95c4a7360 prov:used niiri:36ed7a761df547c262491683cdaa3821 .
 
-niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:cdc151b697c0cb04cbe5c7540f511e3b .
+niiri:5c52d135d7ccce64ed39f6e95c4a7360 prov:used niiri:d716e6c0dfd3a28f17fee84ebd1cb8d0 .
 
-niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:0725082be9bac12c7029d6178bc32234 .
+niiri:5c52d135d7ccce64ed39f6e95c4a7360 prov:used niiri:55ee3044c6cea1caf6e83ad9beb57124 .
 
-niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:92946954f5b6da81dea8e9ac72e36531 .
+niiri:5c52d135d7ccce64ed39f6e95c4a7360 prov:used niiri:141ea0417394588800010fc7717c287c .
 
-niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:74614276020f94983328fde22a285866 .
+niiri:5c52d135d7ccce64ed39f6e95c4a7360 prov:used niiri:4599dcab1df4a55cb237c0ac9ffabeae .
 
-niiri:465c676752e1251c0ebaef3853a92d44
+niiri:884e2eba2c39dc777e612acf6012ee12
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "70.7136543802373"^^xsd:float ;
@@ -551,9 +551,9 @@ niiri:465c676752e1251c0ebaef3853a92d44
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:465c676752e1251c0ebaef3853a92d44 prov:wasGeneratedBy niiri:f9272534debf5f02f91fdae4134c2588 .
+niiri:884e2eba2c39dc777e612acf6012ee12 prov:wasGeneratedBy niiri:5c52d135d7ccce64ed39f6e95c4a7360 .
 
-niiri:dbc3b401b4cc8fc84857cec6f78458b3
+niiri:74482e945645949e91b2950e49c2026c
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -561,22 +561,22 @@ niiri:dbc3b401b4cc8fc84857cec6f78458b3
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:04196d57e8d71d662d0ca3a62551db9d ;
-    nidm_hasMaximumIntensityProjection: niiri:210b7648621d83f3b498261707462aa6 ;
-    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
+    nidm_hasClusterLabelsMap: niiri:49260fa7415b415130049110469bb055 ;
+    nidm_hasMaximumIntensityProjection: niiri:ec756d1c48c0536f53dfa594031fd560 ;
+    nidm_inCoordinateSpace: niiri:31dd9a37443e169f0f7297a3dfb8a1d8 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:04196d57e8d71d662d0ca3a62551db9d
+niiri:49260fa7415b415130049110469bb055
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:210b7648621d83f3b498261707462aa6
+niiri:ec756d1c48c0536f53dfa594031fd560
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:dbc3b401b4cc8fc84857cec6f78458b3 prov:wasGeneratedBy niiri:f9272534debf5f02f91fdae4134c2588 .
+niiri:74482e945645949e91b2950e49c2026c prov:wasGeneratedBy niiri:5c52d135d7ccce64ed39f6e95c4a7360 .
 

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.ttl
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:1f3972d440e0662ae30f95394c472c4b
+niiri:c855a42b9fd2a67825eb0eddad715ed5
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:4aea73471fd7ac02b19849bf1514b0dc
+niiri:6742968a097360dc90801b311279b0d4
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:a8918a8d18ab7b5bda372d8835183a06
+niiri:5dff151e4c0a26653cff2770db2c33fd
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:a8918a8d18ab7b5bda372d8835183a06 prov:wasAssociatedWith niiri:4aea73471fd7ac02b19849bf1514b0dc .
+niiri:5dff151e4c0a26653cff2770db2c33fd prov:wasAssociatedWith niiri:6742968a097360dc90801b311279b0d4 .
 
 _:blank5 a prov:Generation .
 
-niiri:1f3972d440e0662ae30f95394c472c4b prov:qualifiedGeneration _:blank5 .
+niiri:c855a42b9fd2a67825eb0eddad715ed5 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:10:39"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:32:00"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -131,12 +131,12 @@ _:blank5 prov:atTime "2016-01-11T10:10:39"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:327a9ff3946f2ec4986e86c53e18fe08
+niiri:821b1a9b55ebe0032b859ca5150035ba
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:dd9e45ff2bfada42c45b025ad5bbb149
+niiri:ad7c74aa0e194b1d0e6a1fe1c514c722
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -146,37 +146,37 @@ niiri:dd9e45ff2bfada42c45b025ad5bbb149
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:e77033de47473eb122f2a499a902fd95
+niiri:5272f74dd7c9a2ab61942dd0f79ccf4e
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:f0469999987415c033878a3cd80b6440
+niiri:9799d5818262bf28a045fe452798ac27
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:3b2d1088cc3b6cf7a1a53c6096b3f855
+niiri:c586c126a0dc3b44d055a5a4988d7fea
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:f84773591fde4d99c2c8b7683309e6c7 ;
+    dc:description niiri:d46159933e55bc459a8eda437a7d8dba ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) positive feedback\ntask001 co*bf(3)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(3)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:f0469999987415c033878a3cd80b6440 ;
+    nidm_hasDriftModel: niiri:9799d5818262bf28a045fe452798ac27 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
     nidm_hasHRFBasis: spm_SPMsTemporalDerivative: ;
     nidm_hasHRFBasis: spm_SPMsDispersionDerivative: .
 
-niiri:f84773591fde4d99c2c8b7683309e6c7
+niiri:d46159933e55bc459a8eda437a7d8dba
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:27647d7272bcc27c18636264b8b7b214
+niiri:207f859d84e7b611b8afcd2c433d7a99
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -184,230 +184,230 @@ niiri:27647d7272bcc27c18636264b8b7b214
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:646802f08fa4125c11708667c0a5c56f
+niiri:e67c851046927dbfcf08886d4e18e257
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:646802f08fa4125c11708667c0a5c56f prov:wasAssociatedWith niiri:327a9ff3946f2ec4986e86c53e18fe08 .
+niiri:e67c851046927dbfcf08886d4e18e257 prov:wasAssociatedWith niiri:821b1a9b55ebe0032b859ca5150035ba .
 
-niiri:646802f08fa4125c11708667c0a5c56f prov:used niiri:3b2d1088cc3b6cf7a1a53c6096b3f855 .
+niiri:e67c851046927dbfcf08886d4e18e257 prov:used niiri:c586c126a0dc3b44d055a5a4988d7fea .
 
-niiri:646802f08fa4125c11708667c0a5c56f prov:used niiri:e77033de47473eb122f2a499a902fd95 .
+niiri:e67c851046927dbfcf08886d4e18e257 prov:used niiri:5272f74dd7c9a2ab61942dd0f79ccf4e .
 
-niiri:646802f08fa4125c11708667c0a5c56f prov:used niiri:27647d7272bcc27c18636264b8b7b214 .
+niiri:e67c851046927dbfcf08886d4e18e257 prov:used niiri:207f859d84e7b611b8afcd2c433d7a99 .
 
-niiri:004943b083f15c69d419d7bf95a9a882
+niiri:0725082be9bac12c7029d6178bc32234
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:53ea54fabcf9cc3042fa0121e09641e4
+niiri:ba6b6df78ba4f8c1ecf50fd9cc7402c6
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:004943b083f15c69d419d7bf95a9a882 prov:wasDerivedFrom niiri:53ea54fabcf9cc3042fa0121e09641e4 .
+niiri:0725082be9bac12c7029d6178bc32234 prov:wasDerivedFrom niiri:ba6b6df78ba4f8c1ecf50fd9cc7402c6 .
 
-niiri:004943b083f15c69d419d7bf95a9a882 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:0725082be9bac12c7029d6178bc32234 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:06d798c010c8dd98bb5dfc11e39816a5
+niiri:393592a4a2b55eadb7908e667437e023
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.035133361816"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     crypto:sha512 "9cfeeeacd33286a145a42ac9e011a2cdc19a57aa70e2abfe71114ec159be45b10fc5fb995b21bb253624732dc52d9d34cfa34b774edf3fcb1efceb98db468de1"^^xsd:string .
 
-niiri:06d798c010c8dd98bb5dfc11e39816a5 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:393592a4a2b55eadb7908e667437e023 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:76a8e1ecb96d47328c84ded1e8c9fcce
+niiri:513180f96afa3f5d3d4823e976a35799
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
 
-niiri:1c1c45d6750b11a734fe2d0d3d04524b
+niiri:795ad2bb84b798c73c49be9153d72a0c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "05720970946f70a45079d6f6e993cfadfcfd7f2feaa3e1d2478a4b7f2d8508122250847bbebb9f63e10cfc83a8101bc031164e69a4b720ae19d0ed237edc4153"^^xsd:string .
 
-niiri:76a8e1ecb96d47328c84ded1e8c9fcce prov:wasDerivedFrom niiri:1c1c45d6750b11a734fe2d0d3d04524b .
+niiri:513180f96afa3f5d3d4823e976a35799 prov:wasDerivedFrom niiri:795ad2bb84b798c73c49be9153d72a0c .
 
-niiri:76a8e1ecb96d47328c84ded1e8c9fcce prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:513180f96afa3f5d3d4823e976a35799 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:a81b51f7714cfacea14292d4ce12cbf0
+niiri:93a61b8edfa7ff506cb5da35ed98d4be
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
 
-niiri:e341723ff93635384bb667caa931aac3
+niiri:a5f9b5d659bbc028878bf7d5bf78a788
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "7dfb234cef66f41020d9840fa271a63501a32a27d11f6ea831b79c314b7f68243bffc1dfaf789eca3e1ce384b55cf7f4c351c76ed21c15b1bfad448cb5718533"^^xsd:string .
 
-niiri:a81b51f7714cfacea14292d4ce12cbf0 prov:wasDerivedFrom niiri:e341723ff93635384bb667caa931aac3 .
+niiri:93a61b8edfa7ff506cb5da35ed98d4be prov:wasDerivedFrom niiri:a5f9b5d659bbc028878bf7d5bf78a788 .
 
-niiri:a81b51f7714cfacea14292d4ce12cbf0 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:93a61b8edfa7ff506cb5da35ed98d4be prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:f924a4b144030137570a5f4ec3bdd383
+niiri:3df80df10c40ad826b1b1e9ea7e7e6c7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
 
-niiri:4659d0e70e9587adefe084a2e56740c6
+niiri:a7d6b54fe900046a9188ebd7c94f026e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "663dc1415b03fdf028c1664564ab6291bcb3ad6d0490820f5b22566245799297c4780d000158d93d7ffaae4bb2eb267a1acd8871b99d15d0d0c4cd4bdb5d9e68"^^xsd:string .
 
-niiri:f924a4b144030137570a5f4ec3bdd383 prov:wasDerivedFrom niiri:4659d0e70e9587adefe084a2e56740c6 .
+niiri:3df80df10c40ad826b1b1e9ea7e7e6c7 prov:wasDerivedFrom niiri:a7d6b54fe900046a9188ebd7c94f026e .
 
-niiri:f924a4b144030137570a5f4ec3bdd383 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:3df80df10c40ad826b1b1e9ea7e7e6c7 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:e13bd961e1ab6c34ce552b7e2cf3def2
+niiri:40a2f864e7e24137f9a06a85483d9b32
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
 
-niiri:ba6b830f0e3883fbfd2edd369325478e
+niiri:52f862349d1a76a394430446694f64d7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "03416c893a6bd36d720ab1953be4b0f47180f3aa1c2d22fbe74aa1070f97804a275e1f5ee2bec9a395485337986b7592e6284676ed3bddc39bf649d6c48c91de"^^xsd:string .
 
-niiri:e13bd961e1ab6c34ce552b7e2cf3def2 prov:wasDerivedFrom niiri:ba6b830f0e3883fbfd2edd369325478e .
+niiri:40a2f864e7e24137f9a06a85483d9b32 prov:wasDerivedFrom niiri:52f862349d1a76a394430446694f64d7 .
 
-niiri:e13bd961e1ab6c34ce552b7e2cf3def2 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:40a2f864e7e24137f9a06a85483d9b32 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:6907c49ae94c1c59885dff7ba73b6ad2
+niiri:8f5dd25bd7a034b14da4eaea22677e06
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
 
-niiri:b53565d569027fb62e62b8a8fcd63f2d
+niiri:23db4e685c42ed93a8b0bb0f3d56b135
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "27acde5836e2523829c5674edec7a5f66b1080c86ab827a84fa0eb267a95db1e7bcaaa026c6b37df921eaae895c2ed019332fda17800aeaf5863238990b7ca9c"^^xsd:string .
 
-niiri:6907c49ae94c1c59885dff7ba73b6ad2 prov:wasDerivedFrom niiri:b53565d569027fb62e62b8a8fcd63f2d .
+niiri:8f5dd25bd7a034b14da4eaea22677e06 prov:wasDerivedFrom niiri:23db4e685c42ed93a8b0bb0f3d56b135 .
 
-niiri:6907c49ae94c1c59885dff7ba73b6ad2 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:8f5dd25bd7a034b14da4eaea22677e06 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:3e47abc4258d401bfcd12c1c17335fa9
+niiri:008976bbb934e0cd52493ee0c22a6e4a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 6" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
 
-niiri:51f8e9ed2e8e64c7361c7f7a2502b9e9
+niiri:a50d8358acedd8004571c40f28c9cec5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "591a8b7d598a0840aefab5c1305400550852acd74f2256bbe815a51de82bd5e8d56969fbe3d925e9165605ad777a9a1df5e7d8e5552d99e0f8d7c505216fdf42"^^xsd:string .
 
-niiri:3e47abc4258d401bfcd12c1c17335fa9 prov:wasDerivedFrom niiri:51f8e9ed2e8e64c7361c7f7a2502b9e9 .
+niiri:008976bbb934e0cd52493ee0c22a6e4a prov:wasDerivedFrom niiri:a50d8358acedd8004571c40f28c9cec5 .
 
-niiri:3e47abc4258d401bfcd12c1c17335fa9 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:008976bbb934e0cd52493ee0c22a6e4a prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:05f7c6a5d3f20dacc4c00e1767077eb2
+niiri:c69576112591b8fcb20504248cd4a060
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 7" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 .
 
-niiri:e25a10393592506fe41e9eff6aa4bb0f
+niiri:edff09e8ce1f95b3106740677d664a09
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0007.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b4442e57fdbbe43c7374152d776957e9525ba67958ddca2e879f063a43b79317a228120a338c86a410e7faedc80738c7ac91afcead568bbeaf2980e913b7370a"^^xsd:string .
 
-niiri:05f7c6a5d3f20dacc4c00e1767077eb2 prov:wasDerivedFrom niiri:e25a10393592506fe41e9eff6aa4bb0f .
+niiri:c69576112591b8fcb20504248cd4a060 prov:wasDerivedFrom niiri:edff09e8ce1f95b3106740677d664a09 .
 
-niiri:05f7c6a5d3f20dacc4c00e1767077eb2 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:c69576112591b8fcb20504248cd4a060 prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:89cdd5a0418dc30cb86718044231b9fb
+niiri:9b219b0f4f4b15e459d933cb1a0f9b3a
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     crypto:sha512 "e55dbb4bcee078ef7f7cffb3a618fe4900cc54aa2d4482f39b220812891dac5729209d7d84f387d3eac601ae9b0f64b16b6e23eea6f83f23429197dc25975aaf"^^xsd:string .
 
-niiri:87c25e6525ec7ca193b9e43fc70db585
+niiri:b41bd286d1412a95a30af890f595c9a2
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "2d5bbdabc64950a9e8b9f7e9db623cebbff2cd835a3228e6c3f8249fed6f7d681b30b37254d070279984ce6c9e0600e944671ff5a7c68312d647dc3b6eb4330e"^^xsd:string .
 
-niiri:89cdd5a0418dc30cb86718044231b9fb prov:wasDerivedFrom niiri:87c25e6525ec7ca193b9e43fc70db585 .
+niiri:9b219b0f4f4b15e459d933cb1a0f9b3a prov:wasDerivedFrom niiri:b41bd286d1412a95a30af890f595c9a2 .
 
-niiri:89cdd5a0418dc30cb86718044231b9fb prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:9b219b0f4f4b15e459d933cb1a0f9b3a prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:14e90513cadd14ec08d1982515a57568
+niiri:cdc151b697c0cb04cbe5c7540f511e3b
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     crypto:sha512 "80e17a085bd95aaddf708f772f29ca49b44fd1a3a621b55b1c73687e66aba3d4d5ca5d463b38adf7ddfdfb9435f090d31911fc9277418c9a8eced4ef2b88d4dc"^^xsd:string .
 
-niiri:4bff0c6abe7073e4e149a8ef4871bf59
+niiri:aba5ca187a48c5cd49d94ac923660ed3
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4e0032db2fac38eb7ef64e9c6e2348af2bfdab0c05e04dea32b885b6c5f2519bf2e93fa4f7fb9d48292036b950446b841d73fbb92e15a969126e16d093193cee"^^xsd:string .
 
-niiri:14e90513cadd14ec08d1982515a57568 prov:wasDerivedFrom niiri:4bff0c6abe7073e4e149a8ef4871bf59 .
+niiri:cdc151b697c0cb04cbe5c7540f511e3b prov:wasDerivedFrom niiri:aba5ca187a48c5cd49d94ac923660ed3 .
 
-niiri:14e90513cadd14ec08d1982515a57568 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+niiri:cdc151b697c0cb04cbe5c7540f511e3b prov:wasGeneratedBy niiri:e67c851046927dbfcf08886d4e18e257 .
 
-niiri:3184176bcf5c4d11386c89ec66785dc5
+niiri:dda506529adbd8dadb3b3a795151fbb3
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, 0, 0, -1, 0, 0, 0]"^^xsd:string .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60
+niiri:e3eb926753b05559987938d0c0b54b29
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:wasAssociatedWith niiri:327a9ff3946f2ec4986e86c53e18fe08 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:wasAssociatedWith niiri:821b1a9b55ebe0032b859ca5150035ba .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:004943b083f15c69d419d7bf95a9a882 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:0725082be9bac12c7029d6178bc32234 .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:89cdd5a0418dc30cb86718044231b9fb .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:9b219b0f4f4b15e459d933cb1a0f9b3a .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:3b2d1088cc3b6cf7a1a53c6096b3f855 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:c586c126a0dc3b44d055a5a4988d7fea .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:3184176bcf5c4d11386c89ec66785dc5 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:dda506529adbd8dadb3b3a795151fbb3 .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:76a8e1ecb96d47328c84ded1e8c9fcce .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:513180f96afa3f5d3d4823e976a35799 .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:a81b51f7714cfacea14292d4ce12cbf0 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:93a61b8edfa7ff506cb5da35ed98d4be .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:f924a4b144030137570a5f4ec3bdd383 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:3df80df10c40ad826b1b1e9ea7e7e6c7 .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:e13bd961e1ab6c34ce552b7e2cf3def2 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:40a2f864e7e24137f9a06a85483d9b32 .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:6907c49ae94c1c59885dff7ba73b6ad2 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:8f5dd25bd7a034b14da4eaea22677e06 .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:3e47abc4258d401bfcd12c1c17335fa9 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:008976bbb934e0cd52493ee0c22a6e4a .
 
-niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:05f7c6a5d3f20dacc4c00e1767077eb2 .
+niiri:e3eb926753b05559987938d0c0b54b29 prov:used niiri:c69576112591b8fcb20504248cd4a060 .
 
-niiri:36547963b0180bf5445943624ff36ab5
+niiri:9cd280f9a6bb55ac54967cdba205b396
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -417,124 +417,124 @@ niiri:36547963b0180bf5445943624ff36ab5
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "210.999999999887"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     crypto:sha512 "861f189848ac564804db8d7d7d6a9970a77ba0c0ffb158a758286519a0f03587e0ca9212a3e324139de312ee530d0b4922a68f8d63141ae762ae109abd9cd0f7"^^xsd:string .
 
-niiri:6f69458ac8e2905970d1867b3a690ea7
+niiri:45f730ecf126ce9ea7d1fa843be720ed
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "957b56d667b0101f7737111353cf7027bd3a5250b64386a416e7dbff994334124bc217c1123f1565ade6e2de13adb18951063665f5a483eee01f6cf4a3ef46aa"^^xsd:string .
 
-niiri:36547963b0180bf5445943624ff36ab5 prov:wasDerivedFrom niiri:6f69458ac8e2905970d1867b3a690ea7 .
+niiri:9cd280f9a6bb55ac54967cdba205b396 prov:wasDerivedFrom niiri:45f730ecf126ce9ea7d1fa843be720ed .
 
-niiri:36547963b0180bf5445943624ff36ab5 prov:wasGeneratedBy niiri:0949319d2ef4c6c93abc59fd5ab36c60 .
+niiri:9cd280f9a6bb55ac54967cdba205b396 prov:wasGeneratedBy niiri:e3eb926753b05559987938d0c0b54b29 .
 
-niiri:1b782d30ef88b5dec50d781f0f8c7b90
+niiri:5f6bfd1e7738d6ee402e8db9bf849c12
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     crypto:sha512 "1b77b11d0ed5eb5364a39bf470d0f2a60530adb3b565ca4d58c5834663570035081dced5ae63a1036f67784fa0d4eb92c202eacfa1c68a761dc92d4c2fdcb635"^^xsd:string .
 
-niiri:3e41323291957893cacf579dfe6cd678
+niiri:05c8f26e316907f21f72409226929af0
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "ed1d9e50bb64b4de72f01f25fc46258c5ff16d5a3d68d40ea557bbba27034b3e58fed559f43140846dfc4326ab88693925e57a7ad459534f78200e11e9ae0fc2"^^xsd:string .
 
-niiri:1b782d30ef88b5dec50d781f0f8c7b90 prov:wasDerivedFrom niiri:3e41323291957893cacf579dfe6cd678 .
+niiri:5f6bfd1e7738d6ee402e8db9bf849c12 prov:wasDerivedFrom niiri:05c8f26e316907f21f72409226929af0 .
 
-niiri:1b782d30ef88b5dec50d781f0f8c7b90 prov:wasGeneratedBy niiri:0949319d2ef4c6c93abc59fd5ab36c60 .
+niiri:5f6bfd1e7738d6ee402e8db9bf849c12 prov:wasGeneratedBy niiri:e3eb926753b05559987938d0c0b54b29 .
 
-niiri:35e15769c5844a4c220e3f2a8ee4db98
+niiri:6771530b3685dd3dff795116450da5b7
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     crypto:sha512 "c82dd92dc43589a48ea05591e3513b0b09d5e196227d549cd8dfe2d6697080f39b3054d1f4b2da18681b3f7d6f9959ed437674a90da99ca27742a7358d832643"^^xsd:string .
 
-niiri:35e15769c5844a4c220e3f2a8ee4db98 prov:wasGeneratedBy niiri:0949319d2ef4c6c93abc59fd5ab36c60 .
+niiri:6771530b3685dd3dff795116450da5b7 prov:wasGeneratedBy niiri:e3eb926753b05559987938d0c0b54b29 .
 
-niiri:7030cadfaa88d7036ca8f29a016c65f8
+niiri:b3d5c88c4c85d76ff21932c996a538d6
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500109473139"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:0dbe0ae4e935c37d15660dce41a4a626 ;
-    nidm_equivalentThreshold: niiri:043660ac38a59f66f758bacb56c24168 .
+    nidm_equivalentThreshold: niiri:7e8b4bd3d47ee964dad44627502a8644 ;
+    nidm_equivalentThreshold: niiri:4b7d70536ac114ad01c0e9b4498d3c07 .
 
-niiri:0dbe0ae4e935c37d15660dce41a4a626
+niiri:7e8b4bd3d47ee964dad44627502a8644
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12930472090591"^^xsd:float .
 
-niiri:043660ac38a59f66f758bacb56c24168
+niiri:4b7d70536ac114ad01c0e9b4498d3c07
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999999071"^^xsd:float .
 
-niiri:da875b2e8e05e4785db8390ac9ca6bea
+niiri:198ec9f3a18190099c85925ab436b938
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:b9c8421cbde2dda368e334ee41445213 ;
-    nidm_equivalentThreshold: niiri:4a5a24bbf6fc3ef6377e86dca3ad0aee .
+    nidm_equivalentThreshold: niiri:bdacc0bac46096d14f3b3dbb41e9fc80 ;
+    nidm_equivalentThreshold: niiri:c68ed99893979c9afe5b40cf03e4138c .
 
-niiri:b9c8421cbde2dda368e334ee41445213
+niiri:bdacc0bac46096d14f3b3dbb41e9fc80
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:4a5a24bbf6fc3ef6377e86dca3ad0aee
+niiri:c68ed99893979c9afe5b40cf03e4138c
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:ce2709f7d21f37e6c1b4b649ea2d0e63
+niiri:92946954f5b6da81dea8e9ac72e36531
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:2a1941c7407f83aa18a742051141d0e3
+niiri:74614276020f94983328fde22a285866
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa
+niiri:f9272534debf5f02f91fdae4134c2588
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:wasAssociatedWith niiri:327a9ff3946f2ec4986e86c53e18fe08 .
+niiri:f9272534debf5f02f91fdae4134c2588 prov:wasAssociatedWith niiri:821b1a9b55ebe0032b859ca5150035ba .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:7030cadfaa88d7036ca8f29a016c65f8 .
+niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:b3d5c88c4c85d76ff21932c996a538d6 .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:da875b2e8e05e4785db8390ac9ca6bea .
+niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:198ec9f3a18190099c85925ab436b938 .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:36547963b0180bf5445943624ff36ab5 .
+niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:9cd280f9a6bb55ac54967cdba205b396 .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:14e90513cadd14ec08d1982515a57568 .
+niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:cdc151b697c0cb04cbe5c7540f511e3b .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:004943b083f15c69d419d7bf95a9a882 .
+niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:0725082be9bac12c7029d6178bc32234 .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:ce2709f7d21f37e6c1b4b649ea2d0e63 .
+niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:92946954f5b6da81dea8e9ac72e36531 .
 
-niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:2a1941c7407f83aa18a742051141d0e3 .
+niiri:f9272534debf5f02f91fdae4134c2588 prov:used niiri:74614276020f94983328fde22a285866 .
 
-niiri:20b1f3fc5f789afa8b55e495a2fb2fe8
+niiri:465c676752e1251c0ebaef3853a92d44
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "70.7136543802373"^^xsd:float ;
@@ -551,9 +551,9 @@ niiri:20b1f3fc5f789afa8b55e495a2fb2fe8
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:20b1f3fc5f789afa8b55e495a2fb2fe8 prov:wasGeneratedBy niiri:18a70c6743d2ee3291ef9fe8ddc693aa .
+niiri:465c676752e1251c0ebaef3853a92d44 prov:wasGeneratedBy niiri:f9272534debf5f02f91fdae4134c2588 .
 
-niiri:0bd3c23f663f5db458405c9f8f024e0e
+niiri:dbc3b401b4cc8fc84857cec6f78458b3
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -561,22 +561,22 @@ niiri:0bd3c23f663f5db458405c9f8f024e0e
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:2a0ad393b6ba67c913ca2734dad76d72 ;
-    nidm_hasMaximumIntensityProjection: niiri:cff9ff1e3ab6021801484e5a4ecd68eb ;
-    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_hasClusterLabelsMap: niiri:04196d57e8d71d662d0ca3a62551db9d ;
+    nidm_hasMaximumIntensityProjection: niiri:210b7648621d83f3b498261707462aa6 ;
+    nidm_inCoordinateSpace: niiri:ad7c74aa0e194b1d0e6a1fe1c514c722 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:2a0ad393b6ba67c913ca2734dad76d72
+niiri:04196d57e8d71d662d0ca3a62551db9d
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:cff9ff1e3ab6021801484e5a4ecd68eb
+niiri:210b7648621d83f3b498261707462aa6
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:0bd3c23f663f5db458405c9f8f024e0e prov:wasGeneratedBy niiri:18a70c6743d2ee3291ef9fe8ddc693aa .
+niiri:dbc3b401b4cc8fc84857cec6f78458b3 prov:wasGeneratedBy niiri:f9272534debf5f02f91fdae4134c2588 .
 

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.ttl
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.ttl
@@ -1,0 +1,582 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:1f3972d440e0662ae30f95394c472c4b
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:4aea73471fd7ac02b19849bf1514b0dc
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:a8918a8d18ab7b5bda372d8835183a06
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:a8918a8d18ab7b5bda372d8835183a06 prov:wasAssociatedWith niiri:4aea73471fd7ac02b19849bf1514b0dc .
+
+_:blank5 a prov:Generation .
+
+niiri:1f3972d440e0662ae30f95394c472c4b prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:10:39"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix spm_SPMsTemporalDerivative: <http://purl.org/nidash/spm#SPM_0000006> .
+@prefix spm_SPMsDispersionDerivative: <http://purl.org/nidash/spm#SPM_0000003> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+
+niiri:327a9ff3946f2ec4986e86c53e18fe08
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:dd9e45ff2bfada42c45b025ad5bbb149
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:e77033de47473eb122f2a499a902fd95
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:f0469999987415c033878a3cd80b6440
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:3b2d1088cc3b6cf7a1a53c6096b3f855
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:f84773591fde4d99c2c8b7683309e6c7 ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) positive feedback\ntask001 co*bf(3)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(3)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:f0469999987415c033878a3cd80b6440 ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
+    nidm_hasHRFBasis: spm_SPMsTemporalDerivative: ;
+    nidm_hasHRFBasis: spm_SPMsDispersionDerivative: .
+
+niiri:f84773591fde4d99c2c8b7683309e6c7
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:27647d7272bcc27c18636264b8b7b214
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:646802f08fa4125c11708667c0a5c56f
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:646802f08fa4125c11708667c0a5c56f prov:wasAssociatedWith niiri:327a9ff3946f2ec4986e86c53e18fe08 .
+
+niiri:646802f08fa4125c11708667c0a5c56f prov:used niiri:3b2d1088cc3b6cf7a1a53c6096b3f855 .
+
+niiri:646802f08fa4125c11708667c0a5c56f prov:used niiri:e77033de47473eb122f2a499a902fd95 .
+
+niiri:646802f08fa4125c11708667c0a5c56f prov:used niiri:27647d7272bcc27c18636264b8b7b214 .
+
+niiri:004943b083f15c69d419d7bf95a9a882
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:53ea54fabcf9cc3042fa0121e09641e4
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
+
+niiri:004943b083f15c69d419d7bf95a9a882 prov:wasDerivedFrom niiri:53ea54fabcf9cc3042fa0121e09641e4 .
+
+niiri:004943b083f15c69d419d7bf95a9a882 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:06d798c010c8dd98bb5dfc11e39816a5
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "121.035133361816"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    crypto:sha512 "9cfeeeacd33286a145a42ac9e011a2cdc19a57aa70e2abfe71114ec159be45b10fc5fb995b21bb253624732dc52d9d34cfa34b774edf3fcb1efceb98db468de1"^^xsd:string .
+
+niiri:06d798c010c8dd98bb5dfc11e39816a5 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:76a8e1ecb96d47328c84ded1e8c9fcce
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+
+niiri:1c1c45d6750b11a734fe2d0d3d04524b
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "05720970946f70a45079d6f6e993cfadfcfd7f2feaa3e1d2478a4b7f2d8508122250847bbebb9f63e10cfc83a8101bc031164e69a4b720ae19d0ed237edc4153"^^xsd:string .
+
+niiri:76a8e1ecb96d47328c84ded1e8c9fcce prov:wasDerivedFrom niiri:1c1c45d6750b11a734fe2d0d3d04524b .
+
+niiri:76a8e1ecb96d47328c84ded1e8c9fcce prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:a81b51f7714cfacea14292d4ce12cbf0
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+
+niiri:e341723ff93635384bb667caa931aac3
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "7dfb234cef66f41020d9840fa271a63501a32a27d11f6ea831b79c314b7f68243bffc1dfaf789eca3e1ce384b55cf7f4c351c76ed21c15b1bfad448cb5718533"^^xsd:string .
+
+niiri:a81b51f7714cfacea14292d4ce12cbf0 prov:wasDerivedFrom niiri:e341723ff93635384bb667caa931aac3 .
+
+niiri:a81b51f7714cfacea14292d4ce12cbf0 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:f924a4b144030137570a5f4ec3bdd383
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+
+niiri:4659d0e70e9587adefe084a2e56740c6
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "663dc1415b03fdf028c1664564ab6291bcb3ad6d0490820f5b22566245799297c4780d000158d93d7ffaae4bb2eb267a1acd8871b99d15d0d0c4cd4bdb5d9e68"^^xsd:string .
+
+niiri:f924a4b144030137570a5f4ec3bdd383 prov:wasDerivedFrom niiri:4659d0e70e9587adefe084a2e56740c6 .
+
+niiri:f924a4b144030137570a5f4ec3bdd383 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:e13bd961e1ab6c34ce552b7e2cf3def2
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 4" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+
+niiri:ba6b830f0e3883fbfd2edd369325478e
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0004.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "03416c893a6bd36d720ab1953be4b0f47180f3aa1c2d22fbe74aa1070f97804a275e1f5ee2bec9a395485337986b7592e6284676ed3bddc39bf649d6c48c91de"^^xsd:string .
+
+niiri:e13bd961e1ab6c34ce552b7e2cf3def2 prov:wasDerivedFrom niiri:ba6b830f0e3883fbfd2edd369325478e .
+
+niiri:e13bd961e1ab6c34ce552b7e2cf3def2 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:6907c49ae94c1c59885dff7ba73b6ad2
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 5" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+
+niiri:b53565d569027fb62e62b8a8fcd63f2d
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0005.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "27acde5836e2523829c5674edec7a5f66b1080c86ab827a84fa0eb267a95db1e7bcaaa026c6b37df921eaae895c2ed019332fda17800aeaf5863238990b7ca9c"^^xsd:string .
+
+niiri:6907c49ae94c1c59885dff7ba73b6ad2 prov:wasDerivedFrom niiri:b53565d569027fb62e62b8a8fcd63f2d .
+
+niiri:6907c49ae94c1c59885dff7ba73b6ad2 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:3e47abc4258d401bfcd12c1c17335fa9
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 6" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+
+niiri:51f8e9ed2e8e64c7361c7f7a2502b9e9
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0006.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "591a8b7d598a0840aefab5c1305400550852acd74f2256bbe815a51de82bd5e8d56969fbe3d925e9165605ad777a9a1df5e7d8e5552d99e0f8d7c505216fdf42"^^xsd:string .
+
+niiri:3e47abc4258d401bfcd12c1c17335fa9 prov:wasDerivedFrom niiri:51f8e9ed2e8e64c7361c7f7a2502b9e9 .
+
+niiri:3e47abc4258d401bfcd12c1c17335fa9 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:05f7c6a5d3f20dacc4c00e1767077eb2
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 7" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 .
+
+niiri:e25a10393592506fe41e9eff6aa4bb0f
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0007.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b4442e57fdbbe43c7374152d776957e9525ba67958ddca2e879f063a43b79317a228120a338c86a410e7faedc80738c7ac91afcead568bbeaf2980e913b7370a"^^xsd:string .
+
+niiri:05f7c6a5d3f20dacc4c00e1767077eb2 prov:wasDerivedFrom niiri:e25a10393592506fe41e9eff6aa4bb0f .
+
+niiri:05f7c6a5d3f20dacc4c00e1767077eb2 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:89cdd5a0418dc30cb86718044231b9fb
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    crypto:sha512 "e55dbb4bcee078ef7f7cffb3a618fe4900cc54aa2d4482f39b220812891dac5729209d7d84f387d3eac601ae9b0f64b16b6e23eea6f83f23429197dc25975aaf"^^xsd:string .
+
+niiri:87c25e6525ec7ca193b9e43fc70db585
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "2d5bbdabc64950a9e8b9f7e9db623cebbff2cd835a3228e6c3f8249fed6f7d681b30b37254d070279984ce6c9e0600e944671ff5a7c68312d647dc3b6eb4330e"^^xsd:string .
+
+niiri:89cdd5a0418dc30cb86718044231b9fb prov:wasDerivedFrom niiri:87c25e6525ec7ca193b9e43fc70db585 .
+
+niiri:89cdd5a0418dc30cb86718044231b9fb prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:14e90513cadd14ec08d1982515a57568
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    crypto:sha512 "80e17a085bd95aaddf708f772f29ca49b44fd1a3a621b55b1c73687e66aba3d4d5ca5d463b38adf7ddfdfb9435f090d31911fc9277418c9a8eced4ef2b88d4dc"^^xsd:string .
+
+niiri:4bff0c6abe7073e4e149a8ef4871bf59
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "4e0032db2fac38eb7ef64e9c6e2348af2bfdab0c05e04dea32b885b6c5f2519bf2e93fa4f7fb9d48292036b950446b841d73fbb92e15a969126e16d093193cee"^^xsd:string .
+
+niiri:14e90513cadd14ec08d1982515a57568 prov:wasDerivedFrom niiri:4bff0c6abe7073e4e149a8ef4871bf59 .
+
+niiri:14e90513cadd14ec08d1982515a57568 prov:wasGeneratedBy niiri:646802f08fa4125c11708667c0a5c56f .
+
+niiri:3184176bcf5c4d11386c89ec66785dc5
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    rdfs:label "Contrast: pos vs neg" ;
+    prov:value "[1, 0, 0, -1, 0, 0, 0]"^^xsd:string .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:wasAssociatedWith niiri:327a9ff3946f2ec4986e86c53e18fe08 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:004943b083f15c69d419d7bf95a9a882 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:89cdd5a0418dc30cb86718044231b9fb .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:3b2d1088cc3b6cf7a1a53c6096b3f855 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:3184176bcf5c4d11386c89ec66785dc5 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:76a8e1ecb96d47328c84ded1e8c9fcce .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:a81b51f7714cfacea14292d4ce12cbf0 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:f924a4b144030137570a5f4ec3bdd383 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:e13bd961e1ab6c34ce552b7e2cf3def2 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:6907c49ae94c1c59885dff7ba73b6ad2 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:3e47abc4258d401bfcd12c1c17335fa9 .
+
+niiri:0949319d2ef4c6c93abc59fd5ab36c60 prov:used niiri:05f7c6a5d3f20dacc4c00e1767077eb2 .
+
+niiri:36547963b0180bf5445943624ff36ab5
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: pos vs neg" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "210.999999999887"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    crypto:sha512 "861f189848ac564804db8d7d7d6a9970a77ba0c0ffb158a758286519a0f03587e0ca9212a3e324139de312ee530d0b4922a68f8d63141ae762ae109abd9cd0f7"^^xsd:string .
+
+niiri:6f69458ac8e2905970d1867b3a690ea7
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "957b56d667b0101f7737111353cf7027bd3a5250b64386a416e7dbff994334124bc217c1123f1565ade6e2de13adb18951063665f5a483eee01f6cf4a3ef46aa"^^xsd:string .
+
+niiri:36547963b0180bf5445943624ff36ab5 prov:wasDerivedFrom niiri:6f69458ac8e2905970d1867b3a690ea7 .
+
+niiri:36547963b0180bf5445943624ff36ab5 prov:wasGeneratedBy niiri:0949319d2ef4c6c93abc59fd5ab36c60 .
+
+niiri:1b782d30ef88b5dec50d781f0f8c7b90
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: pos vs neg" ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    crypto:sha512 "1b77b11d0ed5eb5364a39bf470d0f2a60530adb3b565ca4d58c5834663570035081dced5ae63a1036f67784fa0d4eb92c202eacfa1c68a761dc92d4c2fdcb635"^^xsd:string .
+
+niiri:3e41323291957893cacf579dfe6cd678
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "ed1d9e50bb64b4de72f01f25fc46258c5ff16d5a3d68d40ea557bbba27034b3e58fed559f43140846dfc4326ab88693925e57a7ad459534f78200e11e9ae0fc2"^^xsd:string .
+
+niiri:1b782d30ef88b5dec50d781f0f8c7b90 prov:wasDerivedFrom niiri:3e41323291957893cacf579dfe6cd678 .
+
+niiri:1b782d30ef88b5dec50d781f0f8c7b90 prov:wasGeneratedBy niiri:0949319d2ef4c6c93abc59fd5ab36c60 .
+
+niiri:35e15769c5844a4c220e3f2a8ee4db98
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    crypto:sha512 "c82dd92dc43589a48ea05591e3513b0b09d5e196227d549cd8dfe2d6697080f39b3054d1f4b2da18681b3f7d6f9959ed437674a90da99ca27742a7358d832643"^^xsd:string .
+
+niiri:35e15769c5844a4c220e3f2a8ee4db98 prov:wasGeneratedBy niiri:0949319d2ef4c6c93abc59fd5ab36c60 .
+
+niiri:7030cadfaa88d7036ca8f29a016c65f8
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    prov:value "0.000999500109473139"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:0dbe0ae4e935c37d15660dce41a4a626 ;
+    nidm_equivalentThreshold: niiri:043660ac38a59f66f758bacb56c24168 .
+
+niiri:0dbe0ae4e935c37d15660dce41a4a626
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "3.12930472090591"^^xsd:float .
+
+niiri:043660ac38a59f66f758bacb56c24168
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.999999999999071"^^xsd:float .
+
+niiri:da875b2e8e05e4785db8390ac9ca6bea
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:b9c8421cbde2dda368e334ee41445213 ;
+    nidm_equivalentThreshold: niiri:4a5a24bbf6fc3ef6377e86dca3ad0aee .
+
+niiri:b9c8421cbde2dda368e334ee41445213
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:4a5a24bbf6fc3ef6377e86dca3ad0aee
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:ce2709f7d21f37e6c1b4b649ea2d0e63
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:2a1941c7407f83aa18a742051141d0e3
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:wasAssociatedWith niiri:327a9ff3946f2ec4986e86c53e18fe08 .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:7030cadfaa88d7036ca8f29a016c65f8 .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:da875b2e8e05e4785db8390ac9ca6bea .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:36547963b0180bf5445943624ff36ab5 .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:14e90513cadd14ec08d1982515a57568 .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:004943b083f15c69d419d7bf95a9a882 .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:ce2709f7d21f37e6c1b4b649ea2d0e63 .
+
+niiri:18a70c6743d2ee3291ef9fe8ddc693aa prov:used niiri:2a1941c7407f83aa18a742051141d0e3 .
+
+niiri:20b1f3fc5f789afa8b55e495a2fb2fe8
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
+    nidm_reselSizeInVoxels: "70.7136543802373"^^xsd:float ;
+    nidm_searchVolumeInResels: "2692.90282999741"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[3, 68.9594164134199, 858.533812023484, 2692.90282999741]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[3.99462540569425, 4.05658931798885, 4.36381347533009]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[7.98925081138849, 8.11317863597769, 8.72762695066017]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "8.09886000027364"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "27.7043233277657"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.05796155312953"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:20b1f3fc5f789afa8b55e495a2fb2fe8 prov:wasGeneratedBy niiri:18a70c6743d2ee3291ef9fe8ddc693aa .
+
+niiri:0bd3c23f663f5db458405c9f8f024e0e
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
+    nidm_pValue: "NaN"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:2a0ad393b6ba67c913ca2734dad76d72 ;
+    nidm_hasMaximumIntensityProjection: niiri:cff9ff1e3ab6021801484e5a4ecd68eb ;
+    nidm_inCoordinateSpace: niiri:dd9e45ff2bfada42c45b025ad5bbb149 ;
+    crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
+
+niiri:2a0ad393b6ba67c913ca2734dad76d72
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:cff9ff1e3ab6021801484e5a4ecd68eb
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:0bd3c23f663f5db458405c9f8f024e0e prov:wasGeneratedBy niiri:18a70c6743d2ee3291ef9fe8ddc693aa .
+

--- a/spmexport/ex_spm_cluster_k=10/config.json
+++ b/spmexport/ex_spm_cluster_k=10/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["cluster_k=10/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_cluster_k=10/nidm.provn
+++ b/spmexport/ex_spm_cluster_k=10/nidm.provn
@@ -1,0 +1,429 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:9449f881f320ad65c0195d3387c30a2e,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:062a98df9292e26631122f63a41b58d0,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:f651bbd5783f6da38ccab3cb342e8e99,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:f651bbd5783f6da38ccab3cb342e8e99, niiri:062a98df9292e26631122f63a41b58d0, -)
+  wasGeneratedBy(niiri:9449f881f320ad65c0195d3387c30a2e, niiri:f651bbd5783f6da38ccab3cb342e8e99, 2016-01-11T10:10:44)
+  bundle niiri:9449f881f320ad65c0195d3387c30a2e
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+
+    agent(niiri:5011a96e9a9e647d5829f116e9e2f2ee,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:87e5f074e3bdf383e5e3536f4a27d77f,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:2f77d65f7e8a62a2d5166425b98d93eb,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:6d7587ab20a82666808f9226b4a2699b,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:08e0a01ea31533be60b14d2cc0a2765a,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:224a21c90b30fb683181e5a4d434f85b',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:6d7587ab20a82666808f9226b4a2699b',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:224a21c90b30fb683181e5a4d434f85b,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:6697e72e43e42fd9f394dfd69b32fe3a,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:73e4bcd18595f9be07fc6be49c14f9c8,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:73e4bcd18595f9be07fc6be49c14f9c8, niiri:5011a96e9a9e647d5829f116e9e2f2ee, -)
+    used(niiri:73e4bcd18595f9be07fc6be49c14f9c8, niiri:08e0a01ea31533be60b14d2cc0a2765a, -)
+    used(niiri:73e4bcd18595f9be07fc6be49c14f9c8, niiri:2f77d65f7e8a62a2d5166425b98d93eb, -)
+    used(niiri:73e4bcd18595f9be07fc6be49c14f9c8, niiri:6697e72e43e42fd9f394dfd69b32fe3a, -)
+    entity(niiri:c94b6bb9cefdda1ca08b6aa65ba38d43,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    entity(niiri:6a6ffd37e1447a6da9f6fa3f00725ccb,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
+    wasDerivedFrom(niiri:c94b6bb9cefdda1ca08b6aa65ba38d43, niiri:6a6ffd37e1447a6da9f6fa3f00725ccb, -, -, -)
+    wasGeneratedBy(niiri:c94b6bb9cefdda1ca08b6aa65ba38d43, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
+    entity(niiri:d6bff2c35013b26528176ecaab0aa740,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "121.744659423828" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
+    wasGeneratedBy(niiri:d6bff2c35013b26528176ecaab0aa740, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
+    entity(niiri:7a09cffef2a3dea868bf6a59a4586f94,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f'])
+    entity(niiri:2f8eafff2f7b1f6e0000c1fa4371055e,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
+    wasDerivedFrom(niiri:7a09cffef2a3dea868bf6a59a4586f94, niiri:2f8eafff2f7b1f6e0000c1fa4371055e, -, -, -)
+    wasGeneratedBy(niiri:7a09cffef2a3dea868bf6a59a4586f94, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
+    entity(niiri:07400ebb43ba60f54c44501344a4b56e,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f'])
+    entity(niiri:f5bdbc7353a5afa43109b95d30313c05,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
+    wasDerivedFrom(niiri:07400ebb43ba60f54c44501344a4b56e, niiri:f5bdbc7353a5afa43109b95d30313c05, -, -, -)
+    wasGeneratedBy(niiri:07400ebb43ba60f54c44501344a4b56e, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
+    entity(niiri:5d08d6b8a41532b39634538b2891e0fc,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f'])
+    entity(niiri:7495cb56f2e748c5f495d5036a7893ea,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
+    wasDerivedFrom(niiri:5d08d6b8a41532b39634538b2891e0fc, niiri:7495cb56f2e748c5f495d5036a7893ea, -, -, -)
+    wasGeneratedBy(niiri:5d08d6b8a41532b39634538b2891e0fc, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
+    entity(niiri:a88c9d654c14f8a90bfa7adfeddf2fc8,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
+    entity(niiri:04d9cb6363085b466b1dc55b4ebd4560,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
+    wasDerivedFrom(niiri:a88c9d654c14f8a90bfa7adfeddf2fc8, niiri:04d9cb6363085b466b1dc55b4ebd4560, -, -, -)
+    wasGeneratedBy(niiri:a88c9d654c14f8a90bfa7adfeddf2fc8, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
+    entity(niiri:467a9e29edf6b22ca7e25b823dea3e7d,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
+    entity(niiri:721f7d6540e9b6d370dd1632cdb5acda,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
+    wasDerivedFrom(niiri:467a9e29edf6b22ca7e25b823dea3e7d, niiri:721f7d6540e9b6d370dd1632cdb5acda, -, -, -)
+    wasGeneratedBy(niiri:467a9e29edf6b22ca7e25b823dea3e7d, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
+    entity(niiri:18b2f17a14a90f5777b07c55b110f8a5,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        prov:label = "Contrast: pos vs neg" %% xsd:string,
+        prov:value = "[1, -1, 0]" %% xsd:string])
+    activity(niiri:d64590c390e5de26a3120129667418d4,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:d64590c390e5de26a3120129667418d4, niiri:5011a96e9a9e647d5829f116e9e2f2ee, -)
+    used(niiri:d64590c390e5de26a3120129667418d4, niiri:c94b6bb9cefdda1ca08b6aa65ba38d43, -)
+    used(niiri:d64590c390e5de26a3120129667418d4, niiri:a88c9d654c14f8a90bfa7adfeddf2fc8, -)
+    used(niiri:d64590c390e5de26a3120129667418d4, niiri:08e0a01ea31533be60b14d2cc0a2765a, -)
+    used(niiri:d64590c390e5de26a3120129667418d4, niiri:18b2f17a14a90f5777b07c55b110f8a5, -)
+    used(niiri:d64590c390e5de26a3120129667418d4, niiri:7a09cffef2a3dea868bf6a59a4586f94, -)
+    used(niiri:d64590c390e5de26a3120129667418d4, niiri:07400ebb43ba60f54c44501344a4b56e, -)
+    used(niiri:d64590c390e5de26a3120129667418d4, niiri:5d08d6b8a41532b39634538b2891e0fc, -)
+    entity(niiri:79ba69c016442c10f09aea4fdd4eba43,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: pos vs neg" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
+    entity(niiri:0666702921cf126beef3ee114c5593c0,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
+    wasDerivedFrom(niiri:79ba69c016442c10f09aea4fdd4eba43, niiri:0666702921cf126beef3ee114c5593c0, -, -, -)
+    wasGeneratedBy(niiri:79ba69c016442c10f09aea4fdd4eba43, niiri:d64590c390e5de26a3120129667418d4, -)
+    entity(niiri:27dd101123da0ecd4789cbd170394fc4,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: pos vs neg" %% xsd:string,
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
+    entity(niiri:d1b03d4237a689cc2bf0fed073f39d38,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
+    wasDerivedFrom(niiri:27dd101123da0ecd4789cbd170394fc4, niiri:d1b03d4237a689cc2bf0fed073f39d38, -, -, -)
+    wasGeneratedBy(niiri:27dd101123da0ecd4789cbd170394fc4, niiri:d64590c390e5de26a3120129667418d4, -)
+    entity(niiri:0876d6ced1df2b733994c394eb2987ab,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
+    wasGeneratedBy(niiri:0876d6ced1df2b733994c394eb2987ab, niiri:d64590c390e5de26a3120129667418d4, -)
+    entity(niiri:a96bfe771da694d4deaca900ed24aa26,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
+        prov:value = "0.000999499751574873" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:0e9b34e0700ccef01e185b1bb6503625',
+        nidm_equivalentThreshold: = 'niiri:b1d0f45c117a40ae1d0672f42d7ee8ee'])
+    entity(niiri:0e9b34e0700ccef01e185b1bb6503625,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "3.12856968604193" %% xsd:float])
+    entity(niiri:b1d0f45c117a40ae1d0672f42d7ee8ee,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.999999999998566" %% xsd:float])
+    entity(niiri:ad376ea1c4942b6d0ae711a894d3e2de,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:e8f3acb443dea652057348179b459923',
+        nidm_equivalentThreshold: = 'niiri:396eddd1ebb2cca6516c3e872baf274d'])
+    entity(niiri:e8f3acb443dea652057348179b459923,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:396eddd1ebb2cca6516c3e872baf274d,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:724450a5b7af89d3b7806bbded2f930f,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:894e6d58b20b5595d52c5c8ecb1992e6,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:b82408568590536603047ae743dc72dc,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:b82408568590536603047ae743dc72dc, niiri:5011a96e9a9e647d5829f116e9e2f2ee, -)
+    used(niiri:b82408568590536603047ae743dc72dc, niiri:a96bfe771da694d4deaca900ed24aa26, -)
+    used(niiri:b82408568590536603047ae743dc72dc, niiri:ad376ea1c4942b6d0ae711a894d3e2de, -)
+    used(niiri:b82408568590536603047ae743dc72dc, niiri:79ba69c016442c10f09aea4fdd4eba43, -)
+    used(niiri:b82408568590536603047ae743dc72dc, niiri:467a9e29edf6b22ca7e25b823dea3e7d, -)
+    used(niiri:b82408568590536603047ae743dc72dc, niiri:c94b6bb9cefdda1ca08b6aa65ba38d43, -)
+    used(niiri:b82408568590536603047ae743dc72dc, niiri:724450a5b7af89d3b7806bbded2f930f, -)
+    used(niiri:b82408568590536603047ae743dc72dc, niiri:894e6d58b20b5595d52c5c8ecb1992e6, -)
+    entity(niiri:d81475d12fd44c5d43edf8f88a66b7d3,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
+        nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
+        nidm_searchVolumeInResels: = "2650.12011223711" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.01704921884936, 4.07618247398105, 4.38831339907177]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.03409843769872, 8.1523649479621, 8.77662679814353]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "8.23486077915088" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "27.2707251644655" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.05094049746367" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    wasGeneratedBy(niiri:d81475d12fd44c5d43edf8f88a66b7d3, niiri:b82408568590536603047ae743dc72dc, -)
+    entity(niiri:a0053e188033e4d983abdb7f15cf7bf3,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
+        nidm_pValue: = "NaN" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:98caab641764a7f4bf5cef915e96ddf4',
+        nidm_hasMaximumIntensityProjection: = 'niiri:293ecd5ffdaae7066ab03a8c333f120b',
+        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
+    entity(niiri:98caab641764a7f4bf5cef915e96ddf4,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:293ecd5ffdaae7066ab03a8c333f120b,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:a0053e188033e4d983abdb7f15cf7bf3, niiri:b82408568590536603047ae743dc72dc, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_cluster_k=10/nidm.provn
+++ b/spmexport/ex_spm_cluster_k=10/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:c60878523466befdb4ba03bec2a31f3c,
+  entity(niiri:f8f4959f331b60ba01cd45132ece134e,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:74bc372b868aad9af801c2a853977679,
+  agent(niiri:0fb2a4cee78fbd169d6cadc2dfb52cdb,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:9ef76f336a18a57bf45ca202a46e5c9f,
+  activity(niiri:25764e7c2fab4be9a26de9e58f89c317,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:9ef76f336a18a57bf45ca202a46e5c9f, niiri:74bc372b868aad9af801c2a853977679, -)
-  wasGeneratedBy(niiri:c60878523466befdb4ba03bec2a31f3c, niiri:9ef76f336a18a57bf45ca202a46e5c9f, 2016-01-11T10:32:06)
-  bundle niiri:c60878523466befdb4ba03bec2a31f3c
+  wasAssociatedWith(niiri:25764e7c2fab4be9a26de9e58f89c317, niiri:0fb2a4cee78fbd169d6cadc2dfb52cdb, -)
+  wasGeneratedBy(niiri:f8f4959f331b60ba01cd45132ece134e, niiri:25764e7c2fab4be9a26de9e58f89c317, 2016-01-11T10:43:26)
+  bundle niiri:f8f4959f331b60ba01cd45132ece134e
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:1d0e9f058cf6254a45a221ea959dd872,
+    agent(niiri:36e0ca6e862ec6354f9837b33735c25b,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:be0006a57dffdd0820b4b36657cc9b94,
+    entity(niiri:86fbbec53aa7243bc5d23697658a64ea,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:eb713efa2e1fcb60d21f2884b08dc899,
+    entity(niiri:8e2f547b88d0b10dd503b6f33eb34fdf,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:f137d651dee30f9caf333f41e6364794,
+    entity(niiri:3345c91fd2591b0f2c2f6b3c9028f2dd,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:c8ab5704c73f1a9bb81f64cb1449243e,
+    entity(niiri:f1dfb0da2f98dbeb54f3aafd24e0e798,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:eecb83ec61dce78815637ca966505c20',
+        dc:description = 'niiri:38f212e9d7122c63fb10fbe9b7eacdf0',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:f137d651dee30f9caf333f41e6364794',
+        nidm_hasDriftModel: = 'niiri:3345c91fd2591b0f2c2f6b3c9028f2dd',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:eecb83ec61dce78815637ca966505c20,
+    entity(niiri:38f212e9d7122c63fb10fbe9b7eacdf0,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:aab6190fe17da63a98083b3eec133959,
+    entity(niiri:c512b23a0b5137e168cf0fbd7ff9e103,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:7c90be579fb4f97b5579f5d12f0ef01e,
+    activity(niiri:bbf4abb1d4e900034f7e2514c9d594ec,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:7c90be579fb4f97b5579f5d12f0ef01e, niiri:1d0e9f058cf6254a45a221ea959dd872, -)
-    used(niiri:7c90be579fb4f97b5579f5d12f0ef01e, niiri:c8ab5704c73f1a9bb81f64cb1449243e, -)
-    used(niiri:7c90be579fb4f97b5579f5d12f0ef01e, niiri:eb713efa2e1fcb60d21f2884b08dc899, -)
-    used(niiri:7c90be579fb4f97b5579f5d12f0ef01e, niiri:aab6190fe17da63a98083b3eec133959, -)
-    entity(niiri:c798bba76a13857f8244d5ad67ff103b,
+    wasAssociatedWith(niiri:bbf4abb1d4e900034f7e2514c9d594ec, niiri:36e0ca6e862ec6354f9837b33735c25b, -)
+    used(niiri:bbf4abb1d4e900034f7e2514c9d594ec, niiri:f1dfb0da2f98dbeb54f3aafd24e0e798, -)
+    used(niiri:bbf4abb1d4e900034f7e2514c9d594ec, niiri:8e2f547b88d0b10dd503b6f33eb34fdf, -)
+    used(niiri:bbf4abb1d4e900034f7e2514c9d594ec, niiri:c512b23a0b5137e168cf0fbd7ff9e103, -)
+    entity(niiri:1ed2d81eecb89474d5a861917dd60e81,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:e9b2e75d3b7ec541b60914377333b3be,
+    entity(niiri:14fea21e8246f5d8a83a3c81f9efa499,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:c798bba76a13857f8244d5ad67ff103b, niiri:e9b2e75d3b7ec541b60914377333b3be, -, -, -)
-    wasGeneratedBy(niiri:c798bba76a13857f8244d5ad67ff103b, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
-    entity(niiri:69606415c39792ea689be7af6a0b0bb6,
+    wasDerivedFrom(niiri:1ed2d81eecb89474d5a861917dd60e81, niiri:14fea21e8246f5d8a83a3c81f9efa499, -, -, -)
+    wasGeneratedBy(niiri:1ed2d81eecb89474d5a861917dd60e81, niiri:bbf4abb1d4e900034f7e2514c9d594ec, -)
+    entity(niiri:667c362b175ef1267cc6af7adb4a2e1d,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:69606415c39792ea689be7af6a0b0bb6, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
-    entity(niiri:17a43d125a7f79b826e0854c9208a82f,
+    wasGeneratedBy(niiri:667c362b175ef1267cc6af7adb4a2e1d, niiri:bbf4abb1d4e900034f7e2514c9d594ec, -)
+    entity(niiri:f61676e7d608d77611de78e41c4847aa,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94'])
-    entity(niiri:14254ef88d467810b2dbee23a6ae18a2,
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea'])
+    entity(niiri:740e6d1f27ce4332e8358c7a43f5e17b,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:17a43d125a7f79b826e0854c9208a82f, niiri:14254ef88d467810b2dbee23a6ae18a2, -, -, -)
-    wasGeneratedBy(niiri:17a43d125a7f79b826e0854c9208a82f, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
-    entity(niiri:7a7c15d2b4bfdb97b404fc0e16d83823,
+    wasDerivedFrom(niiri:f61676e7d608d77611de78e41c4847aa, niiri:740e6d1f27ce4332e8358c7a43f5e17b, -, -, -)
+    wasGeneratedBy(niiri:f61676e7d608d77611de78e41c4847aa, niiri:bbf4abb1d4e900034f7e2514c9d594ec, -)
+    entity(niiri:54ea04431ae710eb05e81741cc32410e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94'])
-    entity(niiri:7f42342c32069b3e6ec221bbeab6f472,
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea'])
+    entity(niiri:3f0f272a8f4a6b36aeede2139854c5a1,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:7a7c15d2b4bfdb97b404fc0e16d83823, niiri:7f42342c32069b3e6ec221bbeab6f472, -, -, -)
-    wasGeneratedBy(niiri:7a7c15d2b4bfdb97b404fc0e16d83823, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
-    entity(niiri:24f0614f12d5f2985cce3d892be55bcc,
+    wasDerivedFrom(niiri:54ea04431ae710eb05e81741cc32410e, niiri:3f0f272a8f4a6b36aeede2139854c5a1, -, -, -)
+    wasGeneratedBy(niiri:54ea04431ae710eb05e81741cc32410e, niiri:bbf4abb1d4e900034f7e2514c9d594ec, -)
+    entity(niiri:514ad018ba4d5e4b572be280b0667d18,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94'])
-    entity(niiri:607ca1c2f891e4ce713ca8444b3429fe,
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea'])
+    entity(niiri:cc8c0c3ae879b09e3c53cd1c8813da3c,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:24f0614f12d5f2985cce3d892be55bcc, niiri:607ca1c2f891e4ce713ca8444b3429fe, -, -, -)
-    wasGeneratedBy(niiri:24f0614f12d5f2985cce3d892be55bcc, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
-    entity(niiri:aa47cd87d32100529ed9ccb7ff9f596d,
+    wasDerivedFrom(niiri:514ad018ba4d5e4b572be280b0667d18, niiri:cc8c0c3ae879b09e3c53cd1c8813da3c, -, -, -)
+    wasGeneratedBy(niiri:514ad018ba4d5e4b572be280b0667d18, niiri:bbf4abb1d4e900034f7e2514c9d594ec, -)
+    entity(niiri:9e6316cdd5d5173a2d217ddeb1d7b4b8,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:32a4f215fd539ba5ce8e3fd646e19810,
+    entity(niiri:6e6b75ffa063c7fd257930a57f439401,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:aa47cd87d32100529ed9ccb7ff9f596d, niiri:32a4f215fd539ba5ce8e3fd646e19810, -, -, -)
-    wasGeneratedBy(niiri:aa47cd87d32100529ed9ccb7ff9f596d, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
-    entity(niiri:ae93c509341f396c5dd29a576a0f196b,
+    wasDerivedFrom(niiri:9e6316cdd5d5173a2d217ddeb1d7b4b8, niiri:6e6b75ffa063c7fd257930a57f439401, -, -, -)
+    wasGeneratedBy(niiri:9e6316cdd5d5173a2d217ddeb1d7b4b8, niiri:bbf4abb1d4e900034f7e2514c9d594ec, -)
+    entity(niiri:8b8985a1b7809ee217a07d3a01112aad,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:c574ee9b1828f6901f22dd38af2f4498,
+    entity(niiri:f17454fc2b30cfefd7bb4a0d8940c2d1,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:ae93c509341f396c5dd29a576a0f196b, niiri:c574ee9b1828f6901f22dd38af2f4498, -, -, -)
-    wasGeneratedBy(niiri:ae93c509341f396c5dd29a576a0f196b, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
-    entity(niiri:4855ce8cf932e2c0213dbe52e5931dd3,
+    wasDerivedFrom(niiri:8b8985a1b7809ee217a07d3a01112aad, niiri:f17454fc2b30cfefd7bb4a0d8940c2d1, -, -, -)
+    wasGeneratedBy(niiri:8b8985a1b7809ee217a07d3a01112aad, niiri:bbf4abb1d4e900034f7e2514c9d594ec, -)
+    entity(niiri:0b65c6badbfb7cfbb69c356ceda191a3,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:23058168747c80b31801d261abaf2585,
+    activity(niiri:013c2f9958e67d5f41df562f07751576,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:23058168747c80b31801d261abaf2585, niiri:1d0e9f058cf6254a45a221ea959dd872, -)
-    used(niiri:23058168747c80b31801d261abaf2585, niiri:c798bba76a13857f8244d5ad67ff103b, -)
-    used(niiri:23058168747c80b31801d261abaf2585, niiri:aa47cd87d32100529ed9ccb7ff9f596d, -)
-    used(niiri:23058168747c80b31801d261abaf2585, niiri:c8ab5704c73f1a9bb81f64cb1449243e, -)
-    used(niiri:23058168747c80b31801d261abaf2585, niiri:4855ce8cf932e2c0213dbe52e5931dd3, -)
-    used(niiri:23058168747c80b31801d261abaf2585, niiri:17a43d125a7f79b826e0854c9208a82f, -)
-    used(niiri:23058168747c80b31801d261abaf2585, niiri:7a7c15d2b4bfdb97b404fc0e16d83823, -)
-    used(niiri:23058168747c80b31801d261abaf2585, niiri:24f0614f12d5f2985cce3d892be55bcc, -)
-    entity(niiri:3be097d50565d12830332d18ecd1880b,
+    wasAssociatedWith(niiri:013c2f9958e67d5f41df562f07751576, niiri:36e0ca6e862ec6354f9837b33735c25b, -)
+    used(niiri:013c2f9958e67d5f41df562f07751576, niiri:1ed2d81eecb89474d5a861917dd60e81, -)
+    used(niiri:013c2f9958e67d5f41df562f07751576, niiri:9e6316cdd5d5173a2d217ddeb1d7b4b8, -)
+    used(niiri:013c2f9958e67d5f41df562f07751576, niiri:f1dfb0da2f98dbeb54f3aafd24e0e798, -)
+    used(niiri:013c2f9958e67d5f41df562f07751576, niiri:0b65c6badbfb7cfbb69c356ceda191a3, -)
+    used(niiri:013c2f9958e67d5f41df562f07751576, niiri:f61676e7d608d77611de78e41c4847aa, -)
+    used(niiri:013c2f9958e67d5f41df562f07751576, niiri:54ea04431ae710eb05e81741cc32410e, -)
+    used(niiri:013c2f9958e67d5f41df562f07751576, niiri:514ad018ba4d5e4b572be280b0667d18, -)
+    entity(niiri:a7b5269861512e622fc8bb26dd1620ca,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:c5af634b6d6d3deb00ab9c5c0075afb2,
+    entity(niiri:6f4f218c58a0b571ffd4969c2d5121bc,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:3be097d50565d12830332d18ecd1880b, niiri:c5af634b6d6d3deb00ab9c5c0075afb2, -, -, -)
-    wasGeneratedBy(niiri:3be097d50565d12830332d18ecd1880b, niiri:23058168747c80b31801d261abaf2585, -)
-    entity(niiri:f4f453b84f2b87845707493a3e41f364,
+    wasDerivedFrom(niiri:a7b5269861512e622fc8bb26dd1620ca, niiri:6f4f218c58a0b571ffd4969c2d5121bc, -, -, -)
+    wasGeneratedBy(niiri:a7b5269861512e622fc8bb26dd1620ca, niiri:013c2f9958e67d5f41df562f07751576, -)
+    entity(niiri:006639a78a9af29178283b1fda7faa95,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:21436c6961fca1af4342e037b0700593,
+    entity(niiri:d5e56b78c24e6dee0385caabf0543fac,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:f4f453b84f2b87845707493a3e41f364, niiri:21436c6961fca1af4342e037b0700593, -, -, -)
-    wasGeneratedBy(niiri:f4f453b84f2b87845707493a3e41f364, niiri:23058168747c80b31801d261abaf2585, -)
-    entity(niiri:625c994b0145a32cc974b8ed37d688e1,
+    wasDerivedFrom(niiri:006639a78a9af29178283b1fda7faa95, niiri:d5e56b78c24e6dee0385caabf0543fac, -, -, -)
+    wasGeneratedBy(niiri:006639a78a9af29178283b1fda7faa95, niiri:013c2f9958e67d5f41df562f07751576, -)
+    entity(niiri:cd8091b6f5b7827b1b16705109d4bd28,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:625c994b0145a32cc974b8ed37d688e1, niiri:23058168747c80b31801d261abaf2585, -)
-    entity(niiri:d4752660d42d5cf12c96b2666e7a2f38,
+    wasGeneratedBy(niiri:cd8091b6f5b7827b1b16705109d4bd28, niiri:013c2f9958e67d5f41df562f07751576, -)
+    entity(niiri:f9baa5ab83d70de5496f1564ff4eefd8,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
         prov:value = "0.000999499751574873" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:d0868054f274b2d15c52d8ede9b646c0',
-        nidm_equivalentThreshold: = 'niiri:5a521f9d3fba49a3acde5b1cf93758d7'])
-    entity(niiri:d0868054f274b2d15c52d8ede9b646c0,
+        nidm_equivalentThreshold: = 'niiri:d3cd6b74aa515ea691704d65a66e0ba5',
+        nidm_equivalentThreshold: = 'niiri:e40a357f9371360109c3bef80abba047'])
+    entity(niiri:d3cd6b74aa515ea691704d65a66e0ba5,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12856968604193" %% xsd:float])
-    entity(niiri:5a521f9d3fba49a3acde5b1cf93758d7,
+    entity(niiri:e40a357f9371360109c3bef80abba047,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999998566" %% xsd:float])
-    entity(niiri:7526e35038af3d726a0b80bf3340e666,
+    entity(niiri:b9a503337ee32e1fd7e03b9e9f2220cb,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:0ce252a9fb798e0ba134c46ee264a392',
-        nidm_equivalentThreshold: = 'niiri:7ea350b304b22e98c9b597be5d0aef1f'])
-    entity(niiri:0ce252a9fb798e0ba134c46ee264a392,
+        nidm_equivalentThreshold: = 'niiri:cef7b9ec311e390ce9be1c15654f5293',
+        nidm_equivalentThreshold: = 'niiri:c9466ee7581e8486c97cd0b89bfbe7ee'])
+    entity(niiri:cef7b9ec311e390ce9be1c15654f5293,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:7ea350b304b22e98c9b597be5d0aef1f,
+    entity(niiri:c9466ee7581e8486c97cd0b89bfbe7ee,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:c8b753e0bcb57800366a856147cea55c,
+    entity(niiri:e833ce816e4c682014ec3d1d268d0a82,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:3e4d94b2d4fec863a3e05a90d08e7d50,
+    entity(niiri:fdf123bdda05a0d3813bfaaccde5b1e7,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:b73c8647e3bbc090bd87c70ab3528a16,
+    activity(niiri:c01b1327eb97e1658fc71f26818ac635,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:1d0e9f058cf6254a45a221ea959dd872, -)
-    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:d4752660d42d5cf12c96b2666e7a2f38, -)
-    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:7526e35038af3d726a0b80bf3340e666, -)
-    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:3be097d50565d12830332d18ecd1880b, -)
-    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:ae93c509341f396c5dd29a576a0f196b, -)
-    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:c798bba76a13857f8244d5ad67ff103b, -)
-    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:c8b753e0bcb57800366a856147cea55c, -)
-    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:3e4d94b2d4fec863a3e05a90d08e7d50, -)
-    entity(niiri:ebd7e2e8cb7de028c38b7aaa31263974,
+    wasAssociatedWith(niiri:c01b1327eb97e1658fc71f26818ac635, niiri:36e0ca6e862ec6354f9837b33735c25b, -)
+    used(niiri:c01b1327eb97e1658fc71f26818ac635, niiri:f9baa5ab83d70de5496f1564ff4eefd8, -)
+    used(niiri:c01b1327eb97e1658fc71f26818ac635, niiri:b9a503337ee32e1fd7e03b9e9f2220cb, -)
+    used(niiri:c01b1327eb97e1658fc71f26818ac635, niiri:a7b5269861512e622fc8bb26dd1620ca, -)
+    used(niiri:c01b1327eb97e1658fc71f26818ac635, niiri:8b8985a1b7809ee217a07d3a01112aad, -)
+    used(niiri:c01b1327eb97e1658fc71f26818ac635, niiri:1ed2d81eecb89474d5a861917dd60e81, -)
+    used(niiri:c01b1327eb97e1658fc71f26818ac635, niiri:e833ce816e4c682014ec3d1d268d0a82, -)
+    used(niiri:c01b1327eb97e1658fc71f26818ac635, niiri:fdf123bdda05a0d3813bfaaccde5b1e7, -)
+    entity(niiri:174520937654bec46a1c4a4edc02cc6f,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:ebd7e2e8cb7de028c38b7aaa31263974, niiri:b73c8647e3bbc090bd87c70ab3528a16, -)
-    entity(niiri:b028d10934794cf9d7f19d4e97b56f77,
+    wasGeneratedBy(niiri:174520937654bec46a1c4a4edc02cc6f, niiri:c01b1327eb97e1658fc71f26818ac635, -)
+    entity(niiri:c213548113940d5da49331eadadfb1da,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:41a4758f7848a95406ccd26939a9ca0b',
-        nidm_hasMaximumIntensityProjection: = 'niiri:eda5c22f8ccd76c85fc65f583e891449',
-        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
+        nidm_hasClusterLabelsMap: = 'niiri:32a5f7aac5c14b2f9e374b1f8f6ec22c',
+        nidm_hasMaximumIntensityProjection: = 'niiri:9549ef1c93f294e158b22b63ca640e6c',
+        nidm_inCoordinateSpace: = 'niiri:86fbbec53aa7243bc5d23697658a64ea',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:41a4758f7848a95406ccd26939a9ca0b,
+    entity(niiri:32a5f7aac5c14b2f9e374b1f8f6ec22c,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:eda5c22f8ccd76c85fc65f583e891449,
+    entity(niiri:9549ef1c93f294e158b22b63ca640e6c,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:b028d10934794cf9d7f19d4e97b56f77, niiri:b73c8647e3bbc090bd87c70ab3528a16, -)
+    wasGeneratedBy(niiri:c213548113940d5da49331eadadfb1da, niiri:c01b1327eb97e1658fc71f26818ac635, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_cluster_k=10/nidm.provn
+++ b/spmexport/ex_spm_cluster_k=10/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:9449f881f320ad65c0195d3387c30a2e,
+  entity(niiri:c60878523466befdb4ba03bec2a31f3c,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:062a98df9292e26631122f63a41b58d0,
+  agent(niiri:74bc372b868aad9af801c2a853977679,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:f651bbd5783f6da38ccab3cb342e8e99,
+  activity(niiri:9ef76f336a18a57bf45ca202a46e5c9f,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:f651bbd5783f6da38ccab3cb342e8e99, niiri:062a98df9292e26631122f63a41b58d0, -)
-  wasGeneratedBy(niiri:9449f881f320ad65c0195d3387c30a2e, niiri:f651bbd5783f6da38ccab3cb342e8e99, 2016-01-11T10:10:44)
-  bundle niiri:9449f881f320ad65c0195d3387c30a2e
+  wasAssociatedWith(niiri:9ef76f336a18a57bf45ca202a46e5c9f, niiri:74bc372b868aad9af801c2a853977679, -)
+  wasGeneratedBy(niiri:c60878523466befdb4ba03bec2a31f3c, niiri:9ef76f336a18a57bf45ca202a46e5c9f, 2016-01-11T10:32:06)
+  bundle niiri:c60878523466befdb4ba03bec2a31f3c
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:5011a96e9a9e647d5829f116e9e2f2ee,
+    agent(niiri:1d0e9f058cf6254a45a221ea959dd872,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:87e5f074e3bdf383e5e3536f4a27d77f,
+    entity(niiri:be0006a57dffdd0820b4b36657cc9b94,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:2f77d65f7e8a62a2d5166425b98d93eb,
+    entity(niiri:eb713efa2e1fcb60d21f2884b08dc899,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:6d7587ab20a82666808f9226b4a2699b,
+    entity(niiri:f137d651dee30f9caf333f41e6364794,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:08e0a01ea31533be60b14d2cc0a2765a,
+    entity(niiri:c8ab5704c73f1a9bb81f64cb1449243e,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:224a21c90b30fb683181e5a4d434f85b',
+        dc:description = 'niiri:eecb83ec61dce78815637ca966505c20',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:6d7587ab20a82666808f9226b4a2699b',
+        nidm_hasDriftModel: = 'niiri:f137d651dee30f9caf333f41e6364794',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:224a21c90b30fb683181e5a4d434f85b,
+    entity(niiri:eecb83ec61dce78815637ca966505c20,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:6697e72e43e42fd9f394dfd69b32fe3a,
+    entity(niiri:aab6190fe17da63a98083b3eec133959,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:73e4bcd18595f9be07fc6be49c14f9c8,
+    activity(niiri:7c90be579fb4f97b5579f5d12f0ef01e,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:73e4bcd18595f9be07fc6be49c14f9c8, niiri:5011a96e9a9e647d5829f116e9e2f2ee, -)
-    used(niiri:73e4bcd18595f9be07fc6be49c14f9c8, niiri:08e0a01ea31533be60b14d2cc0a2765a, -)
-    used(niiri:73e4bcd18595f9be07fc6be49c14f9c8, niiri:2f77d65f7e8a62a2d5166425b98d93eb, -)
-    used(niiri:73e4bcd18595f9be07fc6be49c14f9c8, niiri:6697e72e43e42fd9f394dfd69b32fe3a, -)
-    entity(niiri:c94b6bb9cefdda1ca08b6aa65ba38d43,
+    wasAssociatedWith(niiri:7c90be579fb4f97b5579f5d12f0ef01e, niiri:1d0e9f058cf6254a45a221ea959dd872, -)
+    used(niiri:7c90be579fb4f97b5579f5d12f0ef01e, niiri:c8ab5704c73f1a9bb81f64cb1449243e, -)
+    used(niiri:7c90be579fb4f97b5579f5d12f0ef01e, niiri:eb713efa2e1fcb60d21f2884b08dc899, -)
+    used(niiri:7c90be579fb4f97b5579f5d12f0ef01e, niiri:aab6190fe17da63a98083b3eec133959, -)
+    entity(niiri:c798bba76a13857f8244d5ad67ff103b,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:6a6ffd37e1447a6da9f6fa3f00725ccb,
+    entity(niiri:e9b2e75d3b7ec541b60914377333b3be,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:c94b6bb9cefdda1ca08b6aa65ba38d43, niiri:6a6ffd37e1447a6da9f6fa3f00725ccb, -, -, -)
-    wasGeneratedBy(niiri:c94b6bb9cefdda1ca08b6aa65ba38d43, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
-    entity(niiri:d6bff2c35013b26528176ecaab0aa740,
+    wasDerivedFrom(niiri:c798bba76a13857f8244d5ad67ff103b, niiri:e9b2e75d3b7ec541b60914377333b3be, -, -, -)
+    wasGeneratedBy(niiri:c798bba76a13857f8244d5ad67ff103b, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
+    entity(niiri:69606415c39792ea689be7af6a0b0bb6,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:d6bff2c35013b26528176ecaab0aa740, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
-    entity(niiri:7a09cffef2a3dea868bf6a59a4586f94,
+    wasGeneratedBy(niiri:69606415c39792ea689be7af6a0b0bb6, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
+    entity(niiri:17a43d125a7f79b826e0854c9208a82f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f'])
-    entity(niiri:2f8eafff2f7b1f6e0000c1fa4371055e,
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94'])
+    entity(niiri:14254ef88d467810b2dbee23a6ae18a2,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:7a09cffef2a3dea868bf6a59a4586f94, niiri:2f8eafff2f7b1f6e0000c1fa4371055e, -, -, -)
-    wasGeneratedBy(niiri:7a09cffef2a3dea868bf6a59a4586f94, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
-    entity(niiri:07400ebb43ba60f54c44501344a4b56e,
+    wasDerivedFrom(niiri:17a43d125a7f79b826e0854c9208a82f, niiri:14254ef88d467810b2dbee23a6ae18a2, -, -, -)
+    wasGeneratedBy(niiri:17a43d125a7f79b826e0854c9208a82f, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
+    entity(niiri:7a7c15d2b4bfdb97b404fc0e16d83823,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f'])
-    entity(niiri:f5bdbc7353a5afa43109b95d30313c05,
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94'])
+    entity(niiri:7f42342c32069b3e6ec221bbeab6f472,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:07400ebb43ba60f54c44501344a4b56e, niiri:f5bdbc7353a5afa43109b95d30313c05, -, -, -)
-    wasGeneratedBy(niiri:07400ebb43ba60f54c44501344a4b56e, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
-    entity(niiri:5d08d6b8a41532b39634538b2891e0fc,
+    wasDerivedFrom(niiri:7a7c15d2b4bfdb97b404fc0e16d83823, niiri:7f42342c32069b3e6ec221bbeab6f472, -, -, -)
+    wasGeneratedBy(niiri:7a7c15d2b4bfdb97b404fc0e16d83823, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
+    entity(niiri:24f0614f12d5f2985cce3d892be55bcc,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f'])
-    entity(niiri:7495cb56f2e748c5f495d5036a7893ea,
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94'])
+    entity(niiri:607ca1c2f891e4ce713ca8444b3429fe,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:5d08d6b8a41532b39634538b2891e0fc, niiri:7495cb56f2e748c5f495d5036a7893ea, -, -, -)
-    wasGeneratedBy(niiri:5d08d6b8a41532b39634538b2891e0fc, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
-    entity(niiri:a88c9d654c14f8a90bfa7adfeddf2fc8,
+    wasDerivedFrom(niiri:24f0614f12d5f2985cce3d892be55bcc, niiri:607ca1c2f891e4ce713ca8444b3429fe, -, -, -)
+    wasGeneratedBy(niiri:24f0614f12d5f2985cce3d892be55bcc, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
+    entity(niiri:aa47cd87d32100529ed9ccb7ff9f596d,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:04d9cb6363085b466b1dc55b4ebd4560,
+    entity(niiri:32a4f215fd539ba5ce8e3fd646e19810,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:a88c9d654c14f8a90bfa7adfeddf2fc8, niiri:04d9cb6363085b466b1dc55b4ebd4560, -, -, -)
-    wasGeneratedBy(niiri:a88c9d654c14f8a90bfa7adfeddf2fc8, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
-    entity(niiri:467a9e29edf6b22ca7e25b823dea3e7d,
+    wasDerivedFrom(niiri:aa47cd87d32100529ed9ccb7ff9f596d, niiri:32a4f215fd539ba5ce8e3fd646e19810, -, -, -)
+    wasGeneratedBy(niiri:aa47cd87d32100529ed9ccb7ff9f596d, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
+    entity(niiri:ae93c509341f396c5dd29a576a0f196b,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:721f7d6540e9b6d370dd1632cdb5acda,
+    entity(niiri:c574ee9b1828f6901f22dd38af2f4498,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:467a9e29edf6b22ca7e25b823dea3e7d, niiri:721f7d6540e9b6d370dd1632cdb5acda, -, -, -)
-    wasGeneratedBy(niiri:467a9e29edf6b22ca7e25b823dea3e7d, niiri:73e4bcd18595f9be07fc6be49c14f9c8, -)
-    entity(niiri:18b2f17a14a90f5777b07c55b110f8a5,
+    wasDerivedFrom(niiri:ae93c509341f396c5dd29a576a0f196b, niiri:c574ee9b1828f6901f22dd38af2f4498, -, -, -)
+    wasGeneratedBy(niiri:ae93c509341f396c5dd29a576a0f196b, niiri:7c90be579fb4f97b5579f5d12f0ef01e, -)
+    entity(niiri:4855ce8cf932e2c0213dbe52e5931dd3,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:d64590c390e5de26a3120129667418d4,
+    activity(niiri:23058168747c80b31801d261abaf2585,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:d64590c390e5de26a3120129667418d4, niiri:5011a96e9a9e647d5829f116e9e2f2ee, -)
-    used(niiri:d64590c390e5de26a3120129667418d4, niiri:c94b6bb9cefdda1ca08b6aa65ba38d43, -)
-    used(niiri:d64590c390e5de26a3120129667418d4, niiri:a88c9d654c14f8a90bfa7adfeddf2fc8, -)
-    used(niiri:d64590c390e5de26a3120129667418d4, niiri:08e0a01ea31533be60b14d2cc0a2765a, -)
-    used(niiri:d64590c390e5de26a3120129667418d4, niiri:18b2f17a14a90f5777b07c55b110f8a5, -)
-    used(niiri:d64590c390e5de26a3120129667418d4, niiri:7a09cffef2a3dea868bf6a59a4586f94, -)
-    used(niiri:d64590c390e5de26a3120129667418d4, niiri:07400ebb43ba60f54c44501344a4b56e, -)
-    used(niiri:d64590c390e5de26a3120129667418d4, niiri:5d08d6b8a41532b39634538b2891e0fc, -)
-    entity(niiri:79ba69c016442c10f09aea4fdd4eba43,
+    wasAssociatedWith(niiri:23058168747c80b31801d261abaf2585, niiri:1d0e9f058cf6254a45a221ea959dd872, -)
+    used(niiri:23058168747c80b31801d261abaf2585, niiri:c798bba76a13857f8244d5ad67ff103b, -)
+    used(niiri:23058168747c80b31801d261abaf2585, niiri:aa47cd87d32100529ed9ccb7ff9f596d, -)
+    used(niiri:23058168747c80b31801d261abaf2585, niiri:c8ab5704c73f1a9bb81f64cb1449243e, -)
+    used(niiri:23058168747c80b31801d261abaf2585, niiri:4855ce8cf932e2c0213dbe52e5931dd3, -)
+    used(niiri:23058168747c80b31801d261abaf2585, niiri:17a43d125a7f79b826e0854c9208a82f, -)
+    used(niiri:23058168747c80b31801d261abaf2585, niiri:7a7c15d2b4bfdb97b404fc0e16d83823, -)
+    used(niiri:23058168747c80b31801d261abaf2585, niiri:24f0614f12d5f2985cce3d892be55bcc, -)
+    entity(niiri:3be097d50565d12830332d18ecd1880b,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:0666702921cf126beef3ee114c5593c0,
+    entity(niiri:c5af634b6d6d3deb00ab9c5c0075afb2,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:79ba69c016442c10f09aea4fdd4eba43, niiri:0666702921cf126beef3ee114c5593c0, -, -, -)
-    wasGeneratedBy(niiri:79ba69c016442c10f09aea4fdd4eba43, niiri:d64590c390e5de26a3120129667418d4, -)
-    entity(niiri:27dd101123da0ecd4789cbd170394fc4,
+    wasDerivedFrom(niiri:3be097d50565d12830332d18ecd1880b, niiri:c5af634b6d6d3deb00ab9c5c0075afb2, -, -, -)
+    wasGeneratedBy(niiri:3be097d50565d12830332d18ecd1880b, niiri:23058168747c80b31801d261abaf2585, -)
+    entity(niiri:f4f453b84f2b87845707493a3e41f364,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:d1b03d4237a689cc2bf0fed073f39d38,
+    entity(niiri:21436c6961fca1af4342e037b0700593,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:27dd101123da0ecd4789cbd170394fc4, niiri:d1b03d4237a689cc2bf0fed073f39d38, -, -, -)
-    wasGeneratedBy(niiri:27dd101123da0ecd4789cbd170394fc4, niiri:d64590c390e5de26a3120129667418d4, -)
-    entity(niiri:0876d6ced1df2b733994c394eb2987ab,
+    wasDerivedFrom(niiri:f4f453b84f2b87845707493a3e41f364, niiri:21436c6961fca1af4342e037b0700593, -, -, -)
+    wasGeneratedBy(niiri:f4f453b84f2b87845707493a3e41f364, niiri:23058168747c80b31801d261abaf2585, -)
+    entity(niiri:625c994b0145a32cc974b8ed37d688e1,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:0876d6ced1df2b733994c394eb2987ab, niiri:d64590c390e5de26a3120129667418d4, -)
-    entity(niiri:a96bfe771da694d4deaca900ed24aa26,
+    wasGeneratedBy(niiri:625c994b0145a32cc974b8ed37d688e1, niiri:23058168747c80b31801d261abaf2585, -)
+    entity(niiri:d4752660d42d5cf12c96b2666e7a2f38,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
         prov:value = "0.000999499751574873" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:0e9b34e0700ccef01e185b1bb6503625',
-        nidm_equivalentThreshold: = 'niiri:b1d0f45c117a40ae1d0672f42d7ee8ee'])
-    entity(niiri:0e9b34e0700ccef01e185b1bb6503625,
+        nidm_equivalentThreshold: = 'niiri:d0868054f274b2d15c52d8ede9b646c0',
+        nidm_equivalentThreshold: = 'niiri:5a521f9d3fba49a3acde5b1cf93758d7'])
+    entity(niiri:d0868054f274b2d15c52d8ede9b646c0,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12856968604193" %% xsd:float])
-    entity(niiri:b1d0f45c117a40ae1d0672f42d7ee8ee,
+    entity(niiri:5a521f9d3fba49a3acde5b1cf93758d7,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999998566" %% xsd:float])
-    entity(niiri:ad376ea1c4942b6d0ae711a894d3e2de,
+    entity(niiri:7526e35038af3d726a0b80bf3340e666,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:e8f3acb443dea652057348179b459923',
-        nidm_equivalentThreshold: = 'niiri:396eddd1ebb2cca6516c3e872baf274d'])
-    entity(niiri:e8f3acb443dea652057348179b459923,
+        nidm_equivalentThreshold: = 'niiri:0ce252a9fb798e0ba134c46ee264a392',
+        nidm_equivalentThreshold: = 'niiri:7ea350b304b22e98c9b597be5d0aef1f'])
+    entity(niiri:0ce252a9fb798e0ba134c46ee264a392,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:396eddd1ebb2cca6516c3e872baf274d,
+    entity(niiri:7ea350b304b22e98c9b597be5d0aef1f,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:724450a5b7af89d3b7806bbded2f930f,
+    entity(niiri:c8b753e0bcb57800366a856147cea55c,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:894e6d58b20b5595d52c5c8ecb1992e6,
+    entity(niiri:3e4d94b2d4fec863a3e05a90d08e7d50,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:b82408568590536603047ae743dc72dc,
+    activity(niiri:b73c8647e3bbc090bd87c70ab3528a16,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:b82408568590536603047ae743dc72dc, niiri:5011a96e9a9e647d5829f116e9e2f2ee, -)
-    used(niiri:b82408568590536603047ae743dc72dc, niiri:a96bfe771da694d4deaca900ed24aa26, -)
-    used(niiri:b82408568590536603047ae743dc72dc, niiri:ad376ea1c4942b6d0ae711a894d3e2de, -)
-    used(niiri:b82408568590536603047ae743dc72dc, niiri:79ba69c016442c10f09aea4fdd4eba43, -)
-    used(niiri:b82408568590536603047ae743dc72dc, niiri:467a9e29edf6b22ca7e25b823dea3e7d, -)
-    used(niiri:b82408568590536603047ae743dc72dc, niiri:c94b6bb9cefdda1ca08b6aa65ba38d43, -)
-    used(niiri:b82408568590536603047ae743dc72dc, niiri:724450a5b7af89d3b7806bbded2f930f, -)
-    used(niiri:b82408568590536603047ae743dc72dc, niiri:894e6d58b20b5595d52c5c8ecb1992e6, -)
-    entity(niiri:d81475d12fd44c5d43edf8f88a66b7d3,
+    wasAssociatedWith(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:1d0e9f058cf6254a45a221ea959dd872, -)
+    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:d4752660d42d5cf12c96b2666e7a2f38, -)
+    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:7526e35038af3d726a0b80bf3340e666, -)
+    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:3be097d50565d12830332d18ecd1880b, -)
+    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:ae93c509341f396c5dd29a576a0f196b, -)
+    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:c798bba76a13857f8244d5ad67ff103b, -)
+    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:c8b753e0bcb57800366a856147cea55c, -)
+    used(niiri:b73c8647e3bbc090bd87c70ab3528a16, niiri:3e4d94b2d4fec863a3e05a90d08e7d50, -)
+    entity(niiri:ebd7e2e8cb7de028c38b7aaa31263974,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:d81475d12fd44c5d43edf8f88a66b7d3, niiri:b82408568590536603047ae743dc72dc, -)
-    entity(niiri:a0053e188033e4d983abdb7f15cf7bf3,
+    wasGeneratedBy(niiri:ebd7e2e8cb7de028c38b7aaa31263974, niiri:b73c8647e3bbc090bd87c70ab3528a16, -)
+    entity(niiri:b028d10934794cf9d7f19d4e97b56f77,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:98caab641764a7f4bf5cef915e96ddf4',
-        nidm_hasMaximumIntensityProjection: = 'niiri:293ecd5ffdaae7066ab03a8c333f120b',
-        nidm_inCoordinateSpace: = 'niiri:87e5f074e3bdf383e5e3536f4a27d77f',
+        nidm_hasClusterLabelsMap: = 'niiri:41a4758f7848a95406ccd26939a9ca0b',
+        nidm_hasMaximumIntensityProjection: = 'niiri:eda5c22f8ccd76c85fc65f583e891449',
+        nidm_inCoordinateSpace: = 'niiri:be0006a57dffdd0820b4b36657cc9b94',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:98caab641764a7f4bf5cef915e96ddf4,
+    entity(niiri:41a4758f7848a95406ccd26939a9ca0b,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:293ecd5ffdaae7066ab03a8c333f120b,
+    entity(niiri:eda5c22f8ccd76c85fc65f583e891449,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:a0053e188033e4d983abdb7f15cf7bf3, niiri:b82408568590536603047ae743dc72dc, -)
+    wasGeneratedBy(niiri:b028d10934794cf9d7f19d4e97b56f77, niiri:b73c8647e3bbc090bd87c70ab3528a16, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_cluster_k=10/nidm.ttl
+++ b/spmexport/ex_spm_cluster_k=10/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:9449f881f320ad65c0195d3387c30a2e
+niiri:c60878523466befdb4ba03bec2a31f3c
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:062a98df9292e26631122f63a41b58d0
+niiri:74bc372b868aad9af801c2a853977679
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:f651bbd5783f6da38ccab3cb342e8e99
+niiri:9ef76f336a18a57bf45ca202a46e5c9f
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:f651bbd5783f6da38ccab3cb342e8e99 prov:wasAssociatedWith niiri:062a98df9292e26631122f63a41b58d0 .
+niiri:9ef76f336a18a57bf45ca202a46e5c9f prov:wasAssociatedWith niiri:74bc372b868aad9af801c2a853977679 .
 
 _:blank5 a prov:Generation .
 
-niiri:9449f881f320ad65c0195d3387c30a2e prov:qualifiedGeneration _:blank5 .
+niiri:c60878523466befdb4ba03bec2a31f3c prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:10:44"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:32:06"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:10:44"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:5011a96e9a9e647d5829f116e9e2f2ee
+niiri:1d0e9f058cf6254a45a221ea959dd872
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:87e5f074e3bdf383e5e3536f4a27d77f
+niiri:be0006a57dffdd0820b4b36657cc9b94
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:87e5f074e3bdf383e5e3536f4a27d77f
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:2f77d65f7e8a62a2d5166425b98d93eb
+niiri:eb713efa2e1fcb60d21f2884b08dc899
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:6d7587ab20a82666808f9226b4a2699b
+niiri:f137d651dee30f9caf333f41e6364794
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:08e0a01ea31533be60b14d2cc0a2765a
+niiri:c8ab5704c73f1a9bb81f64cb1449243e
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:224a21c90b30fb683181e5a4d434f85b ;
+    dc:description niiri:eecb83ec61dce78815637ca966505c20 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:6d7587ab20a82666808f9226b4a2699b ;
+    nidm_hasDriftModel: niiri:f137d651dee30f9caf333f41e6364794 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:224a21c90b30fb683181e5a4d434f85b
+niiri:eecb83ec61dce78815637ca966505c20
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:6697e72e43e42fd9f394dfd69b32fe3a
+niiri:aab6190fe17da63a98083b3eec133959
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:6697e72e43e42fd9f394dfd69b32fe3a
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:73e4bcd18595f9be07fc6be49c14f9c8
+niiri:7c90be579fb4f97b5579f5d12f0ef01e
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:73e4bcd18595f9be07fc6be49c14f9c8 prov:wasAssociatedWith niiri:5011a96e9a9e647d5829f116e9e2f2ee .
+niiri:7c90be579fb4f97b5579f5d12f0ef01e prov:wasAssociatedWith niiri:1d0e9f058cf6254a45a221ea959dd872 .
 
-niiri:73e4bcd18595f9be07fc6be49c14f9c8 prov:used niiri:08e0a01ea31533be60b14d2cc0a2765a .
+niiri:7c90be579fb4f97b5579f5d12f0ef01e prov:used niiri:c8ab5704c73f1a9bb81f64cb1449243e .
 
-niiri:73e4bcd18595f9be07fc6be49c14f9c8 prov:used niiri:2f77d65f7e8a62a2d5166425b98d93eb .
+niiri:7c90be579fb4f97b5579f5d12f0ef01e prov:used niiri:eb713efa2e1fcb60d21f2884b08dc899 .
 
-niiri:73e4bcd18595f9be07fc6be49c14f9c8 prov:used niiri:6697e72e43e42fd9f394dfd69b32fe3a .
+niiri:7c90be579fb4f97b5579f5d12f0ef01e prov:used niiri:aab6190fe17da63a98083b3eec133959 .
 
-niiri:c94b6bb9cefdda1ca08b6aa65ba38d43
+niiri:c798bba76a13857f8244d5ad67ff103b
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:6a6ffd37e1447a6da9f6fa3f00725ccb
+niiri:e9b2e75d3b7ec541b60914377333b3be
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:c94b6bb9cefdda1ca08b6aa65ba38d43 prov:wasDerivedFrom niiri:6a6ffd37e1447a6da9f6fa3f00725ccb .
+niiri:c798bba76a13857f8244d5ad67ff103b prov:wasDerivedFrom niiri:e9b2e75d3b7ec541b60914377333b3be .
 
-niiri:c94b6bb9cefdda1ca08b6aa65ba38d43 prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+niiri:c798bba76a13857f8244d5ad67ff103b prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
 
-niiri:d6bff2c35013b26528176ecaab0aa740
+niiri:69606415c39792ea689be7af6a0b0bb6
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:d6bff2c35013b26528176ecaab0aa740 prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+niiri:69606415c39792ea689be7af6a0b0bb6 prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
 
-niiri:7a09cffef2a3dea868bf6a59a4586f94
+niiri:17a43d125a7f79b826e0854c9208a82f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f .
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 .
 
-niiri:2f8eafff2f7b1f6e0000c1fa4371055e
+niiri:14254ef88d467810b2dbee23a6ae18a2
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:7a09cffef2a3dea868bf6a59a4586f94 prov:wasDerivedFrom niiri:2f8eafff2f7b1f6e0000c1fa4371055e .
+niiri:17a43d125a7f79b826e0854c9208a82f prov:wasDerivedFrom niiri:14254ef88d467810b2dbee23a6ae18a2 .
 
-niiri:7a09cffef2a3dea868bf6a59a4586f94 prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+niiri:17a43d125a7f79b826e0854c9208a82f prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
 
-niiri:07400ebb43ba60f54c44501344a4b56e
+niiri:7a7c15d2b4bfdb97b404fc0e16d83823
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f .
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 .
 
-niiri:f5bdbc7353a5afa43109b95d30313c05
+niiri:7f42342c32069b3e6ec221bbeab6f472
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:07400ebb43ba60f54c44501344a4b56e prov:wasDerivedFrom niiri:f5bdbc7353a5afa43109b95d30313c05 .
+niiri:7a7c15d2b4bfdb97b404fc0e16d83823 prov:wasDerivedFrom niiri:7f42342c32069b3e6ec221bbeab6f472 .
 
-niiri:07400ebb43ba60f54c44501344a4b56e prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+niiri:7a7c15d2b4bfdb97b404fc0e16d83823 prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
 
-niiri:5d08d6b8a41532b39634538b2891e0fc
+niiri:24f0614f12d5f2985cce3d892be55bcc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f .
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 .
 
-niiri:7495cb56f2e748c5f495d5036a7893ea
+niiri:607ca1c2f891e4ce713ca8444b3429fe
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:5d08d6b8a41532b39634538b2891e0fc prov:wasDerivedFrom niiri:7495cb56f2e748c5f495d5036a7893ea .
+niiri:24f0614f12d5f2985cce3d892be55bcc prov:wasDerivedFrom niiri:607ca1c2f891e4ce713ca8444b3429fe .
 
-niiri:5d08d6b8a41532b39634538b2891e0fc prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+niiri:24f0614f12d5f2985cce3d892be55bcc prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
 
-niiri:a88c9d654c14f8a90bfa7adfeddf2fc8
+niiri:aa47cd87d32100529ed9ccb7ff9f596d
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:04d9cb6363085b466b1dc55b4ebd4560
+niiri:32a4f215fd539ba5ce8e3fd646e19810
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:a88c9d654c14f8a90bfa7adfeddf2fc8 prov:wasDerivedFrom niiri:04d9cb6363085b466b1dc55b4ebd4560 .
+niiri:aa47cd87d32100529ed9ccb7ff9f596d prov:wasDerivedFrom niiri:32a4f215fd539ba5ce8e3fd646e19810 .
 
-niiri:a88c9d654c14f8a90bfa7adfeddf2fc8 prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+niiri:aa47cd87d32100529ed9ccb7ff9f596d prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
 
-niiri:467a9e29edf6b22ca7e25b823dea3e7d
+niiri:ae93c509341f396c5dd29a576a0f196b
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:721f7d6540e9b6d370dd1632cdb5acda
+niiri:c574ee9b1828f6901f22dd38af2f4498
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:467a9e29edf6b22ca7e25b823dea3e7d prov:wasDerivedFrom niiri:721f7d6540e9b6d370dd1632cdb5acda .
+niiri:ae93c509341f396c5dd29a576a0f196b prov:wasDerivedFrom niiri:c574ee9b1828f6901f22dd38af2f4498 .
 
-niiri:467a9e29edf6b22ca7e25b823dea3e7d prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+niiri:ae93c509341f396c5dd29a576a0f196b prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
 
-niiri:18b2f17a14a90f5777b07c55b110f8a5
+niiri:4855ce8cf932e2c0213dbe52e5931dd3
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:d64590c390e5de26a3120129667418d4
+niiri:23058168747c80b31801d261abaf2585
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:d64590c390e5de26a3120129667418d4 prov:wasAssociatedWith niiri:5011a96e9a9e647d5829f116e9e2f2ee .
+niiri:23058168747c80b31801d261abaf2585 prov:wasAssociatedWith niiri:1d0e9f058cf6254a45a221ea959dd872 .
 
-niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:c94b6bb9cefdda1ca08b6aa65ba38d43 .
+niiri:23058168747c80b31801d261abaf2585 prov:used niiri:c798bba76a13857f8244d5ad67ff103b .
 
-niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:a88c9d654c14f8a90bfa7adfeddf2fc8 .
+niiri:23058168747c80b31801d261abaf2585 prov:used niiri:aa47cd87d32100529ed9ccb7ff9f596d .
 
-niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:08e0a01ea31533be60b14d2cc0a2765a .
+niiri:23058168747c80b31801d261abaf2585 prov:used niiri:c8ab5704c73f1a9bb81f64cb1449243e .
 
-niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:18b2f17a14a90f5777b07c55b110f8a5 .
+niiri:23058168747c80b31801d261abaf2585 prov:used niiri:4855ce8cf932e2c0213dbe52e5931dd3 .
 
-niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:7a09cffef2a3dea868bf6a59a4586f94 .
+niiri:23058168747c80b31801d261abaf2585 prov:used niiri:17a43d125a7f79b826e0854c9208a82f .
 
-niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:07400ebb43ba60f54c44501344a4b56e .
+niiri:23058168747c80b31801d261abaf2585 prov:used niiri:7a7c15d2b4bfdb97b404fc0e16d83823 .
 
-niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:5d08d6b8a41532b39634538b2891e0fc .
+niiri:23058168747c80b31801d261abaf2585 prov:used niiri:24f0614f12d5f2985cce3d892be55bcc .
 
-niiri:79ba69c016442c10f09aea4fdd4eba43
+niiri:3be097d50565d12830332d18ecd1880b
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:79ba69c016442c10f09aea4fdd4eba43
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:0666702921cf126beef3ee114c5593c0
+niiri:c5af634b6d6d3deb00ab9c5c0075afb2
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:79ba69c016442c10f09aea4fdd4eba43 prov:wasDerivedFrom niiri:0666702921cf126beef3ee114c5593c0 .
+niiri:3be097d50565d12830332d18ecd1880b prov:wasDerivedFrom niiri:c5af634b6d6d3deb00ab9c5c0075afb2 .
 
-niiri:79ba69c016442c10f09aea4fdd4eba43 prov:wasGeneratedBy niiri:d64590c390e5de26a3120129667418d4 .
+niiri:3be097d50565d12830332d18ecd1880b prov:wasGeneratedBy niiri:23058168747c80b31801d261abaf2585 .
 
-niiri:27dd101123da0ecd4789cbd170394fc4
+niiri:f4f453b84f2b87845707493a3e41f364
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:d1b03d4237a689cc2bf0fed073f39d38
+niiri:21436c6961fca1af4342e037b0700593
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:27dd101123da0ecd4789cbd170394fc4 prov:wasDerivedFrom niiri:d1b03d4237a689cc2bf0fed073f39d38 .
+niiri:f4f453b84f2b87845707493a3e41f364 prov:wasDerivedFrom niiri:21436c6961fca1af4342e037b0700593 .
 
-niiri:27dd101123da0ecd4789cbd170394fc4 prov:wasGeneratedBy niiri:d64590c390e5de26a3120129667418d4 .
+niiri:f4f453b84f2b87845707493a3e41f364 prov:wasGeneratedBy niiri:23058168747c80b31801d261abaf2585 .
 
-niiri:0876d6ced1df2b733994c394eb2987ab
+niiri:625c994b0145a32cc974b8ed37d688e1
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:0876d6ced1df2b733994c394eb2987ab prov:wasGeneratedBy niiri:d64590c390e5de26a3120129667418d4 .
+niiri:625c994b0145a32cc974b8ed37d688e1 prov:wasGeneratedBy niiri:23058168747c80b31801d261abaf2585 .
 
-niiri:a96bfe771da694d4deaca900ed24aa26
+niiri:d4752660d42d5cf12c96b2666e7a2f38
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
     prov:value "0.000999499751574873"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:0e9b34e0700ccef01e185b1bb6503625 ;
-    nidm_equivalentThreshold: niiri:b1d0f45c117a40ae1d0672f42d7ee8ee .
+    nidm_equivalentThreshold: niiri:d0868054f274b2d15c52d8ede9b646c0 ;
+    nidm_equivalentThreshold: niiri:5a521f9d3fba49a3acde5b1cf93758d7 .
 
-niiri:0e9b34e0700ccef01e185b1bb6503625
+niiri:d0868054f274b2d15c52d8ede9b646c0
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12856968604193"^^xsd:float .
 
-niiri:b1d0f45c117a40ae1d0672f42d7ee8ee
+niiri:5a521f9d3fba49a3acde5b1cf93758d7
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999998566"^^xsd:float .
 
-niiri:ad376ea1c4942b6d0ae711a894d3e2de
+niiri:7526e35038af3d726a0b80bf3340e666
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:e8f3acb443dea652057348179b459923 ;
-    nidm_equivalentThreshold: niiri:396eddd1ebb2cca6516c3e872baf274d .
+    nidm_equivalentThreshold: niiri:0ce252a9fb798e0ba134c46ee264a392 ;
+    nidm_equivalentThreshold: niiri:7ea350b304b22e98c9b597be5d0aef1f .
 
-niiri:e8f3acb443dea652057348179b459923
+niiri:0ce252a9fb798e0ba134c46ee264a392
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:396eddd1ebb2cca6516c3e872baf274d
+niiri:7ea350b304b22e98c9b597be5d0aef1f
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:724450a5b7af89d3b7806bbded2f930f
+niiri:c8b753e0bcb57800366a856147cea55c
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:894e6d58b20b5595d52c5c8ecb1992e6
+niiri:3e4d94b2d4fec863a3e05a90d08e7d50
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:b82408568590536603047ae743dc72dc
+niiri:b73c8647e3bbc090bd87c70ab3528a16
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:b82408568590536603047ae743dc72dc prov:wasAssociatedWith niiri:5011a96e9a9e647d5829f116e9e2f2ee .
+niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:wasAssociatedWith niiri:1d0e9f058cf6254a45a221ea959dd872 .
 
-niiri:b82408568590536603047ae743dc72dc prov:used niiri:a96bfe771da694d4deaca900ed24aa26 .
+niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:d4752660d42d5cf12c96b2666e7a2f38 .
 
-niiri:b82408568590536603047ae743dc72dc prov:used niiri:ad376ea1c4942b6d0ae711a894d3e2de .
+niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:7526e35038af3d726a0b80bf3340e666 .
 
-niiri:b82408568590536603047ae743dc72dc prov:used niiri:79ba69c016442c10f09aea4fdd4eba43 .
+niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:3be097d50565d12830332d18ecd1880b .
 
-niiri:b82408568590536603047ae743dc72dc prov:used niiri:467a9e29edf6b22ca7e25b823dea3e7d .
+niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:ae93c509341f396c5dd29a576a0f196b .
 
-niiri:b82408568590536603047ae743dc72dc prov:used niiri:c94b6bb9cefdda1ca08b6aa65ba38d43 .
+niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:c798bba76a13857f8244d5ad67ff103b .
 
-niiri:b82408568590536603047ae743dc72dc prov:used niiri:724450a5b7af89d3b7806bbded2f930f .
+niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:c8b753e0bcb57800366a856147cea55c .
 
-niiri:b82408568590536603047ae743dc72dc prov:used niiri:894e6d58b20b5595d52c5c8ecb1992e6 .
+niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:3e4d94b2d4fec863a3e05a90d08e7d50 .
 
-niiri:d81475d12fd44c5d43edf8f88a66b7d3
+niiri:ebd7e2e8cb7de028c38b7aaa31263974
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:d81475d12fd44c5d43edf8f88a66b7d3
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:d81475d12fd44c5d43edf8f88a66b7d3 prov:wasGeneratedBy niiri:b82408568590536603047ae743dc72dc .
+niiri:ebd7e2e8cb7de028c38b7aaa31263974 prov:wasGeneratedBy niiri:b73c8647e3bbc090bd87c70ab3528a16 .
 
-niiri:a0053e188033e4d983abdb7f15cf7bf3
+niiri:b028d10934794cf9d7f19d4e97b56f77
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:a0053e188033e4d983abdb7f15cf7bf3
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:98caab641764a7f4bf5cef915e96ddf4 ;
-    nidm_hasMaximumIntensityProjection: niiri:293ecd5ffdaae7066ab03a8c333f120b ;
-    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_hasClusterLabelsMap: niiri:41a4758f7848a95406ccd26939a9ca0b ;
+    nidm_hasMaximumIntensityProjection: niiri:eda5c22f8ccd76c85fc65f583e891449 ;
+    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:98caab641764a7f4bf5cef915e96ddf4
+niiri:41a4758f7848a95406ccd26939a9ca0b
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:293ecd5ffdaae7066ab03a8c333f120b
+niiri:eda5c22f8ccd76c85fc65f583e891449
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:a0053e188033e4d983abdb7f15cf7bf3 prov:wasGeneratedBy niiri:b82408568590536603047ae743dc72dc .
+niiri:b028d10934794cf9d7f19d4e97b56f77 prov:wasGeneratedBy niiri:b73c8647e3bbc090bd87c70ab3528a16 .
 

--- a/spmexport/ex_spm_cluster_k=10/nidm.ttl
+++ b/spmexport/ex_spm_cluster_k=10/nidm.ttl
@@ -1,0 +1,510 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:9449f881f320ad65c0195d3387c30a2e
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:062a98df9292e26631122f63a41b58d0
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:f651bbd5783f6da38ccab3cb342e8e99
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:f651bbd5783f6da38ccab3cb342e8e99 prov:wasAssociatedWith niiri:062a98df9292e26631122f63a41b58d0 .
+
+_:blank5 a prov:Generation .
+
+niiri:9449f881f320ad65c0195d3387c30a2e prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:10:44"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+
+niiri:5011a96e9a9e647d5829f116e9e2f2ee
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:87e5f074e3bdf383e5e3536f4a27d77f
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:2f77d65f7e8a62a2d5166425b98d93eb
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:6d7587ab20a82666808f9226b4a2699b
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:08e0a01ea31533be60b14d2cc0a2765a
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:224a21c90b30fb683181e5a4d434f85b ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:6d7587ab20a82666808f9226b4a2699b ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:224a21c90b30fb683181e5a4d434f85b
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:6697e72e43e42fd9f394dfd69b32fe3a
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:73e4bcd18595f9be07fc6be49c14f9c8
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:73e4bcd18595f9be07fc6be49c14f9c8 prov:wasAssociatedWith niiri:5011a96e9a9e647d5829f116e9e2f2ee .
+
+niiri:73e4bcd18595f9be07fc6be49c14f9c8 prov:used niiri:08e0a01ea31533be60b14d2cc0a2765a .
+
+niiri:73e4bcd18595f9be07fc6be49c14f9c8 prov:used niiri:2f77d65f7e8a62a2d5166425b98d93eb .
+
+niiri:73e4bcd18595f9be07fc6be49c14f9c8 prov:used niiri:6697e72e43e42fd9f394dfd69b32fe3a .
+
+niiri:c94b6bb9cefdda1ca08b6aa65ba38d43
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:6a6ffd37e1447a6da9f6fa3f00725ccb
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
+
+niiri:c94b6bb9cefdda1ca08b6aa65ba38d43 prov:wasDerivedFrom niiri:6a6ffd37e1447a6da9f6fa3f00725ccb .
+
+niiri:c94b6bb9cefdda1ca08b6aa65ba38d43 prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+
+niiri:d6bff2c35013b26528176ecaab0aa740
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "121.744659423828"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
+
+niiri:d6bff2c35013b26528176ecaab0aa740 prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+
+niiri:7a09cffef2a3dea868bf6a59a4586f94
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f .
+
+niiri:2f8eafff2f7b1f6e0000c1fa4371055e
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
+
+niiri:7a09cffef2a3dea868bf6a59a4586f94 prov:wasDerivedFrom niiri:2f8eafff2f7b1f6e0000c1fa4371055e .
+
+niiri:7a09cffef2a3dea868bf6a59a4586f94 prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+
+niiri:07400ebb43ba60f54c44501344a4b56e
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f .
+
+niiri:f5bdbc7353a5afa43109b95d30313c05
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
+
+niiri:07400ebb43ba60f54c44501344a4b56e prov:wasDerivedFrom niiri:f5bdbc7353a5afa43109b95d30313c05 .
+
+niiri:07400ebb43ba60f54c44501344a4b56e prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+
+niiri:5d08d6b8a41532b39634538b2891e0fc
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f .
+
+niiri:7495cb56f2e748c5f495d5036a7893ea
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
+
+niiri:5d08d6b8a41532b39634538b2891e0fc prov:wasDerivedFrom niiri:7495cb56f2e748c5f495d5036a7893ea .
+
+niiri:5d08d6b8a41532b39634538b2891e0fc prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+
+niiri:a88c9d654c14f8a90bfa7adfeddf2fc8
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
+
+niiri:04d9cb6363085b466b1dc55b4ebd4560
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
+
+niiri:a88c9d654c14f8a90bfa7adfeddf2fc8 prov:wasDerivedFrom niiri:04d9cb6363085b466b1dc55b4ebd4560 .
+
+niiri:a88c9d654c14f8a90bfa7adfeddf2fc8 prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+
+niiri:467a9e29edf6b22ca7e25b823dea3e7d
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
+
+niiri:721f7d6540e9b6d370dd1632cdb5acda
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
+
+niiri:467a9e29edf6b22ca7e25b823dea3e7d prov:wasDerivedFrom niiri:721f7d6540e9b6d370dd1632cdb5acda .
+
+niiri:467a9e29edf6b22ca7e25b823dea3e7d prov:wasGeneratedBy niiri:73e4bcd18595f9be07fc6be49c14f9c8 .
+
+niiri:18b2f17a14a90f5777b07c55b110f8a5
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    rdfs:label "Contrast: pos vs neg" ;
+    prov:value "[1, -1, 0]"^^xsd:string .
+
+niiri:d64590c390e5de26a3120129667418d4
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:d64590c390e5de26a3120129667418d4 prov:wasAssociatedWith niiri:5011a96e9a9e647d5829f116e9e2f2ee .
+
+niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:c94b6bb9cefdda1ca08b6aa65ba38d43 .
+
+niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:a88c9d654c14f8a90bfa7adfeddf2fc8 .
+
+niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:08e0a01ea31533be60b14d2cc0a2765a .
+
+niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:18b2f17a14a90f5777b07c55b110f8a5 .
+
+niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:7a09cffef2a3dea868bf6a59a4586f94 .
+
+niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:07400ebb43ba60f54c44501344a4b56e .
+
+niiri:d64590c390e5de26a3120129667418d4 prov:used niiri:5d08d6b8a41532b39634538b2891e0fc .
+
+niiri:79ba69c016442c10f09aea4fdd4eba43
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: pos vs neg" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
+
+niiri:0666702921cf126beef3ee114c5593c0
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
+
+niiri:79ba69c016442c10f09aea4fdd4eba43 prov:wasDerivedFrom niiri:0666702921cf126beef3ee114c5593c0 .
+
+niiri:79ba69c016442c10f09aea4fdd4eba43 prov:wasGeneratedBy niiri:d64590c390e5de26a3120129667418d4 .
+
+niiri:27dd101123da0ecd4789cbd170394fc4
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: pos vs neg" ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
+
+niiri:d1b03d4237a689cc2bf0fed073f39d38
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
+
+niiri:27dd101123da0ecd4789cbd170394fc4 prov:wasDerivedFrom niiri:d1b03d4237a689cc2bf0fed073f39d38 .
+
+niiri:27dd101123da0ecd4789cbd170394fc4 prov:wasGeneratedBy niiri:d64590c390e5de26a3120129667418d4 .
+
+niiri:0876d6ced1df2b733994c394eb2987ab
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
+
+niiri:0876d6ced1df2b733994c394eb2987ab prov:wasGeneratedBy niiri:d64590c390e5de26a3120129667418d4 .
+
+niiri:a96bfe771da694d4deaca900ed24aa26
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
+    prov:value "0.000999499751574873"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:0e9b34e0700ccef01e185b1bb6503625 ;
+    nidm_equivalentThreshold: niiri:b1d0f45c117a40ae1d0672f42d7ee8ee .
+
+niiri:0e9b34e0700ccef01e185b1bb6503625
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "3.12856968604193"^^xsd:float .
+
+niiri:b1d0f45c117a40ae1d0672f42d7ee8ee
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.999999999998566"^^xsd:float .
+
+niiri:ad376ea1c4942b6d0ae711a894d3e2de
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:e8f3acb443dea652057348179b459923 ;
+    nidm_equivalentThreshold: niiri:396eddd1ebb2cca6516c3e872baf274d .
+
+niiri:e8f3acb443dea652057348179b459923
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:396eddd1ebb2cca6516c3e872baf274d
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:724450a5b7af89d3b7806bbded2f930f
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:894e6d58b20b5595d52c5c8ecb1992e6
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:b82408568590536603047ae743dc72dc
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:b82408568590536603047ae743dc72dc prov:wasAssociatedWith niiri:5011a96e9a9e647d5829f116e9e2f2ee .
+
+niiri:b82408568590536603047ae743dc72dc prov:used niiri:a96bfe771da694d4deaca900ed24aa26 .
+
+niiri:b82408568590536603047ae743dc72dc prov:used niiri:ad376ea1c4942b6d0ae711a894d3e2de .
+
+niiri:b82408568590536603047ae743dc72dc prov:used niiri:79ba69c016442c10f09aea4fdd4eba43 .
+
+niiri:b82408568590536603047ae743dc72dc prov:used niiri:467a9e29edf6b22ca7e25b823dea3e7d .
+
+niiri:b82408568590536603047ae743dc72dc prov:used niiri:c94b6bb9cefdda1ca08b6aa65ba38d43 .
+
+niiri:b82408568590536603047ae743dc72dc prov:used niiri:724450a5b7af89d3b7806bbded2f930f .
+
+niiri:b82408568590536603047ae743dc72dc prov:used niiri:894e6d58b20b5595d52c5c8ecb1992e6 .
+
+niiri:d81475d12fd44c5d43edf8f88a66b7d3
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
+    nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
+    nidm_searchVolumeInResels: "2650.12011223711"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.01704921884936, 4.07618247398105, 4.38831339907177]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.03409843769872, 8.1523649479621, 8.77662679814353]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "8.23486077915088"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "27.2707251644655"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.05094049746367"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:d81475d12fd44c5d43edf8f88a66b7d3 prov:wasGeneratedBy niiri:b82408568590536603047ae743dc72dc .
+
+niiri:a0053e188033e4d983abdb7f15cf7bf3
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
+    nidm_pValue: "NaN"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:98caab641764a7f4bf5cef915e96ddf4 ;
+    nidm_hasMaximumIntensityProjection: niiri:293ecd5ffdaae7066ab03a8c333f120b ;
+    nidm_inCoordinateSpace: niiri:87e5f074e3bdf383e5e3536f4a27d77f ;
+    crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
+
+niiri:98caab641764a7f4bf5cef915e96ddf4
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:293ecd5ffdaae7066ab03a8c333f120b
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:a0053e188033e4d983abdb7f15cf7bf3 prov:wasGeneratedBy niiri:b82408568590536603047ae743dc72dc .
+

--- a/spmexport/ex_spm_cluster_k=10/nidm.ttl
+++ b/spmexport/ex_spm_cluster_k=10/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:c60878523466befdb4ba03bec2a31f3c
+niiri:f8f4959f331b60ba01cd45132ece134e
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:74bc372b868aad9af801c2a853977679
+niiri:0fb2a4cee78fbd169d6cadc2dfb52cdb
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:9ef76f336a18a57bf45ca202a46e5c9f
+niiri:25764e7c2fab4be9a26de9e58f89c317
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:9ef76f336a18a57bf45ca202a46e5c9f prov:wasAssociatedWith niiri:74bc372b868aad9af801c2a853977679 .
+niiri:25764e7c2fab4be9a26de9e58f89c317 prov:wasAssociatedWith niiri:0fb2a4cee78fbd169d6cadc2dfb52cdb .
 
 _:blank5 a prov:Generation .
 
-niiri:c60878523466befdb4ba03bec2a31f3c prov:qualifiedGeneration _:blank5 .
+niiri:f8f4959f331b60ba01cd45132ece134e prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:32:06"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:43:26"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:32:06"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:1d0e9f058cf6254a45a221ea959dd872
+niiri:36e0ca6e862ec6354f9837b33735c25b
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:be0006a57dffdd0820b4b36657cc9b94
+niiri:86fbbec53aa7243bc5d23697658a64ea
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:be0006a57dffdd0820b4b36657cc9b94
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:eb713efa2e1fcb60d21f2884b08dc899
+niiri:8e2f547b88d0b10dd503b6f33eb34fdf
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:f137d651dee30f9caf333f41e6364794
+niiri:3345c91fd2591b0f2c2f6b3c9028f2dd
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:c8ab5704c73f1a9bb81f64cb1449243e
+niiri:f1dfb0da2f98dbeb54f3aafd24e0e798
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:eecb83ec61dce78815637ca966505c20 ;
+    dc:description niiri:38f212e9d7122c63fb10fbe9b7eacdf0 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:f137d651dee30f9caf333f41e6364794 ;
+    nidm_hasDriftModel: niiri:3345c91fd2591b0f2c2f6b3c9028f2dd ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:eecb83ec61dce78815637ca966505c20
+niiri:38f212e9d7122c63fb10fbe9b7eacdf0
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:aab6190fe17da63a98083b3eec133959
+niiri:c512b23a0b5137e168cf0fbd7ff9e103
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:aab6190fe17da63a98083b3eec133959
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:7c90be579fb4f97b5579f5d12f0ef01e
+niiri:bbf4abb1d4e900034f7e2514c9d594ec
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:7c90be579fb4f97b5579f5d12f0ef01e prov:wasAssociatedWith niiri:1d0e9f058cf6254a45a221ea959dd872 .
+niiri:bbf4abb1d4e900034f7e2514c9d594ec prov:wasAssociatedWith niiri:36e0ca6e862ec6354f9837b33735c25b .
 
-niiri:7c90be579fb4f97b5579f5d12f0ef01e prov:used niiri:c8ab5704c73f1a9bb81f64cb1449243e .
+niiri:bbf4abb1d4e900034f7e2514c9d594ec prov:used niiri:f1dfb0da2f98dbeb54f3aafd24e0e798 .
 
-niiri:7c90be579fb4f97b5579f5d12f0ef01e prov:used niiri:eb713efa2e1fcb60d21f2884b08dc899 .
+niiri:bbf4abb1d4e900034f7e2514c9d594ec prov:used niiri:8e2f547b88d0b10dd503b6f33eb34fdf .
 
-niiri:7c90be579fb4f97b5579f5d12f0ef01e prov:used niiri:aab6190fe17da63a98083b3eec133959 .
+niiri:bbf4abb1d4e900034f7e2514c9d594ec prov:used niiri:c512b23a0b5137e168cf0fbd7ff9e103 .
 
-niiri:c798bba76a13857f8244d5ad67ff103b
+niiri:1ed2d81eecb89474d5a861917dd60e81
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:e9b2e75d3b7ec541b60914377333b3be
+niiri:14fea21e8246f5d8a83a3c81f9efa499
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:c798bba76a13857f8244d5ad67ff103b prov:wasDerivedFrom niiri:e9b2e75d3b7ec541b60914377333b3be .
+niiri:1ed2d81eecb89474d5a861917dd60e81 prov:wasDerivedFrom niiri:14fea21e8246f5d8a83a3c81f9efa499 .
 
-niiri:c798bba76a13857f8244d5ad67ff103b prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
+niiri:1ed2d81eecb89474d5a861917dd60e81 prov:wasGeneratedBy niiri:bbf4abb1d4e900034f7e2514c9d594ec .
 
-niiri:69606415c39792ea689be7af6a0b0bb6
+niiri:667c362b175ef1267cc6af7adb4a2e1d
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:69606415c39792ea689be7af6a0b0bb6 prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
+niiri:667c362b175ef1267cc6af7adb4a2e1d prov:wasGeneratedBy niiri:bbf4abb1d4e900034f7e2514c9d594ec .
 
-niiri:17a43d125a7f79b826e0854c9208a82f
+niiri:f61676e7d608d77611de78e41c4847aa
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 .
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea .
 
-niiri:14254ef88d467810b2dbee23a6ae18a2
+niiri:740e6d1f27ce4332e8358c7a43f5e17b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:17a43d125a7f79b826e0854c9208a82f prov:wasDerivedFrom niiri:14254ef88d467810b2dbee23a6ae18a2 .
+niiri:f61676e7d608d77611de78e41c4847aa prov:wasDerivedFrom niiri:740e6d1f27ce4332e8358c7a43f5e17b .
 
-niiri:17a43d125a7f79b826e0854c9208a82f prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
+niiri:f61676e7d608d77611de78e41c4847aa prov:wasGeneratedBy niiri:bbf4abb1d4e900034f7e2514c9d594ec .
 
-niiri:7a7c15d2b4bfdb97b404fc0e16d83823
+niiri:54ea04431ae710eb05e81741cc32410e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 .
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea .
 
-niiri:7f42342c32069b3e6ec221bbeab6f472
+niiri:3f0f272a8f4a6b36aeede2139854c5a1
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:7a7c15d2b4bfdb97b404fc0e16d83823 prov:wasDerivedFrom niiri:7f42342c32069b3e6ec221bbeab6f472 .
+niiri:54ea04431ae710eb05e81741cc32410e prov:wasDerivedFrom niiri:3f0f272a8f4a6b36aeede2139854c5a1 .
 
-niiri:7a7c15d2b4bfdb97b404fc0e16d83823 prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
+niiri:54ea04431ae710eb05e81741cc32410e prov:wasGeneratedBy niiri:bbf4abb1d4e900034f7e2514c9d594ec .
 
-niiri:24f0614f12d5f2985cce3d892be55bcc
+niiri:514ad018ba4d5e4b572be280b0667d18
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 .
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea .
 
-niiri:607ca1c2f891e4ce713ca8444b3429fe
+niiri:cc8c0c3ae879b09e3c53cd1c8813da3c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:24f0614f12d5f2985cce3d892be55bcc prov:wasDerivedFrom niiri:607ca1c2f891e4ce713ca8444b3429fe .
+niiri:514ad018ba4d5e4b572be280b0667d18 prov:wasDerivedFrom niiri:cc8c0c3ae879b09e3c53cd1c8813da3c .
 
-niiri:24f0614f12d5f2985cce3d892be55bcc prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
+niiri:514ad018ba4d5e4b572be280b0667d18 prov:wasGeneratedBy niiri:bbf4abb1d4e900034f7e2514c9d594ec .
 
-niiri:aa47cd87d32100529ed9ccb7ff9f596d
+niiri:9e6316cdd5d5173a2d217ddeb1d7b4b8
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:32a4f215fd539ba5ce8e3fd646e19810
+niiri:6e6b75ffa063c7fd257930a57f439401
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:aa47cd87d32100529ed9ccb7ff9f596d prov:wasDerivedFrom niiri:32a4f215fd539ba5ce8e3fd646e19810 .
+niiri:9e6316cdd5d5173a2d217ddeb1d7b4b8 prov:wasDerivedFrom niiri:6e6b75ffa063c7fd257930a57f439401 .
 
-niiri:aa47cd87d32100529ed9ccb7ff9f596d prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
+niiri:9e6316cdd5d5173a2d217ddeb1d7b4b8 prov:wasGeneratedBy niiri:bbf4abb1d4e900034f7e2514c9d594ec .
 
-niiri:ae93c509341f396c5dd29a576a0f196b
+niiri:8b8985a1b7809ee217a07d3a01112aad
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:c574ee9b1828f6901f22dd38af2f4498
+niiri:f17454fc2b30cfefd7bb4a0d8940c2d1
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:ae93c509341f396c5dd29a576a0f196b prov:wasDerivedFrom niiri:c574ee9b1828f6901f22dd38af2f4498 .
+niiri:8b8985a1b7809ee217a07d3a01112aad prov:wasDerivedFrom niiri:f17454fc2b30cfefd7bb4a0d8940c2d1 .
 
-niiri:ae93c509341f396c5dd29a576a0f196b prov:wasGeneratedBy niiri:7c90be579fb4f97b5579f5d12f0ef01e .
+niiri:8b8985a1b7809ee217a07d3a01112aad prov:wasGeneratedBy niiri:bbf4abb1d4e900034f7e2514c9d594ec .
 
-niiri:4855ce8cf932e2c0213dbe52e5931dd3
+niiri:0b65c6badbfb7cfbb69c356ceda191a3
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:23058168747c80b31801d261abaf2585
+niiri:013c2f9958e67d5f41df562f07751576
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:23058168747c80b31801d261abaf2585 prov:wasAssociatedWith niiri:1d0e9f058cf6254a45a221ea959dd872 .
+niiri:013c2f9958e67d5f41df562f07751576 prov:wasAssociatedWith niiri:36e0ca6e862ec6354f9837b33735c25b .
 
-niiri:23058168747c80b31801d261abaf2585 prov:used niiri:c798bba76a13857f8244d5ad67ff103b .
+niiri:013c2f9958e67d5f41df562f07751576 prov:used niiri:1ed2d81eecb89474d5a861917dd60e81 .
 
-niiri:23058168747c80b31801d261abaf2585 prov:used niiri:aa47cd87d32100529ed9ccb7ff9f596d .
+niiri:013c2f9958e67d5f41df562f07751576 prov:used niiri:9e6316cdd5d5173a2d217ddeb1d7b4b8 .
 
-niiri:23058168747c80b31801d261abaf2585 prov:used niiri:c8ab5704c73f1a9bb81f64cb1449243e .
+niiri:013c2f9958e67d5f41df562f07751576 prov:used niiri:f1dfb0da2f98dbeb54f3aafd24e0e798 .
 
-niiri:23058168747c80b31801d261abaf2585 prov:used niiri:4855ce8cf932e2c0213dbe52e5931dd3 .
+niiri:013c2f9958e67d5f41df562f07751576 prov:used niiri:0b65c6badbfb7cfbb69c356ceda191a3 .
 
-niiri:23058168747c80b31801d261abaf2585 prov:used niiri:17a43d125a7f79b826e0854c9208a82f .
+niiri:013c2f9958e67d5f41df562f07751576 prov:used niiri:f61676e7d608d77611de78e41c4847aa .
 
-niiri:23058168747c80b31801d261abaf2585 prov:used niiri:7a7c15d2b4bfdb97b404fc0e16d83823 .
+niiri:013c2f9958e67d5f41df562f07751576 prov:used niiri:54ea04431ae710eb05e81741cc32410e .
 
-niiri:23058168747c80b31801d261abaf2585 prov:used niiri:24f0614f12d5f2985cce3d892be55bcc .
+niiri:013c2f9958e67d5f41df562f07751576 prov:used niiri:514ad018ba4d5e4b572be280b0667d18 .
 
-niiri:3be097d50565d12830332d18ecd1880b
+niiri:a7b5269861512e622fc8bb26dd1620ca
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:3be097d50565d12830332d18ecd1880b
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:c5af634b6d6d3deb00ab9c5c0075afb2
+niiri:6f4f218c58a0b571ffd4969c2d5121bc
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:3be097d50565d12830332d18ecd1880b prov:wasDerivedFrom niiri:c5af634b6d6d3deb00ab9c5c0075afb2 .
+niiri:a7b5269861512e622fc8bb26dd1620ca prov:wasDerivedFrom niiri:6f4f218c58a0b571ffd4969c2d5121bc .
 
-niiri:3be097d50565d12830332d18ecd1880b prov:wasGeneratedBy niiri:23058168747c80b31801d261abaf2585 .
+niiri:a7b5269861512e622fc8bb26dd1620ca prov:wasGeneratedBy niiri:013c2f9958e67d5f41df562f07751576 .
 
-niiri:f4f453b84f2b87845707493a3e41f364
+niiri:006639a78a9af29178283b1fda7faa95
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:21436c6961fca1af4342e037b0700593
+niiri:d5e56b78c24e6dee0385caabf0543fac
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:f4f453b84f2b87845707493a3e41f364 prov:wasDerivedFrom niiri:21436c6961fca1af4342e037b0700593 .
+niiri:006639a78a9af29178283b1fda7faa95 prov:wasDerivedFrom niiri:d5e56b78c24e6dee0385caabf0543fac .
 
-niiri:f4f453b84f2b87845707493a3e41f364 prov:wasGeneratedBy niiri:23058168747c80b31801d261abaf2585 .
+niiri:006639a78a9af29178283b1fda7faa95 prov:wasGeneratedBy niiri:013c2f9958e67d5f41df562f07751576 .
 
-niiri:625c994b0145a32cc974b8ed37d688e1
+niiri:cd8091b6f5b7827b1b16705109d4bd28
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:625c994b0145a32cc974b8ed37d688e1 prov:wasGeneratedBy niiri:23058168747c80b31801d261abaf2585 .
+niiri:cd8091b6f5b7827b1b16705109d4bd28 prov:wasGeneratedBy niiri:013c2f9958e67d5f41df562f07751576 .
 
-niiri:d4752660d42d5cf12c96b2666e7a2f38
+niiri:f9baa5ab83d70de5496f1564ff4eefd8
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
     prov:value "0.000999499751574873"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:d0868054f274b2d15c52d8ede9b646c0 ;
-    nidm_equivalentThreshold: niiri:5a521f9d3fba49a3acde5b1cf93758d7 .
+    nidm_equivalentThreshold: niiri:d3cd6b74aa515ea691704d65a66e0ba5 ;
+    nidm_equivalentThreshold: niiri:e40a357f9371360109c3bef80abba047 .
 
-niiri:d0868054f274b2d15c52d8ede9b646c0
+niiri:d3cd6b74aa515ea691704d65a66e0ba5
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12856968604193"^^xsd:float .
 
-niiri:5a521f9d3fba49a3acde5b1cf93758d7
+niiri:e40a357f9371360109c3bef80abba047
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999998566"^^xsd:float .
 
-niiri:7526e35038af3d726a0b80bf3340e666
+niiri:b9a503337ee32e1fd7e03b9e9f2220cb
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:0ce252a9fb798e0ba134c46ee264a392 ;
-    nidm_equivalentThreshold: niiri:7ea350b304b22e98c9b597be5d0aef1f .
+    nidm_equivalentThreshold: niiri:cef7b9ec311e390ce9be1c15654f5293 ;
+    nidm_equivalentThreshold: niiri:c9466ee7581e8486c97cd0b89bfbe7ee .
 
-niiri:0ce252a9fb798e0ba134c46ee264a392
+niiri:cef7b9ec311e390ce9be1c15654f5293
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:7ea350b304b22e98c9b597be5d0aef1f
+niiri:c9466ee7581e8486c97cd0b89bfbe7ee
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:c8b753e0bcb57800366a856147cea55c
+niiri:e833ce816e4c682014ec3d1d268d0a82
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:3e4d94b2d4fec863a3e05a90d08e7d50
+niiri:fdf123bdda05a0d3813bfaaccde5b1e7
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16
+niiri:c01b1327eb97e1658fc71f26818ac635
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:wasAssociatedWith niiri:1d0e9f058cf6254a45a221ea959dd872 .
+niiri:c01b1327eb97e1658fc71f26818ac635 prov:wasAssociatedWith niiri:36e0ca6e862ec6354f9837b33735c25b .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:d4752660d42d5cf12c96b2666e7a2f38 .
+niiri:c01b1327eb97e1658fc71f26818ac635 prov:used niiri:f9baa5ab83d70de5496f1564ff4eefd8 .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:7526e35038af3d726a0b80bf3340e666 .
+niiri:c01b1327eb97e1658fc71f26818ac635 prov:used niiri:b9a503337ee32e1fd7e03b9e9f2220cb .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:3be097d50565d12830332d18ecd1880b .
+niiri:c01b1327eb97e1658fc71f26818ac635 prov:used niiri:a7b5269861512e622fc8bb26dd1620ca .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:ae93c509341f396c5dd29a576a0f196b .
+niiri:c01b1327eb97e1658fc71f26818ac635 prov:used niiri:8b8985a1b7809ee217a07d3a01112aad .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:c798bba76a13857f8244d5ad67ff103b .
+niiri:c01b1327eb97e1658fc71f26818ac635 prov:used niiri:1ed2d81eecb89474d5a861917dd60e81 .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:c8b753e0bcb57800366a856147cea55c .
+niiri:c01b1327eb97e1658fc71f26818ac635 prov:used niiri:e833ce816e4c682014ec3d1d268d0a82 .
 
-niiri:b73c8647e3bbc090bd87c70ab3528a16 prov:used niiri:3e4d94b2d4fec863a3e05a90d08e7d50 .
+niiri:c01b1327eb97e1658fc71f26818ac635 prov:used niiri:fdf123bdda05a0d3813bfaaccde5b1e7 .
 
-niiri:ebd7e2e8cb7de028c38b7aaa31263974
+niiri:174520937654bec46a1c4a4edc02cc6f
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:ebd7e2e8cb7de028c38b7aaa31263974
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:ebd7e2e8cb7de028c38b7aaa31263974 prov:wasGeneratedBy niiri:b73c8647e3bbc090bd87c70ab3528a16 .
+niiri:174520937654bec46a1c4a4edc02cc6f prov:wasGeneratedBy niiri:c01b1327eb97e1658fc71f26818ac635 .
 
-niiri:b028d10934794cf9d7f19d4e97b56f77
+niiri:c213548113940d5da49331eadadfb1da
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:b028d10934794cf9d7f19d4e97b56f77
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:41a4758f7848a95406ccd26939a9ca0b ;
-    nidm_hasMaximumIntensityProjection: niiri:eda5c22f8ccd76c85fc65f583e891449 ;
-    nidm_inCoordinateSpace: niiri:be0006a57dffdd0820b4b36657cc9b94 ;
+    nidm_hasClusterLabelsMap: niiri:32a5f7aac5c14b2f9e374b1f8f6ec22c ;
+    nidm_hasMaximumIntensityProjection: niiri:9549ef1c93f294e158b22b63ca640e6c ;
+    nidm_inCoordinateSpace: niiri:86fbbec53aa7243bc5d23697658a64ea ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:41a4758f7848a95406ccd26939a9ca0b
+niiri:32a5f7aac5c14b2f9e374b1f8f6ec22c
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:eda5c22f8ccd76c85fc65f583e891449
+niiri:9549ef1c93f294e158b22b63ca640e6c
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:b028d10934794cf9d7f19d4e97b56f77 prov:wasGeneratedBy niiri:b73c8647e3bbc090bd87c70ab3528a16 .
+niiri:c213548113940d5da49331eadadfb1da prov:wasGeneratedBy niiri:c01b1327eb97e1658fc71f26818ac635 .
 

--- a/spmexport/ex_spm_conjunction/config.json
+++ b/spmexport/ex_spm_conjunction/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["conjunction/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_conjunction/nidm.provn
+++ b/spmexport/ex_spm_conjunction/nidm.provn
@@ -1,0 +1,1316 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:e8889926d05a35c367676e2b266a5d9e,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:229b0f08cfcf3f699fd45d952761f576,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:1051dc20a62ed1558eac0a1a2fb70588,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:1051dc20a62ed1558eac0a1a2fb70588, niiri:229b0f08cfcf3f699fd45d952761f576, -)
+  wasGeneratedBy(niiri:e8889926d05a35c367676e2b266a5d9e, niiri:1051dc20a62ed1558eac0a1a2fb70588, 2016-01-11T10:11:03)
+  bundle niiri:e8889926d05a35c367676e2b266a5d9e
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_ConjunctionInference <http://purl.org/nidash/nidm#NIDM_0000011>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+    prefix nidm_SupraThresholdCluster <http://purl.org/nidash/nidm#NIDM_0000070>
+    prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
+    prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+    prefix nidm_qValueFDR <http://purl.org/nidash/nidm#NIDM_0000119>
+    prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
+    prefix nidm_Peak <http://purl.org/nidash/nidm#NIDM_0000062>
+    prefix nidm_equivalentZStatistic <http://purl.org/nidash/nidm#NIDM_0000092>
+    prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
+    prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
+
+    agent(niiri:0b3ed3b43289bfce69e1dd8e0a580555,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:08ce005cf94169deadd293b9f0386fc0,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:12128f6eb829f1af879e8f015ce78ee5,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:4d9192c7fd08ad2bb7c4ff9503e7546b,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:62719c37cb7f1155944ed6252b71ec01,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:df48ccc999ebf8ca6f4c3e5bc939230c',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:4d9192c7fd08ad2bb7c4ff9503e7546b',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:df48ccc999ebf8ca6f4c3e5bc939230c,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:9cca745d6e07ffe830a810c73a4beb94,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:814ac7079ffe5eac40b4e81f109d77d3,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:814ac7079ffe5eac40b4e81f109d77d3, niiri:0b3ed3b43289bfce69e1dd8e0a580555, -)
+    used(niiri:814ac7079ffe5eac40b4e81f109d77d3, niiri:62719c37cb7f1155944ed6252b71ec01, -)
+    used(niiri:814ac7079ffe5eac40b4e81f109d77d3, niiri:12128f6eb829f1af879e8f015ce78ee5, -)
+    used(niiri:814ac7079ffe5eac40b4e81f109d77d3, niiri:9cca745d6e07ffe830a810c73a4beb94, -)
+    entity(niiri:fa56d066478b2ea71a6e1c4d5d549487,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
+    entity(niiri:e4a6119a50fded21c14197bcf296ab06,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
+    wasDerivedFrom(niiri:fa56d066478b2ea71a6e1c4d5d549487, niiri:e4a6119a50fded21c14197bcf296ab06, -, -, -)
+    wasGeneratedBy(niiri:fa56d066478b2ea71a6e1c4d5d549487, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:e5e2aba57bea3f7fc5a3f8657c80a53b,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "108.038318634033" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
+    wasGeneratedBy(niiri:e5e2aba57bea3f7fc5a3f8657c80a53b, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:8dc72e026b46807ff7610978144a50a7,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
+    entity(niiri:4ae89562691298e404907d30c17d6405,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f" %% xsd:string])
+    wasDerivedFrom(niiri:8dc72e026b46807ff7610978144a50a7, niiri:4ae89562691298e404907d30c17d6405, -, -, -)
+    wasGeneratedBy(niiri:8dc72e026b46807ff7610978144a50a7, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:c92fcc94226b041e076498dac96ae002,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
+    entity(niiri:70eb7916777b2ccbe5e1004599b6b16f,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
+    wasDerivedFrom(niiri:c92fcc94226b041e076498dac96ae002, niiri:70eb7916777b2ccbe5e1004599b6b16f, -, -, -)
+    wasGeneratedBy(niiri:c92fcc94226b041e076498dac96ae002, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:e709d65a8b7aad133a26fc434e5810c1,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
+    entity(niiri:5c45b10466b418609ad8f78d1d37f2a6,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb" %% xsd:string])
+    wasDerivedFrom(niiri:e709d65a8b7aad133a26fc434e5810c1, niiri:5c45b10466b418609ad8f78d1d37f2a6, -, -, -)
+    wasGeneratedBy(niiri:e709d65a8b7aad133a26fc434e5810c1, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:68dce10b86eb716a09c05d6bff88fb86,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 4" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
+    entity(niiri:2ec5caa6c30b03a58e93533d26263bf0,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0004.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6" %% xsd:string])
+    wasDerivedFrom(niiri:68dce10b86eb716a09c05d6bff88fb86, niiri:2ec5caa6c30b03a58e93533d26263bf0, -, -, -)
+    wasGeneratedBy(niiri:68dce10b86eb716a09c05d6bff88fb86, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:1835bec3a94146206bbc4c8dd879125c,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 5" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
+    entity(niiri:7cfa6c3f159704f4e89cdb27e96c7bc1,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0005.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff" %% xsd:string])
+    wasDerivedFrom(niiri:1835bec3a94146206bbc4c8dd879125c, niiri:7cfa6c3f159704f4e89cdb27e96c7bc1, -, -, -)
+    wasGeneratedBy(niiri:1835bec3a94146206bbc4c8dd879125c, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:3f4483bbcd6a762700a3897d004115aa,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 6" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
+    entity(niiri:5924cb43042ba2ca9b3e72dff64b49b5,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0006.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
+    wasDerivedFrom(niiri:3f4483bbcd6a762700a3897d004115aa, niiri:5924cb43042ba2ca9b3e72dff64b49b5, -, -, -)
+    wasGeneratedBy(niiri:3f4483bbcd6a762700a3897d004115aa, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:0584af123d5f6deb3954a3ac1bf9afaf,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8" %% xsd:string])
+    entity(niiri:751ce5b565c5ac0b6fcbae2755edacc1,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81" %% xsd:string])
+    wasDerivedFrom(niiri:0584af123d5f6deb3954a3ac1bf9afaf, niiri:751ce5b565c5ac0b6fcbae2755edacc1, -, -, -)
+    wasGeneratedBy(niiri:0584af123d5f6deb3954a3ac1bf9afaf, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:5e5f72d3a313df47ed1675f196ba2790,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8" %% xsd:string])
+    entity(niiri:c43d5c20b335994694e0ce99c69c63d2,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29" %% xsd:string])
+    wasDerivedFrom(niiri:5e5f72d3a313df47ed1675f196ba2790, niiri:c43d5c20b335994694e0ce99c69c63d2, -, -, -)
+    wasGeneratedBy(niiri:5e5f72d3a313df47ed1675f196ba2790, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
+    entity(niiri:fff3d3a4810634aa02f29f0c1f5fbb8f,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        prov:label = "Contrast: mr vs plain" %% xsd:string,
+        prov:value = "[1, 1, -1, -1, 0, 0]" %% xsd:string])
+    activity(niiri:ed2f36215d4ae0d42c3aefe5ecd86175,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation 1"])
+    wasAssociatedWith(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:0b3ed3b43289bfce69e1dd8e0a580555, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:fa56d066478b2ea71a6e1c4d5d549487, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:0584af123d5f6deb3954a3ac1bf9afaf, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:62719c37cb7f1155944ed6252b71ec01, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:fff3d3a4810634aa02f29f0c1f5fbb8f, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:8dc72e026b46807ff7610978144a50a7, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:c92fcc94226b041e076498dac96ae002, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:e709d65a8b7aad133a26fc434e5810c1, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:68dce10b86eb716a09c05d6bff88fb86, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:1835bec3a94146206bbc4c8dd879125c, -)
+    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:3f4483bbcd6a762700a3897d004115aa, -)
+    entity(niiri:33170469490d72c603cf1ad06ce86637,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic_0001.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic_0001.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: mr vs plain" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "aba2fef7900cacda1ed84fe5edf867bd2b0fc6ae7eb4919967798d7f219a6d8ad5454fe8e0bdf4a7cfa6402e73287e703c285d12df0a282e40438ec36153e715" %% xsd:string])
+    entity(niiri:0d5089a0bd1af4fc6f9474726c757a3b,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782" %% xsd:string])
+    wasDerivedFrom(niiri:33170469490d72c603cf1ad06ce86637, niiri:0d5089a0bd1af4fc6f9474726c757a3b, -, -, -)
+    wasGeneratedBy(niiri:33170469490d72c603cf1ad06ce86637, niiri:ed2f36215d4ae0d42c3aefe5ecd86175, -)
+    entity(niiri:a15220866e3ff78e30b1d06f1e2ad332,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast_0001.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast_0001.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: mr vs plain" %% xsd:string,
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5" %% xsd:string])
+    entity(niiri:c06e95223a98daddc50df12b0ef668ef,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28" %% xsd:string])
+    wasDerivedFrom(niiri:a15220866e3ff78e30b1d06f1e2ad332, niiri:c06e95223a98daddc50df12b0ef668ef, -, -, -)
+    wasGeneratedBy(niiri:a15220866e3ff78e30b1d06f1e2ad332, niiri:ed2f36215d4ae0d42c3aefe5ecd86175, -)
+    entity(niiri:88f8800367c7c2b2a2d1a301d933782c,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError_0001.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError_0001.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b" %% xsd:string])
+    wasGeneratedBy(niiri:88f8800367c7c2b2a2d1a301d933782c, niiri:ed2f36215d4ae0d42c3aefe5ecd86175, -)
+    entity(niiri:59cd72b8af1baa0c5eb355990015dbc8,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
+        prov:label = "Contrast: switch vs nonswitch" %% xsd:string,
+        prov:value = "[1, -1, 1, -1, 0, 0]" %% xsd:string])
+    activity(niiri:bb82cadb0c0a63033cb0b69845e19933,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation 2"])
+    wasAssociatedWith(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:0b3ed3b43289bfce69e1dd8e0a580555, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:fa56d066478b2ea71a6e1c4d5d549487, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:0584af123d5f6deb3954a3ac1bf9afaf, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:62719c37cb7f1155944ed6252b71ec01, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:59cd72b8af1baa0c5eb355990015dbc8, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:8dc72e026b46807ff7610978144a50a7, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:c92fcc94226b041e076498dac96ae002, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:e709d65a8b7aad133a26fc434e5810c1, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:68dce10b86eb716a09c05d6bff88fb86, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:1835bec3a94146206bbc4c8dd879125c, -)
+    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:3f4483bbcd6a762700a3897d004115aa, -)
+    entity(niiri:cdd7c42099c33f420a6755aca2f2279f,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic_0002.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic_0002.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: switch vs nonswitch" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "1c375cdc8f2b00f93f3d6f1a09aafa5670d35ffcf2c82ef061151bfb047463e482e971d67ce3e3e2496f37b1621f5d732a0a1f88c773f5d5fa077cb6a3e38501" %% xsd:string])
+    entity(niiri:f364d39b2363c17f9d16acb9c59c6a34,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "313c8e34e107b1e9bec46074e7a1cef289427618869119eff1c8044a2b5b8e5a340c899a78f40a3f8b938dbbbde53bd16c096da55f2e07a7c9e334cfd1e471f2" %% xsd:string])
+    wasDerivedFrom(niiri:cdd7c42099c33f420a6755aca2f2279f, niiri:f364d39b2363c17f9d16acb9c59c6a34, -, -, -)
+    wasGeneratedBy(niiri:cdd7c42099c33f420a6755aca2f2279f, niiri:bb82cadb0c0a63033cb0b69845e19933, -)
+    entity(niiri:e302d7d850e61776b5bb1245b4e05648,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast_0002.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast_0002.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: switch vs nonswitch" %% xsd:string,
+        nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "77720bd21fb296db2e69c9742318c52f7cf6b08f94a83c5c1e30d5b8b21b1fd218de32fcc3a96aa2d067d5b06015e85e863ab87907741d2d7c9993740f668dc2" %% xsd:string])
+    entity(niiri:4488f35b0475365c16a619d4367e2596,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "6983d8888c458d8a073f84054db2587b0a71764e64c30ea7e4a13cd0e6b2e301eaea1b570822b24b635b464fd233c3801a9205ddcd2dcffcda7cd99679d2734a" %% xsd:string])
+    wasDerivedFrom(niiri:e302d7d850e61776b5bb1245b4e05648, niiri:4488f35b0475365c16a619d4367e2596, -, -, -)
+    wasGeneratedBy(niiri:e302d7d850e61776b5bb1245b4e05648, niiri:bb82cadb0c0a63033cb0b69845e19933, -)
+    entity(niiri:f0fc139f8e55d67381833c5bf0ad8776,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError_0002.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError_0002.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "1bb21447dcf3cc1eeb9453c707178e4d87161242c69e18795e0e2b30496c9e657ed2f202d4c9cd364aea5a04e4e46fe70ca830e1db14dd2e0f20af754281c3f2" %% xsd:string])
+    wasGeneratedBy(niiri:f0fc139f8e55d67381833c5bf0ad8776, niiri:bb82cadb0c0a63033cb0b69845e19933, -)
+    entity(niiri:fc0dadbc5f694e6ae907492f74e6940a,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.048771 (unc.)" %% xsd:string,
+        prov:value = "0.0487705952532708" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:4e24c86c0c11cc5f53096bcd0ce1dee2',
+        nidm_equivalentThreshold: = 'niiri:f9486c7fafc049f9442fc8a37aad071b'])
+    entity(niiri:4e24c86c0c11cc5f53096bcd0ce1dee2,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "1.65278686445912" %% xsd:float])
+    entity(niiri:f9486c7fafc049f9442fc8a37aad071b,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:6f5dc8bb78b50ed4e5df8f9ad38d9464,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:92687adf3abda3ba46eb627518e50083',
+        nidm_equivalentThreshold: = 'niiri:6af6d4d06a49094c399e6ccf744121ef'])
+    entity(niiri:92687adf3abda3ba46eb627518e50083,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:6af6d4d06a49094c399e6ccf744121ef,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:c90078d4c679070cca4a029f082015c6,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:e225a30061c1008b5fab26894ccaf377,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6,
+        [prov:type = 'nidm_ConjunctionInference:',
+        prov:label = "Conjunction Inference"])
+    wasAssociatedWith(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:0b3ed3b43289bfce69e1dd8e0a580555, -)
+    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:fc0dadbc5f694e6ae907492f74e6940a, -)
+    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:6f5dc8bb78b50ed4e5df8f9ad38d9464, -)
+    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:33170469490d72c603cf1ad06ce86637, -)
+    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:cdd7c42099c33f420a6755aca2f2279f, -)
+    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:5e5f72d3a313df47ed1675f196ba2790, -)
+    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:fa56d066478b2ea71a6e1c4d5d549487, -)
+    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:c90078d4c679070cca4a029f082015c6, -)
+    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:e225a30061c1008b5fab26894ccaf377, -)
+    entity(niiri:5659ce7e18cccaee79d052589cc49082,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
+        nidm_reselSizeInVoxels: = "68.4409986586553" %% xsd:float,
+        nidm_searchVolumeInResels: = "2811.45809925534" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[5, 96.6116867805852, 900.100332657535, 2811.45809925534]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.16320607513012, 4.05765428344905, 4.05147708968699]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.32641215026024, 8.1153085668981, 8.10295417937398]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "65.6719601732437" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "221.248707519578" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.08514693703219" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
+    wasGeneratedBy(niiri:5659ce7e18cccaee79d052589cc49082, niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, -)
+    entity(niiri:f3637fafb926481fff6bd8938c6a8550,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "30" %% xsd:int,
+        nidm_pValue: = "1" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:225cba9527198fe0f9f286e4794b0c09',
+        nidm_hasMaximumIntensityProjection: = 'niiri:b314a44bd0faae613b91c61054d712ba',
+        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        crypto:sha512 = "bcf45ac744752d54a29a2b918eda586a0e6637179a62a2eef62afd03f594bb4bdb4d2171625040d21c22a02d3a13fd0312ce1b83f6a6aecf34c432299e21c864" %% xsd:string])
+    entity(niiri:225cba9527198fe0f9f286e4794b0c09,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:b314a44bd0faae613b91c61054d712ba,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:f3637fafb926481fff6bd8938c6a8550, niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, -)
+    entity(niiri:1ca2ed8885126a13f37d342c5bda82b6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "95" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.38805689370206" %% xsd:float,
+        nidm_pValueUncorrected: = "0.213014928043125" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "1" %% xsd:int])
+    wasDerivedFrom(niiri:1ca2ed8885126a13f37d342c5bda82b6, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:b6ec4ee5c26bd5170b56e954e84a7789,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.782510669800627" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "2" %% xsd:int])
+    wasDerivedFrom(niiri:b6ec4ee5c26bd5170b56e954e84a7789, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:67aa7dea8d858564a8b4505070c20ab3,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "9" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.131500126771774" %% xsd:float,
+        nidm_pValueUncorrected: = "0.725158209956759" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "3" %% xsd:int])
+    wasDerivedFrom(niiri:67aa7dea8d858564a8b4505070c20ab3, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:8eb556353f8e288e589eef37024ef068,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.611975830727683" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "4" %% xsd:int])
+    wasDerivedFrom(niiri:8eb556353f8e288e589eef37024ef068, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:4f970219224428039454afd130e40f48,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160722377165502" %% xsd:float,
+        nidm_pValueUncorrected: = "0.692555940999578" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "5" %% xsd:int])
+    wasDerivedFrom(niiri:4f970219224428039454afd130e40f48, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:c2a5888cb7cfb94104a85fdf0c0a0975,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.611975830727683" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "6" %% xsd:int])
+    wasDerivedFrom(niiri:c2a5888cb7cfb94104a85fdf0c0a0975, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:5e85e47c2fc2758e5d466cd2123b2254,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "24" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.350667004724731" %% xsd:float,
+        nidm_pValueUncorrected: = "0.539029201377477" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "7" %% xsd:int])
+    wasDerivedFrom(niiri:5e85e47c2fc2758e5d466cd2123b2254, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:6105338324e4b950666042ae82d011fd,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.782510669800627" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "8" %% xsd:int])
+    wasDerivedFrom(niiri:6105338324e4b950666042ae82d011fd, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:4f020dcb9018a1690cba2cbf60dc38b0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "41" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.599056133071416" %% xsd:float,
+        nidm_pValueUncorrected: = "0.413484921872381" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "9" %% xsd:int])
+    wasDerivedFrom(niiri:4f020dcb9018a1690cba2cbf60dc38b0, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:68b9b03c7822e1a0b86cd9e68fe99ca2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.782510669800627" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "10" %% xsd:int])
+    wasDerivedFrom(niiri:68b9b03c7822e1a0b86cd9e68fe99ca2, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.611975830727683" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "11" %% xsd:int])
+    wasDerivedFrom(niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:f626ba6b4ad8b422a9e8b6208607d5c7,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.829311832510809" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "12" %% xsd:int])
+    wasDerivedFrom(niiri:f626ba6b4ad8b422a9e8b6208607d5c7, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:dd3a390096e9240d96d84a6fa0b53334,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.829311832510809" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "13" %% xsd:int])
+    wasDerivedFrom(niiri:dd3a390096e9240d96d84a6fa0b53334, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:b38cc3f1a8c8b355373259707d78b430,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.11688900157491" %% xsd:float,
+        nidm_pValueUncorrected: = "0.742972344559258" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "14" %% xsd:int])
+    wasDerivedFrom(niiri:b38cc3f1a8c8b355373259707d78b430, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:708b36a85852210d2aa37cd0a43c31d6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.11688900157491" %% xsd:float,
+        nidm_pValueUncorrected: = "0.742972344559258" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "15" %% xsd:int])
+    wasDerivedFrom(niiri:708b36a85852210d2aa37cd0a43c31d6, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:9fb5666ada501891fcef9d333ed6afff,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.829311832510809" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "16" %% xsd:int])
+    wasDerivedFrom(niiri:9fb5666ada501891fcef9d333ed6afff, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:756837e339677511c64f8da38004cd2e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.888782432018751" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "17" %% xsd:int])
+    wasDerivedFrom(niiri:756837e339677511c64f8da38004cd2e, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:303983981b9e7155b24ee729485e35d5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.856846591224654" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "18" %% xsd:int])
+    wasDerivedFrom(niiri:303983981b9e7155b24ee729485e35d5, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:ff25cf8967cf153c0c4bac8744bfd4de,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.829311832510809" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "19" %% xsd:int])
+    wasDerivedFrom(niiri:ff25cf8967cf153c0c4bac8744bfd4de, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:1e1d5e2b654ff9dfd561671bb14dac45,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.928417166750593" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "20" %% xsd:int])
+    wasDerivedFrom(niiri:1e1d5e2b654ff9dfd561671bb14dac45, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:04d3366efa2ae78508ba78d4f6d3fbd4,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.856846591224654" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "21" %% xsd:int])
+    wasDerivedFrom(niiri:04d3366efa2ae78508ba78d4f6d3fbd4, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:471616239367dd0b8f23af62cd1178af,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.928417166750593" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "22" %% xsd:int])
+    wasDerivedFrom(niiri:471616239367dd0b8f23af62cd1178af, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:146e852a595d2bd9bf43b63cb1ffe554,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.928417166750593" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "23" %% xsd:int])
+    wasDerivedFrom(niiri:146e852a595d2bd9bf43b63cb1ffe554, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:c76d475fb44856dbc3b3660c08027d10,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.928417166750593" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "24" %% xsd:int])
+    wasDerivedFrom(niiri:c76d475fb44856dbc3b3660c08027d10, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:171a3293a830389fbc0eeedac10ab2ef,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.856846591224654" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "25" %% xsd:int])
+    wasDerivedFrom(niiri:171a3293a830389fbc0eeedac10ab2ef, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:230b132218201af072b76732d6cd366e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.928417166750593" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "26" %% xsd:int])
+    wasDerivedFrom(niiri:230b132218201af072b76732d6cd366e, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:88b6854434c4c7d7d77b89858ff66d15,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.928417166750593" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "27" %% xsd:int])
+    wasDerivedFrom(niiri:88b6854434c4c7d7d77b89858ff66d15, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:983ff16f46a1aa2fb13613f2c2f88011,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.888782432018751" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "28" %% xsd:int])
+    wasDerivedFrom(niiri:983ff16f46a1aa2fb13613f2c2f88011, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:a6327d343c9ff6cf00c6cbe83308072b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.888782432018751" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "29" %% xsd:int])
+    wasDerivedFrom(niiri:a6327d343c9ff6cf00c6cbe83308072b, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:92ac4a8cb0a6c243ecb32fc66fd3deab,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.928417166750593" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "30" %% xsd:int])
+    wasDerivedFrom(niiri:92ac4a8cb0a6c243ecb32fc66fd3deab, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
+    entity(niiri:c3e496eea557d318020009e75ea064a9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0001" %% xsd:string,
+        prov:location = 'niiri:33b9e64baedb78edec3c778ac3503e57',
+        prov:value = "2.29849815368652" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.28220028418391" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0112387591680547" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:33b9e64baedb78edec3c778ac3503e57,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0001" %% xsd:string,
+        nidm_coordinateVector: = "[-28,24,4]" %% xsd:string])
+    wasDerivedFrom(niiri:c3e496eea557d318020009e75ea064a9, niiri:1ca2ed8885126a13f37d342c5bda82b6, -, -, -)
+    entity(niiri:304c8f977e3d31328f1ba8cc597ceb18,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0002" %% xsd:string,
+        prov:location = 'niiri:39b6eca99b5b73480b968ea12add2484',
+        prov:value = "2.07190132141113" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.0619285244841" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0196072706834085" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:39b6eca99b5b73480b968ea12add2484,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0002" %% xsd:string,
+        nidm_coordinateVector: = "[-28,26,12]" %% xsd:string])
+    wasDerivedFrom(niiri:304c8f977e3d31328f1ba8cc597ceb18, niiri:1ca2ed8885126a13f37d342c5bda82b6, -, -, -)
+    entity(niiri:02fb69f52c0371d7e8083f1d698b5486,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0003" %% xsd:string,
+        prov:location = 'niiri:0545dc10de1e5d6701474796bc5135b3',
+        prov:value = "2.18201637268066" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.16893530312973" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0150437980271687" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:0545dc10de1e5d6701474796bc5135b3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0003" %% xsd:string,
+        nidm_coordinateVector: = "[52,48,12]" %% xsd:string])
+    wasDerivedFrom(niiri:02fb69f52c0371d7e8083f1d698b5486, niiri:b6ec4ee5c26bd5170b56e954e84a7789, -, -, -)
+    entity(niiri:47905f0ed8d89646a0b2df5e003f1e2a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0004" %% xsd:string,
+        prov:location = 'niiri:d0d2bf61fd3a0931a0e3bdd8f49eed93',
+        prov:value = "2.13869571685791" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.12682533173394" %% xsd:float,
+        nidm_pValueUncorrected: = "0.016717299356924" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:d0d2bf61fd3a0931a0e3bdd8f49eed93,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0004" %% xsd:string,
+        nidm_coordinateVector: = "[34,-54,52]" %% xsd:string])
+    wasDerivedFrom(niiri:47905f0ed8d89646a0b2df5e003f1e2a, niiri:67aa7dea8d858564a8b4505070c20ab3, -, -, -)
+    entity(niiri:091b7fa1943f270ddc578020b6bf4b81,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0005" %% xsd:string,
+        prov:location = 'niiri:2d030121bd3e3440189b9362d24d0e82',
+        prov:value = "2.13825297355652" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.12639503027273" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0167351906128659" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:2d030121bd3e3440189b9362d24d0e82,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0005" %% xsd:string,
+        nidm_coordinateVector: = "[36,-84,2]" %% xsd:string])
+    wasDerivedFrom(niiri:091b7fa1943f270ddc578020b6bf4b81, niiri:8eb556353f8e288e589eef37024ef068, -, -, -)
+    entity(niiri:225874e925381c31ec2075213af93cc8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0006" %% xsd:string,
+        prov:location = 'niiri:7506c87aedf9336f1b97442d8e526f2f',
+        prov:value = "2.1293613910675" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.11775365245473" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0170979681968485" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:7506c87aedf9336f1b97442d8e526f2f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0006" %% xsd:string,
+        nidm_coordinateVector: = "[30,68,12]" %% xsd:string])
+    wasDerivedFrom(niiri:225874e925381c31ec2075213af93cc8, niiri:4f970219224428039454afd130e40f48, -, -, -)
+    entity(niiri:eb6fb2c76c756484f30c7d09b66c5c43,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0007" %% xsd:string,
+        prov:location = 'niiri:99c662c8509b716d461c456391b45b37',
+        prov:value = "2.11468005180359" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.10348692366691" %% xsd:float,
+        nidm_pValueUncorrected: = "0.017711613581637" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:99c662c8509b716d461c456391b45b37,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0007" %% xsd:string,
+        nidm_coordinateVector: = "[34,-84,14]" %% xsd:string])
+    wasDerivedFrom(niiri:eb6fb2c76c756484f30c7d09b66c5c43, niiri:c2a5888cb7cfb94104a85fdf0c0a0975, -, -, -)
+    entity(niiri:db15f3aea3a0b1689952a5924009614a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0008" %% xsd:string,
+        prov:location = 'niiri:ec58debeeea826abc9378be9d6ccee92',
+        prov:value = "2.01981115341187" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.01135476956162" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0221439986174564" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:ec58debeeea826abc9378be9d6ccee92,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0008" %% xsd:string,
+        nidm_coordinateVector: = "[-42,20,36]" %% xsd:string])
+    wasDerivedFrom(niiri:db15f3aea3a0b1689952a5924009614a, niiri:5e85e47c2fc2758e5d466cd2123b2254, -, -, -)
+    entity(niiri:a9e83bfae2a235a9cc20adac4118915b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0009" %% xsd:string,
+        prov:location = 'niiri:3991fe3c2e71f1b8e7f88c795fa8f2b0',
+        prov:value = "1.9834691286087" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.97609535691968" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0240719891024281" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:3991fe3c2e71f1b8e7f88c795fa8f2b0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0009" %% xsd:string,
+        nidm_coordinateVector: = "[34,-78,36]" %% xsd:string])
+    wasDerivedFrom(niiri:a9e83bfae2a235a9cc20adac4118915b, niiri:6105338324e4b950666042ae82d011fd, -, -, -)
+    entity(niiri:2f99eaddb3b1956eee9400c73e729457,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0010" %% xsd:string,
+        prov:location = 'niiri:94ba0436d49d4f1ac392af5f6adb2756',
+        prov:value = "1.94259870052338" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.93647164753299" %% xsd:float,
+        nidm_pValueUncorrected: = "0.026404980891827" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:94ba0436d49d4f1ac392af5f6adb2756,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0010" %% xsd:string,
+        nidm_coordinateVector: = "[-48,18,18]" %% xsd:string])
+    wasDerivedFrom(niiri:2f99eaddb3b1956eee9400c73e729457, niiri:4f020dcb9018a1690cba2cbf60dc38b0, -, -, -)
+    entity(niiri:e21f5c3bb0d87db0399aa6aeaae8fa17,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0011" %% xsd:string,
+        prov:location = 'niiri:026fbe87ef12da1f1cb8f58505c5a35d',
+        prov:value = "1.89261054992676" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.88805796389517" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0295090846561562" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:026fbe87ef12da1f1cb8f58505c5a35d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0011" %% xsd:string,
+        nidm_coordinateVector: = "[-40,20,8]" %% xsd:string])
+    wasDerivedFrom(niiri:e21f5c3bb0d87db0399aa6aeaae8fa17, niiri:4f020dcb9018a1690cba2cbf60dc38b0, -, -, -)
+    entity(niiri:819a69b124962a6bc39aa80cdc398a30,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0012" %% xsd:string,
+        prov:location = 'niiri:0d0ffa2881f696dcc6b1d489a15348ec',
+        prov:value = "1.9298506975174" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.92411963399221" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0271697947905869" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:0d0ffa2881f696dcc6b1d489a15348ec,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0012" %% xsd:string,
+        nidm_coordinateVector: = "[22,-82,6]" %% xsd:string])
+    wasDerivedFrom(niiri:819a69b124962a6bc39aa80cdc398a30, niiri:68b9b03c7822e1a0b86cd9e68fe99ca2, -, -, -)
+    entity(niiri:df4034a52a0223c24e52134353933b85,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0013" %% xsd:string,
+        prov:location = 'niiri:b2e026ac20229c679280d6521ef462e2',
+        prov:value = "1.87824356555939" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.87415494022171" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0304545363496075" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:b2e026ac20229c679280d6521ef462e2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0013" %% xsd:string,
+        nidm_coordinateVector: = "[-34,22,20]" %% xsd:string])
+    wasDerivedFrom(niiri:df4034a52a0223c24e52134353933b85, niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9, -, -, -)
+    entity(niiri:56e0435b5a93b3ea44eb4880caa46f6e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0014" %% xsd:string,
+        prov:location = 'niiri:64c2cf7669582f994375fb0c99a90889',
+        prov:value = "1.85802888870239" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.85460257678401" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0318264999487402" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:64c2cf7669582f994375fb0c99a90889,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0014" %% xsd:string,
+        nidm_coordinateVector: = "[16,-100,10]" %% xsd:string])
+    wasDerivedFrom(niiri:56e0435b5a93b3ea44eb4880caa46f6e, niiri:f626ba6b4ad8b422a9e8b6208607d5c7, -, -, -)
+    entity(niiri:1585cde397394ce1852eabdc3e6069bc,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0015" %% xsd:string,
+        prov:location = 'niiri:f72c8e0f5976a1f9554754dc1a644aec',
+        prov:value = "1.82612562179565" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.82376887581619" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0340935105624357" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:f72c8e0f5976a1f9554754dc1a644aec,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0015" %% xsd:string,
+        nidm_coordinateVector: = "[-22,6,14]" %% xsd:string])
+    wasDerivedFrom(niiri:1585cde397394ce1852eabdc3e6069bc, niiri:dd3a390096e9240d96d84a6fa0b53334, -, -, -)
+    entity(niiri:fc1bd52acb4a54ac65706ec77b597664,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0016" %% xsd:string,
+        prov:location = 'niiri:b916c3481037d35a043ee9bca1bfa812',
+        prov:value = "1.8208144903183" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.81863886421642" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0344832722280412" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:b916c3481037d35a043ee9bca1bfa812,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0016" %% xsd:string,
+        nidm_coordinateVector: = "[32,-66,0]" %% xsd:string])
+    wasDerivedFrom(niiri:fc1bd52acb4a54ac65706ec77b597664, niiri:b38cc3f1a8c8b355373259707d78b430, -, -, -)
+    entity(niiri:dd9b23180ca6d48364bbd5e03598085b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0017" %% xsd:string,
+        prov:location = 'niiri:e19da916a650e437d894081ea2700363',
+        prov:value = "1.79377067089081" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.79253174586373" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0365239143287336" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:e19da916a650e437d894081ea2700363,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0017" %% xsd:string,
+        nidm_coordinateVector: = "[-28,8,14]" %% xsd:string])
+    wasDerivedFrom(niiri:dd9b23180ca6d48364bbd5e03598085b, niiri:708b36a85852210d2aa37cd0a43c31d6, -, -, -)
+    entity(niiri:60833962d796c1925bb5caa354752e20,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0018" %% xsd:string,
+        prov:location = 'niiri:0286ca8f9f6d1abb7e43fe83af301e65',
+        prov:value = "1.79001986980438" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.78891283515708" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0368144271933957" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:0286ca8f9f6d1abb7e43fe83af301e65,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0018" %% xsd:string,
+        nidm_coordinateVector: = "[-20,26,28]" %% xsd:string])
+    wasDerivedFrom(niiri:60833962d796c1925bb5caa354752e20, niiri:9fb5666ada501891fcef9d333ed6afff, -, -, -)
+    entity(niiri:f44eff18cdf7e25979cf1141a5338fc0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0019" %% xsd:string,
+        prov:location = 'niiri:9d4722db398870c6b3ea92787232d10a',
+        prov:value = "1.74872362613678" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.749102772694" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0401366280244358" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:9d4722db398870c6b3ea92787232d10a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0019" %% xsd:string,
+        nidm_coordinateVector: = "[-54,28,20]" %% xsd:string])
+    wasDerivedFrom(niiri:f44eff18cdf7e25979cf1141a5338fc0, niiri:756837e339677511c64f8da38004cd2e, -, -, -)
+    entity(niiri:7d958f3e975bddab9f95985faaae5cad,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0020" %% xsd:string,
+        prov:location = 'niiri:338c9616ae26c8e59158924ee7b04682',
+        prov:value = "1.73660695552826" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73743465054505" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0411552397567266" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:338c9616ae26c8e59158924ee7b04682,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0020" %% xsd:string,
+        nidm_coordinateVector: = "[36,-56,-12]" %% xsd:string])
+    wasDerivedFrom(niiri:7d958f3e975bddab9f95985faaae5cad, niiri:303983981b9e7155b24ee729485e35d5, -, -, -)
+    entity(niiri:8f47804dc4763167b41a429473c75db8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0021" %% xsd:string,
+        prov:location = 'niiri:590b0466ddb6db870e7a7eb6ccc2f0c5',
+        prov:value = "1.72697401046753" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.72816258455492" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0419795398198842" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:590b0466ddb6db870e7a7eb6ccc2f0c5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0021" %% xsd:string,
+        nidm_coordinateVector: = "[12,74,8]" %% xsd:string])
+    wasDerivedFrom(niiri:8f47804dc4763167b41a429473c75db8, niiri:ff25cf8967cf153c0c4bac8744bfd4de, -, -, -)
+    entity(niiri:d86f7773fa7f7c82a9d04542bdbbd522,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0022" %% xsd:string,
+        prov:location = 'niiri:4a94efdcb82d851208aa8b066ac5c604',
+        prov:value = "1.69681537151337" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.69915940103581" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0446445768205113" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:4a94efdcb82d851208aa8b066ac5c604,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0022" %% xsd:string,
+        nidm_coordinateVector: = "[-28,50,36]" %% xsd:string])
+    wasDerivedFrom(niiri:d86f7773fa7f7c82a9d04542bdbbd522, niiri:1e1d5e2b654ff9dfd561671bb14dac45, -, -, -)
+    entity(niiri:27b1286570a35003fd1cb892df5003ee,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0023" %% xsd:string,
+        prov:location = 'niiri:fd0f08df1132bd69544d5c2bc67a8ce1',
+        prov:value = "1.69281709194183" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.69531733220798" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0450076192977755" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:fd0f08df1132bd69544d5c2bc67a8ce1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0023" %% xsd:string,
+        nidm_coordinateVector: = "[-54,28,12]" %% xsd:string])
+    wasDerivedFrom(niiri:27b1286570a35003fd1cb892df5003ee, niiri:04d3366efa2ae78508ba78d4f6d3fbd4, -, -, -)
+    entity(niiri:39aa9652e5edc473ede61063b5f9330b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0024" %% xsd:string,
+        prov:location = 'niiri:f19ef86275c6e6fc9f17827d454cea6f',
+        prov:value = "1.68880593776703" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.69146362670159" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0453741445419741" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:f19ef86275c6e6fc9f17827d454cea6f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0024" %% xsd:string,
+        nidm_coordinateVector: = "[26,-92,18]" %% xsd:string])
+    wasDerivedFrom(niiri:39aa9652e5edc473ede61063b5f9330b, niiri:471616239367dd0b8f23af62cd1178af, -, -, -)
+    entity(niiri:9607bb62ecc6289f2476a8bb82c2c966,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0025" %% xsd:string,
+        prov:location = 'niiri:9759d63712f31dd71f970ba24fdc02ba',
+        prov:value = "1.68117702007294" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.68413622248109" %% xsd:float,
+        nidm_pValueUncorrected: = "0.046077672706774" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:9759d63712f31dd71f970ba24fdc02ba,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0025" %% xsd:string,
+        nidm_coordinateVector: = "[42,-78,6]" %% xsd:string])
+    wasDerivedFrom(niiri:9607bb62ecc6289f2476a8bb82c2c966, niiri:146e852a595d2bd9bf43b63cb1ffe554, -, -, -)
+    entity(niiri:5aac45256e13cd03a2a1e390f5df998d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0026" %% xsd:string,
+        prov:location = 'niiri:7b8ba463b7a085d4623751d494579f21',
+        prov:value = "1.67713749408722" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.68025745484094" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0464536174884935" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:7b8ba463b7a085d4623751d494579f21,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0026" %% xsd:string,
+        nidm_coordinateVector: = "[-12,26,36]" %% xsd:string])
+    wasDerivedFrom(niiri:5aac45256e13cd03a2a1e390f5df998d, niiri:c76d475fb44856dbc3b3660c08027d10, -, -, -)
+    entity(niiri:aa7acc61eb0d336d8adfd1c279535ef0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0027" %% xsd:string,
+        prov:location = 'niiri:f60e25b0c2abc9fe4d73f5854c0adbee',
+        prov:value = "1.67311263084412" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.6763935381234" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0468305669041873" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:f60e25b0c2abc9fe4d73f5854c0adbee,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0027" %% xsd:string,
+        nidm_coordinateVector: = "[12,-94,-32]" %% xsd:string])
+    wasDerivedFrom(niiri:aa7acc61eb0d336d8adfd1c279535ef0, niiri:171a3293a830389fbc0eeedac10ab2ef, -, -, -)
+    entity(niiri:309b2780bdf657c8f0c7a6410916169c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0028" %% xsd:string,
+        prov:location = 'niiri:967f245c1c386892dbecddea40037b53',
+        prov:value = "1.67067694664001" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.67405562956399" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0470598334324596" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:967f245c1c386892dbecddea40037b53,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0028" %% xsd:string,
+        nidm_coordinateVector: = "[24,-92,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:309b2780bdf657c8f0c7a6410916169c, niiri:230b132218201af072b76732d6cd366e, -, -, -)
+    entity(niiri:ed3607586490b22746adf59129afa310,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0029" %% xsd:string,
+        prov:location = 'niiri:fddb34281430a5ac7649b34b53b04c89',
+        prov:value = "1.66812241077423" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.67160394831323" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0473012228473357" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:fddb34281430a5ac7649b34b53b04c89,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0029" %% xsd:string,
+        nidm_coordinateVector: = "[-24,22,22]" %% xsd:string])
+    wasDerivedFrom(niiri:ed3607586490b22746adf59129afa310, niiri:88b6854434c4c7d7d77b89858ff66d15, -, -, -)
+    entity(niiri:cb35f3207972df7107e6d2aea1bfbde2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0030" %% xsd:string,
+        prov:location = 'niiri:36ff55a8118b6b1b3e001a7636293a8f',
+        prov:value = "1.66770362854004" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.67120205793481" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0473408869609759" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:36ff55a8118b6b1b3e001a7636293a8f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0030" %% xsd:string,
+        nidm_coordinateVector: = "[26,-90,22]" %% xsd:string])
+    wasDerivedFrom(niiri:cb35f3207972df7107e6d2aea1bfbde2, niiri:983ff16f46a1aa2fb13613f2c2f88011, -, -, -)
+    entity(niiri:9545b4314633cb0868f593c5d38febb7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0031" %% xsd:string,
+        prov:location = 'niiri:9803db31221b2c078fe55c084d5d83ed',
+        prov:value = "1.66512632369995" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.66872889854066" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0475855596349387" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:9803db31221b2c078fe55c084d5d83ed,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0031" %% xsd:string,
+        nidm_coordinateVector: = "[32,-60,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:9545b4314633cb0868f593c5d38febb7, niiri:a6327d343c9ff6cf00c6cbe83308072b, -, -, -)
+    entity(niiri:02317feaa78e69f7d7f9737af5644214,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0032" %% xsd:string,
+        prov:location = 'niiri:5d4415f1293150147830ba8d2fe89e88',
+        prov:value = "1.6600536108017" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.66386211897632" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0480699933329287" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
+    entity(niiri:5d4415f1293150147830ba8d2fe89e88,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0032" %% xsd:string,
+        nidm_coordinateVector: = "[-44,-56,-32]" %% xsd:string])
+    wasDerivedFrom(niiri:02317feaa78e69f7d7f9737af5644214, niiri:92ac4a8cb0a6c243ecb32fc66fd3deab, -, -, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_conjunction/nidm.provn
+++ b/spmexport/ex_spm_conjunction/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:cffd7ffff967c97f168edddb606cca3c,
+  entity(niiri:0f83f9bf10402721cd1f28d1c65e3f71,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:6fca6103f9b3748f1135346eed723b1e,
+  agent(niiri:eeba9c732c26ca897cc0d1f656c3b236,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:08e852b60d68cd3f03fbb91135fc698a,
+  activity(niiri:d55d1dd1d9d6736496f4293e6106b164,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:08e852b60d68cd3f03fbb91135fc698a, niiri:6fca6103f9b3748f1135346eed723b1e, -)
-  wasGeneratedBy(niiri:cffd7ffff967c97f168edddb606cca3c, niiri:08e852b60d68cd3f03fbb91135fc698a, 2016-01-11T10:33:19)
-  bundle niiri:cffd7ffff967c97f168edddb606cca3c
+  wasAssociatedWith(niiri:d55d1dd1d9d6736496f4293e6106b164, niiri:eeba9c732c26ca897cc0d1f656c3b236, -)
+  wasGeneratedBy(niiri:0f83f9bf10402721cd1f28d1c65e3f71, niiri:d55d1dd1d9d6736496f4293e6106b164, 2016-01-11T10:43:39)
+  bundle niiri:0f83f9bf10402721cd1f28d1c65e3f71
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -126,12 +126,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:8d702deb7794ff140970aa83183f0cd7,
+    agent(niiri:cb9ec8de70f8a46b05f9b00f1883e6e0,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:13472aa35bbca29434f4e7a96e64854b,
+    entity(niiri:a20719c557449bd5bf360e90b505fb48,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -140,189 +140,189 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:b8bc1fafeb07d65d7429038c792c1fff,
+    entity(niiri:412dc80f675b09e5e6c9352c510f1f89,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:c75a5447273e9c598f256e39304eded4,
+    entity(niiri:a0e266509c65e3246b4c851021598aff,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:c7f99aa282bcb84887dac079b6e639e3,
+    entity(niiri:10f301ea7889fbb6a952cababcce34fe,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:e68886708e4b26ae6e709f5fa4808690',
+        dc:description = 'niiri:7d64806fe60b51292c19828deba7d11f',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:c75a5447273e9c598f256e39304eded4',
+        nidm_hasDriftModel: = 'niiri:a0e266509c65e3246b4c851021598aff',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:e68886708e4b26ae6e709f5fa4808690,
+    entity(niiri:7d64806fe60b51292c19828deba7d11f,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:937d29c8162661dc3675b67810a67ae3,
+    entity(niiri:761acb19ce110d3cf37c18c19f80d83e,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:9b702b46c5dd95ed19b8b5140da841d6,
+    activity(niiri:471ca2377b5aa5d10b4545192e237109,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:9b702b46c5dd95ed19b8b5140da841d6, niiri:8d702deb7794ff140970aa83183f0cd7, -)
-    used(niiri:9b702b46c5dd95ed19b8b5140da841d6, niiri:c7f99aa282bcb84887dac079b6e639e3, -)
-    used(niiri:9b702b46c5dd95ed19b8b5140da841d6, niiri:b8bc1fafeb07d65d7429038c792c1fff, -)
-    used(niiri:9b702b46c5dd95ed19b8b5140da841d6, niiri:937d29c8162661dc3675b67810a67ae3, -)
-    entity(niiri:8b400bad67e910ddcd25ffed64d4900a,
+    wasAssociatedWith(niiri:471ca2377b5aa5d10b4545192e237109, niiri:cb9ec8de70f8a46b05f9b00f1883e6e0, -)
+    used(niiri:471ca2377b5aa5d10b4545192e237109, niiri:10f301ea7889fbb6a952cababcce34fe, -)
+    used(niiri:471ca2377b5aa5d10b4545192e237109, niiri:412dc80f675b09e5e6c9352c510f1f89, -)
+    used(niiri:471ca2377b5aa5d10b4545192e237109, niiri:761acb19ce110d3cf37c18c19f80d83e, -)
+    entity(niiri:efba4501de55e8526336b6836a6ae200,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    entity(niiri:705430105fed94e345e5a467681058e2,
+    entity(niiri:18970d89e1bbabdc87e35704e6f635b0,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
-    wasDerivedFrom(niiri:8b400bad67e910ddcd25ffed64d4900a, niiri:705430105fed94e345e5a467681058e2, -, -, -)
-    wasGeneratedBy(niiri:8b400bad67e910ddcd25ffed64d4900a, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:9dd086507743fe730b7d24b70cf7ed3a,
+    wasDerivedFrom(niiri:efba4501de55e8526336b6836a6ae200, niiri:18970d89e1bbabdc87e35704e6f635b0, -, -, -)
+    wasGeneratedBy(niiri:efba4501de55e8526336b6836a6ae200, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:77d010fab23851bd6028211d704252eb,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "108.038318634033" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
-    wasGeneratedBy(niiri:9dd086507743fe730b7d24b70cf7ed3a, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:d70991e4ec5c9a6234d6391c2a0dbdb0,
+    wasGeneratedBy(niiri:77d010fab23851bd6028211d704252eb, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:3683ca493bbee171d03b3ef585672d79,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
-    entity(niiri:406110ec41e71d7260a38848d82dfc7f,
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48'])
+    entity(niiri:c39d23eb52261f4deee536da546c13f3,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f" %% xsd:string])
-    wasDerivedFrom(niiri:d70991e4ec5c9a6234d6391c2a0dbdb0, niiri:406110ec41e71d7260a38848d82dfc7f, -, -, -)
-    wasGeneratedBy(niiri:d70991e4ec5c9a6234d6391c2a0dbdb0, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:32d8ca8f9ba66fe36d7b9eae3f419596,
+    wasDerivedFrom(niiri:3683ca493bbee171d03b3ef585672d79, niiri:c39d23eb52261f4deee536da546c13f3, -, -, -)
+    wasGeneratedBy(niiri:3683ca493bbee171d03b3ef585672d79, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:eb368d3d6647d9a31aacf5f9b11ecfe6,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
-    entity(niiri:e83351acdbbde0ef0a33cf50fbc3990f,
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48'])
+    entity(niiri:7d50efe9f235518078d0b9014b5a58db,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
-    wasDerivedFrom(niiri:32d8ca8f9ba66fe36d7b9eae3f419596, niiri:e83351acdbbde0ef0a33cf50fbc3990f, -, -, -)
-    wasGeneratedBy(niiri:32d8ca8f9ba66fe36d7b9eae3f419596, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:5cdc01b7d93b811fc7e1114f880e74d3,
+    wasDerivedFrom(niiri:eb368d3d6647d9a31aacf5f9b11ecfe6, niiri:7d50efe9f235518078d0b9014b5a58db, -, -, -)
+    wasGeneratedBy(niiri:eb368d3d6647d9a31aacf5f9b11ecfe6, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:ff5a99a88137732fdd67c267f5b782fb,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
-    entity(niiri:3397f8fdb55baa2ce4ca23110660f606,
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48'])
+    entity(niiri:3e034235342c659548ea19f21365ac98,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb" %% xsd:string])
-    wasDerivedFrom(niiri:5cdc01b7d93b811fc7e1114f880e74d3, niiri:3397f8fdb55baa2ce4ca23110660f606, -, -, -)
-    wasGeneratedBy(niiri:5cdc01b7d93b811fc7e1114f880e74d3, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:48ca995ae7b89bd0222a3d1652dc6d81,
+    wasDerivedFrom(niiri:ff5a99a88137732fdd67c267f5b782fb, niiri:3e034235342c659548ea19f21365ac98, -, -, -)
+    wasGeneratedBy(niiri:ff5a99a88137732fdd67c267f5b782fb, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:8ee5de50f97ce036bd5874d973aff645,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
-    entity(niiri:0182339ddbc9fc0f31bf47a8695e88ac,
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48'])
+    entity(niiri:2dc09730618833b7076c46d997ed617e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6" %% xsd:string])
-    wasDerivedFrom(niiri:48ca995ae7b89bd0222a3d1652dc6d81, niiri:0182339ddbc9fc0f31bf47a8695e88ac, -, -, -)
-    wasGeneratedBy(niiri:48ca995ae7b89bd0222a3d1652dc6d81, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:d00e71a2693f38940a6abe5fe0a27e14,
+    wasDerivedFrom(niiri:8ee5de50f97ce036bd5874d973aff645, niiri:2dc09730618833b7076c46d997ed617e, -, -, -)
+    wasGeneratedBy(niiri:8ee5de50f97ce036bd5874d973aff645, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:0c5942394b91a9b1655999404665d3ae,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
-    entity(niiri:6051fccc3fa5e6b6878fdcfe17232d70,
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48'])
+    entity(niiri:1e18c988fe1ef58a2d490ab8c8eb098e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff" %% xsd:string])
-    wasDerivedFrom(niiri:d00e71a2693f38940a6abe5fe0a27e14, niiri:6051fccc3fa5e6b6878fdcfe17232d70, -, -, -)
-    wasGeneratedBy(niiri:d00e71a2693f38940a6abe5fe0a27e14, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:05115890f603e4e9e4e1a672eb3683b5,
+    wasDerivedFrom(niiri:0c5942394b91a9b1655999404665d3ae, niiri:1e18c988fe1ef58a2d490ab8c8eb098e, -, -, -)
+    wasGeneratedBy(niiri:0c5942394b91a9b1655999404665d3ae, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:c85b48521a1b46a36a19262e86027bf8,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 6" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
-    entity(niiri:699a8d86d7db0ddab1d01e042dc3ae4f,
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48'])
+    entity(niiri:3deaac4dcf0815f7391f7527ee76d664,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0006.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
-    wasDerivedFrom(niiri:05115890f603e4e9e4e1a672eb3683b5, niiri:699a8d86d7db0ddab1d01e042dc3ae4f, -, -, -)
-    wasGeneratedBy(niiri:05115890f603e4e9e4e1a672eb3683b5, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:b60ee6cea0e97b11abbbfad263cb8893,
+    wasDerivedFrom(niiri:c85b48521a1b46a36a19262e86027bf8, niiri:3deaac4dcf0815f7391f7527ee76d664, -, -, -)
+    wasGeneratedBy(niiri:c85b48521a1b46a36a19262e86027bf8, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:ee077cef30635017426e07dc1b836810,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8" %% xsd:string])
-    entity(niiri:03ebca4bd2e13ea96ce505ab726aaa82,
+    entity(niiri:0b55d977fad609b4df4bd812336f1688,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81" %% xsd:string])
-    wasDerivedFrom(niiri:b60ee6cea0e97b11abbbfad263cb8893, niiri:03ebca4bd2e13ea96ce505ab726aaa82, -, -, -)
-    wasGeneratedBy(niiri:b60ee6cea0e97b11abbbfad263cb8893, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:7e51e600d6dbaf94e50bb1c27b2e2a06,
+    wasDerivedFrom(niiri:ee077cef30635017426e07dc1b836810, niiri:0b55d977fad609b4df4bd812336f1688, -, -, -)
+    wasGeneratedBy(niiri:ee077cef30635017426e07dc1b836810, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:cf667e831a88369697952d416decc6d4,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8" %% xsd:string])
-    entity(niiri:b1cfa368972409a292f285346c36c011,
+    entity(niiri:8af3c223fce9ad0e0d14bb8852e619e4,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29" %% xsd:string])
-    wasDerivedFrom(niiri:7e51e600d6dbaf94e50bb1c27b2e2a06, niiri:b1cfa368972409a292f285346c36c011, -, -, -)
-    wasGeneratedBy(niiri:7e51e600d6dbaf94e50bb1c27b2e2a06, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
-    entity(niiri:75efb902a39cf1021609db5de272351c,
+    wasDerivedFrom(niiri:cf667e831a88369697952d416decc6d4, niiri:8af3c223fce9ad0e0d14bb8852e619e4, -, -, -)
+    wasGeneratedBy(niiri:cf667e831a88369697952d416decc6d4, niiri:471ca2377b5aa5d10b4545192e237109, -)
+    entity(niiri:8338f1fe29b4713b0cf3f9a7508ca58c,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         prov:label = "Contrast: mr vs plain" %% xsd:string,
         prov:value = "[1, 1, -1, -1, 0, 0]" %% xsd:string])
-    activity(niiri:a08187124a8a759239103ba1a7917d6c,
+    activity(niiri:74edcbe57f1ceaf17e08a718e8ad82f4,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation 1"])
-    wasAssociatedWith(niiri:a08187124a8a759239103ba1a7917d6c, niiri:8d702deb7794ff140970aa83183f0cd7, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:8b400bad67e910ddcd25ffed64d4900a, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:b60ee6cea0e97b11abbbfad263cb8893, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:c7f99aa282bcb84887dac079b6e639e3, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:75efb902a39cf1021609db5de272351c, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:d70991e4ec5c9a6234d6391c2a0dbdb0, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:32d8ca8f9ba66fe36d7b9eae3f419596, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:5cdc01b7d93b811fc7e1114f880e74d3, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:48ca995ae7b89bd0222a3d1652dc6d81, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:d00e71a2693f38940a6abe5fe0a27e14, -)
-    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:05115890f603e4e9e4e1a672eb3683b5, -)
-    entity(niiri:6c08012b8665ffafe1d80de0f06b0deb,
+    wasAssociatedWith(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:cb9ec8de70f8a46b05f9b00f1883e6e0, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:efba4501de55e8526336b6836a6ae200, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:ee077cef30635017426e07dc1b836810, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:10f301ea7889fbb6a952cababcce34fe, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:8338f1fe29b4713b0cf3f9a7508ca58c, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:3683ca493bbee171d03b3ef585672d79, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:eb368d3d6647d9a31aacf5f9b11ecfe6, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:ff5a99a88137732fdd67c267f5b782fb, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:8ee5de50f97ce036bd5874d973aff645, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:0c5942394b91a9b1655999404665d3ae, -)
+    used(niiri:74edcbe57f1ceaf17e08a718e8ad82f4, niiri:c85b48521a1b46a36a19262e86027bf8, -)
+    entity(niiri:0081f7c080166e5d3d8565a0c11e236a,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic_0001.nii.gz" %% xsd:string,
@@ -332,61 +332,61 @@ document
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "aba2fef7900cacda1ed84fe5edf867bd2b0fc6ae7eb4919967798d7f219a6d8ad5454fe8e0bdf4a7cfa6402e73287e703c285d12df0a282e40438ec36153e715" %% xsd:string])
-    entity(niiri:0aabcd9c646fada4d1e8380aa19581c0,
+    entity(niiri:949b74649bd08c95a9f824ac1678464d,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782" %% xsd:string])
-    wasDerivedFrom(niiri:6c08012b8665ffafe1d80de0f06b0deb, niiri:0aabcd9c646fada4d1e8380aa19581c0, -, -, -)
-    wasGeneratedBy(niiri:6c08012b8665ffafe1d80de0f06b0deb, niiri:a08187124a8a759239103ba1a7917d6c, -)
-    entity(niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3,
+    wasDerivedFrom(niiri:0081f7c080166e5d3d8565a0c11e236a, niiri:949b74649bd08c95a9f824ac1678464d, -, -, -)
+    wasGeneratedBy(niiri:0081f7c080166e5d3d8565a0c11e236a, niiri:74edcbe57f1ceaf17e08a718e8ad82f4, -)
+    entity(niiri:26bf2d06873dd8d79c8b746890887ca8,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: mr vs plain" %% xsd:string,
         nidm_contrastName: = "mr vs plain" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5" %% xsd:string])
-    entity(niiri:7bcc38cb25e8a636c411c67b7c86b4af,
+    entity(niiri:63d374d0241354bf1ed97477cea42858,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28" %% xsd:string])
-    wasDerivedFrom(niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3, niiri:7bcc38cb25e8a636c411c67b7c86b4af, -, -, -)
-    wasGeneratedBy(niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3, niiri:a08187124a8a759239103ba1a7917d6c, -)
-    entity(niiri:ea53b05d76e1a79956319d8ef8524624,
+    wasDerivedFrom(niiri:26bf2d06873dd8d79c8b746890887ca8, niiri:63d374d0241354bf1ed97477cea42858, -, -, -)
+    wasGeneratedBy(niiri:26bf2d06873dd8d79c8b746890887ca8, niiri:74edcbe57f1ceaf17e08a718e8ad82f4, -)
+    entity(niiri:3c0366159408b6e12cad21bbe49be06a,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b" %% xsd:string])
-    wasGeneratedBy(niiri:ea53b05d76e1a79956319d8ef8524624, niiri:a08187124a8a759239103ba1a7917d6c, -)
-    entity(niiri:25693c09a24b28e659ccec8659964759,
+    wasGeneratedBy(niiri:3c0366159408b6e12cad21bbe49be06a, niiri:74edcbe57f1ceaf17e08a718e8ad82f4, -)
+    entity(niiri:a1cccf791324c5aa54ce4418b889d599,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
         prov:label = "Contrast: switch vs nonswitch" %% xsd:string,
         prov:value = "[1, -1, 1, -1, 0, 0]" %% xsd:string])
-    activity(niiri:8f29f58ca8f23c2abe4da18512df00f0,
+    activity(niiri:c8ee0e32dfe6dfe48e13949337f73f3e,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation 2"])
-    wasAssociatedWith(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:8d702deb7794ff140970aa83183f0cd7, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:8b400bad67e910ddcd25ffed64d4900a, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:b60ee6cea0e97b11abbbfad263cb8893, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:c7f99aa282bcb84887dac079b6e639e3, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:25693c09a24b28e659ccec8659964759, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:d70991e4ec5c9a6234d6391c2a0dbdb0, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:32d8ca8f9ba66fe36d7b9eae3f419596, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:5cdc01b7d93b811fc7e1114f880e74d3, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:48ca995ae7b89bd0222a3d1652dc6d81, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:d00e71a2693f38940a6abe5fe0a27e14, -)
-    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:05115890f603e4e9e4e1a672eb3683b5, -)
-    entity(niiri:ed5e976f74b812d550d5f16796c155fc,
+    wasAssociatedWith(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:cb9ec8de70f8a46b05f9b00f1883e6e0, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:efba4501de55e8526336b6836a6ae200, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:ee077cef30635017426e07dc1b836810, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:10f301ea7889fbb6a952cababcce34fe, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:a1cccf791324c5aa54ce4418b889d599, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:3683ca493bbee171d03b3ef585672d79, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:eb368d3d6647d9a31aacf5f9b11ecfe6, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:ff5a99a88137732fdd67c267f5b782fb, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:8ee5de50f97ce036bd5874d973aff645, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:0c5942394b91a9b1655999404665d3ae, -)
+    used(niiri:c8ee0e32dfe6dfe48e13949337f73f3e, niiri:c85b48521a1b46a36a19262e86027bf8, -)
+    entity(niiri:ac4c58fb7bd0dd7beff85fc9a96e4533,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic_0002.nii.gz" %% xsd:string,
@@ -396,103 +396,103 @@ document
         nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "1c375cdc8f2b00f93f3d6f1a09aafa5670d35ffcf2c82ef061151bfb047463e482e971d67ce3e3e2496f37b1621f5d732a0a1f88c773f5d5fa077cb6a3e38501" %% xsd:string])
-    entity(niiri:93258b59372b373e6266047487de0072,
+    entity(niiri:9ab90a28f7edbe61d65f190105744ee8,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "313c8e34e107b1e9bec46074e7a1cef289427618869119eff1c8044a2b5b8e5a340c899a78f40a3f8b938dbbbde53bd16c096da55f2e07a7c9e334cfd1e471f2" %% xsd:string])
-    wasDerivedFrom(niiri:ed5e976f74b812d550d5f16796c155fc, niiri:93258b59372b373e6266047487de0072, -, -, -)
-    wasGeneratedBy(niiri:ed5e976f74b812d550d5f16796c155fc, niiri:8f29f58ca8f23c2abe4da18512df00f0, -)
-    entity(niiri:05f1c1dcd9cada95daa2b92b3aae94eb,
+    wasDerivedFrom(niiri:ac4c58fb7bd0dd7beff85fc9a96e4533, niiri:9ab90a28f7edbe61d65f190105744ee8, -, -, -)
+    wasGeneratedBy(niiri:ac4c58fb7bd0dd7beff85fc9a96e4533, niiri:c8ee0e32dfe6dfe48e13949337f73f3e, -)
+    entity(niiri:9e9f6a19fc0f4208a6a335f309d1862a,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast_0002.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: switch vs nonswitch" %% xsd:string,
         nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "77720bd21fb296db2e69c9742318c52f7cf6b08f94a83c5c1e30d5b8b21b1fd218de32fcc3a96aa2d067d5b06015e85e863ab87907741d2d7c9993740f668dc2" %% xsd:string])
-    entity(niiri:9b02ce638a46ac45c6d4d3fd693e255f,
+    entity(niiri:cf0dd4590780a8c7970131949a2b4500,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "6983d8888c458d8a073f84054db2587b0a71764e64c30ea7e4a13cd0e6b2e301eaea1b570822b24b635b464fd233c3801a9205ddcd2dcffcda7cd99679d2734a" %% xsd:string])
-    wasDerivedFrom(niiri:05f1c1dcd9cada95daa2b92b3aae94eb, niiri:9b02ce638a46ac45c6d4d3fd693e255f, -, -, -)
-    wasGeneratedBy(niiri:05f1c1dcd9cada95daa2b92b3aae94eb, niiri:8f29f58ca8f23c2abe4da18512df00f0, -)
-    entity(niiri:8576d98d89e7380306ae7a7b2bfa7f6e,
+    wasDerivedFrom(niiri:9e9f6a19fc0f4208a6a335f309d1862a, niiri:cf0dd4590780a8c7970131949a2b4500, -, -, -)
+    wasGeneratedBy(niiri:9e9f6a19fc0f4208a6a335f309d1862a, niiri:c8ee0e32dfe6dfe48e13949337f73f3e, -)
+    entity(niiri:9136706f694cea9ffa8b9c0b0de1f597,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError_0002.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "1bb21447dcf3cc1eeb9453c707178e4d87161242c69e18795e0e2b30496c9e657ed2f202d4c9cd364aea5a04e4e46fe70ca830e1db14dd2e0f20af754281c3f2" %% xsd:string])
-    wasGeneratedBy(niiri:8576d98d89e7380306ae7a7b2bfa7f6e, niiri:8f29f58ca8f23c2abe4da18512df00f0, -)
-    entity(niiri:c92560dc79ef7986810602e2fa8cc698,
+    wasGeneratedBy(niiri:9136706f694cea9ffa8b9c0b0de1f597, niiri:c8ee0e32dfe6dfe48e13949337f73f3e, -)
+    entity(niiri:60123493cb33f88b9a3327ad2a637b87,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.048771 (unc.)" %% xsd:string,
         prov:value = "0.0487705952532708" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:f7e7ca44a8f41bda88372604c4fbbb68',
-        nidm_equivalentThreshold: = 'niiri:9b07472e1eaca0cce525f30fb31c894c'])
-    entity(niiri:f7e7ca44a8f41bda88372604c4fbbb68,
+        nidm_equivalentThreshold: = 'niiri:638a4732421302a54cf0be9a27369150',
+        nidm_equivalentThreshold: = 'niiri:ed853489f8fdf815fc5ed7496ddd241b'])
+    entity(niiri:638a4732421302a54cf0be9a27369150,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "1.65278686445912" %% xsd:float])
-    entity(niiri:9b07472e1eaca0cce525f30fb31c894c,
+    entity(niiri:ed853489f8fdf815fc5ed7496ddd241b,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:5e669b6d10f715c60759eb817713a4a2,
+    entity(niiri:b804be5b39ce5630087cb019f1156946,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:b39d449d635c93f3ffe4f11fdc273353',
-        nidm_equivalentThreshold: = 'niiri:a369532528403ad4850204e071f04758'])
-    entity(niiri:b39d449d635c93f3ffe4f11fdc273353,
+        nidm_equivalentThreshold: = 'niiri:65bb020863c05b303995c32c462aadcf',
+        nidm_equivalentThreshold: = 'niiri:b4cf11c506c0a8d87ff7e68091e492a2'])
+    entity(niiri:65bb020863c05b303995c32c462aadcf,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:a369532528403ad4850204e071f04758,
+    entity(niiri:b4cf11c506c0a8d87ff7e68091e492a2,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:d71d80f794ac0f7a94273b376d163e89,
+    entity(niiri:c0adc769180c2b6c732944a463ad0a30,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:b8086c9fb20252dc9ec4a7fa41470165,
+    entity(niiri:a8f1c26c551ab0ecca69d1dba8fc240c,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:047da8bd1155d93bb9e94d1cb47f6f2e,
+    activity(niiri:1ef65de2c8af67e889eb1a5edb6ded01,
         [prov:type = 'nidm_ConjunctionInference:',
         prov:label = "Conjunction Inference"])
-    wasAssociatedWith(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:8d702deb7794ff140970aa83183f0cd7, -)
-    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:c92560dc79ef7986810602e2fa8cc698, -)
-    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:5e669b6d10f715c60759eb817713a4a2, -)
-    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:6c08012b8665ffafe1d80de0f06b0deb, -)
-    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:ed5e976f74b812d550d5f16796c155fc, -)
-    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:7e51e600d6dbaf94e50bb1c27b2e2a06, -)
-    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:8b400bad67e910ddcd25ffed64d4900a, -)
-    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:d71d80f794ac0f7a94273b376d163e89, -)
-    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:b8086c9fb20252dc9ec4a7fa41470165, -)
-    entity(niiri:af86aeaa13e45fe4af977676f9dbb2d6,
+    wasAssociatedWith(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:cb9ec8de70f8a46b05f9b00f1883e6e0, -)
+    used(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:60123493cb33f88b9a3327ad2a637b87, -)
+    used(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:b804be5b39ce5630087cb019f1156946, -)
+    used(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:0081f7c080166e5d3d8565a0c11e236a, -)
+    used(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:ac4c58fb7bd0dd7beff85fc9a96e4533, -)
+    used(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:cf667e831a88369697952d416decc6d4, -)
+    used(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:efba4501de55e8526336b6836a6ae200, -)
+    used(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:c0adc769180c2b6c732944a463ad0a30, -)
+    used(niiri:1ef65de2c8af67e889eb1a5edb6ded01, niiri:a8f1c26c551ab0ecca69d1dba8fc240c, -)
+    entity(niiri:b308d4f0fa9f576ab8a01377b15c5772,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
         nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
         nidm_reselSizeInVoxels: = "68.4409986586553" %% xsd:float,
@@ -508,8 +508,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    wasGeneratedBy(niiri:af86aeaa13e45fe4af977676f9dbb2d6, niiri:047da8bd1155d93bb9e94d1cb47f6f2e, -)
-    entity(niiri:2561c31d8316e8b6110351c09d382626,
+    wasGeneratedBy(niiri:b308d4f0fa9f576ab8a01377b15c5772, niiri:1ef65de2c8af67e889eb1a5edb6ded01, -)
+    entity(niiri:92e947f394c2f3c0510a6df10b8b47fe,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -517,22 +517,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "30" %% xsd:int,
         nidm_pValue: = "1" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:555b51c020185cf7d98d6cae3d6dd6b7',
-        nidm_hasMaximumIntensityProjection: = 'niiri:72e33120e4a0cf389b3663a56945e615',
-        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
+        nidm_hasClusterLabelsMap: = 'niiri:7d8fcdb4306ccb182826202d0a4b9853',
+        nidm_hasMaximumIntensityProjection: = 'niiri:c901604c3768f064cc5d70178aa81394',
+        nidm_inCoordinateSpace: = 'niiri:a20719c557449bd5bf360e90b505fb48',
         crypto:sha512 = "bcf45ac744752d54a29a2b918eda586a0e6637179a62a2eef62afd03f594bb4bdb4d2171625040d21c22a02d3a13fd0312ce1b83f6a6aecf34c432299e21c864" %% xsd:string])
-    entity(niiri:555b51c020185cf7d98d6cae3d6dd6b7,
+    entity(niiri:7d8fcdb4306ccb182826202d0a4b9853,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:72e33120e4a0cf389b3663a56945e615,
+    entity(niiri:c901604c3768f064cc5d70178aa81394,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:2561c31d8316e8b6110351c09d382626, niiri:047da8bd1155d93bb9e94d1cb47f6f2e, -)
-    entity(niiri:8d1a8ab2f5e6753052e300d592e3d511,
+    wasGeneratedBy(niiri:92e947f394c2f3c0510a6df10b8b47fe, niiri:1ef65de2c8af67e889eb1a5edb6ded01, -)
+    entity(niiri:d0ef6f3ab84b7a20a23c8ec80505c8cc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "95" %% xsd:int,
@@ -541,8 +541,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:8d1a8ab2f5e6753052e300d592e3d511, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:5a1ad49de526d8a54452b31baf96a75d,
+    wasDerivedFrom(niiri:d0ef6f3ab84b7a20a23c8ec80505c8cc, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:73637205faaca2b93f30cf26719da2b3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -551,8 +551,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:5a1ad49de526d8a54452b31baf96a75d, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:c00f026631fe0b6f988efa4d30db781f,
+    wasDerivedFrom(niiri:73637205faaca2b93f30cf26719da2b3, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:49cbd2656968943cca2fb0ddde2c880a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -561,8 +561,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:c00f026631fe0b6f988efa4d30db781f, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:b712b8f6d2df400be64fe19b957abb10,
+    wasDerivedFrom(niiri:49cbd2656968943cca2fb0ddde2c880a, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:686c4840892e9778876349ccd6236841,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -571,8 +571,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:b712b8f6d2df400be64fe19b957abb10, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:f66d2da458d706e0d1c123fd3dc589c7,
+    wasDerivedFrom(niiri:686c4840892e9778876349ccd6236841, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:2e2b55b222631d083aed83513341f4bf,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -581,8 +581,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:f66d2da458d706e0d1c123fd3dc589c7, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:70a3e9df88095bfe99637dabf4110acd,
+    wasDerivedFrom(niiri:2e2b55b222631d083aed83513341f4bf, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:a8bfd334e76be268255831f5a8092aee,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -591,8 +591,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:70a3e9df88095bfe99637dabf4110acd, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:027812928b4d9dc645c81857d81e13ca,
+    wasDerivedFrom(niiri:a8bfd334e76be268255831f5a8092aee, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:fe4c4fd75ebef375c6e3c2cff33277a4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -601,8 +601,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:027812928b4d9dc645c81857d81e13ca, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:fec8e2c65ce7d1cf6e18804683d824ca,
+    wasDerivedFrom(niiri:fe4c4fd75ebef375c6e3c2cff33277a4, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:5bae05b5a604a8c03d7992ce19d15723,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -611,8 +611,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:fec8e2c65ce7d1cf6e18804683d824ca, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:c9f251722e6a9f1501e325fdf2f516f3,
+    wasDerivedFrom(niiri:5bae05b5a604a8c03d7992ce19d15723, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:ec6a8c27bdfd0dc1de40b1f7c9c1ca61,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "41" %% xsd:int,
@@ -621,8 +621,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:c9f251722e6a9f1501e325fdf2f516f3, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:ac00f4348e517214c5428caad74cc6dc,
+    wasDerivedFrom(niiri:ec6a8c27bdfd0dc1de40b1f7c9c1ca61, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:f5e21a9b1b5fbfef7061a46469d52a7a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -631,8 +631,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:ac00f4348e517214c5428caad74cc6dc, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:8050ff9b05fe42d3b13b693c3d4dfc3c,
+    wasDerivedFrom(niiri:f5e21a9b1b5fbfef7061a46469d52a7a, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:4dd108385a724afeea8f83f29506f956,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -641,8 +641,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:8050ff9b05fe42d3b13b693c3d4dfc3c, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:d1592c70ca4448ee46f3c8df3c20043c,
+    wasDerivedFrom(niiri:4dd108385a724afeea8f83f29506f956, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:22e2be3780622fb9d23b8f1c07f56968,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -651,8 +651,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:d1592c70ca4448ee46f3c8df3c20043c, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:5828f74c2c43b3883378f9cd1e63925b,
+    wasDerivedFrom(niiri:22e2be3780622fb9d23b8f1c07f56968, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:ad5ca42e9fcec5d33eda403de4d6999b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -661,8 +661,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:5828f74c2c43b3883378f9cd1e63925b, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:5922affac179cd07256e72fbcf8a2c8a,
+    wasDerivedFrom(niiri:ad5ca42e9fcec5d33eda403de4d6999b, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:59b84888054fd89394ca79e89db37a1a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -671,8 +671,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:5922affac179cd07256e72fbcf8a2c8a, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:8481b546970e4cc30b9a0415842a3ea3,
+    wasDerivedFrom(niiri:59b84888054fd89394ca79e89db37a1a, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:1adc127c7534eabbebd796b9fd4f9864,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -681,8 +681,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:8481b546970e4cc30b9a0415842a3ea3, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:f4471bd4ad44f0353136ecfba3e12d38,
+    wasDerivedFrom(niiri:1adc127c7534eabbebd796b9fd4f9864, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:e434b384036bdebb84beb66ec3ab0e46,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -691,8 +691,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:f4471bd4ad44f0353136ecfba3e12d38, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:7651662ffb846c59d0275b64f39a5a3e,
+    wasDerivedFrom(niiri:e434b384036bdebb84beb66ec3ab0e46, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:2614ceb972cd9fc6b34c52dc1b41a5f5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -701,8 +701,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:7651662ffb846c59d0275b64f39a5a3e, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:cb4cab1d498471cf714b96e648ba0b84,
+    wasDerivedFrom(niiri:2614ceb972cd9fc6b34c52dc1b41a5f5, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:ec3da526be8b471a22bb953dc0be2fa1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -711,8 +711,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:cb4cab1d498471cf714b96e648ba0b84, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:b49a13ef4f81cb056a0cf2c1e1e37613,
+    wasDerivedFrom(niiri:ec3da526be8b471a22bb953dc0be2fa1, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:5bafbb05bd32dfb4238362ae3eba5d83,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -721,8 +721,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:b49a13ef4f81cb056a0cf2c1e1e37613, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:3bf344699ca63226f8a0986e9e22dc4d,
+    wasDerivedFrom(niiri:5bafbb05bd32dfb4238362ae3eba5d83, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:6a5bcf79ca8e87d784ab402166cef0c3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -731,8 +731,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:3bf344699ca63226f8a0986e9e22dc4d, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:7a1aa46f25bc46f59f7f644a1d2d768c,
+    wasDerivedFrom(niiri:6a5bcf79ca8e87d784ab402166cef0c3, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:b0b739a752e19f94dc7e9b7f2e2fd571,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -741,8 +741,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:7a1aa46f25bc46f59f7f644a1d2d768c, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:95103dd9bdac7741d90f99939247bf4e,
+    wasDerivedFrom(niiri:b0b739a752e19f94dc7e9b7f2e2fd571, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:48c59f311f10dc10f49d77de1a4f0b19,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -751,8 +751,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:95103dd9bdac7741d90f99939247bf4e, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:11fe90c3ae56c74edb8f27b7b4d64c01,
+    wasDerivedFrom(niiri:48c59f311f10dc10f49d77de1a4f0b19, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:7be9b12db5e680d03919fb39de296487,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -761,8 +761,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:11fe90c3ae56c74edb8f27b7b4d64c01, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:d17fffe11eaba3b9e149fce8bdc2b9da,
+    wasDerivedFrom(niiri:7be9b12db5e680d03919fb39de296487, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:91f68c6405b3afe515a6b371bde2705b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -771,8 +771,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:d17fffe11eaba3b9e149fce8bdc2b9da, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:a97b8d1eb95bad3103d70c3a170b35e6,
+    wasDerivedFrom(niiri:91f68c6405b3afe515a6b371bde2705b, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:bc270be21bea419f18154dda040f4b5a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -781,8 +781,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:a97b8d1eb95bad3103d70c3a170b35e6, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:34de4bc8669d7effba126acecd7e71ca,
+    wasDerivedFrom(niiri:bc270be21bea419f18154dda040f4b5a, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:a0aa1a732baf12f3b4e5c27b6348115e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -791,8 +791,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:34de4bc8669d7effba126acecd7e71ca, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:34640314cb90b81bff8b479f4c75ae6f,
+    wasDerivedFrom(niiri:a0aa1a732baf12f3b4e5c27b6348115e, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:ac0917bc41fde1dbed179cd897e7c568,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -801,8 +801,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:34640314cb90b81bff8b479f4c75ae6f, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:79c1b8c3935c1efdd0d31d231222a6e3,
+    wasDerivedFrom(niiri:ac0917bc41fde1dbed179cd897e7c568, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:61bb215e601050cd1cdc9f7b9c8847a0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -811,8 +811,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:79c1b8c3935c1efdd0d31d231222a6e3, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:1171e027eba41be4b53953810af155f9,
+    wasDerivedFrom(niiri:61bb215e601050cd1cdc9f7b9c8847a0, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:d5aeba7a4d0595b94af060fe6c391161,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -821,8 +821,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:1171e027eba41be4b53953810af155f9, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:54a8bffd20ef66a79cc779bd8e630f0f,
+    wasDerivedFrom(niiri:d5aeba7a4d0595b94af060fe6c391161, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:7cc7f4ff997ef1b13f17a0bc068a7e4d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -831,486 +831,486 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:54a8bffd20ef66a79cc779bd8e630f0f, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
-    entity(niiri:49979752257c9cdd1a1f63a018b04845,
+    wasDerivedFrom(niiri:7cc7f4ff997ef1b13f17a0bc068a7e4d, niiri:92e947f394c2f3c0510a6df10b8b47fe, -, -, -)
+    entity(niiri:88d6372fcd216d65fe2483efb1cab96b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:062dc6f5cf37590aa5348de9d124c531',
+        prov:location = 'niiri:b8d86c6b672d58838d802608a6188a5c',
         prov:value = "2.29849815368652" %% xsd:float,
         nidm_equivalentZStatistic: = "2.28220028418391" %% xsd:float,
         nidm_pValueUncorrected: = "0.0112387591680547" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:062dc6f5cf37590aa5348de9d124c531,
+    entity(niiri:b8d86c6b672d58838d802608a6188a5c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[-28,24,4]" %% xsd:string])
-    wasDerivedFrom(niiri:49979752257c9cdd1a1f63a018b04845, niiri:8d1a8ab2f5e6753052e300d592e3d511, -, -, -)
-    entity(niiri:eb0f15f09bbeede75a83373d3a94b783,
+    wasDerivedFrom(niiri:88d6372fcd216d65fe2483efb1cab96b, niiri:d0ef6f3ab84b7a20a23c8ec80505c8cc, -, -, -)
+    entity(niiri:05799e7b9d366ec82513f9cbc958c708,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:9fcee8551b5114a52e472ad1844f220e',
+        prov:location = 'niiri:854506f4d16d5d4d7ae0c1a6c81136a2',
         prov:value = "2.07190132141113" %% xsd:float,
         nidm_equivalentZStatistic: = "2.0619285244841" %% xsd:float,
         nidm_pValueUncorrected: = "0.0196072706834085" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:9fcee8551b5114a52e472ad1844f220e,
+    entity(niiri:854506f4d16d5d4d7ae0c1a6c81136a2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[-28,26,12]" %% xsd:string])
-    wasDerivedFrom(niiri:eb0f15f09bbeede75a83373d3a94b783, niiri:8d1a8ab2f5e6753052e300d592e3d511, -, -, -)
-    entity(niiri:a9d3e1abbc30e49d34ae695e931b45f7,
+    wasDerivedFrom(niiri:05799e7b9d366ec82513f9cbc958c708, niiri:d0ef6f3ab84b7a20a23c8ec80505c8cc, -, -, -)
+    entity(niiri:2cc73a46aa9d23dc31a80b81911f20bd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:adcb8119812e818906df4629ebb6d39e',
+        prov:location = 'niiri:b0cdd28c72fac14914669b1d5f9e7166',
         prov:value = "2.18201637268066" %% xsd:float,
         nidm_equivalentZStatistic: = "2.16893530312973" %% xsd:float,
         nidm_pValueUncorrected: = "0.0150437980271687" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:adcb8119812e818906df4629ebb6d39e,
+    entity(niiri:b0cdd28c72fac14914669b1d5f9e7166,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[52,48,12]" %% xsd:string])
-    wasDerivedFrom(niiri:a9d3e1abbc30e49d34ae695e931b45f7, niiri:5a1ad49de526d8a54452b31baf96a75d, -, -, -)
-    entity(niiri:a312bb2d4a36613077f4d362f5263e2d,
+    wasDerivedFrom(niiri:2cc73a46aa9d23dc31a80b81911f20bd, niiri:73637205faaca2b93f30cf26719da2b3, -, -, -)
+    entity(niiri:0ad8c5359685ef2987e4c8431b9b4b3d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:1e8d56d4ce620a2af884f53f0162a677',
+        prov:location = 'niiri:c9a17b4c4634579ffee9d8ab9dc849c8',
         prov:value = "2.13869571685791" %% xsd:float,
         nidm_equivalentZStatistic: = "2.12682533173394" %% xsd:float,
         nidm_pValueUncorrected: = "0.016717299356924" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:1e8d56d4ce620a2af884f53f0162a677,
+    entity(niiri:c9a17b4c4634579ffee9d8ab9dc849c8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[34,-54,52]" %% xsd:string])
-    wasDerivedFrom(niiri:a312bb2d4a36613077f4d362f5263e2d, niiri:c00f026631fe0b6f988efa4d30db781f, -, -, -)
-    entity(niiri:49271d60759060cc512c32272ea47c9f,
+    wasDerivedFrom(niiri:0ad8c5359685ef2987e4c8431b9b4b3d, niiri:49cbd2656968943cca2fb0ddde2c880a, -, -, -)
+    entity(niiri:8f72ab30468dd866917659059a620828,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:14acc5ae182e2d6aa091d9670f63d86c',
+        prov:location = 'niiri:6ac73daf2055ade16d16be059b6e9905',
         prov:value = "2.13825297355652" %% xsd:float,
         nidm_equivalentZStatistic: = "2.12639503027273" %% xsd:float,
         nidm_pValueUncorrected: = "0.0167351906128659" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:14acc5ae182e2d6aa091d9670f63d86c,
+    entity(niiri:6ac73daf2055ade16d16be059b6e9905,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[36,-84,2]" %% xsd:string])
-    wasDerivedFrom(niiri:49271d60759060cc512c32272ea47c9f, niiri:b712b8f6d2df400be64fe19b957abb10, -, -, -)
-    entity(niiri:08989f7c63c852798e88db3aa5231385,
+    wasDerivedFrom(niiri:8f72ab30468dd866917659059a620828, niiri:686c4840892e9778876349ccd6236841, -, -, -)
+    entity(niiri:8e889d6489807dc3530c536d4635b766,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:72593e56b8c30845ae2b8f8970fe5e42',
+        prov:location = 'niiri:166f1e7cdee01aa4e88c32bb8e80de44',
         prov:value = "2.1293613910675" %% xsd:float,
         nidm_equivalentZStatistic: = "2.11775365245473" %% xsd:float,
         nidm_pValueUncorrected: = "0.0170979681968485" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:72593e56b8c30845ae2b8f8970fe5e42,
+    entity(niiri:166f1e7cdee01aa4e88c32bb8e80de44,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[30,68,12]" %% xsd:string])
-    wasDerivedFrom(niiri:08989f7c63c852798e88db3aa5231385, niiri:f66d2da458d706e0d1c123fd3dc589c7, -, -, -)
-    entity(niiri:58feba2e44840c92dea201d54bffa5fb,
+    wasDerivedFrom(niiri:8e889d6489807dc3530c536d4635b766, niiri:2e2b55b222631d083aed83513341f4bf, -, -, -)
+    entity(niiri:81290e20f66d908da83d57e4a241e47a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:d7ec0d3731cf2369dd44267e354a7988',
+        prov:location = 'niiri:a3c0d136a716ce9e78c8c4b4c5dbb827',
         prov:value = "2.11468005180359" %% xsd:float,
         nidm_equivalentZStatistic: = "2.10348692366691" %% xsd:float,
         nidm_pValueUncorrected: = "0.017711613581637" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:d7ec0d3731cf2369dd44267e354a7988,
+    entity(niiri:a3c0d136a716ce9e78c8c4b4c5dbb827,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[34,-84,14]" %% xsd:string])
-    wasDerivedFrom(niiri:58feba2e44840c92dea201d54bffa5fb, niiri:70a3e9df88095bfe99637dabf4110acd, -, -, -)
-    entity(niiri:9e3518c2e9867ca98860f754d7379642,
+    wasDerivedFrom(niiri:81290e20f66d908da83d57e4a241e47a, niiri:a8bfd334e76be268255831f5a8092aee, -, -, -)
+    entity(niiri:96b78cc86a3bd580ac464e4c29bd68ca,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:29e408397e3b3c1a20cd94269d9240df',
+        prov:location = 'niiri:eea9c1a497f9c48804e4b7a793b39718',
         prov:value = "2.01981115341187" %% xsd:float,
         nidm_equivalentZStatistic: = "2.01135476956162" %% xsd:float,
         nidm_pValueUncorrected: = "0.0221439986174564" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:29e408397e3b3c1a20cd94269d9240df,
+    entity(niiri:eea9c1a497f9c48804e4b7a793b39718,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[-42,20,36]" %% xsd:string])
-    wasDerivedFrom(niiri:9e3518c2e9867ca98860f754d7379642, niiri:027812928b4d9dc645c81857d81e13ca, -, -, -)
-    entity(niiri:01a776de2155c1d064f799ee0b13d27c,
+    wasDerivedFrom(niiri:96b78cc86a3bd580ac464e4c29bd68ca, niiri:fe4c4fd75ebef375c6e3c2cff33277a4, -, -, -)
+    entity(niiri:f45dcaf8f9451f6fd2cc5a23f2e8bd72,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:3af3a4e516f1d0712e480617661e0990',
+        prov:location = 'niiri:c5216e1840027be6069e98e52e3209fc',
         prov:value = "1.9834691286087" %% xsd:float,
         nidm_equivalentZStatistic: = "1.97609535691968" %% xsd:float,
         nidm_pValueUncorrected: = "0.0240719891024281" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:3af3a4e516f1d0712e480617661e0990,
+    entity(niiri:c5216e1840027be6069e98e52e3209fc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[34,-78,36]" %% xsd:string])
-    wasDerivedFrom(niiri:01a776de2155c1d064f799ee0b13d27c, niiri:fec8e2c65ce7d1cf6e18804683d824ca, -, -, -)
-    entity(niiri:a3fdd163c99c50f21394bb2564810f40,
+    wasDerivedFrom(niiri:f45dcaf8f9451f6fd2cc5a23f2e8bd72, niiri:5bae05b5a604a8c03d7992ce19d15723, -, -, -)
+    entity(niiri:3ee91f3ca48f4bcc3b193def1b5210de,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:14cae94fd17fb2d01fda8a8022d07f31',
+        prov:location = 'niiri:6547c4b945de1fb82a5079cabd74be59',
         prov:value = "1.94259870052338" %% xsd:float,
         nidm_equivalentZStatistic: = "1.93647164753299" %% xsd:float,
         nidm_pValueUncorrected: = "0.026404980891827" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:14cae94fd17fb2d01fda8a8022d07f31,
+    entity(niiri:6547c4b945de1fb82a5079cabd74be59,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[-48,18,18]" %% xsd:string])
-    wasDerivedFrom(niiri:a3fdd163c99c50f21394bb2564810f40, niiri:c9f251722e6a9f1501e325fdf2f516f3, -, -, -)
-    entity(niiri:42a4152bc3193944f970885860f254f1,
+    wasDerivedFrom(niiri:3ee91f3ca48f4bcc3b193def1b5210de, niiri:ec6a8c27bdfd0dc1de40b1f7c9c1ca61, -, -, -)
+    entity(niiri:473c3f54b00fd0cf793318f86ff57737,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:0ccdcec00484fe14b2ed7552c64faa47',
+        prov:location = 'niiri:a5ff8a5e336ee59e2b09e35c94d52a05',
         prov:value = "1.89261054992676" %% xsd:float,
         nidm_equivalentZStatistic: = "1.88805796389517" %% xsd:float,
         nidm_pValueUncorrected: = "0.0295090846561562" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:0ccdcec00484fe14b2ed7552c64faa47,
+    entity(niiri:a5ff8a5e336ee59e2b09e35c94d52a05,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[-40,20,8]" %% xsd:string])
-    wasDerivedFrom(niiri:42a4152bc3193944f970885860f254f1, niiri:c9f251722e6a9f1501e325fdf2f516f3, -, -, -)
-    entity(niiri:d8ef073869f2d518eeb58c051015c0e4,
+    wasDerivedFrom(niiri:473c3f54b00fd0cf793318f86ff57737, niiri:ec6a8c27bdfd0dc1de40b1f7c9c1ca61, -, -, -)
+    entity(niiri:c42b73a95973777217be1e34edd264ae,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:2179a81fd9206716047be8cff2e08728',
+        prov:location = 'niiri:a8d08db32827a4d6e6a628b65af65cb5',
         prov:value = "1.9298506975174" %% xsd:float,
         nidm_equivalentZStatistic: = "1.92411963399221" %% xsd:float,
         nidm_pValueUncorrected: = "0.0271697947905869" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:2179a81fd9206716047be8cff2e08728,
+    entity(niiri:a8d08db32827a4d6e6a628b65af65cb5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[22,-82,6]" %% xsd:string])
-    wasDerivedFrom(niiri:d8ef073869f2d518eeb58c051015c0e4, niiri:ac00f4348e517214c5428caad74cc6dc, -, -, -)
-    entity(niiri:b6b23fa7071c0e8366f51f689cb58e5d,
+    wasDerivedFrom(niiri:c42b73a95973777217be1e34edd264ae, niiri:f5e21a9b1b5fbfef7061a46469d52a7a, -, -, -)
+    entity(niiri:028b80cf6e69e5686f99c26f2649d550,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:00466efda7ed6e546b9bbd911f3047a8',
+        prov:location = 'niiri:0399384e6771d05bb0bfb55e8fd5efea',
         prov:value = "1.87824356555939" %% xsd:float,
         nidm_equivalentZStatistic: = "1.87415494022171" %% xsd:float,
         nidm_pValueUncorrected: = "0.0304545363496075" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:00466efda7ed6e546b9bbd911f3047a8,
+    entity(niiri:0399384e6771d05bb0bfb55e8fd5efea,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[-34,22,20]" %% xsd:string])
-    wasDerivedFrom(niiri:b6b23fa7071c0e8366f51f689cb58e5d, niiri:8050ff9b05fe42d3b13b693c3d4dfc3c, -, -, -)
-    entity(niiri:aa1e6f75cb3a2b76e5c3d6a02f70c7d7,
+    wasDerivedFrom(niiri:028b80cf6e69e5686f99c26f2649d550, niiri:4dd108385a724afeea8f83f29506f956, -, -, -)
+    entity(niiri:a01a1373ffd50de536bbd54bbc1c0acc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:7645318f716537f0f6e55e58acb4daf1',
+        prov:location = 'niiri:2a132b1ddf9d81308098d3ab72eb1f47',
         prov:value = "1.85802888870239" %% xsd:float,
         nidm_equivalentZStatistic: = "1.85460257678401" %% xsd:float,
         nidm_pValueUncorrected: = "0.0318264999487402" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:7645318f716537f0f6e55e58acb4daf1,
+    entity(niiri:2a132b1ddf9d81308098d3ab72eb1f47,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[16,-100,10]" %% xsd:string])
-    wasDerivedFrom(niiri:aa1e6f75cb3a2b76e5c3d6a02f70c7d7, niiri:d1592c70ca4448ee46f3c8df3c20043c, -, -, -)
-    entity(niiri:6cdd0ffff75a1252b7fa916661fdf669,
+    wasDerivedFrom(niiri:a01a1373ffd50de536bbd54bbc1c0acc, niiri:22e2be3780622fb9d23b8f1c07f56968, -, -, -)
+    entity(niiri:fbc87c3ab2258e712f04df3e38d5ba88,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:7ce3f7015bebf95ed663572f98652879',
+        prov:location = 'niiri:9da3e7879821713d932e61f75f334985',
         prov:value = "1.82612562179565" %% xsd:float,
         nidm_equivalentZStatistic: = "1.82376887581619" %% xsd:float,
         nidm_pValueUncorrected: = "0.0340935105624357" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:7ce3f7015bebf95ed663572f98652879,
+    entity(niiri:9da3e7879821713d932e61f75f334985,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[-22,6,14]" %% xsd:string])
-    wasDerivedFrom(niiri:6cdd0ffff75a1252b7fa916661fdf669, niiri:5828f74c2c43b3883378f9cd1e63925b, -, -, -)
-    entity(niiri:15a87b6382e2fb49ba7ce1b2c5a4bdfc,
+    wasDerivedFrom(niiri:fbc87c3ab2258e712f04df3e38d5ba88, niiri:ad5ca42e9fcec5d33eda403de4d6999b, -, -, -)
+    entity(niiri:db1f9bccc6f6f3575cae57f75b8893e7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:0b796279bb1597f56c7a837b6943278f',
+        prov:location = 'niiri:74a138449469747a3becacb7af05fee9',
         prov:value = "1.8208144903183" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81863886421642" %% xsd:float,
         nidm_pValueUncorrected: = "0.0344832722280412" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:0b796279bb1597f56c7a837b6943278f,
+    entity(niiri:74a138449469747a3becacb7af05fee9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[32,-66,0]" %% xsd:string])
-    wasDerivedFrom(niiri:15a87b6382e2fb49ba7ce1b2c5a4bdfc, niiri:5922affac179cd07256e72fbcf8a2c8a, -, -, -)
-    entity(niiri:11111874c48fbc8c67f5d0d02dfca56b,
+    wasDerivedFrom(niiri:db1f9bccc6f6f3575cae57f75b8893e7, niiri:59b84888054fd89394ca79e89db37a1a, -, -, -)
+    entity(niiri:fd4823052a3b2b916c9711e82c692f6d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:c7a615d1d896aa881dbf7d7894ede9ea',
+        prov:location = 'niiri:358cfcb1fe658862409258cd91599e3f',
         prov:value = "1.79377067089081" %% xsd:float,
         nidm_equivalentZStatistic: = "1.79253174586373" %% xsd:float,
         nidm_pValueUncorrected: = "0.0365239143287336" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:c7a615d1d896aa881dbf7d7894ede9ea,
+    entity(niiri:358cfcb1fe658862409258cd91599e3f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[-28,8,14]" %% xsd:string])
-    wasDerivedFrom(niiri:11111874c48fbc8c67f5d0d02dfca56b, niiri:8481b546970e4cc30b9a0415842a3ea3, -, -, -)
-    entity(niiri:cc9da452ad344d07d30c0d718ee350f6,
+    wasDerivedFrom(niiri:fd4823052a3b2b916c9711e82c692f6d, niiri:1adc127c7534eabbebd796b9fd4f9864, -, -, -)
+    entity(niiri:edfc43bda64635dc436bf9d8067737b4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:a19b00cbab738b2c3a78288527aba3cf',
+        prov:location = 'niiri:37eae5d7ee27a39dbd8ecb3031f41152',
         prov:value = "1.79001986980438" %% xsd:float,
         nidm_equivalentZStatistic: = "1.78891283515708" %% xsd:float,
         nidm_pValueUncorrected: = "0.0368144271933957" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:a19b00cbab738b2c3a78288527aba3cf,
+    entity(niiri:37eae5d7ee27a39dbd8ecb3031f41152,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[-20,26,28]" %% xsd:string])
-    wasDerivedFrom(niiri:cc9da452ad344d07d30c0d718ee350f6, niiri:f4471bd4ad44f0353136ecfba3e12d38, -, -, -)
-    entity(niiri:19d8b89fc4f6b3b5666d4b8f5df7a590,
+    wasDerivedFrom(niiri:edfc43bda64635dc436bf9d8067737b4, niiri:e434b384036bdebb84beb66ec3ab0e46, -, -, -)
+    entity(niiri:c3afbb34b6f65109a267ccdad31e7973,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:8d6b2fe61e5731fecf31a4effa4301bb',
+        prov:location = 'niiri:d897b02082f3c5a824dc2e51eeb4dc4b',
         prov:value = "1.74872362613678" %% xsd:float,
         nidm_equivalentZStatistic: = "1.749102772694" %% xsd:float,
         nidm_pValueUncorrected: = "0.0401366280244358" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:8d6b2fe61e5731fecf31a4effa4301bb,
+    entity(niiri:d897b02082f3c5a824dc2e51eeb4dc4b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[-54,28,20]" %% xsd:string])
-    wasDerivedFrom(niiri:19d8b89fc4f6b3b5666d4b8f5df7a590, niiri:7651662ffb846c59d0275b64f39a5a3e, -, -, -)
-    entity(niiri:6cd1d0f09d96998ec6d45fc8967bef7d,
+    wasDerivedFrom(niiri:c3afbb34b6f65109a267ccdad31e7973, niiri:2614ceb972cd9fc6b34c52dc1b41a5f5, -, -, -)
+    entity(niiri:e907edb71265482c80e5f66d1d6e91b8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:6e4b134d42d62e3fa90a9cdfa4b0c3ab',
+        prov:location = 'niiri:965ceb6364a0ab724dfa5f50081f8986',
         prov:value = "1.73660695552826" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73743465054505" %% xsd:float,
         nidm_pValueUncorrected: = "0.0411552397567266" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:6e4b134d42d62e3fa90a9cdfa4b0c3ab,
+    entity(niiri:965ceb6364a0ab724dfa5f50081f8986,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[36,-56,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:6cd1d0f09d96998ec6d45fc8967bef7d, niiri:cb4cab1d498471cf714b96e648ba0b84, -, -, -)
-    entity(niiri:971088d1bdd0b1a1c9e797b9ba272eee,
+    wasDerivedFrom(niiri:e907edb71265482c80e5f66d1d6e91b8, niiri:ec3da526be8b471a22bb953dc0be2fa1, -, -, -)
+    entity(niiri:2da4239466c6f6f9ee10a0a471049fa4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:2bcb7950634a9079bfc9f15710195ba5',
+        prov:location = 'niiri:fb0363ab0fd8d2a250664870c37f5c5e',
         prov:value = "1.72697401046753" %% xsd:float,
         nidm_equivalentZStatistic: = "1.72816258455492" %% xsd:float,
         nidm_pValueUncorrected: = "0.0419795398198842" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:2bcb7950634a9079bfc9f15710195ba5,
+    entity(niiri:fb0363ab0fd8d2a250664870c37f5c5e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[12,74,8]" %% xsd:string])
-    wasDerivedFrom(niiri:971088d1bdd0b1a1c9e797b9ba272eee, niiri:b49a13ef4f81cb056a0cf2c1e1e37613, -, -, -)
-    entity(niiri:3b1b90046e2cc738e068e3ccdc5b8e08,
+    wasDerivedFrom(niiri:2da4239466c6f6f9ee10a0a471049fa4, niiri:5bafbb05bd32dfb4238362ae3eba5d83, -, -, -)
+    entity(niiri:3f4c593f7a6d6dae3f96844bb716736d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:6e3632bdadbdb54596f9986ced7c5a42',
+        prov:location = 'niiri:07eb7b3b90495441876e6151ab6ae024',
         prov:value = "1.69681537151337" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69915940103581" %% xsd:float,
         nidm_pValueUncorrected: = "0.0446445768205113" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:6e3632bdadbdb54596f9986ced7c5a42,
+    entity(niiri:07eb7b3b90495441876e6151ab6ae024,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[-28,50,36]" %% xsd:string])
-    wasDerivedFrom(niiri:3b1b90046e2cc738e068e3ccdc5b8e08, niiri:3bf344699ca63226f8a0986e9e22dc4d, -, -, -)
-    entity(niiri:2f7d1feb589408c3bf50b3384d89d8a9,
+    wasDerivedFrom(niiri:3f4c593f7a6d6dae3f96844bb716736d, niiri:6a5bcf79ca8e87d784ab402166cef0c3, -, -, -)
+    entity(niiri:0b92adf0c91c746e0d4bc7d4e912eb7f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:42729ea56a022800e2b3fffe2fd2c1ec',
+        prov:location = 'niiri:215c5a5ba29bc68e48edc75ac5a622ad',
         prov:value = "1.69281709194183" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69531733220798" %% xsd:float,
         nidm_pValueUncorrected: = "0.0450076192977755" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:42729ea56a022800e2b3fffe2fd2c1ec,
+    entity(niiri:215c5a5ba29bc68e48edc75ac5a622ad,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-54,28,12]" %% xsd:string])
-    wasDerivedFrom(niiri:2f7d1feb589408c3bf50b3384d89d8a9, niiri:7a1aa46f25bc46f59f7f644a1d2d768c, -, -, -)
-    entity(niiri:90b76ff68e1f93610f550c0f2f46cdec,
+    wasDerivedFrom(niiri:0b92adf0c91c746e0d4bc7d4e912eb7f, niiri:b0b739a752e19f94dc7e9b7f2e2fd571, -, -, -)
+    entity(niiri:f0bc82a01b95dd842cbd908afc0de71e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:8e160c47f33d388aedd45037581833c0',
+        prov:location = 'niiri:8aff729756e0d5609d60b03f30b2b19b',
         prov:value = "1.68880593776703" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69146362670159" %% xsd:float,
         nidm_pValueUncorrected: = "0.0453741445419741" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:8e160c47f33d388aedd45037581833c0,
+    entity(niiri:8aff729756e0d5609d60b03f30b2b19b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[26,-92,18]" %% xsd:string])
-    wasDerivedFrom(niiri:90b76ff68e1f93610f550c0f2f46cdec, niiri:95103dd9bdac7741d90f99939247bf4e, -, -, -)
-    entity(niiri:9a6229796a5042d2de9c8d840d333151,
+    wasDerivedFrom(niiri:f0bc82a01b95dd842cbd908afc0de71e, niiri:48c59f311f10dc10f49d77de1a4f0b19, -, -, -)
+    entity(niiri:0840cfd3a11590229894c9ba9dfab5f8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:ba88244ebec57bcb6456c8f846311dbb',
+        prov:location = 'niiri:be7064ec70a1f76c9a5a622f21cfa8a2',
         prov:value = "1.68117702007294" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68413622248109" %% xsd:float,
         nidm_pValueUncorrected: = "0.046077672706774" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:ba88244ebec57bcb6456c8f846311dbb,
+    entity(niiri:be7064ec70a1f76c9a5a622f21cfa8a2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[42,-78,6]" %% xsd:string])
-    wasDerivedFrom(niiri:9a6229796a5042d2de9c8d840d333151, niiri:11fe90c3ae56c74edb8f27b7b4d64c01, -, -, -)
-    entity(niiri:54b18d3082b4cad596142f7ef9736d8a,
+    wasDerivedFrom(niiri:0840cfd3a11590229894c9ba9dfab5f8, niiri:7be9b12db5e680d03919fb39de296487, -, -, -)
+    entity(niiri:90bd3554714a9493852b84311d6860bd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:d6201606a3ba435a6e09c9caf89150df',
+        prov:location = 'niiri:d499932592dbf96669738734d592eb47',
         prov:value = "1.67713749408722" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68025745484094" %% xsd:float,
         nidm_pValueUncorrected: = "0.0464536174884935" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:d6201606a3ba435a6e09c9caf89150df,
+    entity(niiri:d499932592dbf96669738734d592eb47,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[-12,26,36]" %% xsd:string])
-    wasDerivedFrom(niiri:54b18d3082b4cad596142f7ef9736d8a, niiri:d17fffe11eaba3b9e149fce8bdc2b9da, -, -, -)
-    entity(niiri:8197741d55030f4c7e2a1d984b7bf1bc,
+    wasDerivedFrom(niiri:90bd3554714a9493852b84311d6860bd, niiri:91f68c6405b3afe515a6b371bde2705b, -, -, -)
+    entity(niiri:aa2dffe1faaea5caed6375c3b4e045b0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:7d3b2943cac3fe81f3de71425355d797',
+        prov:location = 'niiri:78cbe6728daa58c4d387dc6a12b3cd49',
         prov:value = "1.67311263084412" %% xsd:float,
         nidm_equivalentZStatistic: = "1.6763935381234" %% xsd:float,
         nidm_pValueUncorrected: = "0.0468305669041873" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:7d3b2943cac3fe81f3de71425355d797,
+    entity(niiri:78cbe6728daa58c4d387dc6a12b3cd49,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[12,-94,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:8197741d55030f4c7e2a1d984b7bf1bc, niiri:a97b8d1eb95bad3103d70c3a170b35e6, -, -, -)
-    entity(niiri:d119a32be5090208facc1946a3d5fa33,
+    wasDerivedFrom(niiri:aa2dffe1faaea5caed6375c3b4e045b0, niiri:bc270be21bea419f18154dda040f4b5a, -, -, -)
+    entity(niiri:a2404795b5e5daf6990eb6eae12c16b9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:2925ce3db3c2888712ca8f3f3d1f1619',
+        prov:location = 'niiri:a2828afb8f1e151f00c5aa59f3740437',
         prov:value = "1.67067694664001" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67405562956399" %% xsd:float,
         nidm_pValueUncorrected: = "0.0470598334324596" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:2925ce3db3c2888712ca8f3f3d1f1619,
+    entity(niiri:a2828afb8f1e151f00c5aa59f3740437,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[24,-92,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:d119a32be5090208facc1946a3d5fa33, niiri:34de4bc8669d7effba126acecd7e71ca, -, -, -)
-    entity(niiri:81ad744134f8137223e00d7f8e9efb1d,
+    wasDerivedFrom(niiri:a2404795b5e5daf6990eb6eae12c16b9, niiri:a0aa1a732baf12f3b4e5c27b6348115e, -, -, -)
+    entity(niiri:0d07f87dea9e3e960a3f3d038d8a70f7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:576bfeaced7698758e2dcea95224fe2a',
+        prov:location = 'niiri:595f816eefa45e24291f4b683c43e80b',
         prov:value = "1.66812241077423" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67160394831323" %% xsd:float,
         nidm_pValueUncorrected: = "0.0473012228473357" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:576bfeaced7698758e2dcea95224fe2a,
+    entity(niiri:595f816eefa45e24291f4b683c43e80b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[-24,22,22]" %% xsd:string])
-    wasDerivedFrom(niiri:81ad744134f8137223e00d7f8e9efb1d, niiri:34640314cb90b81bff8b479f4c75ae6f, -, -, -)
-    entity(niiri:fffda3a756d7aadecaf95c9b79ca9f9d,
+    wasDerivedFrom(niiri:0d07f87dea9e3e960a3f3d038d8a70f7, niiri:ac0917bc41fde1dbed179cd897e7c568, -, -, -)
+    entity(niiri:8aa103d7be8ec3c7c7aaca22852c2981,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:ef0fc7140e631601df1c9ed09b66ef7f',
+        prov:location = 'niiri:69ddaf3b72e3c6582f239bd415aec36d',
         prov:value = "1.66770362854004" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67120205793481" %% xsd:float,
         nidm_pValueUncorrected: = "0.0473408869609759" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:ef0fc7140e631601df1c9ed09b66ef7f,
+    entity(niiri:69ddaf3b72e3c6582f239bd415aec36d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[26,-90,22]" %% xsd:string])
-    wasDerivedFrom(niiri:fffda3a756d7aadecaf95c9b79ca9f9d, niiri:79c1b8c3935c1efdd0d31d231222a6e3, -, -, -)
-    entity(niiri:ff04f5c6feedf70958adb3464fd72d76,
+    wasDerivedFrom(niiri:8aa103d7be8ec3c7c7aaca22852c2981, niiri:61bb215e601050cd1cdc9f7b9c8847a0, -, -, -)
+    entity(niiri:cca9c4b0e0b571b547941afc4ee7ea62,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:9eabe9da21cf05a8ae9ca9e3b467bcea',
+        prov:location = 'niiri:4bb531975458fd0966f3aedd36987c11',
         prov:value = "1.66512632369995" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66872889854066" %% xsd:float,
         nidm_pValueUncorrected: = "0.0475855596349387" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:9eabe9da21cf05a8ae9ca9e3b467bcea,
+    entity(niiri:4bb531975458fd0966f3aedd36987c11,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[32,-60,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:ff04f5c6feedf70958adb3464fd72d76, niiri:1171e027eba41be4b53953810af155f9, -, -, -)
-    entity(niiri:498867695b58631e8cf68e8990cdf642,
+    wasDerivedFrom(niiri:cca9c4b0e0b571b547941afc4ee7ea62, niiri:d5aeba7a4d0595b94af060fe6c391161, -, -, -)
+    entity(niiri:4aab3c20ee5490ed595e356c8953578b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:23a47d1f73da07fee4779591d3a6aa53',
+        prov:location = 'niiri:74de56127dfe231995995a89993e9bd2',
         prov:value = "1.6600536108017" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66386211897632" %% xsd:float,
         nidm_pValueUncorrected: = "0.0480699933329287" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:23a47d1f73da07fee4779591d3a6aa53,
+    entity(niiri:74de56127dfe231995995a89993e9bd2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[-44,-56,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:498867695b58631e8cf68e8990cdf642, niiri:54a8bffd20ef66a79cc779bd8e630f0f, -, -, -)
+    wasDerivedFrom(niiri:4aab3c20ee5490ed595e356c8953578b, niiri:7cc7f4ff997ef1b13f17a0bc068a7e4d, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_conjunction/nidm.provn
+++ b/spmexport/ex_spm_conjunction/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:e8889926d05a35c367676e2b266a5d9e,
+  entity(niiri:cffd7ffff967c97f168edddb606cca3c,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:229b0f08cfcf3f699fd45d952761f576,
+  agent(niiri:6fca6103f9b3748f1135346eed723b1e,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:1051dc20a62ed1558eac0a1a2fb70588,
+  activity(niiri:08e852b60d68cd3f03fbb91135fc698a,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:1051dc20a62ed1558eac0a1a2fb70588, niiri:229b0f08cfcf3f699fd45d952761f576, -)
-  wasGeneratedBy(niiri:e8889926d05a35c367676e2b266a5d9e, niiri:1051dc20a62ed1558eac0a1a2fb70588, 2016-01-11T10:11:03)
-  bundle niiri:e8889926d05a35c367676e2b266a5d9e
+  wasAssociatedWith(niiri:08e852b60d68cd3f03fbb91135fc698a, niiri:6fca6103f9b3748f1135346eed723b1e, -)
+  wasGeneratedBy(niiri:cffd7ffff967c97f168edddb606cca3c, niiri:08e852b60d68cd3f03fbb91135fc698a, 2016-01-11T10:33:19)
+  bundle niiri:cffd7ffff967c97f168edddb606cca3c
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -126,12 +126,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:0b3ed3b43289bfce69e1dd8e0a580555,
+    agent(niiri:8d702deb7794ff140970aa83183f0cd7,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:08ce005cf94169deadd293b9f0386fc0,
+    entity(niiri:13472aa35bbca29434f4e7a96e64854b,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -140,189 +140,189 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:12128f6eb829f1af879e8f015ce78ee5,
+    entity(niiri:b8bc1fafeb07d65d7429038c792c1fff,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:4d9192c7fd08ad2bb7c4ff9503e7546b,
+    entity(niiri:c75a5447273e9c598f256e39304eded4,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:62719c37cb7f1155944ed6252b71ec01,
+    entity(niiri:c7f99aa282bcb84887dac079b6e639e3,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:df48ccc999ebf8ca6f4c3e5bc939230c',
+        dc:description = 'niiri:e68886708e4b26ae6e709f5fa4808690',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:4d9192c7fd08ad2bb7c4ff9503e7546b',
+        nidm_hasDriftModel: = 'niiri:c75a5447273e9c598f256e39304eded4',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:df48ccc999ebf8ca6f4c3e5bc939230c,
+    entity(niiri:e68886708e4b26ae6e709f5fa4808690,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:9cca745d6e07ffe830a810c73a4beb94,
+    entity(niiri:937d29c8162661dc3675b67810a67ae3,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:814ac7079ffe5eac40b4e81f109d77d3,
+    activity(niiri:9b702b46c5dd95ed19b8b5140da841d6,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:814ac7079ffe5eac40b4e81f109d77d3, niiri:0b3ed3b43289bfce69e1dd8e0a580555, -)
-    used(niiri:814ac7079ffe5eac40b4e81f109d77d3, niiri:62719c37cb7f1155944ed6252b71ec01, -)
-    used(niiri:814ac7079ffe5eac40b4e81f109d77d3, niiri:12128f6eb829f1af879e8f015ce78ee5, -)
-    used(niiri:814ac7079ffe5eac40b4e81f109d77d3, niiri:9cca745d6e07ffe830a810c73a4beb94, -)
-    entity(niiri:fa56d066478b2ea71a6e1c4d5d549487,
+    wasAssociatedWith(niiri:9b702b46c5dd95ed19b8b5140da841d6, niiri:8d702deb7794ff140970aa83183f0cd7, -)
+    used(niiri:9b702b46c5dd95ed19b8b5140da841d6, niiri:c7f99aa282bcb84887dac079b6e639e3, -)
+    used(niiri:9b702b46c5dd95ed19b8b5140da841d6, niiri:b8bc1fafeb07d65d7429038c792c1fff, -)
+    used(niiri:9b702b46c5dd95ed19b8b5140da841d6, niiri:937d29c8162661dc3675b67810a67ae3, -)
+    entity(niiri:8b400bad67e910ddcd25ffed64d4900a,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    entity(niiri:e4a6119a50fded21c14197bcf296ab06,
+    entity(niiri:705430105fed94e345e5a467681058e2,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
-    wasDerivedFrom(niiri:fa56d066478b2ea71a6e1c4d5d549487, niiri:e4a6119a50fded21c14197bcf296ab06, -, -, -)
-    wasGeneratedBy(niiri:fa56d066478b2ea71a6e1c4d5d549487, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:e5e2aba57bea3f7fc5a3f8657c80a53b,
+    wasDerivedFrom(niiri:8b400bad67e910ddcd25ffed64d4900a, niiri:705430105fed94e345e5a467681058e2, -, -, -)
+    wasGeneratedBy(niiri:8b400bad67e910ddcd25ffed64d4900a, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:9dd086507743fe730b7d24b70cf7ed3a,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "108.038318634033" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
-    wasGeneratedBy(niiri:e5e2aba57bea3f7fc5a3f8657c80a53b, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:8dc72e026b46807ff7610978144a50a7,
+    wasGeneratedBy(niiri:9dd086507743fe730b7d24b70cf7ed3a, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:d70991e4ec5c9a6234d6391c2a0dbdb0,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
-    entity(niiri:4ae89562691298e404907d30c17d6405,
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
+    entity(niiri:406110ec41e71d7260a38848d82dfc7f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f" %% xsd:string])
-    wasDerivedFrom(niiri:8dc72e026b46807ff7610978144a50a7, niiri:4ae89562691298e404907d30c17d6405, -, -, -)
-    wasGeneratedBy(niiri:8dc72e026b46807ff7610978144a50a7, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:c92fcc94226b041e076498dac96ae002,
+    wasDerivedFrom(niiri:d70991e4ec5c9a6234d6391c2a0dbdb0, niiri:406110ec41e71d7260a38848d82dfc7f, -, -, -)
+    wasGeneratedBy(niiri:d70991e4ec5c9a6234d6391c2a0dbdb0, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:32d8ca8f9ba66fe36d7b9eae3f419596,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
-    entity(niiri:70eb7916777b2ccbe5e1004599b6b16f,
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
+    entity(niiri:e83351acdbbde0ef0a33cf50fbc3990f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
-    wasDerivedFrom(niiri:c92fcc94226b041e076498dac96ae002, niiri:70eb7916777b2ccbe5e1004599b6b16f, -, -, -)
-    wasGeneratedBy(niiri:c92fcc94226b041e076498dac96ae002, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:e709d65a8b7aad133a26fc434e5810c1,
+    wasDerivedFrom(niiri:32d8ca8f9ba66fe36d7b9eae3f419596, niiri:e83351acdbbde0ef0a33cf50fbc3990f, -, -, -)
+    wasGeneratedBy(niiri:32d8ca8f9ba66fe36d7b9eae3f419596, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:5cdc01b7d93b811fc7e1114f880e74d3,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
-    entity(niiri:5c45b10466b418609ad8f78d1d37f2a6,
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
+    entity(niiri:3397f8fdb55baa2ce4ca23110660f606,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb" %% xsd:string])
-    wasDerivedFrom(niiri:e709d65a8b7aad133a26fc434e5810c1, niiri:5c45b10466b418609ad8f78d1d37f2a6, -, -, -)
-    wasGeneratedBy(niiri:e709d65a8b7aad133a26fc434e5810c1, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:68dce10b86eb716a09c05d6bff88fb86,
+    wasDerivedFrom(niiri:5cdc01b7d93b811fc7e1114f880e74d3, niiri:3397f8fdb55baa2ce4ca23110660f606, -, -, -)
+    wasGeneratedBy(niiri:5cdc01b7d93b811fc7e1114f880e74d3, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:48ca995ae7b89bd0222a3d1652dc6d81,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
-    entity(niiri:2ec5caa6c30b03a58e93533d26263bf0,
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
+    entity(niiri:0182339ddbc9fc0f31bf47a8695e88ac,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6" %% xsd:string])
-    wasDerivedFrom(niiri:68dce10b86eb716a09c05d6bff88fb86, niiri:2ec5caa6c30b03a58e93533d26263bf0, -, -, -)
-    wasGeneratedBy(niiri:68dce10b86eb716a09c05d6bff88fb86, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:1835bec3a94146206bbc4c8dd879125c,
+    wasDerivedFrom(niiri:48ca995ae7b89bd0222a3d1652dc6d81, niiri:0182339ddbc9fc0f31bf47a8695e88ac, -, -, -)
+    wasGeneratedBy(niiri:48ca995ae7b89bd0222a3d1652dc6d81, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:d00e71a2693f38940a6abe5fe0a27e14,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
-    entity(niiri:7cfa6c3f159704f4e89cdb27e96c7bc1,
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
+    entity(niiri:6051fccc3fa5e6b6878fdcfe17232d70,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff" %% xsd:string])
-    wasDerivedFrom(niiri:1835bec3a94146206bbc4c8dd879125c, niiri:7cfa6c3f159704f4e89cdb27e96c7bc1, -, -, -)
-    wasGeneratedBy(niiri:1835bec3a94146206bbc4c8dd879125c, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:3f4483bbcd6a762700a3897d004115aa,
+    wasDerivedFrom(niiri:d00e71a2693f38940a6abe5fe0a27e14, niiri:6051fccc3fa5e6b6878fdcfe17232d70, -, -, -)
+    wasGeneratedBy(niiri:d00e71a2693f38940a6abe5fe0a27e14, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:05115890f603e4e9e4e1a672eb3683b5,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 6" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0'])
-    entity(niiri:5924cb43042ba2ca9b3e72dff64b49b5,
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b'])
+    entity(niiri:699a8d86d7db0ddab1d01e042dc3ae4f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0006.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
-    wasDerivedFrom(niiri:3f4483bbcd6a762700a3897d004115aa, niiri:5924cb43042ba2ca9b3e72dff64b49b5, -, -, -)
-    wasGeneratedBy(niiri:3f4483bbcd6a762700a3897d004115aa, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:0584af123d5f6deb3954a3ac1bf9afaf,
+    wasDerivedFrom(niiri:05115890f603e4e9e4e1a672eb3683b5, niiri:699a8d86d7db0ddab1d01e042dc3ae4f, -, -, -)
+    wasGeneratedBy(niiri:05115890f603e4e9e4e1a672eb3683b5, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:b60ee6cea0e97b11abbbfad263cb8893,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8" %% xsd:string])
-    entity(niiri:751ce5b565c5ac0b6fcbae2755edacc1,
+    entity(niiri:03ebca4bd2e13ea96ce505ab726aaa82,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81" %% xsd:string])
-    wasDerivedFrom(niiri:0584af123d5f6deb3954a3ac1bf9afaf, niiri:751ce5b565c5ac0b6fcbae2755edacc1, -, -, -)
-    wasGeneratedBy(niiri:0584af123d5f6deb3954a3ac1bf9afaf, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:5e5f72d3a313df47ed1675f196ba2790,
+    wasDerivedFrom(niiri:b60ee6cea0e97b11abbbfad263cb8893, niiri:03ebca4bd2e13ea96ce505ab726aaa82, -, -, -)
+    wasGeneratedBy(niiri:b60ee6cea0e97b11abbbfad263cb8893, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:7e51e600d6dbaf94e50bb1c27b2e2a06,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8" %% xsd:string])
-    entity(niiri:c43d5c20b335994694e0ce99c69c63d2,
+    entity(niiri:b1cfa368972409a292f285346c36c011,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29" %% xsd:string])
-    wasDerivedFrom(niiri:5e5f72d3a313df47ed1675f196ba2790, niiri:c43d5c20b335994694e0ce99c69c63d2, -, -, -)
-    wasGeneratedBy(niiri:5e5f72d3a313df47ed1675f196ba2790, niiri:814ac7079ffe5eac40b4e81f109d77d3, -)
-    entity(niiri:fff3d3a4810634aa02f29f0c1f5fbb8f,
+    wasDerivedFrom(niiri:7e51e600d6dbaf94e50bb1c27b2e2a06, niiri:b1cfa368972409a292f285346c36c011, -, -, -)
+    wasGeneratedBy(niiri:7e51e600d6dbaf94e50bb1c27b2e2a06, niiri:9b702b46c5dd95ed19b8b5140da841d6, -)
+    entity(niiri:75efb902a39cf1021609db5de272351c,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         prov:label = "Contrast: mr vs plain" %% xsd:string,
         prov:value = "[1, 1, -1, -1, 0, 0]" %% xsd:string])
-    activity(niiri:ed2f36215d4ae0d42c3aefe5ecd86175,
+    activity(niiri:a08187124a8a759239103ba1a7917d6c,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation 1"])
-    wasAssociatedWith(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:0b3ed3b43289bfce69e1dd8e0a580555, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:fa56d066478b2ea71a6e1c4d5d549487, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:0584af123d5f6deb3954a3ac1bf9afaf, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:62719c37cb7f1155944ed6252b71ec01, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:fff3d3a4810634aa02f29f0c1f5fbb8f, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:8dc72e026b46807ff7610978144a50a7, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:c92fcc94226b041e076498dac96ae002, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:e709d65a8b7aad133a26fc434e5810c1, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:68dce10b86eb716a09c05d6bff88fb86, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:1835bec3a94146206bbc4c8dd879125c, -)
-    used(niiri:ed2f36215d4ae0d42c3aefe5ecd86175, niiri:3f4483bbcd6a762700a3897d004115aa, -)
-    entity(niiri:33170469490d72c603cf1ad06ce86637,
+    wasAssociatedWith(niiri:a08187124a8a759239103ba1a7917d6c, niiri:8d702deb7794ff140970aa83183f0cd7, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:8b400bad67e910ddcd25ffed64d4900a, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:b60ee6cea0e97b11abbbfad263cb8893, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:c7f99aa282bcb84887dac079b6e639e3, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:75efb902a39cf1021609db5de272351c, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:d70991e4ec5c9a6234d6391c2a0dbdb0, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:32d8ca8f9ba66fe36d7b9eae3f419596, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:5cdc01b7d93b811fc7e1114f880e74d3, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:48ca995ae7b89bd0222a3d1652dc6d81, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:d00e71a2693f38940a6abe5fe0a27e14, -)
+    used(niiri:a08187124a8a759239103ba1a7917d6c, niiri:05115890f603e4e9e4e1a672eb3683b5, -)
+    entity(niiri:6c08012b8665ffafe1d80de0f06b0deb,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic_0001.nii.gz" %% xsd:string,
@@ -332,61 +332,61 @@ document
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "aba2fef7900cacda1ed84fe5edf867bd2b0fc6ae7eb4919967798d7f219a6d8ad5454fe8e0bdf4a7cfa6402e73287e703c285d12df0a282e40438ec36153e715" %% xsd:string])
-    entity(niiri:0d5089a0bd1af4fc6f9474726c757a3b,
+    entity(niiri:0aabcd9c646fada4d1e8380aa19581c0,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782" %% xsd:string])
-    wasDerivedFrom(niiri:33170469490d72c603cf1ad06ce86637, niiri:0d5089a0bd1af4fc6f9474726c757a3b, -, -, -)
-    wasGeneratedBy(niiri:33170469490d72c603cf1ad06ce86637, niiri:ed2f36215d4ae0d42c3aefe5ecd86175, -)
-    entity(niiri:a15220866e3ff78e30b1d06f1e2ad332,
+    wasDerivedFrom(niiri:6c08012b8665ffafe1d80de0f06b0deb, niiri:0aabcd9c646fada4d1e8380aa19581c0, -, -, -)
+    wasGeneratedBy(niiri:6c08012b8665ffafe1d80de0f06b0deb, niiri:a08187124a8a759239103ba1a7917d6c, -)
+    entity(niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: mr vs plain" %% xsd:string,
         nidm_contrastName: = "mr vs plain" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5" %% xsd:string])
-    entity(niiri:c06e95223a98daddc50df12b0ef668ef,
+    entity(niiri:7bcc38cb25e8a636c411c67b7c86b4af,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28" %% xsd:string])
-    wasDerivedFrom(niiri:a15220866e3ff78e30b1d06f1e2ad332, niiri:c06e95223a98daddc50df12b0ef668ef, -, -, -)
-    wasGeneratedBy(niiri:a15220866e3ff78e30b1d06f1e2ad332, niiri:ed2f36215d4ae0d42c3aefe5ecd86175, -)
-    entity(niiri:88f8800367c7c2b2a2d1a301d933782c,
+    wasDerivedFrom(niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3, niiri:7bcc38cb25e8a636c411c67b7c86b4af, -, -, -)
+    wasGeneratedBy(niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3, niiri:a08187124a8a759239103ba1a7917d6c, -)
+    entity(niiri:ea53b05d76e1a79956319d8ef8524624,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b" %% xsd:string])
-    wasGeneratedBy(niiri:88f8800367c7c2b2a2d1a301d933782c, niiri:ed2f36215d4ae0d42c3aefe5ecd86175, -)
-    entity(niiri:59cd72b8af1baa0c5eb355990015dbc8,
+    wasGeneratedBy(niiri:ea53b05d76e1a79956319d8ef8524624, niiri:a08187124a8a759239103ba1a7917d6c, -)
+    entity(niiri:25693c09a24b28e659ccec8659964759,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
         prov:label = "Contrast: switch vs nonswitch" %% xsd:string,
         prov:value = "[1, -1, 1, -1, 0, 0]" %% xsd:string])
-    activity(niiri:bb82cadb0c0a63033cb0b69845e19933,
+    activity(niiri:8f29f58ca8f23c2abe4da18512df00f0,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation 2"])
-    wasAssociatedWith(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:0b3ed3b43289bfce69e1dd8e0a580555, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:fa56d066478b2ea71a6e1c4d5d549487, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:0584af123d5f6deb3954a3ac1bf9afaf, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:62719c37cb7f1155944ed6252b71ec01, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:59cd72b8af1baa0c5eb355990015dbc8, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:8dc72e026b46807ff7610978144a50a7, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:c92fcc94226b041e076498dac96ae002, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:e709d65a8b7aad133a26fc434e5810c1, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:68dce10b86eb716a09c05d6bff88fb86, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:1835bec3a94146206bbc4c8dd879125c, -)
-    used(niiri:bb82cadb0c0a63033cb0b69845e19933, niiri:3f4483bbcd6a762700a3897d004115aa, -)
-    entity(niiri:cdd7c42099c33f420a6755aca2f2279f,
+    wasAssociatedWith(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:8d702deb7794ff140970aa83183f0cd7, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:8b400bad67e910ddcd25ffed64d4900a, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:b60ee6cea0e97b11abbbfad263cb8893, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:c7f99aa282bcb84887dac079b6e639e3, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:25693c09a24b28e659ccec8659964759, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:d70991e4ec5c9a6234d6391c2a0dbdb0, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:32d8ca8f9ba66fe36d7b9eae3f419596, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:5cdc01b7d93b811fc7e1114f880e74d3, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:48ca995ae7b89bd0222a3d1652dc6d81, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:d00e71a2693f38940a6abe5fe0a27e14, -)
+    used(niiri:8f29f58ca8f23c2abe4da18512df00f0, niiri:05115890f603e4e9e4e1a672eb3683b5, -)
+    entity(niiri:ed5e976f74b812d550d5f16796c155fc,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic_0002.nii.gz" %% xsd:string,
@@ -396,103 +396,103 @@ document
         nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "1c375cdc8f2b00f93f3d6f1a09aafa5670d35ffcf2c82ef061151bfb047463e482e971d67ce3e3e2496f37b1621f5d732a0a1f88c773f5d5fa077cb6a3e38501" %% xsd:string])
-    entity(niiri:f364d39b2363c17f9d16acb9c59c6a34,
+    entity(niiri:93258b59372b373e6266047487de0072,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "313c8e34e107b1e9bec46074e7a1cef289427618869119eff1c8044a2b5b8e5a340c899a78f40a3f8b938dbbbde53bd16c096da55f2e07a7c9e334cfd1e471f2" %% xsd:string])
-    wasDerivedFrom(niiri:cdd7c42099c33f420a6755aca2f2279f, niiri:f364d39b2363c17f9d16acb9c59c6a34, -, -, -)
-    wasGeneratedBy(niiri:cdd7c42099c33f420a6755aca2f2279f, niiri:bb82cadb0c0a63033cb0b69845e19933, -)
-    entity(niiri:e302d7d850e61776b5bb1245b4e05648,
+    wasDerivedFrom(niiri:ed5e976f74b812d550d5f16796c155fc, niiri:93258b59372b373e6266047487de0072, -, -, -)
+    wasGeneratedBy(niiri:ed5e976f74b812d550d5f16796c155fc, niiri:8f29f58ca8f23c2abe4da18512df00f0, -)
+    entity(niiri:05f1c1dcd9cada95daa2b92b3aae94eb,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast_0002.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: switch vs nonswitch" %% xsd:string,
         nidm_contrastName: = "switch vs nonswitch" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "77720bd21fb296db2e69c9742318c52f7cf6b08f94a83c5c1e30d5b8b21b1fd218de32fcc3a96aa2d067d5b06015e85e863ab87907741d2d7c9993740f668dc2" %% xsd:string])
-    entity(niiri:4488f35b0475365c16a619d4367e2596,
+    entity(niiri:9b02ce638a46ac45c6d4d3fd693e255f,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "6983d8888c458d8a073f84054db2587b0a71764e64c30ea7e4a13cd0e6b2e301eaea1b570822b24b635b464fd233c3801a9205ddcd2dcffcda7cd99679d2734a" %% xsd:string])
-    wasDerivedFrom(niiri:e302d7d850e61776b5bb1245b4e05648, niiri:4488f35b0475365c16a619d4367e2596, -, -, -)
-    wasGeneratedBy(niiri:e302d7d850e61776b5bb1245b4e05648, niiri:bb82cadb0c0a63033cb0b69845e19933, -)
-    entity(niiri:f0fc139f8e55d67381833c5bf0ad8776,
+    wasDerivedFrom(niiri:05f1c1dcd9cada95daa2b92b3aae94eb, niiri:9b02ce638a46ac45c6d4d3fd693e255f, -, -, -)
+    wasGeneratedBy(niiri:05f1c1dcd9cada95daa2b92b3aae94eb, niiri:8f29f58ca8f23c2abe4da18512df00f0, -)
+    entity(niiri:8576d98d89e7380306ae7a7b2bfa7f6e,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError_0002.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "1bb21447dcf3cc1eeb9453c707178e4d87161242c69e18795e0e2b30496c9e657ed2f202d4c9cd364aea5a04e4e46fe70ca830e1db14dd2e0f20af754281c3f2" %% xsd:string])
-    wasGeneratedBy(niiri:f0fc139f8e55d67381833c5bf0ad8776, niiri:bb82cadb0c0a63033cb0b69845e19933, -)
-    entity(niiri:fc0dadbc5f694e6ae907492f74e6940a,
+    wasGeneratedBy(niiri:8576d98d89e7380306ae7a7b2bfa7f6e, niiri:8f29f58ca8f23c2abe4da18512df00f0, -)
+    entity(niiri:c92560dc79ef7986810602e2fa8cc698,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.048771 (unc.)" %% xsd:string,
         prov:value = "0.0487705952532708" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:4e24c86c0c11cc5f53096bcd0ce1dee2',
-        nidm_equivalentThreshold: = 'niiri:f9486c7fafc049f9442fc8a37aad071b'])
-    entity(niiri:4e24c86c0c11cc5f53096bcd0ce1dee2,
+        nidm_equivalentThreshold: = 'niiri:f7e7ca44a8f41bda88372604c4fbbb68',
+        nidm_equivalentThreshold: = 'niiri:9b07472e1eaca0cce525f30fb31c894c'])
+    entity(niiri:f7e7ca44a8f41bda88372604c4fbbb68,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "1.65278686445912" %% xsd:float])
-    entity(niiri:f9486c7fafc049f9442fc8a37aad071b,
+    entity(niiri:9b07472e1eaca0cce525f30fb31c894c,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:6f5dc8bb78b50ed4e5df8f9ad38d9464,
+    entity(niiri:5e669b6d10f715c60759eb817713a4a2,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:92687adf3abda3ba46eb627518e50083',
-        nidm_equivalentThreshold: = 'niiri:6af6d4d06a49094c399e6ccf744121ef'])
-    entity(niiri:92687adf3abda3ba46eb627518e50083,
+        nidm_equivalentThreshold: = 'niiri:b39d449d635c93f3ffe4f11fdc273353',
+        nidm_equivalentThreshold: = 'niiri:a369532528403ad4850204e071f04758'])
+    entity(niiri:b39d449d635c93f3ffe4f11fdc273353,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:6af6d4d06a49094c399e6ccf744121ef,
+    entity(niiri:a369532528403ad4850204e071f04758,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:c90078d4c679070cca4a029f082015c6,
+    entity(niiri:d71d80f794ac0f7a94273b376d163e89,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:e225a30061c1008b5fab26894ccaf377,
+    entity(niiri:b8086c9fb20252dc9ec4a7fa41470165,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6,
+    activity(niiri:047da8bd1155d93bb9e94d1cb47f6f2e,
         [prov:type = 'nidm_ConjunctionInference:',
         prov:label = "Conjunction Inference"])
-    wasAssociatedWith(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:0b3ed3b43289bfce69e1dd8e0a580555, -)
-    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:fc0dadbc5f694e6ae907492f74e6940a, -)
-    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:6f5dc8bb78b50ed4e5df8f9ad38d9464, -)
-    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:33170469490d72c603cf1ad06ce86637, -)
-    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:cdd7c42099c33f420a6755aca2f2279f, -)
-    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:5e5f72d3a313df47ed1675f196ba2790, -)
-    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:fa56d066478b2ea71a6e1c4d5d549487, -)
-    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:c90078d4c679070cca4a029f082015c6, -)
-    used(niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, niiri:e225a30061c1008b5fab26894ccaf377, -)
-    entity(niiri:5659ce7e18cccaee79d052589cc49082,
+    wasAssociatedWith(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:8d702deb7794ff140970aa83183f0cd7, -)
+    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:c92560dc79ef7986810602e2fa8cc698, -)
+    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:5e669b6d10f715c60759eb817713a4a2, -)
+    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:6c08012b8665ffafe1d80de0f06b0deb, -)
+    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:ed5e976f74b812d550d5f16796c155fc, -)
+    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:7e51e600d6dbaf94e50bb1c27b2e2a06, -)
+    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:8b400bad67e910ddcd25ffed64d4900a, -)
+    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:d71d80f794ac0f7a94273b376d163e89, -)
+    used(niiri:047da8bd1155d93bb9e94d1cb47f6f2e, niiri:b8086c9fb20252dc9ec4a7fa41470165, -)
+    entity(niiri:af86aeaa13e45fe4af977676f9dbb2d6,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
         nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
         nidm_reselSizeInVoxels: = "68.4409986586553" %% xsd:float,
@@ -508,8 +508,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    wasGeneratedBy(niiri:5659ce7e18cccaee79d052589cc49082, niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, -)
-    entity(niiri:f3637fafb926481fff6bd8938c6a8550,
+    wasGeneratedBy(niiri:af86aeaa13e45fe4af977676f9dbb2d6, niiri:047da8bd1155d93bb9e94d1cb47f6f2e, -)
+    entity(niiri:2561c31d8316e8b6110351c09d382626,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -517,22 +517,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "30" %% xsd:int,
         nidm_pValue: = "1" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:225cba9527198fe0f9f286e4794b0c09',
-        nidm_hasMaximumIntensityProjection: = 'niiri:b314a44bd0faae613b91c61054d712ba',
-        nidm_inCoordinateSpace: = 'niiri:08ce005cf94169deadd293b9f0386fc0',
+        nidm_hasClusterLabelsMap: = 'niiri:555b51c020185cf7d98d6cae3d6dd6b7',
+        nidm_hasMaximumIntensityProjection: = 'niiri:72e33120e4a0cf389b3663a56945e615',
+        nidm_inCoordinateSpace: = 'niiri:13472aa35bbca29434f4e7a96e64854b',
         crypto:sha512 = "bcf45ac744752d54a29a2b918eda586a0e6637179a62a2eef62afd03f594bb4bdb4d2171625040d21c22a02d3a13fd0312ce1b83f6a6aecf34c432299e21c864" %% xsd:string])
-    entity(niiri:225cba9527198fe0f9f286e4794b0c09,
+    entity(niiri:555b51c020185cf7d98d6cae3d6dd6b7,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:b314a44bd0faae613b91c61054d712ba,
+    entity(niiri:72e33120e4a0cf389b3663a56945e615,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:f3637fafb926481fff6bd8938c6a8550, niiri:e99ac3c1e07c5c1b8b9b94dad780efc6, -)
-    entity(niiri:1ca2ed8885126a13f37d342c5bda82b6,
+    wasGeneratedBy(niiri:2561c31d8316e8b6110351c09d382626, niiri:047da8bd1155d93bb9e94d1cb47f6f2e, -)
+    entity(niiri:8d1a8ab2f5e6753052e300d592e3d511,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "95" %% xsd:int,
@@ -541,8 +541,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:1ca2ed8885126a13f37d342c5bda82b6, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:b6ec4ee5c26bd5170b56e954e84a7789,
+    wasDerivedFrom(niiri:8d1a8ab2f5e6753052e300d592e3d511, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:5a1ad49de526d8a54452b31baf96a75d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -551,8 +551,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:b6ec4ee5c26bd5170b56e954e84a7789, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:67aa7dea8d858564a8b4505070c20ab3,
+    wasDerivedFrom(niiri:5a1ad49de526d8a54452b31baf96a75d, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:c00f026631fe0b6f988efa4d30db781f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -561,8 +561,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:67aa7dea8d858564a8b4505070c20ab3, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:8eb556353f8e288e589eef37024ef068,
+    wasDerivedFrom(niiri:c00f026631fe0b6f988efa4d30db781f, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:b712b8f6d2df400be64fe19b957abb10,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -571,8 +571,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:8eb556353f8e288e589eef37024ef068, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:4f970219224428039454afd130e40f48,
+    wasDerivedFrom(niiri:b712b8f6d2df400be64fe19b957abb10, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:f66d2da458d706e0d1c123fd3dc589c7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -581,8 +581,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:4f970219224428039454afd130e40f48, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:c2a5888cb7cfb94104a85fdf0c0a0975,
+    wasDerivedFrom(niiri:f66d2da458d706e0d1c123fd3dc589c7, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:70a3e9df88095bfe99637dabf4110acd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -591,8 +591,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:c2a5888cb7cfb94104a85fdf0c0a0975, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:5e85e47c2fc2758e5d466cd2123b2254,
+    wasDerivedFrom(niiri:70a3e9df88095bfe99637dabf4110acd, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:027812928b4d9dc645c81857d81e13ca,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -601,8 +601,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:5e85e47c2fc2758e5d466cd2123b2254, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:6105338324e4b950666042ae82d011fd,
+    wasDerivedFrom(niiri:027812928b4d9dc645c81857d81e13ca, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:fec8e2c65ce7d1cf6e18804683d824ca,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -611,8 +611,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:6105338324e4b950666042ae82d011fd, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:4f020dcb9018a1690cba2cbf60dc38b0,
+    wasDerivedFrom(niiri:fec8e2c65ce7d1cf6e18804683d824ca, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:c9f251722e6a9f1501e325fdf2f516f3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "41" %% xsd:int,
@@ -621,8 +621,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:4f020dcb9018a1690cba2cbf60dc38b0, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:68b9b03c7822e1a0b86cd9e68fe99ca2,
+    wasDerivedFrom(niiri:c9f251722e6a9f1501e325fdf2f516f3, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:ac00f4348e517214c5428caad74cc6dc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -631,8 +631,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:68b9b03c7822e1a0b86cd9e68fe99ca2, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9,
+    wasDerivedFrom(niiri:ac00f4348e517214c5428caad74cc6dc, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:8050ff9b05fe42d3b13b693c3d4dfc3c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -641,8 +641,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:f626ba6b4ad8b422a9e8b6208607d5c7,
+    wasDerivedFrom(niiri:8050ff9b05fe42d3b13b693c3d4dfc3c, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:d1592c70ca4448ee46f3c8df3c20043c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -651,8 +651,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:f626ba6b4ad8b422a9e8b6208607d5c7, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:dd3a390096e9240d96d84a6fa0b53334,
+    wasDerivedFrom(niiri:d1592c70ca4448ee46f3c8df3c20043c, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:5828f74c2c43b3883378f9cd1e63925b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -661,8 +661,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:dd3a390096e9240d96d84a6fa0b53334, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:b38cc3f1a8c8b355373259707d78b430,
+    wasDerivedFrom(niiri:5828f74c2c43b3883378f9cd1e63925b, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:5922affac179cd07256e72fbcf8a2c8a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -671,8 +671,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:b38cc3f1a8c8b355373259707d78b430, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:708b36a85852210d2aa37cd0a43c31d6,
+    wasDerivedFrom(niiri:5922affac179cd07256e72fbcf8a2c8a, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:8481b546970e4cc30b9a0415842a3ea3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -681,8 +681,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:708b36a85852210d2aa37cd0a43c31d6, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:9fb5666ada501891fcef9d333ed6afff,
+    wasDerivedFrom(niiri:8481b546970e4cc30b9a0415842a3ea3, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:f4471bd4ad44f0353136ecfba3e12d38,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -691,8 +691,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:9fb5666ada501891fcef9d333ed6afff, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:756837e339677511c64f8da38004cd2e,
+    wasDerivedFrom(niiri:f4471bd4ad44f0353136ecfba3e12d38, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:7651662ffb846c59d0275b64f39a5a3e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -701,8 +701,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:756837e339677511c64f8da38004cd2e, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:303983981b9e7155b24ee729485e35d5,
+    wasDerivedFrom(niiri:7651662ffb846c59d0275b64f39a5a3e, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:cb4cab1d498471cf714b96e648ba0b84,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -711,8 +711,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:303983981b9e7155b24ee729485e35d5, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:ff25cf8967cf153c0c4bac8744bfd4de,
+    wasDerivedFrom(niiri:cb4cab1d498471cf714b96e648ba0b84, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:b49a13ef4f81cb056a0cf2c1e1e37613,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -721,8 +721,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:ff25cf8967cf153c0c4bac8744bfd4de, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:1e1d5e2b654ff9dfd561671bb14dac45,
+    wasDerivedFrom(niiri:b49a13ef4f81cb056a0cf2c1e1e37613, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:3bf344699ca63226f8a0986e9e22dc4d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -731,8 +731,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:1e1d5e2b654ff9dfd561671bb14dac45, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:04d3366efa2ae78508ba78d4f6d3fbd4,
+    wasDerivedFrom(niiri:3bf344699ca63226f8a0986e9e22dc4d, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:7a1aa46f25bc46f59f7f644a1d2d768c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -741,8 +741,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:04d3366efa2ae78508ba78d4f6d3fbd4, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:471616239367dd0b8f23af62cd1178af,
+    wasDerivedFrom(niiri:7a1aa46f25bc46f59f7f644a1d2d768c, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:95103dd9bdac7741d90f99939247bf4e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -751,8 +751,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:471616239367dd0b8f23af62cd1178af, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:146e852a595d2bd9bf43b63cb1ffe554,
+    wasDerivedFrom(niiri:95103dd9bdac7741d90f99939247bf4e, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:11fe90c3ae56c74edb8f27b7b4d64c01,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -761,8 +761,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:146e852a595d2bd9bf43b63cb1ffe554, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:c76d475fb44856dbc3b3660c08027d10,
+    wasDerivedFrom(niiri:11fe90c3ae56c74edb8f27b7b4d64c01, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:d17fffe11eaba3b9e149fce8bdc2b9da,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -771,8 +771,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:c76d475fb44856dbc3b3660c08027d10, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:171a3293a830389fbc0eeedac10ab2ef,
+    wasDerivedFrom(niiri:d17fffe11eaba3b9e149fce8bdc2b9da, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:a97b8d1eb95bad3103d70c3a170b35e6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -781,8 +781,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:171a3293a830389fbc0eeedac10ab2ef, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:230b132218201af072b76732d6cd366e,
+    wasDerivedFrom(niiri:a97b8d1eb95bad3103d70c3a170b35e6, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:34de4bc8669d7effba126acecd7e71ca,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -791,8 +791,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:230b132218201af072b76732d6cd366e, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:88b6854434c4c7d7d77b89858ff66d15,
+    wasDerivedFrom(niiri:34de4bc8669d7effba126acecd7e71ca, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:34640314cb90b81bff8b479f4c75ae6f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -801,8 +801,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:88b6854434c4c7d7d77b89858ff66d15, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:983ff16f46a1aa2fb13613f2c2f88011,
+    wasDerivedFrom(niiri:34640314cb90b81bff8b479f4c75ae6f, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:79c1b8c3935c1efdd0d31d231222a6e3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -811,8 +811,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:983ff16f46a1aa2fb13613f2c2f88011, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:a6327d343c9ff6cf00c6cbe83308072b,
+    wasDerivedFrom(niiri:79c1b8c3935c1efdd0d31d231222a6e3, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:1171e027eba41be4b53953810af155f9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -821,8 +821,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:a6327d343c9ff6cf00c6cbe83308072b, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:92ac4a8cb0a6c243ecb32fc66fd3deab,
+    wasDerivedFrom(niiri:1171e027eba41be4b53953810af155f9, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:54a8bffd20ef66a79cc779bd8e630f0f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -831,486 +831,486 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:92ac4a8cb0a6c243ecb32fc66fd3deab, niiri:f3637fafb926481fff6bd8938c6a8550, -, -, -)
-    entity(niiri:c3e496eea557d318020009e75ea064a9,
+    wasDerivedFrom(niiri:54a8bffd20ef66a79cc779bd8e630f0f, niiri:2561c31d8316e8b6110351c09d382626, -, -, -)
+    entity(niiri:49979752257c9cdd1a1f63a018b04845,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:33b9e64baedb78edec3c778ac3503e57',
+        prov:location = 'niiri:062dc6f5cf37590aa5348de9d124c531',
         prov:value = "2.29849815368652" %% xsd:float,
         nidm_equivalentZStatistic: = "2.28220028418391" %% xsd:float,
         nidm_pValueUncorrected: = "0.0112387591680547" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:33b9e64baedb78edec3c778ac3503e57,
+    entity(niiri:062dc6f5cf37590aa5348de9d124c531,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[-28,24,4]" %% xsd:string])
-    wasDerivedFrom(niiri:c3e496eea557d318020009e75ea064a9, niiri:1ca2ed8885126a13f37d342c5bda82b6, -, -, -)
-    entity(niiri:304c8f977e3d31328f1ba8cc597ceb18,
+    wasDerivedFrom(niiri:49979752257c9cdd1a1f63a018b04845, niiri:8d1a8ab2f5e6753052e300d592e3d511, -, -, -)
+    entity(niiri:eb0f15f09bbeede75a83373d3a94b783,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:39b6eca99b5b73480b968ea12add2484',
+        prov:location = 'niiri:9fcee8551b5114a52e472ad1844f220e',
         prov:value = "2.07190132141113" %% xsd:float,
         nidm_equivalentZStatistic: = "2.0619285244841" %% xsd:float,
         nidm_pValueUncorrected: = "0.0196072706834085" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:39b6eca99b5b73480b968ea12add2484,
+    entity(niiri:9fcee8551b5114a52e472ad1844f220e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[-28,26,12]" %% xsd:string])
-    wasDerivedFrom(niiri:304c8f977e3d31328f1ba8cc597ceb18, niiri:1ca2ed8885126a13f37d342c5bda82b6, -, -, -)
-    entity(niiri:02fb69f52c0371d7e8083f1d698b5486,
+    wasDerivedFrom(niiri:eb0f15f09bbeede75a83373d3a94b783, niiri:8d1a8ab2f5e6753052e300d592e3d511, -, -, -)
+    entity(niiri:a9d3e1abbc30e49d34ae695e931b45f7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:0545dc10de1e5d6701474796bc5135b3',
+        prov:location = 'niiri:adcb8119812e818906df4629ebb6d39e',
         prov:value = "2.18201637268066" %% xsd:float,
         nidm_equivalentZStatistic: = "2.16893530312973" %% xsd:float,
         nidm_pValueUncorrected: = "0.0150437980271687" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:0545dc10de1e5d6701474796bc5135b3,
+    entity(niiri:adcb8119812e818906df4629ebb6d39e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[52,48,12]" %% xsd:string])
-    wasDerivedFrom(niiri:02fb69f52c0371d7e8083f1d698b5486, niiri:b6ec4ee5c26bd5170b56e954e84a7789, -, -, -)
-    entity(niiri:47905f0ed8d89646a0b2df5e003f1e2a,
+    wasDerivedFrom(niiri:a9d3e1abbc30e49d34ae695e931b45f7, niiri:5a1ad49de526d8a54452b31baf96a75d, -, -, -)
+    entity(niiri:a312bb2d4a36613077f4d362f5263e2d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:d0d2bf61fd3a0931a0e3bdd8f49eed93',
+        prov:location = 'niiri:1e8d56d4ce620a2af884f53f0162a677',
         prov:value = "2.13869571685791" %% xsd:float,
         nidm_equivalentZStatistic: = "2.12682533173394" %% xsd:float,
         nidm_pValueUncorrected: = "0.016717299356924" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:d0d2bf61fd3a0931a0e3bdd8f49eed93,
+    entity(niiri:1e8d56d4ce620a2af884f53f0162a677,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[34,-54,52]" %% xsd:string])
-    wasDerivedFrom(niiri:47905f0ed8d89646a0b2df5e003f1e2a, niiri:67aa7dea8d858564a8b4505070c20ab3, -, -, -)
-    entity(niiri:091b7fa1943f270ddc578020b6bf4b81,
+    wasDerivedFrom(niiri:a312bb2d4a36613077f4d362f5263e2d, niiri:c00f026631fe0b6f988efa4d30db781f, -, -, -)
+    entity(niiri:49271d60759060cc512c32272ea47c9f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:2d030121bd3e3440189b9362d24d0e82',
+        prov:location = 'niiri:14acc5ae182e2d6aa091d9670f63d86c',
         prov:value = "2.13825297355652" %% xsd:float,
         nidm_equivalentZStatistic: = "2.12639503027273" %% xsd:float,
         nidm_pValueUncorrected: = "0.0167351906128659" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:2d030121bd3e3440189b9362d24d0e82,
+    entity(niiri:14acc5ae182e2d6aa091d9670f63d86c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[36,-84,2]" %% xsd:string])
-    wasDerivedFrom(niiri:091b7fa1943f270ddc578020b6bf4b81, niiri:8eb556353f8e288e589eef37024ef068, -, -, -)
-    entity(niiri:225874e925381c31ec2075213af93cc8,
+    wasDerivedFrom(niiri:49271d60759060cc512c32272ea47c9f, niiri:b712b8f6d2df400be64fe19b957abb10, -, -, -)
+    entity(niiri:08989f7c63c852798e88db3aa5231385,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:7506c87aedf9336f1b97442d8e526f2f',
+        prov:location = 'niiri:72593e56b8c30845ae2b8f8970fe5e42',
         prov:value = "2.1293613910675" %% xsd:float,
         nidm_equivalentZStatistic: = "2.11775365245473" %% xsd:float,
         nidm_pValueUncorrected: = "0.0170979681968485" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:7506c87aedf9336f1b97442d8e526f2f,
+    entity(niiri:72593e56b8c30845ae2b8f8970fe5e42,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[30,68,12]" %% xsd:string])
-    wasDerivedFrom(niiri:225874e925381c31ec2075213af93cc8, niiri:4f970219224428039454afd130e40f48, -, -, -)
-    entity(niiri:eb6fb2c76c756484f30c7d09b66c5c43,
+    wasDerivedFrom(niiri:08989f7c63c852798e88db3aa5231385, niiri:f66d2da458d706e0d1c123fd3dc589c7, -, -, -)
+    entity(niiri:58feba2e44840c92dea201d54bffa5fb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:99c662c8509b716d461c456391b45b37',
+        prov:location = 'niiri:d7ec0d3731cf2369dd44267e354a7988',
         prov:value = "2.11468005180359" %% xsd:float,
         nidm_equivalentZStatistic: = "2.10348692366691" %% xsd:float,
         nidm_pValueUncorrected: = "0.017711613581637" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:99c662c8509b716d461c456391b45b37,
+    entity(niiri:d7ec0d3731cf2369dd44267e354a7988,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[34,-84,14]" %% xsd:string])
-    wasDerivedFrom(niiri:eb6fb2c76c756484f30c7d09b66c5c43, niiri:c2a5888cb7cfb94104a85fdf0c0a0975, -, -, -)
-    entity(niiri:db15f3aea3a0b1689952a5924009614a,
+    wasDerivedFrom(niiri:58feba2e44840c92dea201d54bffa5fb, niiri:70a3e9df88095bfe99637dabf4110acd, -, -, -)
+    entity(niiri:9e3518c2e9867ca98860f754d7379642,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:ec58debeeea826abc9378be9d6ccee92',
+        prov:location = 'niiri:29e408397e3b3c1a20cd94269d9240df',
         prov:value = "2.01981115341187" %% xsd:float,
         nidm_equivalentZStatistic: = "2.01135476956162" %% xsd:float,
         nidm_pValueUncorrected: = "0.0221439986174564" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:ec58debeeea826abc9378be9d6ccee92,
+    entity(niiri:29e408397e3b3c1a20cd94269d9240df,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[-42,20,36]" %% xsd:string])
-    wasDerivedFrom(niiri:db15f3aea3a0b1689952a5924009614a, niiri:5e85e47c2fc2758e5d466cd2123b2254, -, -, -)
-    entity(niiri:a9e83bfae2a235a9cc20adac4118915b,
+    wasDerivedFrom(niiri:9e3518c2e9867ca98860f754d7379642, niiri:027812928b4d9dc645c81857d81e13ca, -, -, -)
+    entity(niiri:01a776de2155c1d064f799ee0b13d27c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:3991fe3c2e71f1b8e7f88c795fa8f2b0',
+        prov:location = 'niiri:3af3a4e516f1d0712e480617661e0990',
         prov:value = "1.9834691286087" %% xsd:float,
         nidm_equivalentZStatistic: = "1.97609535691968" %% xsd:float,
         nidm_pValueUncorrected: = "0.0240719891024281" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:3991fe3c2e71f1b8e7f88c795fa8f2b0,
+    entity(niiri:3af3a4e516f1d0712e480617661e0990,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[34,-78,36]" %% xsd:string])
-    wasDerivedFrom(niiri:a9e83bfae2a235a9cc20adac4118915b, niiri:6105338324e4b950666042ae82d011fd, -, -, -)
-    entity(niiri:2f99eaddb3b1956eee9400c73e729457,
+    wasDerivedFrom(niiri:01a776de2155c1d064f799ee0b13d27c, niiri:fec8e2c65ce7d1cf6e18804683d824ca, -, -, -)
+    entity(niiri:a3fdd163c99c50f21394bb2564810f40,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:94ba0436d49d4f1ac392af5f6adb2756',
+        prov:location = 'niiri:14cae94fd17fb2d01fda8a8022d07f31',
         prov:value = "1.94259870052338" %% xsd:float,
         nidm_equivalentZStatistic: = "1.93647164753299" %% xsd:float,
         nidm_pValueUncorrected: = "0.026404980891827" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:94ba0436d49d4f1ac392af5f6adb2756,
+    entity(niiri:14cae94fd17fb2d01fda8a8022d07f31,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[-48,18,18]" %% xsd:string])
-    wasDerivedFrom(niiri:2f99eaddb3b1956eee9400c73e729457, niiri:4f020dcb9018a1690cba2cbf60dc38b0, -, -, -)
-    entity(niiri:e21f5c3bb0d87db0399aa6aeaae8fa17,
+    wasDerivedFrom(niiri:a3fdd163c99c50f21394bb2564810f40, niiri:c9f251722e6a9f1501e325fdf2f516f3, -, -, -)
+    entity(niiri:42a4152bc3193944f970885860f254f1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:026fbe87ef12da1f1cb8f58505c5a35d',
+        prov:location = 'niiri:0ccdcec00484fe14b2ed7552c64faa47',
         prov:value = "1.89261054992676" %% xsd:float,
         nidm_equivalentZStatistic: = "1.88805796389517" %% xsd:float,
         nidm_pValueUncorrected: = "0.0295090846561562" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:026fbe87ef12da1f1cb8f58505c5a35d,
+    entity(niiri:0ccdcec00484fe14b2ed7552c64faa47,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[-40,20,8]" %% xsd:string])
-    wasDerivedFrom(niiri:e21f5c3bb0d87db0399aa6aeaae8fa17, niiri:4f020dcb9018a1690cba2cbf60dc38b0, -, -, -)
-    entity(niiri:819a69b124962a6bc39aa80cdc398a30,
+    wasDerivedFrom(niiri:42a4152bc3193944f970885860f254f1, niiri:c9f251722e6a9f1501e325fdf2f516f3, -, -, -)
+    entity(niiri:d8ef073869f2d518eeb58c051015c0e4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:0d0ffa2881f696dcc6b1d489a15348ec',
+        prov:location = 'niiri:2179a81fd9206716047be8cff2e08728',
         prov:value = "1.9298506975174" %% xsd:float,
         nidm_equivalentZStatistic: = "1.92411963399221" %% xsd:float,
         nidm_pValueUncorrected: = "0.0271697947905869" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:0d0ffa2881f696dcc6b1d489a15348ec,
+    entity(niiri:2179a81fd9206716047be8cff2e08728,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[22,-82,6]" %% xsd:string])
-    wasDerivedFrom(niiri:819a69b124962a6bc39aa80cdc398a30, niiri:68b9b03c7822e1a0b86cd9e68fe99ca2, -, -, -)
-    entity(niiri:df4034a52a0223c24e52134353933b85,
+    wasDerivedFrom(niiri:d8ef073869f2d518eeb58c051015c0e4, niiri:ac00f4348e517214c5428caad74cc6dc, -, -, -)
+    entity(niiri:b6b23fa7071c0e8366f51f689cb58e5d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:b2e026ac20229c679280d6521ef462e2',
+        prov:location = 'niiri:00466efda7ed6e546b9bbd911f3047a8',
         prov:value = "1.87824356555939" %% xsd:float,
         nidm_equivalentZStatistic: = "1.87415494022171" %% xsd:float,
         nidm_pValueUncorrected: = "0.0304545363496075" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:b2e026ac20229c679280d6521ef462e2,
+    entity(niiri:00466efda7ed6e546b9bbd911f3047a8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[-34,22,20]" %% xsd:string])
-    wasDerivedFrom(niiri:df4034a52a0223c24e52134353933b85, niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9, -, -, -)
-    entity(niiri:56e0435b5a93b3ea44eb4880caa46f6e,
+    wasDerivedFrom(niiri:b6b23fa7071c0e8366f51f689cb58e5d, niiri:8050ff9b05fe42d3b13b693c3d4dfc3c, -, -, -)
+    entity(niiri:aa1e6f75cb3a2b76e5c3d6a02f70c7d7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:64c2cf7669582f994375fb0c99a90889',
+        prov:location = 'niiri:7645318f716537f0f6e55e58acb4daf1',
         prov:value = "1.85802888870239" %% xsd:float,
         nidm_equivalentZStatistic: = "1.85460257678401" %% xsd:float,
         nidm_pValueUncorrected: = "0.0318264999487402" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:64c2cf7669582f994375fb0c99a90889,
+    entity(niiri:7645318f716537f0f6e55e58acb4daf1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[16,-100,10]" %% xsd:string])
-    wasDerivedFrom(niiri:56e0435b5a93b3ea44eb4880caa46f6e, niiri:f626ba6b4ad8b422a9e8b6208607d5c7, -, -, -)
-    entity(niiri:1585cde397394ce1852eabdc3e6069bc,
+    wasDerivedFrom(niiri:aa1e6f75cb3a2b76e5c3d6a02f70c7d7, niiri:d1592c70ca4448ee46f3c8df3c20043c, -, -, -)
+    entity(niiri:6cdd0ffff75a1252b7fa916661fdf669,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:f72c8e0f5976a1f9554754dc1a644aec',
+        prov:location = 'niiri:7ce3f7015bebf95ed663572f98652879',
         prov:value = "1.82612562179565" %% xsd:float,
         nidm_equivalentZStatistic: = "1.82376887581619" %% xsd:float,
         nidm_pValueUncorrected: = "0.0340935105624357" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:f72c8e0f5976a1f9554754dc1a644aec,
+    entity(niiri:7ce3f7015bebf95ed663572f98652879,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[-22,6,14]" %% xsd:string])
-    wasDerivedFrom(niiri:1585cde397394ce1852eabdc3e6069bc, niiri:dd3a390096e9240d96d84a6fa0b53334, -, -, -)
-    entity(niiri:fc1bd52acb4a54ac65706ec77b597664,
+    wasDerivedFrom(niiri:6cdd0ffff75a1252b7fa916661fdf669, niiri:5828f74c2c43b3883378f9cd1e63925b, -, -, -)
+    entity(niiri:15a87b6382e2fb49ba7ce1b2c5a4bdfc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:b916c3481037d35a043ee9bca1bfa812',
+        prov:location = 'niiri:0b796279bb1597f56c7a837b6943278f',
         prov:value = "1.8208144903183" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81863886421642" %% xsd:float,
         nidm_pValueUncorrected: = "0.0344832722280412" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:b916c3481037d35a043ee9bca1bfa812,
+    entity(niiri:0b796279bb1597f56c7a837b6943278f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[32,-66,0]" %% xsd:string])
-    wasDerivedFrom(niiri:fc1bd52acb4a54ac65706ec77b597664, niiri:b38cc3f1a8c8b355373259707d78b430, -, -, -)
-    entity(niiri:dd9b23180ca6d48364bbd5e03598085b,
+    wasDerivedFrom(niiri:15a87b6382e2fb49ba7ce1b2c5a4bdfc, niiri:5922affac179cd07256e72fbcf8a2c8a, -, -, -)
+    entity(niiri:11111874c48fbc8c67f5d0d02dfca56b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:e19da916a650e437d894081ea2700363',
+        prov:location = 'niiri:c7a615d1d896aa881dbf7d7894ede9ea',
         prov:value = "1.79377067089081" %% xsd:float,
         nidm_equivalentZStatistic: = "1.79253174586373" %% xsd:float,
         nidm_pValueUncorrected: = "0.0365239143287336" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:e19da916a650e437d894081ea2700363,
+    entity(niiri:c7a615d1d896aa881dbf7d7894ede9ea,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[-28,8,14]" %% xsd:string])
-    wasDerivedFrom(niiri:dd9b23180ca6d48364bbd5e03598085b, niiri:708b36a85852210d2aa37cd0a43c31d6, -, -, -)
-    entity(niiri:60833962d796c1925bb5caa354752e20,
+    wasDerivedFrom(niiri:11111874c48fbc8c67f5d0d02dfca56b, niiri:8481b546970e4cc30b9a0415842a3ea3, -, -, -)
+    entity(niiri:cc9da452ad344d07d30c0d718ee350f6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:0286ca8f9f6d1abb7e43fe83af301e65',
+        prov:location = 'niiri:a19b00cbab738b2c3a78288527aba3cf',
         prov:value = "1.79001986980438" %% xsd:float,
         nidm_equivalentZStatistic: = "1.78891283515708" %% xsd:float,
         nidm_pValueUncorrected: = "0.0368144271933957" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:0286ca8f9f6d1abb7e43fe83af301e65,
+    entity(niiri:a19b00cbab738b2c3a78288527aba3cf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[-20,26,28]" %% xsd:string])
-    wasDerivedFrom(niiri:60833962d796c1925bb5caa354752e20, niiri:9fb5666ada501891fcef9d333ed6afff, -, -, -)
-    entity(niiri:f44eff18cdf7e25979cf1141a5338fc0,
+    wasDerivedFrom(niiri:cc9da452ad344d07d30c0d718ee350f6, niiri:f4471bd4ad44f0353136ecfba3e12d38, -, -, -)
+    entity(niiri:19d8b89fc4f6b3b5666d4b8f5df7a590,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:9d4722db398870c6b3ea92787232d10a',
+        prov:location = 'niiri:8d6b2fe61e5731fecf31a4effa4301bb',
         prov:value = "1.74872362613678" %% xsd:float,
         nidm_equivalentZStatistic: = "1.749102772694" %% xsd:float,
         nidm_pValueUncorrected: = "0.0401366280244358" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:9d4722db398870c6b3ea92787232d10a,
+    entity(niiri:8d6b2fe61e5731fecf31a4effa4301bb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[-54,28,20]" %% xsd:string])
-    wasDerivedFrom(niiri:f44eff18cdf7e25979cf1141a5338fc0, niiri:756837e339677511c64f8da38004cd2e, -, -, -)
-    entity(niiri:7d958f3e975bddab9f95985faaae5cad,
+    wasDerivedFrom(niiri:19d8b89fc4f6b3b5666d4b8f5df7a590, niiri:7651662ffb846c59d0275b64f39a5a3e, -, -, -)
+    entity(niiri:6cd1d0f09d96998ec6d45fc8967bef7d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:338c9616ae26c8e59158924ee7b04682',
+        prov:location = 'niiri:6e4b134d42d62e3fa90a9cdfa4b0c3ab',
         prov:value = "1.73660695552826" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73743465054505" %% xsd:float,
         nidm_pValueUncorrected: = "0.0411552397567266" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:338c9616ae26c8e59158924ee7b04682,
+    entity(niiri:6e4b134d42d62e3fa90a9cdfa4b0c3ab,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[36,-56,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:7d958f3e975bddab9f95985faaae5cad, niiri:303983981b9e7155b24ee729485e35d5, -, -, -)
-    entity(niiri:8f47804dc4763167b41a429473c75db8,
+    wasDerivedFrom(niiri:6cd1d0f09d96998ec6d45fc8967bef7d, niiri:cb4cab1d498471cf714b96e648ba0b84, -, -, -)
+    entity(niiri:971088d1bdd0b1a1c9e797b9ba272eee,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:590b0466ddb6db870e7a7eb6ccc2f0c5',
+        prov:location = 'niiri:2bcb7950634a9079bfc9f15710195ba5',
         prov:value = "1.72697401046753" %% xsd:float,
         nidm_equivalentZStatistic: = "1.72816258455492" %% xsd:float,
         nidm_pValueUncorrected: = "0.0419795398198842" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:590b0466ddb6db870e7a7eb6ccc2f0c5,
+    entity(niiri:2bcb7950634a9079bfc9f15710195ba5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[12,74,8]" %% xsd:string])
-    wasDerivedFrom(niiri:8f47804dc4763167b41a429473c75db8, niiri:ff25cf8967cf153c0c4bac8744bfd4de, -, -, -)
-    entity(niiri:d86f7773fa7f7c82a9d04542bdbbd522,
+    wasDerivedFrom(niiri:971088d1bdd0b1a1c9e797b9ba272eee, niiri:b49a13ef4f81cb056a0cf2c1e1e37613, -, -, -)
+    entity(niiri:3b1b90046e2cc738e068e3ccdc5b8e08,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:4a94efdcb82d851208aa8b066ac5c604',
+        prov:location = 'niiri:6e3632bdadbdb54596f9986ced7c5a42',
         prov:value = "1.69681537151337" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69915940103581" %% xsd:float,
         nidm_pValueUncorrected: = "0.0446445768205113" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:4a94efdcb82d851208aa8b066ac5c604,
+    entity(niiri:6e3632bdadbdb54596f9986ced7c5a42,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[-28,50,36]" %% xsd:string])
-    wasDerivedFrom(niiri:d86f7773fa7f7c82a9d04542bdbbd522, niiri:1e1d5e2b654ff9dfd561671bb14dac45, -, -, -)
-    entity(niiri:27b1286570a35003fd1cb892df5003ee,
+    wasDerivedFrom(niiri:3b1b90046e2cc738e068e3ccdc5b8e08, niiri:3bf344699ca63226f8a0986e9e22dc4d, -, -, -)
+    entity(niiri:2f7d1feb589408c3bf50b3384d89d8a9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:fd0f08df1132bd69544d5c2bc67a8ce1',
+        prov:location = 'niiri:42729ea56a022800e2b3fffe2fd2c1ec',
         prov:value = "1.69281709194183" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69531733220798" %% xsd:float,
         nidm_pValueUncorrected: = "0.0450076192977755" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:fd0f08df1132bd69544d5c2bc67a8ce1,
+    entity(niiri:42729ea56a022800e2b3fffe2fd2c1ec,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-54,28,12]" %% xsd:string])
-    wasDerivedFrom(niiri:27b1286570a35003fd1cb892df5003ee, niiri:04d3366efa2ae78508ba78d4f6d3fbd4, -, -, -)
-    entity(niiri:39aa9652e5edc473ede61063b5f9330b,
+    wasDerivedFrom(niiri:2f7d1feb589408c3bf50b3384d89d8a9, niiri:7a1aa46f25bc46f59f7f644a1d2d768c, -, -, -)
+    entity(niiri:90b76ff68e1f93610f550c0f2f46cdec,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:f19ef86275c6e6fc9f17827d454cea6f',
+        prov:location = 'niiri:8e160c47f33d388aedd45037581833c0',
         prov:value = "1.68880593776703" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69146362670159" %% xsd:float,
         nidm_pValueUncorrected: = "0.0453741445419741" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:f19ef86275c6e6fc9f17827d454cea6f,
+    entity(niiri:8e160c47f33d388aedd45037581833c0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[26,-92,18]" %% xsd:string])
-    wasDerivedFrom(niiri:39aa9652e5edc473ede61063b5f9330b, niiri:471616239367dd0b8f23af62cd1178af, -, -, -)
-    entity(niiri:9607bb62ecc6289f2476a8bb82c2c966,
+    wasDerivedFrom(niiri:90b76ff68e1f93610f550c0f2f46cdec, niiri:95103dd9bdac7741d90f99939247bf4e, -, -, -)
+    entity(niiri:9a6229796a5042d2de9c8d840d333151,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:9759d63712f31dd71f970ba24fdc02ba',
+        prov:location = 'niiri:ba88244ebec57bcb6456c8f846311dbb',
         prov:value = "1.68117702007294" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68413622248109" %% xsd:float,
         nidm_pValueUncorrected: = "0.046077672706774" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:9759d63712f31dd71f970ba24fdc02ba,
+    entity(niiri:ba88244ebec57bcb6456c8f846311dbb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[42,-78,6]" %% xsd:string])
-    wasDerivedFrom(niiri:9607bb62ecc6289f2476a8bb82c2c966, niiri:146e852a595d2bd9bf43b63cb1ffe554, -, -, -)
-    entity(niiri:5aac45256e13cd03a2a1e390f5df998d,
+    wasDerivedFrom(niiri:9a6229796a5042d2de9c8d840d333151, niiri:11fe90c3ae56c74edb8f27b7b4d64c01, -, -, -)
+    entity(niiri:54b18d3082b4cad596142f7ef9736d8a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:7b8ba463b7a085d4623751d494579f21',
+        prov:location = 'niiri:d6201606a3ba435a6e09c9caf89150df',
         prov:value = "1.67713749408722" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68025745484094" %% xsd:float,
         nidm_pValueUncorrected: = "0.0464536174884935" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:7b8ba463b7a085d4623751d494579f21,
+    entity(niiri:d6201606a3ba435a6e09c9caf89150df,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[-12,26,36]" %% xsd:string])
-    wasDerivedFrom(niiri:5aac45256e13cd03a2a1e390f5df998d, niiri:c76d475fb44856dbc3b3660c08027d10, -, -, -)
-    entity(niiri:aa7acc61eb0d336d8adfd1c279535ef0,
+    wasDerivedFrom(niiri:54b18d3082b4cad596142f7ef9736d8a, niiri:d17fffe11eaba3b9e149fce8bdc2b9da, -, -, -)
+    entity(niiri:8197741d55030f4c7e2a1d984b7bf1bc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:f60e25b0c2abc9fe4d73f5854c0adbee',
+        prov:location = 'niiri:7d3b2943cac3fe81f3de71425355d797',
         prov:value = "1.67311263084412" %% xsd:float,
         nidm_equivalentZStatistic: = "1.6763935381234" %% xsd:float,
         nidm_pValueUncorrected: = "0.0468305669041873" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:f60e25b0c2abc9fe4d73f5854c0adbee,
+    entity(niiri:7d3b2943cac3fe81f3de71425355d797,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[12,-94,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:aa7acc61eb0d336d8adfd1c279535ef0, niiri:171a3293a830389fbc0eeedac10ab2ef, -, -, -)
-    entity(niiri:309b2780bdf657c8f0c7a6410916169c,
+    wasDerivedFrom(niiri:8197741d55030f4c7e2a1d984b7bf1bc, niiri:a97b8d1eb95bad3103d70c3a170b35e6, -, -, -)
+    entity(niiri:d119a32be5090208facc1946a3d5fa33,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:967f245c1c386892dbecddea40037b53',
+        prov:location = 'niiri:2925ce3db3c2888712ca8f3f3d1f1619',
         prov:value = "1.67067694664001" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67405562956399" %% xsd:float,
         nidm_pValueUncorrected: = "0.0470598334324596" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:967f245c1c386892dbecddea40037b53,
+    entity(niiri:2925ce3db3c2888712ca8f3f3d1f1619,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[24,-92,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:309b2780bdf657c8f0c7a6410916169c, niiri:230b132218201af072b76732d6cd366e, -, -, -)
-    entity(niiri:ed3607586490b22746adf59129afa310,
+    wasDerivedFrom(niiri:d119a32be5090208facc1946a3d5fa33, niiri:34de4bc8669d7effba126acecd7e71ca, -, -, -)
+    entity(niiri:81ad744134f8137223e00d7f8e9efb1d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:fddb34281430a5ac7649b34b53b04c89',
+        prov:location = 'niiri:576bfeaced7698758e2dcea95224fe2a',
         prov:value = "1.66812241077423" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67160394831323" %% xsd:float,
         nidm_pValueUncorrected: = "0.0473012228473357" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:fddb34281430a5ac7649b34b53b04c89,
+    entity(niiri:576bfeaced7698758e2dcea95224fe2a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[-24,22,22]" %% xsd:string])
-    wasDerivedFrom(niiri:ed3607586490b22746adf59129afa310, niiri:88b6854434c4c7d7d77b89858ff66d15, -, -, -)
-    entity(niiri:cb35f3207972df7107e6d2aea1bfbde2,
+    wasDerivedFrom(niiri:81ad744134f8137223e00d7f8e9efb1d, niiri:34640314cb90b81bff8b479f4c75ae6f, -, -, -)
+    entity(niiri:fffda3a756d7aadecaf95c9b79ca9f9d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:36ff55a8118b6b1b3e001a7636293a8f',
+        prov:location = 'niiri:ef0fc7140e631601df1c9ed09b66ef7f',
         prov:value = "1.66770362854004" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67120205793481" %% xsd:float,
         nidm_pValueUncorrected: = "0.0473408869609759" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:36ff55a8118b6b1b3e001a7636293a8f,
+    entity(niiri:ef0fc7140e631601df1c9ed09b66ef7f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[26,-90,22]" %% xsd:string])
-    wasDerivedFrom(niiri:cb35f3207972df7107e6d2aea1bfbde2, niiri:983ff16f46a1aa2fb13613f2c2f88011, -, -, -)
-    entity(niiri:9545b4314633cb0868f593c5d38febb7,
+    wasDerivedFrom(niiri:fffda3a756d7aadecaf95c9b79ca9f9d, niiri:79c1b8c3935c1efdd0d31d231222a6e3, -, -, -)
+    entity(niiri:ff04f5c6feedf70958adb3464fd72d76,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:9803db31221b2c078fe55c084d5d83ed',
+        prov:location = 'niiri:9eabe9da21cf05a8ae9ca9e3b467bcea',
         prov:value = "1.66512632369995" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66872889854066" %% xsd:float,
         nidm_pValueUncorrected: = "0.0475855596349387" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:9803db31221b2c078fe55c084d5d83ed,
+    entity(niiri:9eabe9da21cf05a8ae9ca9e3b467bcea,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[32,-60,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:9545b4314633cb0868f593c5d38febb7, niiri:a6327d343c9ff6cf00c6cbe83308072b, -, -, -)
-    entity(niiri:02317feaa78e69f7d7f9737af5644214,
+    wasDerivedFrom(niiri:ff04f5c6feedf70958adb3464fd72d76, niiri:1171e027eba41be4b53953810af155f9, -, -, -)
+    entity(niiri:498867695b58631e8cf68e8990cdf642,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:5d4415f1293150147830ba8d2fe89e88',
+        prov:location = 'niiri:23a47d1f73da07fee4779591d3a6aa53',
         prov:value = "1.6600536108017" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66386211897632" %% xsd:float,
         nidm_pValueUncorrected: = "0.0480699933329287" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.993657486705384" %% xsd:float])
-    entity(niiri:5d4415f1293150147830ba8d2fe89e88,
+    entity(niiri:23a47d1f73da07fee4779591d3a6aa53,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[-44,-56,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:02317feaa78e69f7d7f9737af5644214, niiri:92ac4a8cb0a6c243ecb32fc66fd3deab, -, -, -)
+    wasDerivedFrom(niiri:498867695b58631e8cf68e8990cdf642, niiri:54a8bffd20ef66a79cc779bd8e630f0f, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_conjunction/nidm.ttl
+++ b/spmexport/ex_spm_conjunction/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:e8889926d05a35c367676e2b266a5d9e
+niiri:cffd7ffff967c97f168edddb606cca3c
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:229b0f08cfcf3f699fd45d952761f576
+niiri:6fca6103f9b3748f1135346eed723b1e
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:1051dc20a62ed1558eac0a1a2fb70588
+niiri:08e852b60d68cd3f03fbb91135fc698a
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:1051dc20a62ed1558eac0a1a2fb70588 prov:wasAssociatedWith niiri:229b0f08cfcf3f699fd45d952761f576 .
+niiri:08e852b60d68cd3f03fbb91135fc698a prov:wasAssociatedWith niiri:6fca6103f9b3748f1135346eed723b1e .
 
 _:blank5 a prov:Generation .
 
-niiri:e8889926d05a35c367676e2b266a5d9e prov:qualifiedGeneration _:blank5 .
+niiri:cffd7ffff967c97f168edddb606cca3c prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:11:03"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:33:19"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -136,12 +136,12 @@ _:blank5 prov:atTime "2016-01-11T10:11:03"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:0b3ed3b43289bfce69e1dd8e0a580555
+niiri:8d702deb7794ff140970aa83183f0cd7
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:08ce005cf94169deadd293b9f0386fc0
+niiri:13472aa35bbca29434f4e7a96e64854b
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -151,35 +151,35 @@ niiri:08ce005cf94169deadd293b9f0386fc0
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:12128f6eb829f1af879e8f015ce78ee5
+niiri:b8bc1fafeb07d65d7429038c792c1fff
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:4d9192c7fd08ad2bb7c4ff9503e7546b
+niiri:c75a5447273e9c598f256e39304eded4
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:62719c37cb7f1155944ed6252b71ec01
+niiri:c7f99aa282bcb84887dac079b6e639e3
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:df48ccc999ebf8ca6f4c3e5bc939230c ;
+    dc:description niiri:e68886708e4b26ae6e709f5fa4808690 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:4d9192c7fd08ad2bb7c4ff9503e7546b ;
+    nidm_hasDriftModel: niiri:c75a5447273e9c598f256e39304eded4 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:df48ccc999ebf8ca6f4c3e5bc939230c
+niiri:e68886708e4b26ae6e709f5fa4808690
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:9cca745d6e07ffe830a810c73a4beb94
+niiri:937d29c8162661dc3675b67810a67ae3
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -187,213 +187,213 @@ niiri:9cca745d6e07ffe830a810c73a4beb94
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:814ac7079ffe5eac40b4e81f109d77d3
+niiri:9b702b46c5dd95ed19b8b5140da841d6
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:814ac7079ffe5eac40b4e81f109d77d3 prov:wasAssociatedWith niiri:0b3ed3b43289bfce69e1dd8e0a580555 .
+niiri:9b702b46c5dd95ed19b8b5140da841d6 prov:wasAssociatedWith niiri:8d702deb7794ff140970aa83183f0cd7 .
 
-niiri:814ac7079ffe5eac40b4e81f109d77d3 prov:used niiri:62719c37cb7f1155944ed6252b71ec01 .
+niiri:9b702b46c5dd95ed19b8b5140da841d6 prov:used niiri:c7f99aa282bcb84887dac079b6e639e3 .
 
-niiri:814ac7079ffe5eac40b4e81f109d77d3 prov:used niiri:12128f6eb829f1af879e8f015ce78ee5 .
+niiri:9b702b46c5dd95ed19b8b5140da841d6 prov:used niiri:b8bc1fafeb07d65d7429038c792c1fff .
 
-niiri:814ac7079ffe5eac40b4e81f109d77d3 prov:used niiri:9cca745d6e07ffe830a810c73a4beb94 .
+niiri:9b702b46c5dd95ed19b8b5140da841d6 prov:used niiri:937d29c8162661dc3675b67810a67ae3 .
 
-niiri:fa56d066478b2ea71a6e1c4d5d549487
+niiri:8b400bad67e910ddcd25ffed64d4900a
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:e4a6119a50fded21c14197bcf296ab06
+niiri:705430105fed94e345e5a467681058e2
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
 
-niiri:fa56d066478b2ea71a6e1c4d5d549487 prov:wasDerivedFrom niiri:e4a6119a50fded21c14197bcf296ab06 .
+niiri:8b400bad67e910ddcd25ffed64d4900a prov:wasDerivedFrom niiri:705430105fed94e345e5a467681058e2 .
 
-niiri:fa56d066478b2ea71a6e1c4d5d549487 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:8b400bad67e910ddcd25ffed64d4900a prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:e5e2aba57bea3f7fc5a3f8657c80a53b
+niiri:9dd086507743fe730b7d24b70cf7ed3a
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "108.038318634033"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
 
-niiri:e5e2aba57bea3f7fc5a3f8657c80a53b prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:9dd086507743fe730b7d24b70cf7ed3a prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:8dc72e026b46807ff7610978144a50a7
+niiri:d70991e4ec5c9a6234d6391c2a0dbdb0
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
 
-niiri:4ae89562691298e404907d30c17d6405
+niiri:406110ec41e71d7260a38848d82dfc7f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f"^^xsd:string .
 
-niiri:8dc72e026b46807ff7610978144a50a7 prov:wasDerivedFrom niiri:4ae89562691298e404907d30c17d6405 .
+niiri:d70991e4ec5c9a6234d6391c2a0dbdb0 prov:wasDerivedFrom niiri:406110ec41e71d7260a38848d82dfc7f .
 
-niiri:8dc72e026b46807ff7610978144a50a7 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:d70991e4ec5c9a6234d6391c2a0dbdb0 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:c92fcc94226b041e076498dac96ae002
+niiri:32d8ca8f9ba66fe36d7b9eae3f419596
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
 
-niiri:70eb7916777b2ccbe5e1004599b6b16f
+niiri:e83351acdbbde0ef0a33cf50fbc3990f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
 
-niiri:c92fcc94226b041e076498dac96ae002 prov:wasDerivedFrom niiri:70eb7916777b2ccbe5e1004599b6b16f .
+niiri:32d8ca8f9ba66fe36d7b9eae3f419596 prov:wasDerivedFrom niiri:e83351acdbbde0ef0a33cf50fbc3990f .
 
-niiri:c92fcc94226b041e076498dac96ae002 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:32d8ca8f9ba66fe36d7b9eae3f419596 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:e709d65a8b7aad133a26fc434e5810c1
+niiri:5cdc01b7d93b811fc7e1114f880e74d3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
 
-niiri:5c45b10466b418609ad8f78d1d37f2a6
+niiri:3397f8fdb55baa2ce4ca23110660f606
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb"^^xsd:string .
 
-niiri:e709d65a8b7aad133a26fc434e5810c1 prov:wasDerivedFrom niiri:5c45b10466b418609ad8f78d1d37f2a6 .
+niiri:5cdc01b7d93b811fc7e1114f880e74d3 prov:wasDerivedFrom niiri:3397f8fdb55baa2ce4ca23110660f606 .
 
-niiri:e709d65a8b7aad133a26fc434e5810c1 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:5cdc01b7d93b811fc7e1114f880e74d3 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:68dce10b86eb716a09c05d6bff88fb86
+niiri:48ca995ae7b89bd0222a3d1652dc6d81
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
 
-niiri:2ec5caa6c30b03a58e93533d26263bf0
+niiri:0182339ddbc9fc0f31bf47a8695e88ac
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6"^^xsd:string .
 
-niiri:68dce10b86eb716a09c05d6bff88fb86 prov:wasDerivedFrom niiri:2ec5caa6c30b03a58e93533d26263bf0 .
+niiri:48ca995ae7b89bd0222a3d1652dc6d81 prov:wasDerivedFrom niiri:0182339ddbc9fc0f31bf47a8695e88ac .
 
-niiri:68dce10b86eb716a09c05d6bff88fb86 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:48ca995ae7b89bd0222a3d1652dc6d81 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:1835bec3a94146206bbc4c8dd879125c
+niiri:d00e71a2693f38940a6abe5fe0a27e14
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
 
-niiri:7cfa6c3f159704f4e89cdb27e96c7bc1
+niiri:6051fccc3fa5e6b6878fdcfe17232d70
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff"^^xsd:string .
 
-niiri:1835bec3a94146206bbc4c8dd879125c prov:wasDerivedFrom niiri:7cfa6c3f159704f4e89cdb27e96c7bc1 .
+niiri:d00e71a2693f38940a6abe5fe0a27e14 prov:wasDerivedFrom niiri:6051fccc3fa5e6b6878fdcfe17232d70 .
 
-niiri:1835bec3a94146206bbc4c8dd879125c prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:d00e71a2693f38940a6abe5fe0a27e14 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:3f4483bbcd6a762700a3897d004115aa
+niiri:05115890f603e4e9e4e1a672eb3683b5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 6" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
 
-niiri:5924cb43042ba2ca9b3e72dff64b49b5
+niiri:699a8d86d7db0ddab1d01e042dc3ae4f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
 
-niiri:3f4483bbcd6a762700a3897d004115aa prov:wasDerivedFrom niiri:5924cb43042ba2ca9b3e72dff64b49b5 .
+niiri:05115890f603e4e9e4e1a672eb3683b5 prov:wasDerivedFrom niiri:699a8d86d7db0ddab1d01e042dc3ae4f .
 
-niiri:3f4483bbcd6a762700a3897d004115aa prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:05115890f603e4e9e4e1a672eb3683b5 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:0584af123d5f6deb3954a3ac1bf9afaf
+niiri:b60ee6cea0e97b11abbbfad263cb8893
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8"^^xsd:string .
 
-niiri:751ce5b565c5ac0b6fcbae2755edacc1
+niiri:03ebca4bd2e13ea96ce505ab726aaa82
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81"^^xsd:string .
 
-niiri:0584af123d5f6deb3954a3ac1bf9afaf prov:wasDerivedFrom niiri:751ce5b565c5ac0b6fcbae2755edacc1 .
+niiri:b60ee6cea0e97b11abbbfad263cb8893 prov:wasDerivedFrom niiri:03ebca4bd2e13ea96ce505ab726aaa82 .
 
-niiri:0584af123d5f6deb3954a3ac1bf9afaf prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:b60ee6cea0e97b11abbbfad263cb8893 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:5e5f72d3a313df47ed1675f196ba2790
+niiri:7e51e600d6dbaf94e50bb1c27b2e2a06
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8"^^xsd:string .
 
-niiri:c43d5c20b335994694e0ce99c69c63d2
+niiri:b1cfa368972409a292f285346c36c011
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29"^^xsd:string .
 
-niiri:5e5f72d3a313df47ed1675f196ba2790 prov:wasDerivedFrom niiri:c43d5c20b335994694e0ce99c69c63d2 .
+niiri:7e51e600d6dbaf94e50bb1c27b2e2a06 prov:wasDerivedFrom niiri:b1cfa368972409a292f285346c36c011 .
 
-niiri:5e5f72d3a313df47ed1675f196ba2790 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+niiri:7e51e600d6dbaf94e50bb1c27b2e2a06 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
 
-niiri:fff3d3a4810634aa02f29f0c1f5fbb8f
+niiri:75efb902a39cf1021609db5de272351c
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     rdfs:label "Contrast: mr vs plain" ;
     prov:value "[1, 1, -1, -1, 0, 0]"^^xsd:string .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175
+niiri:a08187124a8a759239103ba1a7917d6c
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 1" .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:wasAssociatedWith niiri:0b3ed3b43289bfce69e1dd8e0a580555 .
+niiri:a08187124a8a759239103ba1a7917d6c prov:wasAssociatedWith niiri:8d702deb7794ff140970aa83183f0cd7 .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:fa56d066478b2ea71a6e1c4d5d549487 .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:8b400bad67e910ddcd25ffed64d4900a .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:0584af123d5f6deb3954a3ac1bf9afaf .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:b60ee6cea0e97b11abbbfad263cb8893 .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:62719c37cb7f1155944ed6252b71ec01 .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:c7f99aa282bcb84887dac079b6e639e3 .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:fff3d3a4810634aa02f29f0c1f5fbb8f .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:75efb902a39cf1021609db5de272351c .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:8dc72e026b46807ff7610978144a50a7 .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:d70991e4ec5c9a6234d6391c2a0dbdb0 .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:c92fcc94226b041e076498dac96ae002 .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:32d8ca8f9ba66fe36d7b9eae3f419596 .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:e709d65a8b7aad133a26fc434e5810c1 .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:5cdc01b7d93b811fc7e1114f880e74d3 .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:68dce10b86eb716a09c05d6bff88fb86 .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:48ca995ae7b89bd0222a3d1652dc6d81 .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:1835bec3a94146206bbc4c8dd879125c .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:d00e71a2693f38940a6abe5fe0a27e14 .
 
-niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:3f4483bbcd6a762700a3897d004115aa .
+niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:05115890f603e4e9e4e1a672eb3683b5 .
 
-niiri:33170469490d72c603cf1ad06ce86637
+niiri:6c08012b8665ffafe1d80de0f06b0deb
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0001.nii.gz"^^xsd:string ;
@@ -403,84 +403,84 @@ niiri:33170469490d72c603cf1ad06ce86637
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "aba2fef7900cacda1ed84fe5edf867bd2b0fc6ae7eb4919967798d7f219a6d8ad5454fe8e0bdf4a7cfa6402e73287e703c285d12df0a282e40438ec36153e715"^^xsd:string .
 
-niiri:0d5089a0bd1af4fc6f9474726c757a3b
+niiri:0aabcd9c646fada4d1e8380aa19581c0
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782"^^xsd:string .
 
-niiri:33170469490d72c603cf1ad06ce86637 prov:wasDerivedFrom niiri:0d5089a0bd1af4fc6f9474726c757a3b .
+niiri:6c08012b8665ffafe1d80de0f06b0deb prov:wasDerivedFrom niiri:0aabcd9c646fada4d1e8380aa19581c0 .
 
-niiri:33170469490d72c603cf1ad06ce86637 prov:wasGeneratedBy niiri:ed2f36215d4ae0d42c3aefe5ecd86175 .
+niiri:6c08012b8665ffafe1d80de0f06b0deb prov:wasGeneratedBy niiri:a08187124a8a759239103ba1a7917d6c .
 
-niiri:a15220866e3ff78e30b1d06f1e2ad332
+niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: mr vs plain" ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5"^^xsd:string .
 
-niiri:c06e95223a98daddc50df12b0ef668ef
+niiri:7bcc38cb25e8a636c411c67b7c86b4af
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28"^^xsd:string .
 
-niiri:a15220866e3ff78e30b1d06f1e2ad332 prov:wasDerivedFrom niiri:c06e95223a98daddc50df12b0ef668ef .
+niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3 prov:wasDerivedFrom niiri:7bcc38cb25e8a636c411c67b7c86b4af .
 
-niiri:a15220866e3ff78e30b1d06f1e2ad332 prov:wasGeneratedBy niiri:ed2f36215d4ae0d42c3aefe5ecd86175 .
+niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3 prov:wasGeneratedBy niiri:a08187124a8a759239103ba1a7917d6c .
 
-niiri:88f8800367c7c2b2a2d1a301d933782c
+niiri:ea53b05d76e1a79956319d8ef8524624
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b"^^xsd:string .
 
-niiri:88f8800367c7c2b2a2d1a301d933782c prov:wasGeneratedBy niiri:ed2f36215d4ae0d42c3aefe5ecd86175 .
+niiri:ea53b05d76e1a79956319d8ef8524624 prov:wasGeneratedBy niiri:a08187124a8a759239103ba1a7917d6c .
 
-niiri:59cd72b8af1baa0c5eb355990015dbc8
+niiri:25693c09a24b28e659ccec8659964759
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
     rdfs:label "Contrast: switch vs nonswitch" ;
     prov:value "[1, -1, 1, -1, 0, 0]"^^xsd:string .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933
+niiri:8f29f58ca8f23c2abe4da18512df00f0
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 2" .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:wasAssociatedWith niiri:0b3ed3b43289bfce69e1dd8e0a580555 .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:wasAssociatedWith niiri:8d702deb7794ff140970aa83183f0cd7 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:fa56d066478b2ea71a6e1c4d5d549487 .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:8b400bad67e910ddcd25ffed64d4900a .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:0584af123d5f6deb3954a3ac1bf9afaf .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:b60ee6cea0e97b11abbbfad263cb8893 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:62719c37cb7f1155944ed6252b71ec01 .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:c7f99aa282bcb84887dac079b6e639e3 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:59cd72b8af1baa0c5eb355990015dbc8 .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:25693c09a24b28e659ccec8659964759 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:8dc72e026b46807ff7610978144a50a7 .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:d70991e4ec5c9a6234d6391c2a0dbdb0 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:c92fcc94226b041e076498dac96ae002 .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:32d8ca8f9ba66fe36d7b9eae3f419596 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:e709d65a8b7aad133a26fc434e5810c1 .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:5cdc01b7d93b811fc7e1114f880e74d3 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:68dce10b86eb716a09c05d6bff88fb86 .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:48ca995ae7b89bd0222a3d1652dc6d81 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:1835bec3a94146206bbc4c8dd879125c .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:d00e71a2693f38940a6abe5fe0a27e14 .
 
-niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:3f4483bbcd6a762700a3897d004115aa .
+niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:05115890f603e4e9e4e1a672eb3683b5 .
 
-niiri:cdd7c42099c33f420a6755aca2f2279f
+niiri:ed5e976f74b812d550d5f16796c155fc
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0002.nii.gz"^^xsd:string ;
@@ -490,125 +490,125 @@ niiri:cdd7c42099c33f420a6755aca2f2279f
     nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "1c375cdc8f2b00f93f3d6f1a09aafa5670d35ffcf2c82ef061151bfb047463e482e971d67ce3e3e2496f37b1621f5d732a0a1f88c773f5d5fa077cb6a3e38501"^^xsd:string .
 
-niiri:f364d39b2363c17f9d16acb9c59c6a34
+niiri:93258b59372b373e6266047487de0072
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "313c8e34e107b1e9bec46074e7a1cef289427618869119eff1c8044a2b5b8e5a340c899a78f40a3f8b938dbbbde53bd16c096da55f2e07a7c9e334cfd1e471f2"^^xsd:string .
 
-niiri:cdd7c42099c33f420a6755aca2f2279f prov:wasDerivedFrom niiri:f364d39b2363c17f9d16acb9c59c6a34 .
+niiri:ed5e976f74b812d550d5f16796c155fc prov:wasDerivedFrom niiri:93258b59372b373e6266047487de0072 .
 
-niiri:cdd7c42099c33f420a6755aca2f2279f prov:wasGeneratedBy niiri:bb82cadb0c0a63033cb0b69845e19933 .
+niiri:ed5e976f74b812d550d5f16796c155fc prov:wasGeneratedBy niiri:8f29f58ca8f23c2abe4da18512df00f0 .
 
-niiri:e302d7d850e61776b5bb1245b4e05648
+niiri:05f1c1dcd9cada95daa2b92b3aae94eb
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: switch vs nonswitch" ;
     nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "77720bd21fb296db2e69c9742318c52f7cf6b08f94a83c5c1e30d5b8b21b1fd218de32fcc3a96aa2d067d5b06015e85e863ab87907741d2d7c9993740f668dc2"^^xsd:string .
 
-niiri:4488f35b0475365c16a619d4367e2596
+niiri:9b02ce638a46ac45c6d4d3fd693e255f
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "6983d8888c458d8a073f84054db2587b0a71764e64c30ea7e4a13cd0e6b2e301eaea1b570822b24b635b464fd233c3801a9205ddcd2dcffcda7cd99679d2734a"^^xsd:string .
 
-niiri:e302d7d850e61776b5bb1245b4e05648 prov:wasDerivedFrom niiri:4488f35b0475365c16a619d4367e2596 .
+niiri:05f1c1dcd9cada95daa2b92b3aae94eb prov:wasDerivedFrom niiri:9b02ce638a46ac45c6d4d3fd693e255f .
 
-niiri:e302d7d850e61776b5bb1245b4e05648 prov:wasGeneratedBy niiri:bb82cadb0c0a63033cb0b69845e19933 .
+niiri:05f1c1dcd9cada95daa2b92b3aae94eb prov:wasGeneratedBy niiri:8f29f58ca8f23c2abe4da18512df00f0 .
 
-niiri:f0fc139f8e55d67381833c5bf0ad8776
+niiri:8576d98d89e7380306ae7a7b2bfa7f6e
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "1bb21447dcf3cc1eeb9453c707178e4d87161242c69e18795e0e2b30496c9e657ed2f202d4c9cd364aea5a04e4e46fe70ca830e1db14dd2e0f20af754281c3f2"^^xsd:string .
 
-niiri:f0fc139f8e55d67381833c5bf0ad8776 prov:wasGeneratedBy niiri:bb82cadb0c0a63033cb0b69845e19933 .
+niiri:8576d98d89e7380306ae7a7b2bfa7f6e prov:wasGeneratedBy niiri:8f29f58ca8f23c2abe4da18512df00f0 .
 
-niiri:fc0dadbc5f694e6ae907492f74e6940a
+niiri:c92560dc79ef7986810602e2fa8cc698
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.048771 (unc.)" ;
     prov:value "0.0487705952532708"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:4e24c86c0c11cc5f53096bcd0ce1dee2 ;
-    nidm_equivalentThreshold: niiri:f9486c7fafc049f9442fc8a37aad071b .
+    nidm_equivalentThreshold: niiri:f7e7ca44a8f41bda88372604c4fbbb68 ;
+    nidm_equivalentThreshold: niiri:9b07472e1eaca0cce525f30fb31c894c .
 
-niiri:4e24c86c0c11cc5f53096bcd0ce1dee2
+niiri:f7e7ca44a8f41bda88372604c4fbbb68
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "1.65278686445912"^^xsd:float .
 
-niiri:f9486c7fafc049f9442fc8a37aad071b
+niiri:9b07472e1eaca0cce525f30fb31c894c
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:6f5dc8bb78b50ed4e5df8f9ad38d9464
+niiri:5e669b6d10f715c60759eb817713a4a2
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:92687adf3abda3ba46eb627518e50083 ;
-    nidm_equivalentThreshold: niiri:6af6d4d06a49094c399e6ccf744121ef .
+    nidm_equivalentThreshold: niiri:b39d449d635c93f3ffe4f11fdc273353 ;
+    nidm_equivalentThreshold: niiri:a369532528403ad4850204e071f04758 .
 
-niiri:92687adf3abda3ba46eb627518e50083
+niiri:b39d449d635c93f3ffe4f11fdc273353
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:6af6d4d06a49094c399e6ccf744121ef
+niiri:a369532528403ad4850204e071f04758
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:c90078d4c679070cca4a029f082015c6
+niiri:d71d80f794ac0f7a94273b376d163e89
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:e225a30061c1008b5fab26894ccaf377
+niiri:b8086c9fb20252dc9ec4a7fa41470165
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e
     a prov:Activity, nidm_ConjunctionInference: ; 
     rdfs:label "Conjunction Inference" .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:wasAssociatedWith niiri:0b3ed3b43289bfce69e1dd8e0a580555 .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:wasAssociatedWith niiri:8d702deb7794ff140970aa83183f0cd7 .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:fc0dadbc5f694e6ae907492f74e6940a .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:c92560dc79ef7986810602e2fa8cc698 .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:6f5dc8bb78b50ed4e5df8f9ad38d9464 .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:5e669b6d10f715c60759eb817713a4a2 .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:33170469490d72c603cf1ad06ce86637 .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:6c08012b8665ffafe1d80de0f06b0deb .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:cdd7c42099c33f420a6755aca2f2279f .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:ed5e976f74b812d550d5f16796c155fc .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:5e5f72d3a313df47ed1675f196ba2790 .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:7e51e600d6dbaf94e50bb1c27b2e2a06 .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:fa56d066478b2ea71a6e1c4d5d549487 .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:8b400bad67e910ddcd25ffed64d4900a .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:c90078d4c679070cca4a029f082015c6 .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:d71d80f794ac0f7a94273b376d163e89 .
 
-niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:e225a30061c1008b5fab26894ccaf377 .
+niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:b8086c9fb20252dc9ec4a7fa41470165 .
 
-niiri:5659ce7e18cccaee79d052589cc49082
+niiri:af86aeaa13e45fe4af977676f9dbb2d6
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
     nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.4409986586553"^^xsd:float ;
@@ -625,9 +625,9 @@ niiri:5659ce7e18cccaee79d052589cc49082
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:5659ce7e18cccaee79d052589cc49082 prov:wasGeneratedBy niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 .
+niiri:af86aeaa13e45fe4af977676f9dbb2d6 prov:wasGeneratedBy niiri:047da8bd1155d93bb9e94d1cb47f6f2e .
 
-niiri:f3637fafb926481fff6bd8938c6a8550
+niiri:2561c31d8316e8b6110351c09d382626
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -635,26 +635,26 @@ niiri:f3637fafb926481fff6bd8938c6a8550
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "30"^^xsd:int ;
     nidm_pValue: "1"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:225cba9527198fe0f9f286e4794b0c09 ;
-    nidm_hasMaximumIntensityProjection: niiri:b314a44bd0faae613b91c61054d712ba ;
-    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_hasClusterLabelsMap: niiri:555b51c020185cf7d98d6cae3d6dd6b7 ;
+    nidm_hasMaximumIntensityProjection: niiri:72e33120e4a0cf389b3663a56945e615 ;
+    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
     crypto:sha512 "bcf45ac744752d54a29a2b918eda586a0e6637179a62a2eef62afd03f594bb4bdb4d2171625040d21c22a02d3a13fd0312ce1b83f6a6aecf34c432299e21c864"^^xsd:string .
 
-niiri:225cba9527198fe0f9f286e4794b0c09
+niiri:555b51c020185cf7d98d6cae3d6dd6b7
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:b314a44bd0faae613b91c61054d712ba
+niiri:72e33120e4a0cf389b3663a56945e615
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:f3637fafb926481fff6bd8938c6a8550 prov:wasGeneratedBy niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 .
+niiri:2561c31d8316e8b6110351c09d382626 prov:wasGeneratedBy niiri:047da8bd1155d93bb9e94d1cb47f6f2e .
 
-niiri:1ca2ed8885126a13f37d342c5bda82b6
+niiri:8d1a8ab2f5e6753052e300d592e3d511
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "95"^^xsd:int ;
@@ -664,9 +664,9 @@ niiri:1ca2ed8885126a13f37d342c5bda82b6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:1ca2ed8885126a13f37d342c5bda82b6 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:8d1a8ab2f5e6753052e300d592e3d511 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:b6ec4ee5c26bd5170b56e954e84a7789
+niiri:5a1ad49de526d8a54452b31baf96a75d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -676,9 +676,9 @@ niiri:b6ec4ee5c26bd5170b56e954e84a7789
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:b6ec4ee5c26bd5170b56e954e84a7789 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:5a1ad49de526d8a54452b31baf96a75d prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:67aa7dea8d858564a8b4505070c20ab3
+niiri:c00f026631fe0b6f988efa4d30db781f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -688,9 +688,9 @@ niiri:67aa7dea8d858564a8b4505070c20ab3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:67aa7dea8d858564a8b4505070c20ab3 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:c00f026631fe0b6f988efa4d30db781f prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:8eb556353f8e288e589eef37024ef068
+niiri:b712b8f6d2df400be64fe19b957abb10
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -700,9 +700,9 @@ niiri:8eb556353f8e288e589eef37024ef068
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:8eb556353f8e288e589eef37024ef068 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:b712b8f6d2df400be64fe19b957abb10 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:4f970219224428039454afd130e40f48
+niiri:f66d2da458d706e0d1c123fd3dc589c7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -712,9 +712,9 @@ niiri:4f970219224428039454afd130e40f48
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:4f970219224428039454afd130e40f48 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:f66d2da458d706e0d1c123fd3dc589c7 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:c2a5888cb7cfb94104a85fdf0c0a0975
+niiri:70a3e9df88095bfe99637dabf4110acd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -724,9 +724,9 @@ niiri:c2a5888cb7cfb94104a85fdf0c0a0975
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:c2a5888cb7cfb94104a85fdf0c0a0975 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:70a3e9df88095bfe99637dabf4110acd prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:5e85e47c2fc2758e5d466cd2123b2254
+niiri:027812928b4d9dc645c81857d81e13ca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -736,9 +736,9 @@ niiri:5e85e47c2fc2758e5d466cd2123b2254
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:5e85e47c2fc2758e5d466cd2123b2254 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:027812928b4d9dc645c81857d81e13ca prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:6105338324e4b950666042ae82d011fd
+niiri:fec8e2c65ce7d1cf6e18804683d824ca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -748,9 +748,9 @@ niiri:6105338324e4b950666042ae82d011fd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:6105338324e4b950666042ae82d011fd prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:fec8e2c65ce7d1cf6e18804683d824ca prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:4f020dcb9018a1690cba2cbf60dc38b0
+niiri:c9f251722e6a9f1501e325fdf2f516f3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -760,9 +760,9 @@ niiri:4f020dcb9018a1690cba2cbf60dc38b0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:4f020dcb9018a1690cba2cbf60dc38b0 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:c9f251722e6a9f1501e325fdf2f516f3 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:68b9b03c7822e1a0b86cd9e68fe99ca2
+niiri:ac00f4348e517214c5428caad74cc6dc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -772,9 +772,9 @@ niiri:68b9b03c7822e1a0b86cd9e68fe99ca2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:68b9b03c7822e1a0b86cd9e68fe99ca2 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:ac00f4348e517214c5428caad74cc6dc prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9
+niiri:8050ff9b05fe42d3b13b693c3d4dfc3c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -784,9 +784,9 @@ niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:8050ff9b05fe42d3b13b693c3d4dfc3c prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:f626ba6b4ad8b422a9e8b6208607d5c7
+niiri:d1592c70ca4448ee46f3c8df3c20043c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -796,9 +796,9 @@ niiri:f626ba6b4ad8b422a9e8b6208607d5c7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:f626ba6b4ad8b422a9e8b6208607d5c7 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:d1592c70ca4448ee46f3c8df3c20043c prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:dd3a390096e9240d96d84a6fa0b53334
+niiri:5828f74c2c43b3883378f9cd1e63925b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -808,9 +808,9 @@ niiri:dd3a390096e9240d96d84a6fa0b53334
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:dd3a390096e9240d96d84a6fa0b53334 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:5828f74c2c43b3883378f9cd1e63925b prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:b38cc3f1a8c8b355373259707d78b430
+niiri:5922affac179cd07256e72fbcf8a2c8a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -820,9 +820,9 @@ niiri:b38cc3f1a8c8b355373259707d78b430
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:b38cc3f1a8c8b355373259707d78b430 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:5922affac179cd07256e72fbcf8a2c8a prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:708b36a85852210d2aa37cd0a43c31d6
+niiri:8481b546970e4cc30b9a0415842a3ea3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -832,9 +832,9 @@ niiri:708b36a85852210d2aa37cd0a43c31d6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:708b36a85852210d2aa37cd0a43c31d6 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:8481b546970e4cc30b9a0415842a3ea3 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:9fb5666ada501891fcef9d333ed6afff
+niiri:f4471bd4ad44f0353136ecfba3e12d38
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -844,9 +844,9 @@ niiri:9fb5666ada501891fcef9d333ed6afff
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:9fb5666ada501891fcef9d333ed6afff prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:f4471bd4ad44f0353136ecfba3e12d38 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:756837e339677511c64f8da38004cd2e
+niiri:7651662ffb846c59d0275b64f39a5a3e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -856,9 +856,9 @@ niiri:756837e339677511c64f8da38004cd2e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:756837e339677511c64f8da38004cd2e prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:7651662ffb846c59d0275b64f39a5a3e prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:303983981b9e7155b24ee729485e35d5
+niiri:cb4cab1d498471cf714b96e648ba0b84
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -868,9 +868,9 @@ niiri:303983981b9e7155b24ee729485e35d5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:303983981b9e7155b24ee729485e35d5 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:cb4cab1d498471cf714b96e648ba0b84 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:ff25cf8967cf153c0c4bac8744bfd4de
+niiri:b49a13ef4f81cb056a0cf2c1e1e37613
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -880,9 +880,9 @@ niiri:ff25cf8967cf153c0c4bac8744bfd4de
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:ff25cf8967cf153c0c4bac8744bfd4de prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:b49a13ef4f81cb056a0cf2c1e1e37613 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:1e1d5e2b654ff9dfd561671bb14dac45
+niiri:3bf344699ca63226f8a0986e9e22dc4d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -892,9 +892,9 @@ niiri:1e1d5e2b654ff9dfd561671bb14dac45
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:1e1d5e2b654ff9dfd561671bb14dac45 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:3bf344699ca63226f8a0986e9e22dc4d prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:04d3366efa2ae78508ba78d4f6d3fbd4
+niiri:7a1aa46f25bc46f59f7f644a1d2d768c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -904,9 +904,9 @@ niiri:04d3366efa2ae78508ba78d4f6d3fbd4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:04d3366efa2ae78508ba78d4f6d3fbd4 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:7a1aa46f25bc46f59f7f644a1d2d768c prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:471616239367dd0b8f23af62cd1178af
+niiri:95103dd9bdac7741d90f99939247bf4e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -916,9 +916,9 @@ niiri:471616239367dd0b8f23af62cd1178af
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:471616239367dd0b8f23af62cd1178af prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:95103dd9bdac7741d90f99939247bf4e prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:146e852a595d2bd9bf43b63cb1ffe554
+niiri:11fe90c3ae56c74edb8f27b7b4d64c01
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -928,9 +928,9 @@ niiri:146e852a595d2bd9bf43b63cb1ffe554
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:146e852a595d2bd9bf43b63cb1ffe554 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:11fe90c3ae56c74edb8f27b7b4d64c01 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:c76d475fb44856dbc3b3660c08027d10
+niiri:d17fffe11eaba3b9e149fce8bdc2b9da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -940,9 +940,9 @@ niiri:c76d475fb44856dbc3b3660c08027d10
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:c76d475fb44856dbc3b3660c08027d10 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:d17fffe11eaba3b9e149fce8bdc2b9da prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:171a3293a830389fbc0eeedac10ab2ef
+niiri:a97b8d1eb95bad3103d70c3a170b35e6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -952,9 +952,9 @@ niiri:171a3293a830389fbc0eeedac10ab2ef
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:171a3293a830389fbc0eeedac10ab2ef prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:a97b8d1eb95bad3103d70c3a170b35e6 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:230b132218201af072b76732d6cd366e
+niiri:34de4bc8669d7effba126acecd7e71ca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -964,9 +964,9 @@ niiri:230b132218201af072b76732d6cd366e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:230b132218201af072b76732d6cd366e prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:34de4bc8669d7effba126acecd7e71ca prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:88b6854434c4c7d7d77b89858ff66d15
+niiri:34640314cb90b81bff8b479f4c75ae6f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -976,9 +976,9 @@ niiri:88b6854434c4c7d7d77b89858ff66d15
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:88b6854434c4c7d7d77b89858ff66d15 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:34640314cb90b81bff8b479f4c75ae6f prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:983ff16f46a1aa2fb13613f2c2f88011
+niiri:79c1b8c3935c1efdd0d31d231222a6e3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -988,9 +988,9 @@ niiri:983ff16f46a1aa2fb13613f2c2f88011
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:983ff16f46a1aa2fb13613f2c2f88011 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:79c1b8c3935c1efdd0d31d231222a6e3 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:a6327d343c9ff6cf00c6cbe83308072b
+niiri:1171e027eba41be4b53953810af155f9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1000,9 +1000,9 @@ niiri:a6327d343c9ff6cf00c6cbe83308072b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:a6327d343c9ff6cf00c6cbe83308072b prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:1171e027eba41be4b53953810af155f9 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:92ac4a8cb0a6c243ecb32fc66fd3deab
+niiri:54a8bffd20ef66a79cc779bd8e630f0f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1012,549 +1012,549 @@ niiri:92ac4a8cb0a6c243ecb32fc66fd3deab
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:92ac4a8cb0a6c243ecb32fc66fd3deab prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+niiri:54a8bffd20ef66a79cc779bd8e630f0f prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
 
-niiri:c3e496eea557d318020009e75ea064a9
+niiri:49979752257c9cdd1a1f63a018b04845
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:33b9e64baedb78edec3c778ac3503e57 ;
+    prov:atLocation niiri:062dc6f5cf37590aa5348de9d124c531 ;
     prov:value "2.29849815368652"^^xsd:float ;
     nidm_equivalentZStatistic: "2.28220028418391"^^xsd:float ;
     nidm_pValueUncorrected: "0.0112387591680547"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:33b9e64baedb78edec3c778ac3503e57
+niiri:062dc6f5cf37590aa5348de9d124c531
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-28,24,4]"^^xsd:string .
 
-niiri:c3e496eea557d318020009e75ea064a9 prov:wasDerivedFrom niiri:1ca2ed8885126a13f37d342c5bda82b6 .
+niiri:49979752257c9cdd1a1f63a018b04845 prov:wasDerivedFrom niiri:8d1a8ab2f5e6753052e300d592e3d511 .
 
-niiri:304c8f977e3d31328f1ba8cc597ceb18
+niiri:eb0f15f09bbeede75a83373d3a94b783
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:39b6eca99b5b73480b968ea12add2484 ;
+    prov:atLocation niiri:9fcee8551b5114a52e472ad1844f220e ;
     prov:value "2.07190132141113"^^xsd:float ;
     nidm_equivalentZStatistic: "2.0619285244841"^^xsd:float ;
     nidm_pValueUncorrected: "0.0196072706834085"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:39b6eca99b5b73480b968ea12add2484
+niiri:9fcee8551b5114a52e472ad1844f220e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-28,26,12]"^^xsd:string .
 
-niiri:304c8f977e3d31328f1ba8cc597ceb18 prov:wasDerivedFrom niiri:1ca2ed8885126a13f37d342c5bda82b6 .
+niiri:eb0f15f09bbeede75a83373d3a94b783 prov:wasDerivedFrom niiri:8d1a8ab2f5e6753052e300d592e3d511 .
 
-niiri:02fb69f52c0371d7e8083f1d698b5486
+niiri:a9d3e1abbc30e49d34ae695e931b45f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:0545dc10de1e5d6701474796bc5135b3 ;
+    prov:atLocation niiri:adcb8119812e818906df4629ebb6d39e ;
     prov:value "2.18201637268066"^^xsd:float ;
     nidm_equivalentZStatistic: "2.16893530312973"^^xsd:float ;
     nidm_pValueUncorrected: "0.0150437980271687"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:0545dc10de1e5d6701474796bc5135b3
+niiri:adcb8119812e818906df4629ebb6d39e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[52,48,12]"^^xsd:string .
 
-niiri:02fb69f52c0371d7e8083f1d698b5486 prov:wasDerivedFrom niiri:b6ec4ee5c26bd5170b56e954e84a7789 .
+niiri:a9d3e1abbc30e49d34ae695e931b45f7 prov:wasDerivedFrom niiri:5a1ad49de526d8a54452b31baf96a75d .
 
-niiri:47905f0ed8d89646a0b2df5e003f1e2a
+niiri:a312bb2d4a36613077f4d362f5263e2d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:d0d2bf61fd3a0931a0e3bdd8f49eed93 ;
+    prov:atLocation niiri:1e8d56d4ce620a2af884f53f0162a677 ;
     prov:value "2.13869571685791"^^xsd:float ;
     nidm_equivalentZStatistic: "2.12682533173394"^^xsd:float ;
     nidm_pValueUncorrected: "0.016717299356924"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:d0d2bf61fd3a0931a0e3bdd8f49eed93
+niiri:1e8d56d4ce620a2af884f53f0162a677
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-54,52]"^^xsd:string .
 
-niiri:47905f0ed8d89646a0b2df5e003f1e2a prov:wasDerivedFrom niiri:67aa7dea8d858564a8b4505070c20ab3 .
+niiri:a312bb2d4a36613077f4d362f5263e2d prov:wasDerivedFrom niiri:c00f026631fe0b6f988efa4d30db781f .
 
-niiri:091b7fa1943f270ddc578020b6bf4b81
+niiri:49271d60759060cc512c32272ea47c9f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:2d030121bd3e3440189b9362d24d0e82 ;
+    prov:atLocation niiri:14acc5ae182e2d6aa091d9670f63d86c ;
     prov:value "2.13825297355652"^^xsd:float ;
     nidm_equivalentZStatistic: "2.12639503027273"^^xsd:float ;
     nidm_pValueUncorrected: "0.0167351906128659"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:2d030121bd3e3440189b9362d24d0e82
+niiri:14acc5ae182e2d6aa091d9670f63d86c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[36,-84,2]"^^xsd:string .
 
-niiri:091b7fa1943f270ddc578020b6bf4b81 prov:wasDerivedFrom niiri:8eb556353f8e288e589eef37024ef068 .
+niiri:49271d60759060cc512c32272ea47c9f prov:wasDerivedFrom niiri:b712b8f6d2df400be64fe19b957abb10 .
 
-niiri:225874e925381c31ec2075213af93cc8
+niiri:08989f7c63c852798e88db3aa5231385
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:7506c87aedf9336f1b97442d8e526f2f ;
+    prov:atLocation niiri:72593e56b8c30845ae2b8f8970fe5e42 ;
     prov:value "2.1293613910675"^^xsd:float ;
     nidm_equivalentZStatistic: "2.11775365245473"^^xsd:float ;
     nidm_pValueUncorrected: "0.0170979681968485"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:7506c87aedf9336f1b97442d8e526f2f
+niiri:72593e56b8c30845ae2b8f8970fe5e42
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[30,68,12]"^^xsd:string .
 
-niiri:225874e925381c31ec2075213af93cc8 prov:wasDerivedFrom niiri:4f970219224428039454afd130e40f48 .
+niiri:08989f7c63c852798e88db3aa5231385 prov:wasDerivedFrom niiri:f66d2da458d706e0d1c123fd3dc589c7 .
 
-niiri:eb6fb2c76c756484f30c7d09b66c5c43
+niiri:58feba2e44840c92dea201d54bffa5fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:99c662c8509b716d461c456391b45b37 ;
+    prov:atLocation niiri:d7ec0d3731cf2369dd44267e354a7988 ;
     prov:value "2.11468005180359"^^xsd:float ;
     nidm_equivalentZStatistic: "2.10348692366691"^^xsd:float ;
     nidm_pValueUncorrected: "0.017711613581637"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:99c662c8509b716d461c456391b45b37
+niiri:d7ec0d3731cf2369dd44267e354a7988
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[34,-84,14]"^^xsd:string .
 
-niiri:eb6fb2c76c756484f30c7d09b66c5c43 prov:wasDerivedFrom niiri:c2a5888cb7cfb94104a85fdf0c0a0975 .
+niiri:58feba2e44840c92dea201d54bffa5fb prov:wasDerivedFrom niiri:70a3e9df88095bfe99637dabf4110acd .
 
-niiri:db15f3aea3a0b1689952a5924009614a
+niiri:9e3518c2e9867ca98860f754d7379642
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:ec58debeeea826abc9378be9d6ccee92 ;
+    prov:atLocation niiri:29e408397e3b3c1a20cd94269d9240df ;
     prov:value "2.01981115341187"^^xsd:float ;
     nidm_equivalentZStatistic: "2.01135476956162"^^xsd:float ;
     nidm_pValueUncorrected: "0.0221439986174564"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:ec58debeeea826abc9378be9d6ccee92
+niiri:29e408397e3b3c1a20cd94269d9240df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-42,20,36]"^^xsd:string .
 
-niiri:db15f3aea3a0b1689952a5924009614a prov:wasDerivedFrom niiri:5e85e47c2fc2758e5d466cd2123b2254 .
+niiri:9e3518c2e9867ca98860f754d7379642 prov:wasDerivedFrom niiri:027812928b4d9dc645c81857d81e13ca .
 
-niiri:a9e83bfae2a235a9cc20adac4118915b
+niiri:01a776de2155c1d064f799ee0b13d27c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:3991fe3c2e71f1b8e7f88c795fa8f2b0 ;
+    prov:atLocation niiri:3af3a4e516f1d0712e480617661e0990 ;
     prov:value "1.9834691286087"^^xsd:float ;
     nidm_equivalentZStatistic: "1.97609535691968"^^xsd:float ;
     nidm_pValueUncorrected: "0.0240719891024281"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:3991fe3c2e71f1b8e7f88c795fa8f2b0
+niiri:3af3a4e516f1d0712e480617661e0990
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[34,-78,36]"^^xsd:string .
 
-niiri:a9e83bfae2a235a9cc20adac4118915b prov:wasDerivedFrom niiri:6105338324e4b950666042ae82d011fd .
+niiri:01a776de2155c1d064f799ee0b13d27c prov:wasDerivedFrom niiri:fec8e2c65ce7d1cf6e18804683d824ca .
 
-niiri:2f99eaddb3b1956eee9400c73e729457
+niiri:a3fdd163c99c50f21394bb2564810f40
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:94ba0436d49d4f1ac392af5f6adb2756 ;
+    prov:atLocation niiri:14cae94fd17fb2d01fda8a8022d07f31 ;
     prov:value "1.94259870052338"^^xsd:float ;
     nidm_equivalentZStatistic: "1.93647164753299"^^xsd:float ;
     nidm_pValueUncorrected: "0.026404980891827"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:94ba0436d49d4f1ac392af5f6adb2756
+niiri:14cae94fd17fb2d01fda8a8022d07f31
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-48,18,18]"^^xsd:string .
 
-niiri:2f99eaddb3b1956eee9400c73e729457 prov:wasDerivedFrom niiri:4f020dcb9018a1690cba2cbf60dc38b0 .
+niiri:a3fdd163c99c50f21394bb2564810f40 prov:wasDerivedFrom niiri:c9f251722e6a9f1501e325fdf2f516f3 .
 
-niiri:e21f5c3bb0d87db0399aa6aeaae8fa17
+niiri:42a4152bc3193944f970885860f254f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:026fbe87ef12da1f1cb8f58505c5a35d ;
+    prov:atLocation niiri:0ccdcec00484fe14b2ed7552c64faa47 ;
     prov:value "1.89261054992676"^^xsd:float ;
     nidm_equivalentZStatistic: "1.88805796389517"^^xsd:float ;
     nidm_pValueUncorrected: "0.0295090846561562"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:026fbe87ef12da1f1cb8f58505c5a35d
+niiri:0ccdcec00484fe14b2ed7552c64faa47
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-40,20,8]"^^xsd:string .
 
-niiri:e21f5c3bb0d87db0399aa6aeaae8fa17 prov:wasDerivedFrom niiri:4f020dcb9018a1690cba2cbf60dc38b0 .
+niiri:42a4152bc3193944f970885860f254f1 prov:wasDerivedFrom niiri:c9f251722e6a9f1501e325fdf2f516f3 .
 
-niiri:819a69b124962a6bc39aa80cdc398a30
+niiri:d8ef073869f2d518eeb58c051015c0e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:0d0ffa2881f696dcc6b1d489a15348ec ;
+    prov:atLocation niiri:2179a81fd9206716047be8cff2e08728 ;
     prov:value "1.9298506975174"^^xsd:float ;
     nidm_equivalentZStatistic: "1.92411963399221"^^xsd:float ;
     nidm_pValueUncorrected: "0.0271697947905869"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:0d0ffa2881f696dcc6b1d489a15348ec
+niiri:2179a81fd9206716047be8cff2e08728
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[22,-82,6]"^^xsd:string .
 
-niiri:819a69b124962a6bc39aa80cdc398a30 prov:wasDerivedFrom niiri:68b9b03c7822e1a0b86cd9e68fe99ca2 .
+niiri:d8ef073869f2d518eeb58c051015c0e4 prov:wasDerivedFrom niiri:ac00f4348e517214c5428caad74cc6dc .
 
-niiri:df4034a52a0223c24e52134353933b85
+niiri:b6b23fa7071c0e8366f51f689cb58e5d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:b2e026ac20229c679280d6521ef462e2 ;
+    prov:atLocation niiri:00466efda7ed6e546b9bbd911f3047a8 ;
     prov:value "1.87824356555939"^^xsd:float ;
     nidm_equivalentZStatistic: "1.87415494022171"^^xsd:float ;
     nidm_pValueUncorrected: "0.0304545363496075"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:b2e026ac20229c679280d6521ef462e2
+niiri:00466efda7ed6e546b9bbd911f3047a8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-34,22,20]"^^xsd:string .
 
-niiri:df4034a52a0223c24e52134353933b85 prov:wasDerivedFrom niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9 .
+niiri:b6b23fa7071c0e8366f51f689cb58e5d prov:wasDerivedFrom niiri:8050ff9b05fe42d3b13b693c3d4dfc3c .
 
-niiri:56e0435b5a93b3ea44eb4880caa46f6e
+niiri:aa1e6f75cb3a2b76e5c3d6a02f70c7d7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:64c2cf7669582f994375fb0c99a90889 ;
+    prov:atLocation niiri:7645318f716537f0f6e55e58acb4daf1 ;
     prov:value "1.85802888870239"^^xsd:float ;
     nidm_equivalentZStatistic: "1.85460257678401"^^xsd:float ;
     nidm_pValueUncorrected: "0.0318264999487402"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:64c2cf7669582f994375fb0c99a90889
+niiri:7645318f716537f0f6e55e58acb4daf1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[16,-100,10]"^^xsd:string .
 
-niiri:56e0435b5a93b3ea44eb4880caa46f6e prov:wasDerivedFrom niiri:f626ba6b4ad8b422a9e8b6208607d5c7 .
+niiri:aa1e6f75cb3a2b76e5c3d6a02f70c7d7 prov:wasDerivedFrom niiri:d1592c70ca4448ee46f3c8df3c20043c .
 
-niiri:1585cde397394ce1852eabdc3e6069bc
+niiri:6cdd0ffff75a1252b7fa916661fdf669
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:f72c8e0f5976a1f9554754dc1a644aec ;
+    prov:atLocation niiri:7ce3f7015bebf95ed663572f98652879 ;
     prov:value "1.82612562179565"^^xsd:float ;
     nidm_equivalentZStatistic: "1.82376887581619"^^xsd:float ;
     nidm_pValueUncorrected: "0.0340935105624357"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:f72c8e0f5976a1f9554754dc1a644aec
+niiri:7ce3f7015bebf95ed663572f98652879
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-22,6,14]"^^xsd:string .
 
-niiri:1585cde397394ce1852eabdc3e6069bc prov:wasDerivedFrom niiri:dd3a390096e9240d96d84a6fa0b53334 .
+niiri:6cdd0ffff75a1252b7fa916661fdf669 prov:wasDerivedFrom niiri:5828f74c2c43b3883378f9cd1e63925b .
 
-niiri:fc1bd52acb4a54ac65706ec77b597664
+niiri:15a87b6382e2fb49ba7ce1b2c5a4bdfc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:b916c3481037d35a043ee9bca1bfa812 ;
+    prov:atLocation niiri:0b796279bb1597f56c7a837b6943278f ;
     prov:value "1.8208144903183"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81863886421642"^^xsd:float ;
     nidm_pValueUncorrected: "0.0344832722280412"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:b916c3481037d35a043ee9bca1bfa812
+niiri:0b796279bb1597f56c7a837b6943278f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[32,-66,0]"^^xsd:string .
 
-niiri:fc1bd52acb4a54ac65706ec77b597664 prov:wasDerivedFrom niiri:b38cc3f1a8c8b355373259707d78b430 .
+niiri:15a87b6382e2fb49ba7ce1b2c5a4bdfc prov:wasDerivedFrom niiri:5922affac179cd07256e72fbcf8a2c8a .
 
-niiri:dd9b23180ca6d48364bbd5e03598085b
+niiri:11111874c48fbc8c67f5d0d02dfca56b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:e19da916a650e437d894081ea2700363 ;
+    prov:atLocation niiri:c7a615d1d896aa881dbf7d7894ede9ea ;
     prov:value "1.79377067089081"^^xsd:float ;
     nidm_equivalentZStatistic: "1.79253174586373"^^xsd:float ;
     nidm_pValueUncorrected: "0.0365239143287336"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:e19da916a650e437d894081ea2700363
+niiri:c7a615d1d896aa881dbf7d7894ede9ea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-28,8,14]"^^xsd:string .
 
-niiri:dd9b23180ca6d48364bbd5e03598085b prov:wasDerivedFrom niiri:708b36a85852210d2aa37cd0a43c31d6 .
+niiri:11111874c48fbc8c67f5d0d02dfca56b prov:wasDerivedFrom niiri:8481b546970e4cc30b9a0415842a3ea3 .
 
-niiri:60833962d796c1925bb5caa354752e20
+niiri:cc9da452ad344d07d30c0d718ee350f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:0286ca8f9f6d1abb7e43fe83af301e65 ;
+    prov:atLocation niiri:a19b00cbab738b2c3a78288527aba3cf ;
     prov:value "1.79001986980438"^^xsd:float ;
     nidm_equivalentZStatistic: "1.78891283515708"^^xsd:float ;
     nidm_pValueUncorrected: "0.0368144271933957"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:0286ca8f9f6d1abb7e43fe83af301e65
+niiri:a19b00cbab738b2c3a78288527aba3cf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-20,26,28]"^^xsd:string .
 
-niiri:60833962d796c1925bb5caa354752e20 prov:wasDerivedFrom niiri:9fb5666ada501891fcef9d333ed6afff .
+niiri:cc9da452ad344d07d30c0d718ee350f6 prov:wasDerivedFrom niiri:f4471bd4ad44f0353136ecfba3e12d38 .
 
-niiri:f44eff18cdf7e25979cf1141a5338fc0
+niiri:19d8b89fc4f6b3b5666d4b8f5df7a590
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:9d4722db398870c6b3ea92787232d10a ;
+    prov:atLocation niiri:8d6b2fe61e5731fecf31a4effa4301bb ;
     prov:value "1.74872362613678"^^xsd:float ;
     nidm_equivalentZStatistic: "1.749102772694"^^xsd:float ;
     nidm_pValueUncorrected: "0.0401366280244358"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:9d4722db398870c6b3ea92787232d10a
+niiri:8d6b2fe61e5731fecf31a4effa4301bb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-54,28,20]"^^xsd:string .
 
-niiri:f44eff18cdf7e25979cf1141a5338fc0 prov:wasDerivedFrom niiri:756837e339677511c64f8da38004cd2e .
+niiri:19d8b89fc4f6b3b5666d4b8f5df7a590 prov:wasDerivedFrom niiri:7651662ffb846c59d0275b64f39a5a3e .
 
-niiri:7d958f3e975bddab9f95985faaae5cad
+niiri:6cd1d0f09d96998ec6d45fc8967bef7d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:338c9616ae26c8e59158924ee7b04682 ;
+    prov:atLocation niiri:6e4b134d42d62e3fa90a9cdfa4b0c3ab ;
     prov:value "1.73660695552826"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73743465054505"^^xsd:float ;
     nidm_pValueUncorrected: "0.0411552397567266"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:338c9616ae26c8e59158924ee7b04682
+niiri:6e4b134d42d62e3fa90a9cdfa4b0c3ab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[36,-56,-12]"^^xsd:string .
 
-niiri:7d958f3e975bddab9f95985faaae5cad prov:wasDerivedFrom niiri:303983981b9e7155b24ee729485e35d5 .
+niiri:6cd1d0f09d96998ec6d45fc8967bef7d prov:wasDerivedFrom niiri:cb4cab1d498471cf714b96e648ba0b84 .
 
-niiri:8f47804dc4763167b41a429473c75db8
+niiri:971088d1bdd0b1a1c9e797b9ba272eee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:590b0466ddb6db870e7a7eb6ccc2f0c5 ;
+    prov:atLocation niiri:2bcb7950634a9079bfc9f15710195ba5 ;
     prov:value "1.72697401046753"^^xsd:float ;
     nidm_equivalentZStatistic: "1.72816258455492"^^xsd:float ;
     nidm_pValueUncorrected: "0.0419795398198842"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:590b0466ddb6db870e7a7eb6ccc2f0c5
+niiri:2bcb7950634a9079bfc9f15710195ba5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[12,74,8]"^^xsd:string .
 
-niiri:8f47804dc4763167b41a429473c75db8 prov:wasDerivedFrom niiri:ff25cf8967cf153c0c4bac8744bfd4de .
+niiri:971088d1bdd0b1a1c9e797b9ba272eee prov:wasDerivedFrom niiri:b49a13ef4f81cb056a0cf2c1e1e37613 .
 
-niiri:d86f7773fa7f7c82a9d04542bdbbd522
+niiri:3b1b90046e2cc738e068e3ccdc5b8e08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:4a94efdcb82d851208aa8b066ac5c604 ;
+    prov:atLocation niiri:6e3632bdadbdb54596f9986ced7c5a42 ;
     prov:value "1.69681537151337"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69915940103581"^^xsd:float ;
     nidm_pValueUncorrected: "0.0446445768205113"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:4a94efdcb82d851208aa8b066ac5c604
+niiri:6e3632bdadbdb54596f9986ced7c5a42
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-28,50,36]"^^xsd:string .
 
-niiri:d86f7773fa7f7c82a9d04542bdbbd522 prov:wasDerivedFrom niiri:1e1d5e2b654ff9dfd561671bb14dac45 .
+niiri:3b1b90046e2cc738e068e3ccdc5b8e08 prov:wasDerivedFrom niiri:3bf344699ca63226f8a0986e9e22dc4d .
 
-niiri:27b1286570a35003fd1cb892df5003ee
+niiri:2f7d1feb589408c3bf50b3384d89d8a9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:fd0f08df1132bd69544d5c2bc67a8ce1 ;
+    prov:atLocation niiri:42729ea56a022800e2b3fffe2fd2c1ec ;
     prov:value "1.69281709194183"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69531733220798"^^xsd:float ;
     nidm_pValueUncorrected: "0.0450076192977755"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:fd0f08df1132bd69544d5c2bc67a8ce1
+niiri:42729ea56a022800e2b3fffe2fd2c1ec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-54,28,12]"^^xsd:string .
 
-niiri:27b1286570a35003fd1cb892df5003ee prov:wasDerivedFrom niiri:04d3366efa2ae78508ba78d4f6d3fbd4 .
+niiri:2f7d1feb589408c3bf50b3384d89d8a9 prov:wasDerivedFrom niiri:7a1aa46f25bc46f59f7f644a1d2d768c .
 
-niiri:39aa9652e5edc473ede61063b5f9330b
+niiri:90b76ff68e1f93610f550c0f2f46cdec
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:f19ef86275c6e6fc9f17827d454cea6f ;
+    prov:atLocation niiri:8e160c47f33d388aedd45037581833c0 ;
     prov:value "1.68880593776703"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69146362670159"^^xsd:float ;
     nidm_pValueUncorrected: "0.0453741445419741"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:f19ef86275c6e6fc9f17827d454cea6f
+niiri:8e160c47f33d388aedd45037581833c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[26,-92,18]"^^xsd:string .
 
-niiri:39aa9652e5edc473ede61063b5f9330b prov:wasDerivedFrom niiri:471616239367dd0b8f23af62cd1178af .
+niiri:90b76ff68e1f93610f550c0f2f46cdec prov:wasDerivedFrom niiri:95103dd9bdac7741d90f99939247bf4e .
 
-niiri:9607bb62ecc6289f2476a8bb82c2c966
+niiri:9a6229796a5042d2de9c8d840d333151
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:9759d63712f31dd71f970ba24fdc02ba ;
+    prov:atLocation niiri:ba88244ebec57bcb6456c8f846311dbb ;
     prov:value "1.68117702007294"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68413622248109"^^xsd:float ;
     nidm_pValueUncorrected: "0.046077672706774"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:9759d63712f31dd71f970ba24fdc02ba
+niiri:ba88244ebec57bcb6456c8f846311dbb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[42,-78,6]"^^xsd:string .
 
-niiri:9607bb62ecc6289f2476a8bb82c2c966 prov:wasDerivedFrom niiri:146e852a595d2bd9bf43b63cb1ffe554 .
+niiri:9a6229796a5042d2de9c8d840d333151 prov:wasDerivedFrom niiri:11fe90c3ae56c74edb8f27b7b4d64c01 .
 
-niiri:5aac45256e13cd03a2a1e390f5df998d
+niiri:54b18d3082b4cad596142f7ef9736d8a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:7b8ba463b7a085d4623751d494579f21 ;
+    prov:atLocation niiri:d6201606a3ba435a6e09c9caf89150df ;
     prov:value "1.67713749408722"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68025745484094"^^xsd:float ;
     nidm_pValueUncorrected: "0.0464536174884935"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:7b8ba463b7a085d4623751d494579f21
+niiri:d6201606a3ba435a6e09c9caf89150df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-12,26,36]"^^xsd:string .
 
-niiri:5aac45256e13cd03a2a1e390f5df998d prov:wasDerivedFrom niiri:c76d475fb44856dbc3b3660c08027d10 .
+niiri:54b18d3082b4cad596142f7ef9736d8a prov:wasDerivedFrom niiri:d17fffe11eaba3b9e149fce8bdc2b9da .
 
-niiri:aa7acc61eb0d336d8adfd1c279535ef0
+niiri:8197741d55030f4c7e2a1d984b7bf1bc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:f60e25b0c2abc9fe4d73f5854c0adbee ;
+    prov:atLocation niiri:7d3b2943cac3fe81f3de71425355d797 ;
     prov:value "1.67311263084412"^^xsd:float ;
     nidm_equivalentZStatistic: "1.6763935381234"^^xsd:float ;
     nidm_pValueUncorrected: "0.0468305669041873"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:f60e25b0c2abc9fe4d73f5854c0adbee
+niiri:7d3b2943cac3fe81f3de71425355d797
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[12,-94,-32]"^^xsd:string .
 
-niiri:aa7acc61eb0d336d8adfd1c279535ef0 prov:wasDerivedFrom niiri:171a3293a830389fbc0eeedac10ab2ef .
+niiri:8197741d55030f4c7e2a1d984b7bf1bc prov:wasDerivedFrom niiri:a97b8d1eb95bad3103d70c3a170b35e6 .
 
-niiri:309b2780bdf657c8f0c7a6410916169c
+niiri:d119a32be5090208facc1946a3d5fa33
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:967f245c1c386892dbecddea40037b53 ;
+    prov:atLocation niiri:2925ce3db3c2888712ca8f3f3d1f1619 ;
     prov:value "1.67067694664001"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67405562956399"^^xsd:float ;
     nidm_pValueUncorrected: "0.0470598334324596"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:967f245c1c386892dbecddea40037b53
+niiri:2925ce3db3c2888712ca8f3f3d1f1619
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[24,-92,-30]"^^xsd:string .
 
-niiri:309b2780bdf657c8f0c7a6410916169c prov:wasDerivedFrom niiri:230b132218201af072b76732d6cd366e .
+niiri:d119a32be5090208facc1946a3d5fa33 prov:wasDerivedFrom niiri:34de4bc8669d7effba126acecd7e71ca .
 
-niiri:ed3607586490b22746adf59129afa310
+niiri:81ad744134f8137223e00d7f8e9efb1d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:fddb34281430a5ac7649b34b53b04c89 ;
+    prov:atLocation niiri:576bfeaced7698758e2dcea95224fe2a ;
     prov:value "1.66812241077423"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67160394831323"^^xsd:float ;
     nidm_pValueUncorrected: "0.0473012228473357"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:fddb34281430a5ac7649b34b53b04c89
+niiri:576bfeaced7698758e2dcea95224fe2a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-24,22,22]"^^xsd:string .
 
-niiri:ed3607586490b22746adf59129afa310 prov:wasDerivedFrom niiri:88b6854434c4c7d7d77b89858ff66d15 .
+niiri:81ad744134f8137223e00d7f8e9efb1d prov:wasDerivedFrom niiri:34640314cb90b81bff8b479f4c75ae6f .
 
-niiri:cb35f3207972df7107e6d2aea1bfbde2
+niiri:fffda3a756d7aadecaf95c9b79ca9f9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:36ff55a8118b6b1b3e001a7636293a8f ;
+    prov:atLocation niiri:ef0fc7140e631601df1c9ed09b66ef7f ;
     prov:value "1.66770362854004"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67120205793481"^^xsd:float ;
     nidm_pValueUncorrected: "0.0473408869609759"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:36ff55a8118b6b1b3e001a7636293a8f
+niiri:ef0fc7140e631601df1c9ed09b66ef7f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[26,-90,22]"^^xsd:string .
 
-niiri:cb35f3207972df7107e6d2aea1bfbde2 prov:wasDerivedFrom niiri:983ff16f46a1aa2fb13613f2c2f88011 .
+niiri:fffda3a756d7aadecaf95c9b79ca9f9d prov:wasDerivedFrom niiri:79c1b8c3935c1efdd0d31d231222a6e3 .
 
-niiri:9545b4314633cb0868f593c5d38febb7
+niiri:ff04f5c6feedf70958adb3464fd72d76
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:9803db31221b2c078fe55c084d5d83ed ;
+    prov:atLocation niiri:9eabe9da21cf05a8ae9ca9e3b467bcea ;
     prov:value "1.66512632369995"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66872889854066"^^xsd:float ;
     nidm_pValueUncorrected: "0.0475855596349387"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:9803db31221b2c078fe55c084d5d83ed
+niiri:9eabe9da21cf05a8ae9ca9e3b467bcea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[32,-60,-2]"^^xsd:string .
 
-niiri:9545b4314633cb0868f593c5d38febb7 prov:wasDerivedFrom niiri:a6327d343c9ff6cf00c6cbe83308072b .
+niiri:ff04f5c6feedf70958adb3464fd72d76 prov:wasDerivedFrom niiri:1171e027eba41be4b53953810af155f9 .
 
-niiri:02317feaa78e69f7d7f9737af5644214
+niiri:498867695b58631e8cf68e8990cdf642
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:5d4415f1293150147830ba8d2fe89e88 ;
+    prov:atLocation niiri:23a47d1f73da07fee4779591d3a6aa53 ;
     prov:value "1.6600536108017"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66386211897632"^^xsd:float ;
     nidm_pValueUncorrected: "0.0480699933329287"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:5d4415f1293150147830ba8d2fe89e88
+niiri:23a47d1f73da07fee4779591d3a6aa53
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-44,-56,-32]"^^xsd:string .
 
-niiri:02317feaa78e69f7d7f9737af5644214 prov:wasDerivedFrom niiri:92ac4a8cb0a6c243ecb32fc66fd3deab .
+niiri:498867695b58631e8cf68e8990cdf642 prov:wasDerivedFrom niiri:54a8bffd20ef66a79cc779bd8e630f0f .
 

--- a/spmexport/ex_spm_conjunction/nidm.ttl
+++ b/spmexport/ex_spm_conjunction/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:cffd7ffff967c97f168edddb606cca3c
+niiri:0f83f9bf10402721cd1f28d1c65e3f71
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:6fca6103f9b3748f1135346eed723b1e
+niiri:eeba9c732c26ca897cc0d1f656c3b236
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:08e852b60d68cd3f03fbb91135fc698a
+niiri:d55d1dd1d9d6736496f4293e6106b164
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:08e852b60d68cd3f03fbb91135fc698a prov:wasAssociatedWith niiri:6fca6103f9b3748f1135346eed723b1e .
+niiri:d55d1dd1d9d6736496f4293e6106b164 prov:wasAssociatedWith niiri:eeba9c732c26ca897cc0d1f656c3b236 .
 
 _:blank5 a prov:Generation .
 
-niiri:cffd7ffff967c97f168edddb606cca3c prov:qualifiedGeneration _:blank5 .
+niiri:0f83f9bf10402721cd1f28d1c65e3f71 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:33:19"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:43:39"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -136,12 +136,12 @@ _:blank5 prov:atTime "2016-01-11T10:33:19"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:8d702deb7794ff140970aa83183f0cd7
+niiri:cb9ec8de70f8a46b05f9b00f1883e6e0
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:13472aa35bbca29434f4e7a96e64854b
+niiri:a20719c557449bd5bf360e90b505fb48
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -151,35 +151,35 @@ niiri:13472aa35bbca29434f4e7a96e64854b
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:b8bc1fafeb07d65d7429038c792c1fff
+niiri:412dc80f675b09e5e6c9352c510f1f89
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:c75a5447273e9c598f256e39304eded4
+niiri:a0e266509c65e3246b4c851021598aff
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:c7f99aa282bcb84887dac079b6e639e3
+niiri:10f301ea7889fbb6a952cababcce34fe
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:e68886708e4b26ae6e709f5fa4808690 ;
+    dc:description niiri:7d64806fe60b51292c19828deba7d11f ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:c75a5447273e9c598f256e39304eded4 ;
+    nidm_hasDriftModel: niiri:a0e266509c65e3246b4c851021598aff ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:e68886708e4b26ae6e709f5fa4808690
+niiri:7d64806fe60b51292c19828deba7d11f
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:937d29c8162661dc3675b67810a67ae3
+niiri:761acb19ce110d3cf37c18c19f80d83e
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -187,213 +187,213 @@ niiri:937d29c8162661dc3675b67810a67ae3
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:9b702b46c5dd95ed19b8b5140da841d6
+niiri:471ca2377b5aa5d10b4545192e237109
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:9b702b46c5dd95ed19b8b5140da841d6 prov:wasAssociatedWith niiri:8d702deb7794ff140970aa83183f0cd7 .
+niiri:471ca2377b5aa5d10b4545192e237109 prov:wasAssociatedWith niiri:cb9ec8de70f8a46b05f9b00f1883e6e0 .
 
-niiri:9b702b46c5dd95ed19b8b5140da841d6 prov:used niiri:c7f99aa282bcb84887dac079b6e639e3 .
+niiri:471ca2377b5aa5d10b4545192e237109 prov:used niiri:10f301ea7889fbb6a952cababcce34fe .
 
-niiri:9b702b46c5dd95ed19b8b5140da841d6 prov:used niiri:b8bc1fafeb07d65d7429038c792c1fff .
+niiri:471ca2377b5aa5d10b4545192e237109 prov:used niiri:412dc80f675b09e5e6c9352c510f1f89 .
 
-niiri:9b702b46c5dd95ed19b8b5140da841d6 prov:used niiri:937d29c8162661dc3675b67810a67ae3 .
+niiri:471ca2377b5aa5d10b4545192e237109 prov:used niiri:761acb19ce110d3cf37c18c19f80d83e .
 
-niiri:8b400bad67e910ddcd25ffed64d4900a
+niiri:efba4501de55e8526336b6836a6ae200
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:705430105fed94e345e5a467681058e2
+niiri:18970d89e1bbabdc87e35704e6f635b0
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
 
-niiri:8b400bad67e910ddcd25ffed64d4900a prov:wasDerivedFrom niiri:705430105fed94e345e5a467681058e2 .
+niiri:efba4501de55e8526336b6836a6ae200 prov:wasDerivedFrom niiri:18970d89e1bbabdc87e35704e6f635b0 .
 
-niiri:8b400bad67e910ddcd25ffed64d4900a prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:efba4501de55e8526336b6836a6ae200 prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:9dd086507743fe730b7d24b70cf7ed3a
+niiri:77d010fab23851bd6028211d704252eb
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "108.038318634033"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
 
-niiri:9dd086507743fe730b7d24b70cf7ed3a prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:77d010fab23851bd6028211d704252eb prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:d70991e4ec5c9a6234d6391c2a0dbdb0
+niiri:3683ca493bbee171d03b3ef585672d79
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 .
 
-niiri:406110ec41e71d7260a38848d82dfc7f
+niiri:c39d23eb52261f4deee536da546c13f3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f"^^xsd:string .
 
-niiri:d70991e4ec5c9a6234d6391c2a0dbdb0 prov:wasDerivedFrom niiri:406110ec41e71d7260a38848d82dfc7f .
+niiri:3683ca493bbee171d03b3ef585672d79 prov:wasDerivedFrom niiri:c39d23eb52261f4deee536da546c13f3 .
 
-niiri:d70991e4ec5c9a6234d6391c2a0dbdb0 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:3683ca493bbee171d03b3ef585672d79 prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:32d8ca8f9ba66fe36d7b9eae3f419596
+niiri:eb368d3d6647d9a31aacf5f9b11ecfe6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 .
 
-niiri:e83351acdbbde0ef0a33cf50fbc3990f
+niiri:7d50efe9f235518078d0b9014b5a58db
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
 
-niiri:32d8ca8f9ba66fe36d7b9eae3f419596 prov:wasDerivedFrom niiri:e83351acdbbde0ef0a33cf50fbc3990f .
+niiri:eb368d3d6647d9a31aacf5f9b11ecfe6 prov:wasDerivedFrom niiri:7d50efe9f235518078d0b9014b5a58db .
 
-niiri:32d8ca8f9ba66fe36d7b9eae3f419596 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:eb368d3d6647d9a31aacf5f9b11ecfe6 prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:5cdc01b7d93b811fc7e1114f880e74d3
+niiri:ff5a99a88137732fdd67c267f5b782fb
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 .
 
-niiri:3397f8fdb55baa2ce4ca23110660f606
+niiri:3e034235342c659548ea19f21365ac98
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb"^^xsd:string .
 
-niiri:5cdc01b7d93b811fc7e1114f880e74d3 prov:wasDerivedFrom niiri:3397f8fdb55baa2ce4ca23110660f606 .
+niiri:ff5a99a88137732fdd67c267f5b782fb prov:wasDerivedFrom niiri:3e034235342c659548ea19f21365ac98 .
 
-niiri:5cdc01b7d93b811fc7e1114f880e74d3 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:ff5a99a88137732fdd67c267f5b782fb prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:48ca995ae7b89bd0222a3d1652dc6d81
+niiri:8ee5de50f97ce036bd5874d973aff645
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 .
 
-niiri:0182339ddbc9fc0f31bf47a8695e88ac
+niiri:2dc09730618833b7076c46d997ed617e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6"^^xsd:string .
 
-niiri:48ca995ae7b89bd0222a3d1652dc6d81 prov:wasDerivedFrom niiri:0182339ddbc9fc0f31bf47a8695e88ac .
+niiri:8ee5de50f97ce036bd5874d973aff645 prov:wasDerivedFrom niiri:2dc09730618833b7076c46d997ed617e .
 
-niiri:48ca995ae7b89bd0222a3d1652dc6d81 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:8ee5de50f97ce036bd5874d973aff645 prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:d00e71a2693f38940a6abe5fe0a27e14
+niiri:0c5942394b91a9b1655999404665d3ae
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 .
 
-niiri:6051fccc3fa5e6b6878fdcfe17232d70
+niiri:1e18c988fe1ef58a2d490ab8c8eb098e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff"^^xsd:string .
 
-niiri:d00e71a2693f38940a6abe5fe0a27e14 prov:wasDerivedFrom niiri:6051fccc3fa5e6b6878fdcfe17232d70 .
+niiri:0c5942394b91a9b1655999404665d3ae prov:wasDerivedFrom niiri:1e18c988fe1ef58a2d490ab8c8eb098e .
 
-niiri:d00e71a2693f38940a6abe5fe0a27e14 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:0c5942394b91a9b1655999404665d3ae prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:05115890f603e4e9e4e1a672eb3683b5
+niiri:c85b48521a1b46a36a19262e86027bf8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 6" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b .
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 .
 
-niiri:699a8d86d7db0ddab1d01e042dc3ae4f
+niiri:3deaac4dcf0815f7391f7527ee76d664
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
 
-niiri:05115890f603e4e9e4e1a672eb3683b5 prov:wasDerivedFrom niiri:699a8d86d7db0ddab1d01e042dc3ae4f .
+niiri:c85b48521a1b46a36a19262e86027bf8 prov:wasDerivedFrom niiri:3deaac4dcf0815f7391f7527ee76d664 .
 
-niiri:05115890f603e4e9e4e1a672eb3683b5 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:c85b48521a1b46a36a19262e86027bf8 prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:b60ee6cea0e97b11abbbfad263cb8893
+niiri:ee077cef30635017426e07dc1b836810
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8"^^xsd:string .
 
-niiri:03ebca4bd2e13ea96ce505ab726aaa82
+niiri:0b55d977fad609b4df4bd812336f1688
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81"^^xsd:string .
 
-niiri:b60ee6cea0e97b11abbbfad263cb8893 prov:wasDerivedFrom niiri:03ebca4bd2e13ea96ce505ab726aaa82 .
+niiri:ee077cef30635017426e07dc1b836810 prov:wasDerivedFrom niiri:0b55d977fad609b4df4bd812336f1688 .
 
-niiri:b60ee6cea0e97b11abbbfad263cb8893 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:ee077cef30635017426e07dc1b836810 prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:7e51e600d6dbaf94e50bb1c27b2e2a06
+niiri:cf667e831a88369697952d416decc6d4
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8"^^xsd:string .
 
-niiri:b1cfa368972409a292f285346c36c011
+niiri:8af3c223fce9ad0e0d14bb8852e619e4
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29"^^xsd:string .
 
-niiri:7e51e600d6dbaf94e50bb1c27b2e2a06 prov:wasDerivedFrom niiri:b1cfa368972409a292f285346c36c011 .
+niiri:cf667e831a88369697952d416decc6d4 prov:wasDerivedFrom niiri:8af3c223fce9ad0e0d14bb8852e619e4 .
 
-niiri:7e51e600d6dbaf94e50bb1c27b2e2a06 prov:wasGeneratedBy niiri:9b702b46c5dd95ed19b8b5140da841d6 .
+niiri:cf667e831a88369697952d416decc6d4 prov:wasGeneratedBy niiri:471ca2377b5aa5d10b4545192e237109 .
 
-niiri:75efb902a39cf1021609db5de272351c
+niiri:8338f1fe29b4713b0cf3f9a7508ca58c
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     rdfs:label "Contrast: mr vs plain" ;
     prov:value "[1, 1, -1, -1, 0, 0]"^^xsd:string .
 
-niiri:a08187124a8a759239103ba1a7917d6c
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 1" .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:wasAssociatedWith niiri:8d702deb7794ff140970aa83183f0cd7 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:wasAssociatedWith niiri:cb9ec8de70f8a46b05f9b00f1883e6e0 .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:8b400bad67e910ddcd25ffed64d4900a .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:efba4501de55e8526336b6836a6ae200 .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:b60ee6cea0e97b11abbbfad263cb8893 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:ee077cef30635017426e07dc1b836810 .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:c7f99aa282bcb84887dac079b6e639e3 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:10f301ea7889fbb6a952cababcce34fe .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:75efb902a39cf1021609db5de272351c .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:8338f1fe29b4713b0cf3f9a7508ca58c .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:d70991e4ec5c9a6234d6391c2a0dbdb0 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:3683ca493bbee171d03b3ef585672d79 .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:32d8ca8f9ba66fe36d7b9eae3f419596 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:eb368d3d6647d9a31aacf5f9b11ecfe6 .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:5cdc01b7d93b811fc7e1114f880e74d3 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:ff5a99a88137732fdd67c267f5b782fb .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:48ca995ae7b89bd0222a3d1652dc6d81 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:8ee5de50f97ce036bd5874d973aff645 .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:d00e71a2693f38940a6abe5fe0a27e14 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:0c5942394b91a9b1655999404665d3ae .
 
-niiri:a08187124a8a759239103ba1a7917d6c prov:used niiri:05115890f603e4e9e4e1a672eb3683b5 .
+niiri:74edcbe57f1ceaf17e08a718e8ad82f4 prov:used niiri:c85b48521a1b46a36a19262e86027bf8 .
 
-niiri:6c08012b8665ffafe1d80de0f06b0deb
+niiri:0081f7c080166e5d3d8565a0c11e236a
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0001.nii.gz"^^xsd:string ;
@@ -403,84 +403,84 @@ niiri:6c08012b8665ffafe1d80de0f06b0deb
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "aba2fef7900cacda1ed84fe5edf867bd2b0fc6ae7eb4919967798d7f219a6d8ad5454fe8e0bdf4a7cfa6402e73287e703c285d12df0a282e40438ec36153e715"^^xsd:string .
 
-niiri:0aabcd9c646fada4d1e8380aa19581c0
+niiri:949b74649bd08c95a9f824ac1678464d
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782"^^xsd:string .
 
-niiri:6c08012b8665ffafe1d80de0f06b0deb prov:wasDerivedFrom niiri:0aabcd9c646fada4d1e8380aa19581c0 .
+niiri:0081f7c080166e5d3d8565a0c11e236a prov:wasDerivedFrom niiri:949b74649bd08c95a9f824ac1678464d .
 
-niiri:6c08012b8665ffafe1d80de0f06b0deb prov:wasGeneratedBy niiri:a08187124a8a759239103ba1a7917d6c .
+niiri:0081f7c080166e5d3d8565a0c11e236a prov:wasGeneratedBy niiri:74edcbe57f1ceaf17e08a718e8ad82f4 .
 
-niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3
+niiri:26bf2d06873dd8d79c8b746890887ca8
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: mr vs plain" ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5"^^xsd:string .
 
-niiri:7bcc38cb25e8a636c411c67b7c86b4af
+niiri:63d374d0241354bf1ed97477cea42858
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28"^^xsd:string .
 
-niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3 prov:wasDerivedFrom niiri:7bcc38cb25e8a636c411c67b7c86b4af .
+niiri:26bf2d06873dd8d79c8b746890887ca8 prov:wasDerivedFrom niiri:63d374d0241354bf1ed97477cea42858 .
 
-niiri:be4ccc14a00ecbb1dd78a86bd4c15fd3 prov:wasGeneratedBy niiri:a08187124a8a759239103ba1a7917d6c .
+niiri:26bf2d06873dd8d79c8b746890887ca8 prov:wasGeneratedBy niiri:74edcbe57f1ceaf17e08a718e8ad82f4 .
 
-niiri:ea53b05d76e1a79956319d8ef8524624
+niiri:3c0366159408b6e12cad21bbe49be06a
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b"^^xsd:string .
 
-niiri:ea53b05d76e1a79956319d8ef8524624 prov:wasGeneratedBy niiri:a08187124a8a759239103ba1a7917d6c .
+niiri:3c0366159408b6e12cad21bbe49be06a prov:wasGeneratedBy niiri:74edcbe57f1ceaf17e08a718e8ad82f4 .
 
-niiri:25693c09a24b28e659ccec8659964759
+niiri:a1cccf791324c5aa54ce4418b889d599
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
     rdfs:label "Contrast: switch vs nonswitch" ;
     prov:value "[1, -1, 1, -1, 0, 0]"^^xsd:string .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 2" .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:wasAssociatedWith niiri:8d702deb7794ff140970aa83183f0cd7 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:wasAssociatedWith niiri:cb9ec8de70f8a46b05f9b00f1883e6e0 .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:8b400bad67e910ddcd25ffed64d4900a .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:efba4501de55e8526336b6836a6ae200 .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:b60ee6cea0e97b11abbbfad263cb8893 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:ee077cef30635017426e07dc1b836810 .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:c7f99aa282bcb84887dac079b6e639e3 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:10f301ea7889fbb6a952cababcce34fe .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:25693c09a24b28e659ccec8659964759 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:a1cccf791324c5aa54ce4418b889d599 .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:d70991e4ec5c9a6234d6391c2a0dbdb0 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:3683ca493bbee171d03b3ef585672d79 .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:32d8ca8f9ba66fe36d7b9eae3f419596 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:eb368d3d6647d9a31aacf5f9b11ecfe6 .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:5cdc01b7d93b811fc7e1114f880e74d3 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:ff5a99a88137732fdd67c267f5b782fb .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:48ca995ae7b89bd0222a3d1652dc6d81 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:8ee5de50f97ce036bd5874d973aff645 .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:d00e71a2693f38940a6abe5fe0a27e14 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:0c5942394b91a9b1655999404665d3ae .
 
-niiri:8f29f58ca8f23c2abe4da18512df00f0 prov:used niiri:05115890f603e4e9e4e1a672eb3683b5 .
+niiri:c8ee0e32dfe6dfe48e13949337f73f3e prov:used niiri:c85b48521a1b46a36a19262e86027bf8 .
 
-niiri:ed5e976f74b812d550d5f16796c155fc
+niiri:ac4c58fb7bd0dd7beff85fc9a96e4533
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0002.nii.gz"^^xsd:string ;
@@ -490,125 +490,125 @@ niiri:ed5e976f74b812d550d5f16796c155fc
     nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "1c375cdc8f2b00f93f3d6f1a09aafa5670d35ffcf2c82ef061151bfb047463e482e971d67ce3e3e2496f37b1621f5d732a0a1f88c773f5d5fa077cb6a3e38501"^^xsd:string .
 
-niiri:93258b59372b373e6266047487de0072
+niiri:9ab90a28f7edbe61d65f190105744ee8
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "313c8e34e107b1e9bec46074e7a1cef289427618869119eff1c8044a2b5b8e5a340c899a78f40a3f8b938dbbbde53bd16c096da55f2e07a7c9e334cfd1e471f2"^^xsd:string .
 
-niiri:ed5e976f74b812d550d5f16796c155fc prov:wasDerivedFrom niiri:93258b59372b373e6266047487de0072 .
+niiri:ac4c58fb7bd0dd7beff85fc9a96e4533 prov:wasDerivedFrom niiri:9ab90a28f7edbe61d65f190105744ee8 .
 
-niiri:ed5e976f74b812d550d5f16796c155fc prov:wasGeneratedBy niiri:8f29f58ca8f23c2abe4da18512df00f0 .
+niiri:ac4c58fb7bd0dd7beff85fc9a96e4533 prov:wasGeneratedBy niiri:c8ee0e32dfe6dfe48e13949337f73f3e .
 
-niiri:05f1c1dcd9cada95daa2b92b3aae94eb
+niiri:9e9f6a19fc0f4208a6a335f309d1862a
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: switch vs nonswitch" ;
     nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "77720bd21fb296db2e69c9742318c52f7cf6b08f94a83c5c1e30d5b8b21b1fd218de32fcc3a96aa2d067d5b06015e85e863ab87907741d2d7c9993740f668dc2"^^xsd:string .
 
-niiri:9b02ce638a46ac45c6d4d3fd693e255f
+niiri:cf0dd4590780a8c7970131949a2b4500
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "6983d8888c458d8a073f84054db2587b0a71764e64c30ea7e4a13cd0e6b2e301eaea1b570822b24b635b464fd233c3801a9205ddcd2dcffcda7cd99679d2734a"^^xsd:string .
 
-niiri:05f1c1dcd9cada95daa2b92b3aae94eb prov:wasDerivedFrom niiri:9b02ce638a46ac45c6d4d3fd693e255f .
+niiri:9e9f6a19fc0f4208a6a335f309d1862a prov:wasDerivedFrom niiri:cf0dd4590780a8c7970131949a2b4500 .
 
-niiri:05f1c1dcd9cada95daa2b92b3aae94eb prov:wasGeneratedBy niiri:8f29f58ca8f23c2abe4da18512df00f0 .
+niiri:9e9f6a19fc0f4208a6a335f309d1862a prov:wasGeneratedBy niiri:c8ee0e32dfe6dfe48e13949337f73f3e .
 
-niiri:8576d98d89e7380306ae7a7b2bfa7f6e
+niiri:9136706f694cea9ffa8b9c0b0de1f597
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "1bb21447dcf3cc1eeb9453c707178e4d87161242c69e18795e0e2b30496c9e657ed2f202d4c9cd364aea5a04e4e46fe70ca830e1db14dd2e0f20af754281c3f2"^^xsd:string .
 
-niiri:8576d98d89e7380306ae7a7b2bfa7f6e prov:wasGeneratedBy niiri:8f29f58ca8f23c2abe4da18512df00f0 .
+niiri:9136706f694cea9ffa8b9c0b0de1f597 prov:wasGeneratedBy niiri:c8ee0e32dfe6dfe48e13949337f73f3e .
 
-niiri:c92560dc79ef7986810602e2fa8cc698
+niiri:60123493cb33f88b9a3327ad2a637b87
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.048771 (unc.)" ;
     prov:value "0.0487705952532708"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:f7e7ca44a8f41bda88372604c4fbbb68 ;
-    nidm_equivalentThreshold: niiri:9b07472e1eaca0cce525f30fb31c894c .
+    nidm_equivalentThreshold: niiri:638a4732421302a54cf0be9a27369150 ;
+    nidm_equivalentThreshold: niiri:ed853489f8fdf815fc5ed7496ddd241b .
 
-niiri:f7e7ca44a8f41bda88372604c4fbbb68
+niiri:638a4732421302a54cf0be9a27369150
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "1.65278686445912"^^xsd:float .
 
-niiri:9b07472e1eaca0cce525f30fb31c894c
+niiri:ed853489f8fdf815fc5ed7496ddd241b
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:5e669b6d10f715c60759eb817713a4a2
+niiri:b804be5b39ce5630087cb019f1156946
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:b39d449d635c93f3ffe4f11fdc273353 ;
-    nidm_equivalentThreshold: niiri:a369532528403ad4850204e071f04758 .
+    nidm_equivalentThreshold: niiri:65bb020863c05b303995c32c462aadcf ;
+    nidm_equivalentThreshold: niiri:b4cf11c506c0a8d87ff7e68091e492a2 .
 
-niiri:b39d449d635c93f3ffe4f11fdc273353
+niiri:65bb020863c05b303995c32c462aadcf
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:a369532528403ad4850204e071f04758
+niiri:b4cf11c506c0a8d87ff7e68091e492a2
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:d71d80f794ac0f7a94273b376d163e89
+niiri:c0adc769180c2b6c732944a463ad0a30
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:b8086c9fb20252dc9ec4a7fa41470165
+niiri:a8f1c26c551ab0ecca69d1dba8fc240c
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e
+niiri:1ef65de2c8af67e889eb1a5edb6ded01
     a prov:Activity, nidm_ConjunctionInference: ; 
     rdfs:label "Conjunction Inference" .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:wasAssociatedWith niiri:8d702deb7794ff140970aa83183f0cd7 .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:wasAssociatedWith niiri:cb9ec8de70f8a46b05f9b00f1883e6e0 .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:c92560dc79ef7986810602e2fa8cc698 .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:used niiri:60123493cb33f88b9a3327ad2a637b87 .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:5e669b6d10f715c60759eb817713a4a2 .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:used niiri:b804be5b39ce5630087cb019f1156946 .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:6c08012b8665ffafe1d80de0f06b0deb .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:used niiri:0081f7c080166e5d3d8565a0c11e236a .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:ed5e976f74b812d550d5f16796c155fc .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:used niiri:ac4c58fb7bd0dd7beff85fc9a96e4533 .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:7e51e600d6dbaf94e50bb1c27b2e2a06 .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:used niiri:cf667e831a88369697952d416decc6d4 .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:8b400bad67e910ddcd25ffed64d4900a .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:used niiri:efba4501de55e8526336b6836a6ae200 .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:d71d80f794ac0f7a94273b376d163e89 .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:used niiri:c0adc769180c2b6c732944a463ad0a30 .
 
-niiri:047da8bd1155d93bb9e94d1cb47f6f2e prov:used niiri:b8086c9fb20252dc9ec4a7fa41470165 .
+niiri:1ef65de2c8af67e889eb1a5edb6ded01 prov:used niiri:a8f1c26c551ab0ecca69d1dba8fc240c .
 
-niiri:af86aeaa13e45fe4af977676f9dbb2d6
+niiri:b308d4f0fa9f576ab8a01377b15c5772
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
     nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.4409986586553"^^xsd:float ;
@@ -625,9 +625,9 @@ niiri:af86aeaa13e45fe4af977676f9dbb2d6
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:af86aeaa13e45fe4af977676f9dbb2d6 prov:wasGeneratedBy niiri:047da8bd1155d93bb9e94d1cb47f6f2e .
+niiri:b308d4f0fa9f576ab8a01377b15c5772 prov:wasGeneratedBy niiri:1ef65de2c8af67e889eb1a5edb6ded01 .
 
-niiri:2561c31d8316e8b6110351c09d382626
+niiri:92e947f394c2f3c0510a6df10b8b47fe
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -635,26 +635,26 @@ niiri:2561c31d8316e8b6110351c09d382626
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "30"^^xsd:int ;
     nidm_pValue: "1"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:555b51c020185cf7d98d6cae3d6dd6b7 ;
-    nidm_hasMaximumIntensityProjection: niiri:72e33120e4a0cf389b3663a56945e615 ;
-    nidm_inCoordinateSpace: niiri:13472aa35bbca29434f4e7a96e64854b ;
+    nidm_hasClusterLabelsMap: niiri:7d8fcdb4306ccb182826202d0a4b9853 ;
+    nidm_hasMaximumIntensityProjection: niiri:c901604c3768f064cc5d70178aa81394 ;
+    nidm_inCoordinateSpace: niiri:a20719c557449bd5bf360e90b505fb48 ;
     crypto:sha512 "bcf45ac744752d54a29a2b918eda586a0e6637179a62a2eef62afd03f594bb4bdb4d2171625040d21c22a02d3a13fd0312ce1b83f6a6aecf34c432299e21c864"^^xsd:string .
 
-niiri:555b51c020185cf7d98d6cae3d6dd6b7
+niiri:7d8fcdb4306ccb182826202d0a4b9853
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:72e33120e4a0cf389b3663a56945e615
+niiri:c901604c3768f064cc5d70178aa81394
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:2561c31d8316e8b6110351c09d382626 prov:wasGeneratedBy niiri:047da8bd1155d93bb9e94d1cb47f6f2e .
+niiri:92e947f394c2f3c0510a6df10b8b47fe prov:wasGeneratedBy niiri:1ef65de2c8af67e889eb1a5edb6ded01 .
 
-niiri:8d1a8ab2f5e6753052e300d592e3d511
+niiri:d0ef6f3ab84b7a20a23c8ec80505c8cc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "95"^^xsd:int ;
@@ -664,9 +664,9 @@ niiri:8d1a8ab2f5e6753052e300d592e3d511
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:8d1a8ab2f5e6753052e300d592e3d511 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:d0ef6f3ab84b7a20a23c8ec80505c8cc prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:5a1ad49de526d8a54452b31baf96a75d
+niiri:73637205faaca2b93f30cf26719da2b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -676,9 +676,9 @@ niiri:5a1ad49de526d8a54452b31baf96a75d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:5a1ad49de526d8a54452b31baf96a75d prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:73637205faaca2b93f30cf26719da2b3 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:c00f026631fe0b6f988efa4d30db781f
+niiri:49cbd2656968943cca2fb0ddde2c880a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -688,9 +688,9 @@ niiri:c00f026631fe0b6f988efa4d30db781f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:c00f026631fe0b6f988efa4d30db781f prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:49cbd2656968943cca2fb0ddde2c880a prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:b712b8f6d2df400be64fe19b957abb10
+niiri:686c4840892e9778876349ccd6236841
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -700,9 +700,9 @@ niiri:b712b8f6d2df400be64fe19b957abb10
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:b712b8f6d2df400be64fe19b957abb10 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:686c4840892e9778876349ccd6236841 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:f66d2da458d706e0d1c123fd3dc589c7
+niiri:2e2b55b222631d083aed83513341f4bf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -712,9 +712,9 @@ niiri:f66d2da458d706e0d1c123fd3dc589c7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:f66d2da458d706e0d1c123fd3dc589c7 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:2e2b55b222631d083aed83513341f4bf prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:70a3e9df88095bfe99637dabf4110acd
+niiri:a8bfd334e76be268255831f5a8092aee
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -724,9 +724,9 @@ niiri:70a3e9df88095bfe99637dabf4110acd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:70a3e9df88095bfe99637dabf4110acd prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:a8bfd334e76be268255831f5a8092aee prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:027812928b4d9dc645c81857d81e13ca
+niiri:fe4c4fd75ebef375c6e3c2cff33277a4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -736,9 +736,9 @@ niiri:027812928b4d9dc645c81857d81e13ca
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:027812928b4d9dc645c81857d81e13ca prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:fe4c4fd75ebef375c6e3c2cff33277a4 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:fec8e2c65ce7d1cf6e18804683d824ca
+niiri:5bae05b5a604a8c03d7992ce19d15723
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -748,9 +748,9 @@ niiri:fec8e2c65ce7d1cf6e18804683d824ca
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:fec8e2c65ce7d1cf6e18804683d824ca prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:5bae05b5a604a8c03d7992ce19d15723 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:c9f251722e6a9f1501e325fdf2f516f3
+niiri:ec6a8c27bdfd0dc1de40b1f7c9c1ca61
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -760,9 +760,9 @@ niiri:c9f251722e6a9f1501e325fdf2f516f3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:c9f251722e6a9f1501e325fdf2f516f3 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:ec6a8c27bdfd0dc1de40b1f7c9c1ca61 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:ac00f4348e517214c5428caad74cc6dc
+niiri:f5e21a9b1b5fbfef7061a46469d52a7a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -772,9 +772,9 @@ niiri:ac00f4348e517214c5428caad74cc6dc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:ac00f4348e517214c5428caad74cc6dc prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:f5e21a9b1b5fbfef7061a46469d52a7a prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:8050ff9b05fe42d3b13b693c3d4dfc3c
+niiri:4dd108385a724afeea8f83f29506f956
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -784,9 +784,9 @@ niiri:8050ff9b05fe42d3b13b693c3d4dfc3c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:8050ff9b05fe42d3b13b693c3d4dfc3c prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:4dd108385a724afeea8f83f29506f956 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:d1592c70ca4448ee46f3c8df3c20043c
+niiri:22e2be3780622fb9d23b8f1c07f56968
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -796,9 +796,9 @@ niiri:d1592c70ca4448ee46f3c8df3c20043c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:d1592c70ca4448ee46f3c8df3c20043c prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:22e2be3780622fb9d23b8f1c07f56968 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:5828f74c2c43b3883378f9cd1e63925b
+niiri:ad5ca42e9fcec5d33eda403de4d6999b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -808,9 +808,9 @@ niiri:5828f74c2c43b3883378f9cd1e63925b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:5828f74c2c43b3883378f9cd1e63925b prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:ad5ca42e9fcec5d33eda403de4d6999b prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:5922affac179cd07256e72fbcf8a2c8a
+niiri:59b84888054fd89394ca79e89db37a1a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -820,9 +820,9 @@ niiri:5922affac179cd07256e72fbcf8a2c8a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:5922affac179cd07256e72fbcf8a2c8a prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:59b84888054fd89394ca79e89db37a1a prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:8481b546970e4cc30b9a0415842a3ea3
+niiri:1adc127c7534eabbebd796b9fd4f9864
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -832,9 +832,9 @@ niiri:8481b546970e4cc30b9a0415842a3ea3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:8481b546970e4cc30b9a0415842a3ea3 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:1adc127c7534eabbebd796b9fd4f9864 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:f4471bd4ad44f0353136ecfba3e12d38
+niiri:e434b384036bdebb84beb66ec3ab0e46
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -844,9 +844,9 @@ niiri:f4471bd4ad44f0353136ecfba3e12d38
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:f4471bd4ad44f0353136ecfba3e12d38 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:e434b384036bdebb84beb66ec3ab0e46 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:7651662ffb846c59d0275b64f39a5a3e
+niiri:2614ceb972cd9fc6b34c52dc1b41a5f5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -856,9 +856,9 @@ niiri:7651662ffb846c59d0275b64f39a5a3e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:7651662ffb846c59d0275b64f39a5a3e prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:2614ceb972cd9fc6b34c52dc1b41a5f5 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:cb4cab1d498471cf714b96e648ba0b84
+niiri:ec3da526be8b471a22bb953dc0be2fa1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -868,9 +868,9 @@ niiri:cb4cab1d498471cf714b96e648ba0b84
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:cb4cab1d498471cf714b96e648ba0b84 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:ec3da526be8b471a22bb953dc0be2fa1 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:b49a13ef4f81cb056a0cf2c1e1e37613
+niiri:5bafbb05bd32dfb4238362ae3eba5d83
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -880,9 +880,9 @@ niiri:b49a13ef4f81cb056a0cf2c1e1e37613
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:b49a13ef4f81cb056a0cf2c1e1e37613 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:5bafbb05bd32dfb4238362ae3eba5d83 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:3bf344699ca63226f8a0986e9e22dc4d
+niiri:6a5bcf79ca8e87d784ab402166cef0c3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -892,9 +892,9 @@ niiri:3bf344699ca63226f8a0986e9e22dc4d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:3bf344699ca63226f8a0986e9e22dc4d prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:6a5bcf79ca8e87d784ab402166cef0c3 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:7a1aa46f25bc46f59f7f644a1d2d768c
+niiri:b0b739a752e19f94dc7e9b7f2e2fd571
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -904,9 +904,9 @@ niiri:7a1aa46f25bc46f59f7f644a1d2d768c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:7a1aa46f25bc46f59f7f644a1d2d768c prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:b0b739a752e19f94dc7e9b7f2e2fd571 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:95103dd9bdac7741d90f99939247bf4e
+niiri:48c59f311f10dc10f49d77de1a4f0b19
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -916,9 +916,9 @@ niiri:95103dd9bdac7741d90f99939247bf4e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:95103dd9bdac7741d90f99939247bf4e prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:48c59f311f10dc10f49d77de1a4f0b19 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:11fe90c3ae56c74edb8f27b7b4d64c01
+niiri:7be9b12db5e680d03919fb39de296487
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -928,9 +928,9 @@ niiri:11fe90c3ae56c74edb8f27b7b4d64c01
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:11fe90c3ae56c74edb8f27b7b4d64c01 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:7be9b12db5e680d03919fb39de296487 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:d17fffe11eaba3b9e149fce8bdc2b9da
+niiri:91f68c6405b3afe515a6b371bde2705b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -940,9 +940,9 @@ niiri:d17fffe11eaba3b9e149fce8bdc2b9da
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:d17fffe11eaba3b9e149fce8bdc2b9da prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:91f68c6405b3afe515a6b371bde2705b prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:a97b8d1eb95bad3103d70c3a170b35e6
+niiri:bc270be21bea419f18154dda040f4b5a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -952,9 +952,9 @@ niiri:a97b8d1eb95bad3103d70c3a170b35e6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:a97b8d1eb95bad3103d70c3a170b35e6 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:bc270be21bea419f18154dda040f4b5a prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:34de4bc8669d7effba126acecd7e71ca
+niiri:a0aa1a732baf12f3b4e5c27b6348115e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -964,9 +964,9 @@ niiri:34de4bc8669d7effba126acecd7e71ca
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:34de4bc8669d7effba126acecd7e71ca prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:a0aa1a732baf12f3b4e5c27b6348115e prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:34640314cb90b81bff8b479f4c75ae6f
+niiri:ac0917bc41fde1dbed179cd897e7c568
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -976,9 +976,9 @@ niiri:34640314cb90b81bff8b479f4c75ae6f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:34640314cb90b81bff8b479f4c75ae6f prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:ac0917bc41fde1dbed179cd897e7c568 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:79c1b8c3935c1efdd0d31d231222a6e3
+niiri:61bb215e601050cd1cdc9f7b9c8847a0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -988,9 +988,9 @@ niiri:79c1b8c3935c1efdd0d31d231222a6e3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:79c1b8c3935c1efdd0d31d231222a6e3 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:61bb215e601050cd1cdc9f7b9c8847a0 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:1171e027eba41be4b53953810af155f9
+niiri:d5aeba7a4d0595b94af060fe6c391161
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1000,9 +1000,9 @@ niiri:1171e027eba41be4b53953810af155f9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:1171e027eba41be4b53953810af155f9 prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:d5aeba7a4d0595b94af060fe6c391161 prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:54a8bffd20ef66a79cc779bd8e630f0f
+niiri:7cc7f4ff997ef1b13f17a0bc068a7e4d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1012,549 +1012,549 @@ niiri:54a8bffd20ef66a79cc779bd8e630f0f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:54a8bffd20ef66a79cc779bd8e630f0f prov:wasDerivedFrom niiri:2561c31d8316e8b6110351c09d382626 .
+niiri:7cc7f4ff997ef1b13f17a0bc068a7e4d prov:wasDerivedFrom niiri:92e947f394c2f3c0510a6df10b8b47fe .
 
-niiri:49979752257c9cdd1a1f63a018b04845
+niiri:88d6372fcd216d65fe2483efb1cab96b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:062dc6f5cf37590aa5348de9d124c531 ;
+    prov:atLocation niiri:b8d86c6b672d58838d802608a6188a5c ;
     prov:value "2.29849815368652"^^xsd:float ;
     nidm_equivalentZStatistic: "2.28220028418391"^^xsd:float ;
     nidm_pValueUncorrected: "0.0112387591680547"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:062dc6f5cf37590aa5348de9d124c531
+niiri:b8d86c6b672d58838d802608a6188a5c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-28,24,4]"^^xsd:string .
 
-niiri:49979752257c9cdd1a1f63a018b04845 prov:wasDerivedFrom niiri:8d1a8ab2f5e6753052e300d592e3d511 .
+niiri:88d6372fcd216d65fe2483efb1cab96b prov:wasDerivedFrom niiri:d0ef6f3ab84b7a20a23c8ec80505c8cc .
 
-niiri:eb0f15f09bbeede75a83373d3a94b783
+niiri:05799e7b9d366ec82513f9cbc958c708
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:9fcee8551b5114a52e472ad1844f220e ;
+    prov:atLocation niiri:854506f4d16d5d4d7ae0c1a6c81136a2 ;
     prov:value "2.07190132141113"^^xsd:float ;
     nidm_equivalentZStatistic: "2.0619285244841"^^xsd:float ;
     nidm_pValueUncorrected: "0.0196072706834085"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:9fcee8551b5114a52e472ad1844f220e
+niiri:854506f4d16d5d4d7ae0c1a6c81136a2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-28,26,12]"^^xsd:string .
 
-niiri:eb0f15f09bbeede75a83373d3a94b783 prov:wasDerivedFrom niiri:8d1a8ab2f5e6753052e300d592e3d511 .
+niiri:05799e7b9d366ec82513f9cbc958c708 prov:wasDerivedFrom niiri:d0ef6f3ab84b7a20a23c8ec80505c8cc .
 
-niiri:a9d3e1abbc30e49d34ae695e931b45f7
+niiri:2cc73a46aa9d23dc31a80b81911f20bd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:adcb8119812e818906df4629ebb6d39e ;
+    prov:atLocation niiri:b0cdd28c72fac14914669b1d5f9e7166 ;
     prov:value "2.18201637268066"^^xsd:float ;
     nidm_equivalentZStatistic: "2.16893530312973"^^xsd:float ;
     nidm_pValueUncorrected: "0.0150437980271687"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:adcb8119812e818906df4629ebb6d39e
+niiri:b0cdd28c72fac14914669b1d5f9e7166
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[52,48,12]"^^xsd:string .
 
-niiri:a9d3e1abbc30e49d34ae695e931b45f7 prov:wasDerivedFrom niiri:5a1ad49de526d8a54452b31baf96a75d .
+niiri:2cc73a46aa9d23dc31a80b81911f20bd prov:wasDerivedFrom niiri:73637205faaca2b93f30cf26719da2b3 .
 
-niiri:a312bb2d4a36613077f4d362f5263e2d
+niiri:0ad8c5359685ef2987e4c8431b9b4b3d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:1e8d56d4ce620a2af884f53f0162a677 ;
+    prov:atLocation niiri:c9a17b4c4634579ffee9d8ab9dc849c8 ;
     prov:value "2.13869571685791"^^xsd:float ;
     nidm_equivalentZStatistic: "2.12682533173394"^^xsd:float ;
     nidm_pValueUncorrected: "0.016717299356924"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:1e8d56d4ce620a2af884f53f0162a677
+niiri:c9a17b4c4634579ffee9d8ab9dc849c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-54,52]"^^xsd:string .
 
-niiri:a312bb2d4a36613077f4d362f5263e2d prov:wasDerivedFrom niiri:c00f026631fe0b6f988efa4d30db781f .
+niiri:0ad8c5359685ef2987e4c8431b9b4b3d prov:wasDerivedFrom niiri:49cbd2656968943cca2fb0ddde2c880a .
 
-niiri:49271d60759060cc512c32272ea47c9f
+niiri:8f72ab30468dd866917659059a620828
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:14acc5ae182e2d6aa091d9670f63d86c ;
+    prov:atLocation niiri:6ac73daf2055ade16d16be059b6e9905 ;
     prov:value "2.13825297355652"^^xsd:float ;
     nidm_equivalentZStatistic: "2.12639503027273"^^xsd:float ;
     nidm_pValueUncorrected: "0.0167351906128659"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:14acc5ae182e2d6aa091d9670f63d86c
+niiri:6ac73daf2055ade16d16be059b6e9905
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[36,-84,2]"^^xsd:string .
 
-niiri:49271d60759060cc512c32272ea47c9f prov:wasDerivedFrom niiri:b712b8f6d2df400be64fe19b957abb10 .
+niiri:8f72ab30468dd866917659059a620828 prov:wasDerivedFrom niiri:686c4840892e9778876349ccd6236841 .
 
-niiri:08989f7c63c852798e88db3aa5231385
+niiri:8e889d6489807dc3530c536d4635b766
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:72593e56b8c30845ae2b8f8970fe5e42 ;
+    prov:atLocation niiri:166f1e7cdee01aa4e88c32bb8e80de44 ;
     prov:value "2.1293613910675"^^xsd:float ;
     nidm_equivalentZStatistic: "2.11775365245473"^^xsd:float ;
     nidm_pValueUncorrected: "0.0170979681968485"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:72593e56b8c30845ae2b8f8970fe5e42
+niiri:166f1e7cdee01aa4e88c32bb8e80de44
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[30,68,12]"^^xsd:string .
 
-niiri:08989f7c63c852798e88db3aa5231385 prov:wasDerivedFrom niiri:f66d2da458d706e0d1c123fd3dc589c7 .
+niiri:8e889d6489807dc3530c536d4635b766 prov:wasDerivedFrom niiri:2e2b55b222631d083aed83513341f4bf .
 
-niiri:58feba2e44840c92dea201d54bffa5fb
+niiri:81290e20f66d908da83d57e4a241e47a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:d7ec0d3731cf2369dd44267e354a7988 ;
+    prov:atLocation niiri:a3c0d136a716ce9e78c8c4b4c5dbb827 ;
     prov:value "2.11468005180359"^^xsd:float ;
     nidm_equivalentZStatistic: "2.10348692366691"^^xsd:float ;
     nidm_pValueUncorrected: "0.017711613581637"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:d7ec0d3731cf2369dd44267e354a7988
+niiri:a3c0d136a716ce9e78c8c4b4c5dbb827
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[34,-84,14]"^^xsd:string .
 
-niiri:58feba2e44840c92dea201d54bffa5fb prov:wasDerivedFrom niiri:70a3e9df88095bfe99637dabf4110acd .
+niiri:81290e20f66d908da83d57e4a241e47a prov:wasDerivedFrom niiri:a8bfd334e76be268255831f5a8092aee .
 
-niiri:9e3518c2e9867ca98860f754d7379642
+niiri:96b78cc86a3bd580ac464e4c29bd68ca
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:29e408397e3b3c1a20cd94269d9240df ;
+    prov:atLocation niiri:eea9c1a497f9c48804e4b7a793b39718 ;
     prov:value "2.01981115341187"^^xsd:float ;
     nidm_equivalentZStatistic: "2.01135476956162"^^xsd:float ;
     nidm_pValueUncorrected: "0.0221439986174564"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:29e408397e3b3c1a20cd94269d9240df
+niiri:eea9c1a497f9c48804e4b7a793b39718
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-42,20,36]"^^xsd:string .
 
-niiri:9e3518c2e9867ca98860f754d7379642 prov:wasDerivedFrom niiri:027812928b4d9dc645c81857d81e13ca .
+niiri:96b78cc86a3bd580ac464e4c29bd68ca prov:wasDerivedFrom niiri:fe4c4fd75ebef375c6e3c2cff33277a4 .
 
-niiri:01a776de2155c1d064f799ee0b13d27c
+niiri:f45dcaf8f9451f6fd2cc5a23f2e8bd72
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:3af3a4e516f1d0712e480617661e0990 ;
+    prov:atLocation niiri:c5216e1840027be6069e98e52e3209fc ;
     prov:value "1.9834691286087"^^xsd:float ;
     nidm_equivalentZStatistic: "1.97609535691968"^^xsd:float ;
     nidm_pValueUncorrected: "0.0240719891024281"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:3af3a4e516f1d0712e480617661e0990
+niiri:c5216e1840027be6069e98e52e3209fc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[34,-78,36]"^^xsd:string .
 
-niiri:01a776de2155c1d064f799ee0b13d27c prov:wasDerivedFrom niiri:fec8e2c65ce7d1cf6e18804683d824ca .
+niiri:f45dcaf8f9451f6fd2cc5a23f2e8bd72 prov:wasDerivedFrom niiri:5bae05b5a604a8c03d7992ce19d15723 .
 
-niiri:a3fdd163c99c50f21394bb2564810f40
+niiri:3ee91f3ca48f4bcc3b193def1b5210de
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:14cae94fd17fb2d01fda8a8022d07f31 ;
+    prov:atLocation niiri:6547c4b945de1fb82a5079cabd74be59 ;
     prov:value "1.94259870052338"^^xsd:float ;
     nidm_equivalentZStatistic: "1.93647164753299"^^xsd:float ;
     nidm_pValueUncorrected: "0.026404980891827"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:14cae94fd17fb2d01fda8a8022d07f31
+niiri:6547c4b945de1fb82a5079cabd74be59
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-48,18,18]"^^xsd:string .
 
-niiri:a3fdd163c99c50f21394bb2564810f40 prov:wasDerivedFrom niiri:c9f251722e6a9f1501e325fdf2f516f3 .
+niiri:3ee91f3ca48f4bcc3b193def1b5210de prov:wasDerivedFrom niiri:ec6a8c27bdfd0dc1de40b1f7c9c1ca61 .
 
-niiri:42a4152bc3193944f970885860f254f1
+niiri:473c3f54b00fd0cf793318f86ff57737
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:0ccdcec00484fe14b2ed7552c64faa47 ;
+    prov:atLocation niiri:a5ff8a5e336ee59e2b09e35c94d52a05 ;
     prov:value "1.89261054992676"^^xsd:float ;
     nidm_equivalentZStatistic: "1.88805796389517"^^xsd:float ;
     nidm_pValueUncorrected: "0.0295090846561562"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:0ccdcec00484fe14b2ed7552c64faa47
+niiri:a5ff8a5e336ee59e2b09e35c94d52a05
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-40,20,8]"^^xsd:string .
 
-niiri:42a4152bc3193944f970885860f254f1 prov:wasDerivedFrom niiri:c9f251722e6a9f1501e325fdf2f516f3 .
+niiri:473c3f54b00fd0cf793318f86ff57737 prov:wasDerivedFrom niiri:ec6a8c27bdfd0dc1de40b1f7c9c1ca61 .
 
-niiri:d8ef073869f2d518eeb58c051015c0e4
+niiri:c42b73a95973777217be1e34edd264ae
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:2179a81fd9206716047be8cff2e08728 ;
+    prov:atLocation niiri:a8d08db32827a4d6e6a628b65af65cb5 ;
     prov:value "1.9298506975174"^^xsd:float ;
     nidm_equivalentZStatistic: "1.92411963399221"^^xsd:float ;
     nidm_pValueUncorrected: "0.0271697947905869"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:2179a81fd9206716047be8cff2e08728
+niiri:a8d08db32827a4d6e6a628b65af65cb5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[22,-82,6]"^^xsd:string .
 
-niiri:d8ef073869f2d518eeb58c051015c0e4 prov:wasDerivedFrom niiri:ac00f4348e517214c5428caad74cc6dc .
+niiri:c42b73a95973777217be1e34edd264ae prov:wasDerivedFrom niiri:f5e21a9b1b5fbfef7061a46469d52a7a .
 
-niiri:b6b23fa7071c0e8366f51f689cb58e5d
+niiri:028b80cf6e69e5686f99c26f2649d550
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:00466efda7ed6e546b9bbd911f3047a8 ;
+    prov:atLocation niiri:0399384e6771d05bb0bfb55e8fd5efea ;
     prov:value "1.87824356555939"^^xsd:float ;
     nidm_equivalentZStatistic: "1.87415494022171"^^xsd:float ;
     nidm_pValueUncorrected: "0.0304545363496075"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:00466efda7ed6e546b9bbd911f3047a8
+niiri:0399384e6771d05bb0bfb55e8fd5efea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-34,22,20]"^^xsd:string .
 
-niiri:b6b23fa7071c0e8366f51f689cb58e5d prov:wasDerivedFrom niiri:8050ff9b05fe42d3b13b693c3d4dfc3c .
+niiri:028b80cf6e69e5686f99c26f2649d550 prov:wasDerivedFrom niiri:4dd108385a724afeea8f83f29506f956 .
 
-niiri:aa1e6f75cb3a2b76e5c3d6a02f70c7d7
+niiri:a01a1373ffd50de536bbd54bbc1c0acc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:7645318f716537f0f6e55e58acb4daf1 ;
+    prov:atLocation niiri:2a132b1ddf9d81308098d3ab72eb1f47 ;
     prov:value "1.85802888870239"^^xsd:float ;
     nidm_equivalentZStatistic: "1.85460257678401"^^xsd:float ;
     nidm_pValueUncorrected: "0.0318264999487402"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:7645318f716537f0f6e55e58acb4daf1
+niiri:2a132b1ddf9d81308098d3ab72eb1f47
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[16,-100,10]"^^xsd:string .
 
-niiri:aa1e6f75cb3a2b76e5c3d6a02f70c7d7 prov:wasDerivedFrom niiri:d1592c70ca4448ee46f3c8df3c20043c .
+niiri:a01a1373ffd50de536bbd54bbc1c0acc prov:wasDerivedFrom niiri:22e2be3780622fb9d23b8f1c07f56968 .
 
-niiri:6cdd0ffff75a1252b7fa916661fdf669
+niiri:fbc87c3ab2258e712f04df3e38d5ba88
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:7ce3f7015bebf95ed663572f98652879 ;
+    prov:atLocation niiri:9da3e7879821713d932e61f75f334985 ;
     prov:value "1.82612562179565"^^xsd:float ;
     nidm_equivalentZStatistic: "1.82376887581619"^^xsd:float ;
     nidm_pValueUncorrected: "0.0340935105624357"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:7ce3f7015bebf95ed663572f98652879
+niiri:9da3e7879821713d932e61f75f334985
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-22,6,14]"^^xsd:string .
 
-niiri:6cdd0ffff75a1252b7fa916661fdf669 prov:wasDerivedFrom niiri:5828f74c2c43b3883378f9cd1e63925b .
+niiri:fbc87c3ab2258e712f04df3e38d5ba88 prov:wasDerivedFrom niiri:ad5ca42e9fcec5d33eda403de4d6999b .
 
-niiri:15a87b6382e2fb49ba7ce1b2c5a4bdfc
+niiri:db1f9bccc6f6f3575cae57f75b8893e7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:0b796279bb1597f56c7a837b6943278f ;
+    prov:atLocation niiri:74a138449469747a3becacb7af05fee9 ;
     prov:value "1.8208144903183"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81863886421642"^^xsd:float ;
     nidm_pValueUncorrected: "0.0344832722280412"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:0b796279bb1597f56c7a837b6943278f
+niiri:74a138449469747a3becacb7af05fee9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[32,-66,0]"^^xsd:string .
 
-niiri:15a87b6382e2fb49ba7ce1b2c5a4bdfc prov:wasDerivedFrom niiri:5922affac179cd07256e72fbcf8a2c8a .
+niiri:db1f9bccc6f6f3575cae57f75b8893e7 prov:wasDerivedFrom niiri:59b84888054fd89394ca79e89db37a1a .
 
-niiri:11111874c48fbc8c67f5d0d02dfca56b
+niiri:fd4823052a3b2b916c9711e82c692f6d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:c7a615d1d896aa881dbf7d7894ede9ea ;
+    prov:atLocation niiri:358cfcb1fe658862409258cd91599e3f ;
     prov:value "1.79377067089081"^^xsd:float ;
     nidm_equivalentZStatistic: "1.79253174586373"^^xsd:float ;
     nidm_pValueUncorrected: "0.0365239143287336"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:c7a615d1d896aa881dbf7d7894ede9ea
+niiri:358cfcb1fe658862409258cd91599e3f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-28,8,14]"^^xsd:string .
 
-niiri:11111874c48fbc8c67f5d0d02dfca56b prov:wasDerivedFrom niiri:8481b546970e4cc30b9a0415842a3ea3 .
+niiri:fd4823052a3b2b916c9711e82c692f6d prov:wasDerivedFrom niiri:1adc127c7534eabbebd796b9fd4f9864 .
 
-niiri:cc9da452ad344d07d30c0d718ee350f6
+niiri:edfc43bda64635dc436bf9d8067737b4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:a19b00cbab738b2c3a78288527aba3cf ;
+    prov:atLocation niiri:37eae5d7ee27a39dbd8ecb3031f41152 ;
     prov:value "1.79001986980438"^^xsd:float ;
     nidm_equivalentZStatistic: "1.78891283515708"^^xsd:float ;
     nidm_pValueUncorrected: "0.0368144271933957"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:a19b00cbab738b2c3a78288527aba3cf
+niiri:37eae5d7ee27a39dbd8ecb3031f41152
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-20,26,28]"^^xsd:string .
 
-niiri:cc9da452ad344d07d30c0d718ee350f6 prov:wasDerivedFrom niiri:f4471bd4ad44f0353136ecfba3e12d38 .
+niiri:edfc43bda64635dc436bf9d8067737b4 prov:wasDerivedFrom niiri:e434b384036bdebb84beb66ec3ab0e46 .
 
-niiri:19d8b89fc4f6b3b5666d4b8f5df7a590
+niiri:c3afbb34b6f65109a267ccdad31e7973
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:8d6b2fe61e5731fecf31a4effa4301bb ;
+    prov:atLocation niiri:d897b02082f3c5a824dc2e51eeb4dc4b ;
     prov:value "1.74872362613678"^^xsd:float ;
     nidm_equivalentZStatistic: "1.749102772694"^^xsd:float ;
     nidm_pValueUncorrected: "0.0401366280244358"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:8d6b2fe61e5731fecf31a4effa4301bb
+niiri:d897b02082f3c5a824dc2e51eeb4dc4b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-54,28,20]"^^xsd:string .
 
-niiri:19d8b89fc4f6b3b5666d4b8f5df7a590 prov:wasDerivedFrom niiri:7651662ffb846c59d0275b64f39a5a3e .
+niiri:c3afbb34b6f65109a267ccdad31e7973 prov:wasDerivedFrom niiri:2614ceb972cd9fc6b34c52dc1b41a5f5 .
 
-niiri:6cd1d0f09d96998ec6d45fc8967bef7d
+niiri:e907edb71265482c80e5f66d1d6e91b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:6e4b134d42d62e3fa90a9cdfa4b0c3ab ;
+    prov:atLocation niiri:965ceb6364a0ab724dfa5f50081f8986 ;
     prov:value "1.73660695552826"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73743465054505"^^xsd:float ;
     nidm_pValueUncorrected: "0.0411552397567266"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:6e4b134d42d62e3fa90a9cdfa4b0c3ab
+niiri:965ceb6364a0ab724dfa5f50081f8986
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[36,-56,-12]"^^xsd:string .
 
-niiri:6cd1d0f09d96998ec6d45fc8967bef7d prov:wasDerivedFrom niiri:cb4cab1d498471cf714b96e648ba0b84 .
+niiri:e907edb71265482c80e5f66d1d6e91b8 prov:wasDerivedFrom niiri:ec3da526be8b471a22bb953dc0be2fa1 .
 
-niiri:971088d1bdd0b1a1c9e797b9ba272eee
+niiri:2da4239466c6f6f9ee10a0a471049fa4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:2bcb7950634a9079bfc9f15710195ba5 ;
+    prov:atLocation niiri:fb0363ab0fd8d2a250664870c37f5c5e ;
     prov:value "1.72697401046753"^^xsd:float ;
     nidm_equivalentZStatistic: "1.72816258455492"^^xsd:float ;
     nidm_pValueUncorrected: "0.0419795398198842"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:2bcb7950634a9079bfc9f15710195ba5
+niiri:fb0363ab0fd8d2a250664870c37f5c5e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[12,74,8]"^^xsd:string .
 
-niiri:971088d1bdd0b1a1c9e797b9ba272eee prov:wasDerivedFrom niiri:b49a13ef4f81cb056a0cf2c1e1e37613 .
+niiri:2da4239466c6f6f9ee10a0a471049fa4 prov:wasDerivedFrom niiri:5bafbb05bd32dfb4238362ae3eba5d83 .
 
-niiri:3b1b90046e2cc738e068e3ccdc5b8e08
+niiri:3f4c593f7a6d6dae3f96844bb716736d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:6e3632bdadbdb54596f9986ced7c5a42 ;
+    prov:atLocation niiri:07eb7b3b90495441876e6151ab6ae024 ;
     prov:value "1.69681537151337"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69915940103581"^^xsd:float ;
     nidm_pValueUncorrected: "0.0446445768205113"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:6e3632bdadbdb54596f9986ced7c5a42
+niiri:07eb7b3b90495441876e6151ab6ae024
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-28,50,36]"^^xsd:string .
 
-niiri:3b1b90046e2cc738e068e3ccdc5b8e08 prov:wasDerivedFrom niiri:3bf344699ca63226f8a0986e9e22dc4d .
+niiri:3f4c593f7a6d6dae3f96844bb716736d prov:wasDerivedFrom niiri:6a5bcf79ca8e87d784ab402166cef0c3 .
 
-niiri:2f7d1feb589408c3bf50b3384d89d8a9
+niiri:0b92adf0c91c746e0d4bc7d4e912eb7f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:42729ea56a022800e2b3fffe2fd2c1ec ;
+    prov:atLocation niiri:215c5a5ba29bc68e48edc75ac5a622ad ;
     prov:value "1.69281709194183"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69531733220798"^^xsd:float ;
     nidm_pValueUncorrected: "0.0450076192977755"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:42729ea56a022800e2b3fffe2fd2c1ec
+niiri:215c5a5ba29bc68e48edc75ac5a622ad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-54,28,12]"^^xsd:string .
 
-niiri:2f7d1feb589408c3bf50b3384d89d8a9 prov:wasDerivedFrom niiri:7a1aa46f25bc46f59f7f644a1d2d768c .
+niiri:0b92adf0c91c746e0d4bc7d4e912eb7f prov:wasDerivedFrom niiri:b0b739a752e19f94dc7e9b7f2e2fd571 .
 
-niiri:90b76ff68e1f93610f550c0f2f46cdec
+niiri:f0bc82a01b95dd842cbd908afc0de71e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:8e160c47f33d388aedd45037581833c0 ;
+    prov:atLocation niiri:8aff729756e0d5609d60b03f30b2b19b ;
     prov:value "1.68880593776703"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69146362670159"^^xsd:float ;
     nidm_pValueUncorrected: "0.0453741445419741"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:8e160c47f33d388aedd45037581833c0
+niiri:8aff729756e0d5609d60b03f30b2b19b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[26,-92,18]"^^xsd:string .
 
-niiri:90b76ff68e1f93610f550c0f2f46cdec prov:wasDerivedFrom niiri:95103dd9bdac7741d90f99939247bf4e .
+niiri:f0bc82a01b95dd842cbd908afc0de71e prov:wasDerivedFrom niiri:48c59f311f10dc10f49d77de1a4f0b19 .
 
-niiri:9a6229796a5042d2de9c8d840d333151
+niiri:0840cfd3a11590229894c9ba9dfab5f8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:ba88244ebec57bcb6456c8f846311dbb ;
+    prov:atLocation niiri:be7064ec70a1f76c9a5a622f21cfa8a2 ;
     prov:value "1.68117702007294"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68413622248109"^^xsd:float ;
     nidm_pValueUncorrected: "0.046077672706774"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:ba88244ebec57bcb6456c8f846311dbb
+niiri:be7064ec70a1f76c9a5a622f21cfa8a2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[42,-78,6]"^^xsd:string .
 
-niiri:9a6229796a5042d2de9c8d840d333151 prov:wasDerivedFrom niiri:11fe90c3ae56c74edb8f27b7b4d64c01 .
+niiri:0840cfd3a11590229894c9ba9dfab5f8 prov:wasDerivedFrom niiri:7be9b12db5e680d03919fb39de296487 .
 
-niiri:54b18d3082b4cad596142f7ef9736d8a
+niiri:90bd3554714a9493852b84311d6860bd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:d6201606a3ba435a6e09c9caf89150df ;
+    prov:atLocation niiri:d499932592dbf96669738734d592eb47 ;
     prov:value "1.67713749408722"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68025745484094"^^xsd:float ;
     nidm_pValueUncorrected: "0.0464536174884935"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:d6201606a3ba435a6e09c9caf89150df
+niiri:d499932592dbf96669738734d592eb47
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-12,26,36]"^^xsd:string .
 
-niiri:54b18d3082b4cad596142f7ef9736d8a prov:wasDerivedFrom niiri:d17fffe11eaba3b9e149fce8bdc2b9da .
+niiri:90bd3554714a9493852b84311d6860bd prov:wasDerivedFrom niiri:91f68c6405b3afe515a6b371bde2705b .
 
-niiri:8197741d55030f4c7e2a1d984b7bf1bc
+niiri:aa2dffe1faaea5caed6375c3b4e045b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:7d3b2943cac3fe81f3de71425355d797 ;
+    prov:atLocation niiri:78cbe6728daa58c4d387dc6a12b3cd49 ;
     prov:value "1.67311263084412"^^xsd:float ;
     nidm_equivalentZStatistic: "1.6763935381234"^^xsd:float ;
     nidm_pValueUncorrected: "0.0468305669041873"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:7d3b2943cac3fe81f3de71425355d797
+niiri:78cbe6728daa58c4d387dc6a12b3cd49
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[12,-94,-32]"^^xsd:string .
 
-niiri:8197741d55030f4c7e2a1d984b7bf1bc prov:wasDerivedFrom niiri:a97b8d1eb95bad3103d70c3a170b35e6 .
+niiri:aa2dffe1faaea5caed6375c3b4e045b0 prov:wasDerivedFrom niiri:bc270be21bea419f18154dda040f4b5a .
 
-niiri:d119a32be5090208facc1946a3d5fa33
+niiri:a2404795b5e5daf6990eb6eae12c16b9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:2925ce3db3c2888712ca8f3f3d1f1619 ;
+    prov:atLocation niiri:a2828afb8f1e151f00c5aa59f3740437 ;
     prov:value "1.67067694664001"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67405562956399"^^xsd:float ;
     nidm_pValueUncorrected: "0.0470598334324596"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:2925ce3db3c2888712ca8f3f3d1f1619
+niiri:a2828afb8f1e151f00c5aa59f3740437
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[24,-92,-30]"^^xsd:string .
 
-niiri:d119a32be5090208facc1946a3d5fa33 prov:wasDerivedFrom niiri:34de4bc8669d7effba126acecd7e71ca .
+niiri:a2404795b5e5daf6990eb6eae12c16b9 prov:wasDerivedFrom niiri:a0aa1a732baf12f3b4e5c27b6348115e .
 
-niiri:81ad744134f8137223e00d7f8e9efb1d
+niiri:0d07f87dea9e3e960a3f3d038d8a70f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:576bfeaced7698758e2dcea95224fe2a ;
+    prov:atLocation niiri:595f816eefa45e24291f4b683c43e80b ;
     prov:value "1.66812241077423"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67160394831323"^^xsd:float ;
     nidm_pValueUncorrected: "0.0473012228473357"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:576bfeaced7698758e2dcea95224fe2a
+niiri:595f816eefa45e24291f4b683c43e80b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-24,22,22]"^^xsd:string .
 
-niiri:81ad744134f8137223e00d7f8e9efb1d prov:wasDerivedFrom niiri:34640314cb90b81bff8b479f4c75ae6f .
+niiri:0d07f87dea9e3e960a3f3d038d8a70f7 prov:wasDerivedFrom niiri:ac0917bc41fde1dbed179cd897e7c568 .
 
-niiri:fffda3a756d7aadecaf95c9b79ca9f9d
+niiri:8aa103d7be8ec3c7c7aaca22852c2981
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:ef0fc7140e631601df1c9ed09b66ef7f ;
+    prov:atLocation niiri:69ddaf3b72e3c6582f239bd415aec36d ;
     prov:value "1.66770362854004"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67120205793481"^^xsd:float ;
     nidm_pValueUncorrected: "0.0473408869609759"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:ef0fc7140e631601df1c9ed09b66ef7f
+niiri:69ddaf3b72e3c6582f239bd415aec36d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[26,-90,22]"^^xsd:string .
 
-niiri:fffda3a756d7aadecaf95c9b79ca9f9d prov:wasDerivedFrom niiri:79c1b8c3935c1efdd0d31d231222a6e3 .
+niiri:8aa103d7be8ec3c7c7aaca22852c2981 prov:wasDerivedFrom niiri:61bb215e601050cd1cdc9f7b9c8847a0 .
 
-niiri:ff04f5c6feedf70958adb3464fd72d76
+niiri:cca9c4b0e0b571b547941afc4ee7ea62
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:9eabe9da21cf05a8ae9ca9e3b467bcea ;
+    prov:atLocation niiri:4bb531975458fd0966f3aedd36987c11 ;
     prov:value "1.66512632369995"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66872889854066"^^xsd:float ;
     nidm_pValueUncorrected: "0.0475855596349387"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:9eabe9da21cf05a8ae9ca9e3b467bcea
+niiri:4bb531975458fd0966f3aedd36987c11
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[32,-60,-2]"^^xsd:string .
 
-niiri:ff04f5c6feedf70958adb3464fd72d76 prov:wasDerivedFrom niiri:1171e027eba41be4b53953810af155f9 .
+niiri:cca9c4b0e0b571b547941afc4ee7ea62 prov:wasDerivedFrom niiri:d5aeba7a4d0595b94af060fe6c391161 .
 
-niiri:498867695b58631e8cf68e8990cdf642
+niiri:4aab3c20ee5490ed595e356c8953578b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:23a47d1f73da07fee4779591d3a6aa53 ;
+    prov:atLocation niiri:74de56127dfe231995995a89993e9bd2 ;
     prov:value "1.6600536108017"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66386211897632"^^xsd:float ;
     nidm_pValueUncorrected: "0.0480699933329287"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.993657486705384"^^xsd:float .
 
-niiri:23a47d1f73da07fee4779591d3a6aa53
+niiri:74de56127dfe231995995a89993e9bd2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-44,-56,-32]"^^xsd:string .
 
-niiri:498867695b58631e8cf68e8990cdf642 prov:wasDerivedFrom niiri:54a8bffd20ef66a79cc779bd8e630f0f .
+niiri:4aab3c20ee5490ed595e356c8953578b prov:wasDerivedFrom niiri:7cc7f4ff997ef1b13f17a0bc068a7e4d .
 

--- a/spmexport/ex_spm_conjunction/nidm.ttl
+++ b/spmexport/ex_spm_conjunction/nidm.ttl
@@ -1,0 +1,1560 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:e8889926d05a35c367676e2b266a5d9e
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:229b0f08cfcf3f699fd45d952761f576
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:1051dc20a62ed1558eac0a1a2fb70588
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:1051dc20a62ed1558eac0a1a2fb70588 prov:wasAssociatedWith niiri:229b0f08cfcf3f699fd45d952761f576 .
+
+_:blank5 a prov:Generation .
+
+niiri:e8889926d05a35c367676e2b266a5d9e prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:11:03"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_ConjunctionInference: <http://purl.org/nidash/nidm#NIDM_0000011> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070> .
+@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
+@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .
+@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .
+@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082> .
+@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .
+@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092> .
+@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
+@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
+
+niiri:0b3ed3b43289bfce69e1dd8e0a580555
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:08ce005cf94169deadd293b9f0386fc0
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:12128f6eb829f1af879e8f015ce78ee5
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:4d9192c7fd08ad2bb7c4ff9503e7546b
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:62719c37cb7f1155944ed6252b71ec01
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:df48ccc999ebf8ca6f4c3e5bc939230c ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:4d9192c7fd08ad2bb7c4ff9503e7546b ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:df48ccc999ebf8ca6f4c3e5bc939230c
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:9cca745d6e07ffe830a810c73a4beb94
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:814ac7079ffe5eac40b4e81f109d77d3
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:814ac7079ffe5eac40b4e81f109d77d3 prov:wasAssociatedWith niiri:0b3ed3b43289bfce69e1dd8e0a580555 .
+
+niiri:814ac7079ffe5eac40b4e81f109d77d3 prov:used niiri:62719c37cb7f1155944ed6252b71ec01 .
+
+niiri:814ac7079ffe5eac40b4e81f109d77d3 prov:used niiri:12128f6eb829f1af879e8f015ce78ee5 .
+
+niiri:814ac7079ffe5eac40b4e81f109d77d3 prov:used niiri:9cca745d6e07ffe830a810c73a4beb94 .
+
+niiri:fa56d066478b2ea71a6e1c4d5d549487
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
+
+niiri:e4a6119a50fded21c14197bcf296ab06
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
+
+niiri:fa56d066478b2ea71a6e1c4d5d549487 prov:wasDerivedFrom niiri:e4a6119a50fded21c14197bcf296ab06 .
+
+niiri:fa56d066478b2ea71a6e1c4d5d549487 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:e5e2aba57bea3f7fc5a3f8657c80a53b
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "108.038318634033"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
+
+niiri:e5e2aba57bea3f7fc5a3f8657c80a53b prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:8dc72e026b46807ff7610978144a50a7
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+
+niiri:4ae89562691298e404907d30c17d6405
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f"^^xsd:string .
+
+niiri:8dc72e026b46807ff7610978144a50a7 prov:wasDerivedFrom niiri:4ae89562691298e404907d30c17d6405 .
+
+niiri:8dc72e026b46807ff7610978144a50a7 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:c92fcc94226b041e076498dac96ae002
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+
+niiri:70eb7916777b2ccbe5e1004599b6b16f
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
+
+niiri:c92fcc94226b041e076498dac96ae002 prov:wasDerivedFrom niiri:70eb7916777b2ccbe5e1004599b6b16f .
+
+niiri:c92fcc94226b041e076498dac96ae002 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:e709d65a8b7aad133a26fc434e5810c1
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+
+niiri:5c45b10466b418609ad8f78d1d37f2a6
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb"^^xsd:string .
+
+niiri:e709d65a8b7aad133a26fc434e5810c1 prov:wasDerivedFrom niiri:5c45b10466b418609ad8f78d1d37f2a6 .
+
+niiri:e709d65a8b7aad133a26fc434e5810c1 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:68dce10b86eb716a09c05d6bff88fb86
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 4" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+
+niiri:2ec5caa6c30b03a58e93533d26263bf0
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0004.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6"^^xsd:string .
+
+niiri:68dce10b86eb716a09c05d6bff88fb86 prov:wasDerivedFrom niiri:2ec5caa6c30b03a58e93533d26263bf0 .
+
+niiri:68dce10b86eb716a09c05d6bff88fb86 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:1835bec3a94146206bbc4c8dd879125c
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 5" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+
+niiri:7cfa6c3f159704f4e89cdb27e96c7bc1
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0005.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff"^^xsd:string .
+
+niiri:1835bec3a94146206bbc4c8dd879125c prov:wasDerivedFrom niiri:7cfa6c3f159704f4e89cdb27e96c7bc1 .
+
+niiri:1835bec3a94146206bbc4c8dd879125c prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:3f4483bbcd6a762700a3897d004115aa
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 6" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 .
+
+niiri:5924cb43042ba2ca9b3e72dff64b49b5
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0006.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
+
+niiri:3f4483bbcd6a762700a3897d004115aa prov:wasDerivedFrom niiri:5924cb43042ba2ca9b3e72dff64b49b5 .
+
+niiri:3f4483bbcd6a762700a3897d004115aa prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:0584af123d5f6deb3954a3ac1bf9afaf
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8"^^xsd:string .
+
+niiri:751ce5b565c5ac0b6fcbae2755edacc1
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81"^^xsd:string .
+
+niiri:0584af123d5f6deb3954a3ac1bf9afaf prov:wasDerivedFrom niiri:751ce5b565c5ac0b6fcbae2755edacc1 .
+
+niiri:0584af123d5f6deb3954a3ac1bf9afaf prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:5e5f72d3a313df47ed1675f196ba2790
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8"^^xsd:string .
+
+niiri:c43d5c20b335994694e0ce99c69c63d2
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29"^^xsd:string .
+
+niiri:5e5f72d3a313df47ed1675f196ba2790 prov:wasDerivedFrom niiri:c43d5c20b335994694e0ce99c69c63d2 .
+
+niiri:5e5f72d3a313df47ed1675f196ba2790 prov:wasGeneratedBy niiri:814ac7079ffe5eac40b4e81f109d77d3 .
+
+niiri:fff3d3a4810634aa02f29f0c1f5fbb8f
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    rdfs:label "Contrast: mr vs plain" ;
+    prov:value "[1, 1, -1, -1, 0, 0]"^^xsd:string .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation 1" .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:wasAssociatedWith niiri:0b3ed3b43289bfce69e1dd8e0a580555 .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:fa56d066478b2ea71a6e1c4d5d549487 .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:0584af123d5f6deb3954a3ac1bf9afaf .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:62719c37cb7f1155944ed6252b71ec01 .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:fff3d3a4810634aa02f29f0c1f5fbb8f .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:8dc72e026b46807ff7610978144a50a7 .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:c92fcc94226b041e076498dac96ae002 .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:e709d65a8b7aad133a26fc434e5810c1 .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:68dce10b86eb716a09c05d6bff88fb86 .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:1835bec3a94146206bbc4c8dd879125c .
+
+niiri:ed2f36215d4ae0d42c3aefe5ecd86175 prov:used niiri:3f4483bbcd6a762700a3897d004115aa .
+
+niiri:33170469490d72c603cf1ad06ce86637
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic_0001.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic_0001.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: mr vs plain" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "aba2fef7900cacda1ed84fe5edf867bd2b0fc6ae7eb4919967798d7f219a6d8ad5454fe8e0bdf4a7cfa6402e73287e703c285d12df0a282e40438ec36153e715"^^xsd:string .
+
+niiri:0d5089a0bd1af4fc6f9474726c757a3b
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782"^^xsd:string .
+
+niiri:33170469490d72c603cf1ad06ce86637 prov:wasDerivedFrom niiri:0d5089a0bd1af4fc6f9474726c757a3b .
+
+niiri:33170469490d72c603cf1ad06ce86637 prov:wasGeneratedBy niiri:ed2f36215d4ae0d42c3aefe5ecd86175 .
+
+niiri:a15220866e3ff78e30b1d06f1e2ad332
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast_0001.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast_0001.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: mr vs plain" ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5"^^xsd:string .
+
+niiri:c06e95223a98daddc50df12b0ef668ef
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28"^^xsd:string .
+
+niiri:a15220866e3ff78e30b1d06f1e2ad332 prov:wasDerivedFrom niiri:c06e95223a98daddc50df12b0ef668ef .
+
+niiri:a15220866e3ff78e30b1d06f1e2ad332 prov:wasGeneratedBy niiri:ed2f36215d4ae0d42c3aefe5ecd86175 .
+
+niiri:88f8800367c7c2b2a2d1a301d933782c
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError_0001.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError_0001.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b"^^xsd:string .
+
+niiri:88f8800367c7c2b2a2d1a301d933782c prov:wasGeneratedBy niiri:ed2f36215d4ae0d42c3aefe5ecd86175 .
+
+niiri:59cd72b8af1baa0c5eb355990015dbc8
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
+    rdfs:label "Contrast: switch vs nonswitch" ;
+    prov:value "[1, -1, 1, -1, 0, 0]"^^xsd:string .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation 2" .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:wasAssociatedWith niiri:0b3ed3b43289bfce69e1dd8e0a580555 .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:fa56d066478b2ea71a6e1c4d5d549487 .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:0584af123d5f6deb3954a3ac1bf9afaf .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:62719c37cb7f1155944ed6252b71ec01 .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:59cd72b8af1baa0c5eb355990015dbc8 .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:8dc72e026b46807ff7610978144a50a7 .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:c92fcc94226b041e076498dac96ae002 .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:e709d65a8b7aad133a26fc434e5810c1 .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:68dce10b86eb716a09c05d6bff88fb86 .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:1835bec3a94146206bbc4c8dd879125c .
+
+niiri:bb82cadb0c0a63033cb0b69845e19933 prov:used niiri:3f4483bbcd6a762700a3897d004115aa .
+
+niiri:cdd7c42099c33f420a6755aca2f2279f
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic_0002.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic_0002.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: switch vs nonswitch" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "1c375cdc8f2b00f93f3d6f1a09aafa5670d35ffcf2c82ef061151bfb047463e482e971d67ce3e3e2496f37b1621f5d732a0a1f88c773f5d5fa077cb6a3e38501"^^xsd:string .
+
+niiri:f364d39b2363c17f9d16acb9c59c6a34
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "313c8e34e107b1e9bec46074e7a1cef289427618869119eff1c8044a2b5b8e5a340c899a78f40a3f8b938dbbbde53bd16c096da55f2e07a7c9e334cfd1e471f2"^^xsd:string .
+
+niiri:cdd7c42099c33f420a6755aca2f2279f prov:wasDerivedFrom niiri:f364d39b2363c17f9d16acb9c59c6a34 .
+
+niiri:cdd7c42099c33f420a6755aca2f2279f prov:wasGeneratedBy niiri:bb82cadb0c0a63033cb0b69845e19933 .
+
+niiri:e302d7d850e61776b5bb1245b4e05648
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast_0002.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast_0002.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: switch vs nonswitch" ;
+    nidm_contrastName: "switch vs nonswitch"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "77720bd21fb296db2e69c9742318c52f7cf6b08f94a83c5c1e30d5b8b21b1fd218de32fcc3a96aa2d067d5b06015e85e863ab87907741d2d7c9993740f668dc2"^^xsd:string .
+
+niiri:4488f35b0475365c16a619d4367e2596
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "6983d8888c458d8a073f84054db2587b0a71764e64c30ea7e4a13cd0e6b2e301eaea1b570822b24b635b464fd233c3801a9205ddcd2dcffcda7cd99679d2734a"^^xsd:string .
+
+niiri:e302d7d850e61776b5bb1245b4e05648 prov:wasDerivedFrom niiri:4488f35b0475365c16a619d4367e2596 .
+
+niiri:e302d7d850e61776b5bb1245b4e05648 prov:wasGeneratedBy niiri:bb82cadb0c0a63033cb0b69845e19933 .
+
+niiri:f0fc139f8e55d67381833c5bf0ad8776
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError_0002.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError_0002.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "1bb21447dcf3cc1eeb9453c707178e4d87161242c69e18795e0e2b30496c9e657ed2f202d4c9cd364aea5a04e4e46fe70ca830e1db14dd2e0f20af754281c3f2"^^xsd:string .
+
+niiri:f0fc139f8e55d67381833c5bf0ad8776 prov:wasGeneratedBy niiri:bb82cadb0c0a63033cb0b69845e19933 .
+
+niiri:fc0dadbc5f694e6ae907492f74e6940a
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.048771 (unc.)" ;
+    prov:value "0.0487705952532708"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:4e24c86c0c11cc5f53096bcd0ce1dee2 ;
+    nidm_equivalentThreshold: niiri:f9486c7fafc049f9442fc8a37aad071b .
+
+niiri:4e24c86c0c11cc5f53096bcd0ce1dee2
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "1.65278686445912"^^xsd:float .
+
+niiri:f9486c7fafc049f9442fc8a37aad071b
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:6f5dc8bb78b50ed4e5df8f9ad38d9464
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:92687adf3abda3ba46eb627518e50083 ;
+    nidm_equivalentThreshold: niiri:6af6d4d06a49094c399e6ccf744121ef .
+
+niiri:92687adf3abda3ba46eb627518e50083
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:6af6d4d06a49094c399e6ccf744121ef
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:c90078d4c679070cca4a029f082015c6
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:e225a30061c1008b5fab26894ccaf377
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6
+    a prov:Activity, nidm_ConjunctionInference: ; 
+    rdfs:label "Conjunction Inference" .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:wasAssociatedWith niiri:0b3ed3b43289bfce69e1dd8e0a580555 .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:fc0dadbc5f694e6ae907492f74e6940a .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:6f5dc8bb78b50ed4e5df8f9ad38d9464 .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:33170469490d72c603cf1ad06ce86637 .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:cdd7c42099c33f420a6755aca2f2279f .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:5e5f72d3a313df47ed1675f196ba2790 .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:fa56d066478b2ea71a6e1c4d5d549487 .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:c90078d4c679070cca4a029f082015c6 .
+
+niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 prov:used niiri:e225a30061c1008b5fab26894ccaf377 .
+
+niiri:5659ce7e18cccaee79d052589cc49082
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
+    nidm_reselSizeInVoxels: "68.4409986586553"^^xsd:float ;
+    nidm_searchVolumeInResels: "2811.45809925534"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[5, 96.6116867805852, 900.100332657535, 2811.45809925534]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.16320607513012, 4.05765428344905, 4.05147708968699]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.32641215026024, 8.1153085668981, 8.10295417937398]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "65.6719601732437"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "221.248707519578"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.08514693703219"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
+
+niiri:5659ce7e18cccaee79d052589cc49082 prov:wasGeneratedBy niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 .
+
+niiri:f3637fafb926481fff6bd8938c6a8550
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "30"^^xsd:int ;
+    nidm_pValue: "1"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:225cba9527198fe0f9f286e4794b0c09 ;
+    nidm_hasMaximumIntensityProjection: niiri:b314a44bd0faae613b91c61054d712ba ;
+    nidm_inCoordinateSpace: niiri:08ce005cf94169deadd293b9f0386fc0 ;
+    crypto:sha512 "bcf45ac744752d54a29a2b918eda586a0e6637179a62a2eef62afd03f594bb4bdb4d2171625040d21c22a02d3a13fd0312ce1b83f6a6aecf34c432299e21c864"^^xsd:string .
+
+niiri:225cba9527198fe0f9f286e4794b0c09
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:b314a44bd0faae613b91c61054d712ba
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:f3637fafb926481fff6bd8938c6a8550 prov:wasGeneratedBy niiri:e99ac3c1e07c5c1b8b9b94dad780efc6 .
+
+niiri:1ca2ed8885126a13f37d342c5bda82b6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0001" ;
+    nidm_clusterSizeInVoxels: "95"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.38805689370206"^^xsd:float ;
+    nidm_pValueUncorrected: "0.213014928043125"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "1"^^xsd:int .
+
+niiri:1ca2ed8885126a13f37d342c5bda82b6 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:b6ec4ee5c26bd5170b56e954e84a7789
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0002" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.782510669800627"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "2"^^xsd:int .
+
+niiri:b6ec4ee5c26bd5170b56e954e84a7789 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:67aa7dea8d858564a8b4505070c20ab3
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0003" ;
+    nidm_clusterSizeInVoxels: "9"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.131500126771774"^^xsd:float ;
+    nidm_pValueUncorrected: "0.725158209956759"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "3"^^xsd:int .
+
+niiri:67aa7dea8d858564a8b4505070c20ab3 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:8eb556353f8e288e589eef37024ef068
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0004" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.611975830727683"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "4"^^xsd:int .
+
+niiri:8eb556353f8e288e589eef37024ef068 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:4f970219224428039454afd130e40f48
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0005" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160722377165502"^^xsd:float ;
+    nidm_pValueUncorrected: "0.692555940999578"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "5"^^xsd:int .
+
+niiri:4f970219224428039454afd130e40f48 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:c2a5888cb7cfb94104a85fdf0c0a0975
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0006" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.611975830727683"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "6"^^xsd:int .
+
+niiri:c2a5888cb7cfb94104a85fdf0c0a0975 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:5e85e47c2fc2758e5d466cd2123b2254
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0007" ;
+    nidm_clusterSizeInVoxels: "24"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.350667004724731"^^xsd:float ;
+    nidm_pValueUncorrected: "0.539029201377477"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "7"^^xsd:int .
+
+niiri:5e85e47c2fc2758e5d466cd2123b2254 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:6105338324e4b950666042ae82d011fd
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0008" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.782510669800627"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "8"^^xsd:int .
+
+niiri:6105338324e4b950666042ae82d011fd prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:4f020dcb9018a1690cba2cbf60dc38b0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0009" ;
+    nidm_clusterSizeInVoxels: "41"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.599056133071416"^^xsd:float ;
+    nidm_pValueUncorrected: "0.413484921872381"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "9"^^xsd:int .
+
+niiri:4f020dcb9018a1690cba2cbf60dc38b0 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:68b9b03c7822e1a0b86cd9e68fe99ca2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0010" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.782510669800627"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "10"^^xsd:int .
+
+niiri:68b9b03c7822e1a0b86cd9e68fe99ca2 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0011" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.611975830727683"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "11"^^xsd:int .
+
+niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:f626ba6b4ad8b422a9e8b6208607d5c7
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0012" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.829311832510809"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "12"^^xsd:int .
+
+niiri:f626ba6b4ad8b422a9e8b6208607d5c7 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:dd3a390096e9240d96d84a6fa0b53334
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0013" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.829311832510809"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "13"^^xsd:int .
+
+niiri:dd3a390096e9240d96d84a6fa0b53334 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:b38cc3f1a8c8b355373259707d78b430
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0014" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.11688900157491"^^xsd:float ;
+    nidm_pValueUncorrected: "0.742972344559258"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "14"^^xsd:int .
+
+niiri:b38cc3f1a8c8b355373259707d78b430 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:708b36a85852210d2aa37cd0a43c31d6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0015" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.11688900157491"^^xsd:float ;
+    nidm_pValueUncorrected: "0.742972344559258"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "15"^^xsd:int .
+
+niiri:708b36a85852210d2aa37cd0a43c31d6 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:9fb5666ada501891fcef9d333ed6afff
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0016" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.829311832510809"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "16"^^xsd:int .
+
+niiri:9fb5666ada501891fcef9d333ed6afff prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:756837e339677511c64f8da38004cd2e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0017" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.888782432018751"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "17"^^xsd:int .
+
+niiri:756837e339677511c64f8da38004cd2e prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:303983981b9e7155b24ee729485e35d5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0018" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.856846591224654"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "18"^^xsd:int .
+
+niiri:303983981b9e7155b24ee729485e35d5 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:ff25cf8967cf153c0c4bac8744bfd4de
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0019" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.829311832510809"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "19"^^xsd:int .
+
+niiri:ff25cf8967cf153c0c4bac8744bfd4de prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:1e1d5e2b654ff9dfd561671bb14dac45
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0020" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.928417166750593"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "20"^^xsd:int .
+
+niiri:1e1d5e2b654ff9dfd561671bb14dac45 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:04d3366efa2ae78508ba78d4f6d3fbd4
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0021" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.856846591224654"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "21"^^xsd:int .
+
+niiri:04d3366efa2ae78508ba78d4f6d3fbd4 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:471616239367dd0b8f23af62cd1178af
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0022" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.928417166750593"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "22"^^xsd:int .
+
+niiri:471616239367dd0b8f23af62cd1178af prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:146e852a595d2bd9bf43b63cb1ffe554
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0023" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.928417166750593"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "23"^^xsd:int .
+
+niiri:146e852a595d2bd9bf43b63cb1ffe554 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:c76d475fb44856dbc3b3660c08027d10
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0024" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.928417166750593"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "24"^^xsd:int .
+
+niiri:c76d475fb44856dbc3b3660c08027d10 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:171a3293a830389fbc0eeedac10ab2ef
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0025" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.856846591224654"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "25"^^xsd:int .
+
+niiri:171a3293a830389fbc0eeedac10ab2ef prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:230b132218201af072b76732d6cd366e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0026" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.928417166750593"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "26"^^xsd:int .
+
+niiri:230b132218201af072b76732d6cd366e prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:88b6854434c4c7d7d77b89858ff66d15
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0027" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.928417166750593"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "27"^^xsd:int .
+
+niiri:88b6854434c4c7d7d77b89858ff66d15 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:983ff16f46a1aa2fb13613f2c2f88011
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0028" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.888782432018751"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "28"^^xsd:int .
+
+niiri:983ff16f46a1aa2fb13613f2c2f88011 prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:a6327d343c9ff6cf00c6cbe83308072b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0029" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.888782432018751"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "29"^^xsd:int .
+
+niiri:a6327d343c9ff6cf00c6cbe83308072b prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:92ac4a8cb0a6c243ecb32fc66fd3deab
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0030" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.928417166750593"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "30"^^xsd:int .
+
+niiri:92ac4a8cb0a6c243ecb32fc66fd3deab prov:wasDerivedFrom niiri:f3637fafb926481fff6bd8938c6a8550 .
+
+niiri:c3e496eea557d318020009e75ea064a9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0001" ;
+    prov:atLocation niiri:33b9e64baedb78edec3c778ac3503e57 ;
+    prov:value "2.29849815368652"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.28220028418391"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0112387591680547"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:33b9e64baedb78edec3c778ac3503e57
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0001" ;
+    nidm_coordinateVector: "[-28,24,4]"^^xsd:string .
+
+niiri:c3e496eea557d318020009e75ea064a9 prov:wasDerivedFrom niiri:1ca2ed8885126a13f37d342c5bda82b6 .
+
+niiri:304c8f977e3d31328f1ba8cc597ceb18
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0002" ;
+    prov:atLocation niiri:39b6eca99b5b73480b968ea12add2484 ;
+    prov:value "2.07190132141113"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.0619285244841"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0196072706834085"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:39b6eca99b5b73480b968ea12add2484
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0002" ;
+    nidm_coordinateVector: "[-28,26,12]"^^xsd:string .
+
+niiri:304c8f977e3d31328f1ba8cc597ceb18 prov:wasDerivedFrom niiri:1ca2ed8885126a13f37d342c5bda82b6 .
+
+niiri:02fb69f52c0371d7e8083f1d698b5486
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0003" ;
+    prov:atLocation niiri:0545dc10de1e5d6701474796bc5135b3 ;
+    prov:value "2.18201637268066"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.16893530312973"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0150437980271687"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:0545dc10de1e5d6701474796bc5135b3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0003" ;
+    nidm_coordinateVector: "[52,48,12]"^^xsd:string .
+
+niiri:02fb69f52c0371d7e8083f1d698b5486 prov:wasDerivedFrom niiri:b6ec4ee5c26bd5170b56e954e84a7789 .
+
+niiri:47905f0ed8d89646a0b2df5e003f1e2a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0004" ;
+    prov:atLocation niiri:d0d2bf61fd3a0931a0e3bdd8f49eed93 ;
+    prov:value "2.13869571685791"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.12682533173394"^^xsd:float ;
+    nidm_pValueUncorrected: "0.016717299356924"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:d0d2bf61fd3a0931a0e3bdd8f49eed93
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0004" ;
+    nidm_coordinateVector: "[34,-54,52]"^^xsd:string .
+
+niiri:47905f0ed8d89646a0b2df5e003f1e2a prov:wasDerivedFrom niiri:67aa7dea8d858564a8b4505070c20ab3 .
+
+niiri:091b7fa1943f270ddc578020b6bf4b81
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0005" ;
+    prov:atLocation niiri:2d030121bd3e3440189b9362d24d0e82 ;
+    prov:value "2.13825297355652"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.12639503027273"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0167351906128659"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:2d030121bd3e3440189b9362d24d0e82
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0005" ;
+    nidm_coordinateVector: "[36,-84,2]"^^xsd:string .
+
+niiri:091b7fa1943f270ddc578020b6bf4b81 prov:wasDerivedFrom niiri:8eb556353f8e288e589eef37024ef068 .
+
+niiri:225874e925381c31ec2075213af93cc8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0006" ;
+    prov:atLocation niiri:7506c87aedf9336f1b97442d8e526f2f ;
+    prov:value "2.1293613910675"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.11775365245473"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0170979681968485"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:7506c87aedf9336f1b97442d8e526f2f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0006" ;
+    nidm_coordinateVector: "[30,68,12]"^^xsd:string .
+
+niiri:225874e925381c31ec2075213af93cc8 prov:wasDerivedFrom niiri:4f970219224428039454afd130e40f48 .
+
+niiri:eb6fb2c76c756484f30c7d09b66c5c43
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0007" ;
+    prov:atLocation niiri:99c662c8509b716d461c456391b45b37 ;
+    prov:value "2.11468005180359"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.10348692366691"^^xsd:float ;
+    nidm_pValueUncorrected: "0.017711613581637"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:99c662c8509b716d461c456391b45b37
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0007" ;
+    nidm_coordinateVector: "[34,-84,14]"^^xsd:string .
+
+niiri:eb6fb2c76c756484f30c7d09b66c5c43 prov:wasDerivedFrom niiri:c2a5888cb7cfb94104a85fdf0c0a0975 .
+
+niiri:db15f3aea3a0b1689952a5924009614a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0008" ;
+    prov:atLocation niiri:ec58debeeea826abc9378be9d6ccee92 ;
+    prov:value "2.01981115341187"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.01135476956162"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0221439986174564"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:ec58debeeea826abc9378be9d6ccee92
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0008" ;
+    nidm_coordinateVector: "[-42,20,36]"^^xsd:string .
+
+niiri:db15f3aea3a0b1689952a5924009614a prov:wasDerivedFrom niiri:5e85e47c2fc2758e5d466cd2123b2254 .
+
+niiri:a9e83bfae2a235a9cc20adac4118915b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0009" ;
+    prov:atLocation niiri:3991fe3c2e71f1b8e7f88c795fa8f2b0 ;
+    prov:value "1.9834691286087"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.97609535691968"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0240719891024281"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:3991fe3c2e71f1b8e7f88c795fa8f2b0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0009" ;
+    nidm_coordinateVector: "[34,-78,36]"^^xsd:string .
+
+niiri:a9e83bfae2a235a9cc20adac4118915b prov:wasDerivedFrom niiri:6105338324e4b950666042ae82d011fd .
+
+niiri:2f99eaddb3b1956eee9400c73e729457
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0010" ;
+    prov:atLocation niiri:94ba0436d49d4f1ac392af5f6adb2756 ;
+    prov:value "1.94259870052338"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.93647164753299"^^xsd:float ;
+    nidm_pValueUncorrected: "0.026404980891827"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:94ba0436d49d4f1ac392af5f6adb2756
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0010" ;
+    nidm_coordinateVector: "[-48,18,18]"^^xsd:string .
+
+niiri:2f99eaddb3b1956eee9400c73e729457 prov:wasDerivedFrom niiri:4f020dcb9018a1690cba2cbf60dc38b0 .
+
+niiri:e21f5c3bb0d87db0399aa6aeaae8fa17
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0011" ;
+    prov:atLocation niiri:026fbe87ef12da1f1cb8f58505c5a35d ;
+    prov:value "1.89261054992676"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.88805796389517"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0295090846561562"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:026fbe87ef12da1f1cb8f58505c5a35d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0011" ;
+    nidm_coordinateVector: "[-40,20,8]"^^xsd:string .
+
+niiri:e21f5c3bb0d87db0399aa6aeaae8fa17 prov:wasDerivedFrom niiri:4f020dcb9018a1690cba2cbf60dc38b0 .
+
+niiri:819a69b124962a6bc39aa80cdc398a30
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0012" ;
+    prov:atLocation niiri:0d0ffa2881f696dcc6b1d489a15348ec ;
+    prov:value "1.9298506975174"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.92411963399221"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0271697947905869"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:0d0ffa2881f696dcc6b1d489a15348ec
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0012" ;
+    nidm_coordinateVector: "[22,-82,6]"^^xsd:string .
+
+niiri:819a69b124962a6bc39aa80cdc398a30 prov:wasDerivedFrom niiri:68b9b03c7822e1a0b86cd9e68fe99ca2 .
+
+niiri:df4034a52a0223c24e52134353933b85
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0013" ;
+    prov:atLocation niiri:b2e026ac20229c679280d6521ef462e2 ;
+    prov:value "1.87824356555939"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.87415494022171"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0304545363496075"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:b2e026ac20229c679280d6521ef462e2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0013" ;
+    nidm_coordinateVector: "[-34,22,20]"^^xsd:string .
+
+niiri:df4034a52a0223c24e52134353933b85 prov:wasDerivedFrom niiri:9d7bfc795c45dfc1d2a9b0bd65c9fbd9 .
+
+niiri:56e0435b5a93b3ea44eb4880caa46f6e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0014" ;
+    prov:atLocation niiri:64c2cf7669582f994375fb0c99a90889 ;
+    prov:value "1.85802888870239"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.85460257678401"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0318264999487402"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:64c2cf7669582f994375fb0c99a90889
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0014" ;
+    nidm_coordinateVector: "[16,-100,10]"^^xsd:string .
+
+niiri:56e0435b5a93b3ea44eb4880caa46f6e prov:wasDerivedFrom niiri:f626ba6b4ad8b422a9e8b6208607d5c7 .
+
+niiri:1585cde397394ce1852eabdc3e6069bc
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0015" ;
+    prov:atLocation niiri:f72c8e0f5976a1f9554754dc1a644aec ;
+    prov:value "1.82612562179565"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.82376887581619"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0340935105624357"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:f72c8e0f5976a1f9554754dc1a644aec
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0015" ;
+    nidm_coordinateVector: "[-22,6,14]"^^xsd:string .
+
+niiri:1585cde397394ce1852eabdc3e6069bc prov:wasDerivedFrom niiri:dd3a390096e9240d96d84a6fa0b53334 .
+
+niiri:fc1bd52acb4a54ac65706ec77b597664
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0016" ;
+    prov:atLocation niiri:b916c3481037d35a043ee9bca1bfa812 ;
+    prov:value "1.8208144903183"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.81863886421642"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0344832722280412"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:b916c3481037d35a043ee9bca1bfa812
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0016" ;
+    nidm_coordinateVector: "[32,-66,0]"^^xsd:string .
+
+niiri:fc1bd52acb4a54ac65706ec77b597664 prov:wasDerivedFrom niiri:b38cc3f1a8c8b355373259707d78b430 .
+
+niiri:dd9b23180ca6d48364bbd5e03598085b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0017" ;
+    prov:atLocation niiri:e19da916a650e437d894081ea2700363 ;
+    prov:value "1.79377067089081"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.79253174586373"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0365239143287336"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:e19da916a650e437d894081ea2700363
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0017" ;
+    nidm_coordinateVector: "[-28,8,14]"^^xsd:string .
+
+niiri:dd9b23180ca6d48364bbd5e03598085b prov:wasDerivedFrom niiri:708b36a85852210d2aa37cd0a43c31d6 .
+
+niiri:60833962d796c1925bb5caa354752e20
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0018" ;
+    prov:atLocation niiri:0286ca8f9f6d1abb7e43fe83af301e65 ;
+    prov:value "1.79001986980438"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.78891283515708"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0368144271933957"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:0286ca8f9f6d1abb7e43fe83af301e65
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0018" ;
+    nidm_coordinateVector: "[-20,26,28]"^^xsd:string .
+
+niiri:60833962d796c1925bb5caa354752e20 prov:wasDerivedFrom niiri:9fb5666ada501891fcef9d333ed6afff .
+
+niiri:f44eff18cdf7e25979cf1141a5338fc0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0019" ;
+    prov:atLocation niiri:9d4722db398870c6b3ea92787232d10a ;
+    prov:value "1.74872362613678"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.749102772694"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0401366280244358"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:9d4722db398870c6b3ea92787232d10a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0019" ;
+    nidm_coordinateVector: "[-54,28,20]"^^xsd:string .
+
+niiri:f44eff18cdf7e25979cf1141a5338fc0 prov:wasDerivedFrom niiri:756837e339677511c64f8da38004cd2e .
+
+niiri:7d958f3e975bddab9f95985faaae5cad
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0020" ;
+    prov:atLocation niiri:338c9616ae26c8e59158924ee7b04682 ;
+    prov:value "1.73660695552826"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73743465054505"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0411552397567266"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:338c9616ae26c8e59158924ee7b04682
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0020" ;
+    nidm_coordinateVector: "[36,-56,-12]"^^xsd:string .
+
+niiri:7d958f3e975bddab9f95985faaae5cad prov:wasDerivedFrom niiri:303983981b9e7155b24ee729485e35d5 .
+
+niiri:8f47804dc4763167b41a429473c75db8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0021" ;
+    prov:atLocation niiri:590b0466ddb6db870e7a7eb6ccc2f0c5 ;
+    prov:value "1.72697401046753"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.72816258455492"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0419795398198842"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:590b0466ddb6db870e7a7eb6ccc2f0c5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0021" ;
+    nidm_coordinateVector: "[12,74,8]"^^xsd:string .
+
+niiri:8f47804dc4763167b41a429473c75db8 prov:wasDerivedFrom niiri:ff25cf8967cf153c0c4bac8744bfd4de .
+
+niiri:d86f7773fa7f7c82a9d04542bdbbd522
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0022" ;
+    prov:atLocation niiri:4a94efdcb82d851208aa8b066ac5c604 ;
+    prov:value "1.69681537151337"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.69915940103581"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0446445768205113"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:4a94efdcb82d851208aa8b066ac5c604
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0022" ;
+    nidm_coordinateVector: "[-28,50,36]"^^xsd:string .
+
+niiri:d86f7773fa7f7c82a9d04542bdbbd522 prov:wasDerivedFrom niiri:1e1d5e2b654ff9dfd561671bb14dac45 .
+
+niiri:27b1286570a35003fd1cb892df5003ee
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0023" ;
+    prov:atLocation niiri:fd0f08df1132bd69544d5c2bc67a8ce1 ;
+    prov:value "1.69281709194183"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.69531733220798"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0450076192977755"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:fd0f08df1132bd69544d5c2bc67a8ce1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0023" ;
+    nidm_coordinateVector: "[-54,28,12]"^^xsd:string .
+
+niiri:27b1286570a35003fd1cb892df5003ee prov:wasDerivedFrom niiri:04d3366efa2ae78508ba78d4f6d3fbd4 .
+
+niiri:39aa9652e5edc473ede61063b5f9330b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0024" ;
+    prov:atLocation niiri:f19ef86275c6e6fc9f17827d454cea6f ;
+    prov:value "1.68880593776703"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.69146362670159"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0453741445419741"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:f19ef86275c6e6fc9f17827d454cea6f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0024" ;
+    nidm_coordinateVector: "[26,-92,18]"^^xsd:string .
+
+niiri:39aa9652e5edc473ede61063b5f9330b prov:wasDerivedFrom niiri:471616239367dd0b8f23af62cd1178af .
+
+niiri:9607bb62ecc6289f2476a8bb82c2c966
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0025" ;
+    prov:atLocation niiri:9759d63712f31dd71f970ba24fdc02ba ;
+    prov:value "1.68117702007294"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.68413622248109"^^xsd:float ;
+    nidm_pValueUncorrected: "0.046077672706774"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:9759d63712f31dd71f970ba24fdc02ba
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0025" ;
+    nidm_coordinateVector: "[42,-78,6]"^^xsd:string .
+
+niiri:9607bb62ecc6289f2476a8bb82c2c966 prov:wasDerivedFrom niiri:146e852a595d2bd9bf43b63cb1ffe554 .
+
+niiri:5aac45256e13cd03a2a1e390f5df998d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0026" ;
+    prov:atLocation niiri:7b8ba463b7a085d4623751d494579f21 ;
+    prov:value "1.67713749408722"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.68025745484094"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0464536174884935"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:7b8ba463b7a085d4623751d494579f21
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0026" ;
+    nidm_coordinateVector: "[-12,26,36]"^^xsd:string .
+
+niiri:5aac45256e13cd03a2a1e390f5df998d prov:wasDerivedFrom niiri:c76d475fb44856dbc3b3660c08027d10 .
+
+niiri:aa7acc61eb0d336d8adfd1c279535ef0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0027" ;
+    prov:atLocation niiri:f60e25b0c2abc9fe4d73f5854c0adbee ;
+    prov:value "1.67311263084412"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.6763935381234"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0468305669041873"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:f60e25b0c2abc9fe4d73f5854c0adbee
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0027" ;
+    nidm_coordinateVector: "[12,-94,-32]"^^xsd:string .
+
+niiri:aa7acc61eb0d336d8adfd1c279535ef0 prov:wasDerivedFrom niiri:171a3293a830389fbc0eeedac10ab2ef .
+
+niiri:309b2780bdf657c8f0c7a6410916169c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0028" ;
+    prov:atLocation niiri:967f245c1c386892dbecddea40037b53 ;
+    prov:value "1.67067694664001"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.67405562956399"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0470598334324596"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:967f245c1c386892dbecddea40037b53
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0028" ;
+    nidm_coordinateVector: "[24,-92,-30]"^^xsd:string .
+
+niiri:309b2780bdf657c8f0c7a6410916169c prov:wasDerivedFrom niiri:230b132218201af072b76732d6cd366e .
+
+niiri:ed3607586490b22746adf59129afa310
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0029" ;
+    prov:atLocation niiri:fddb34281430a5ac7649b34b53b04c89 ;
+    prov:value "1.66812241077423"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.67160394831323"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0473012228473357"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:fddb34281430a5ac7649b34b53b04c89
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0029" ;
+    nidm_coordinateVector: "[-24,22,22]"^^xsd:string .
+
+niiri:ed3607586490b22746adf59129afa310 prov:wasDerivedFrom niiri:88b6854434c4c7d7d77b89858ff66d15 .
+
+niiri:cb35f3207972df7107e6d2aea1bfbde2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0030" ;
+    prov:atLocation niiri:36ff55a8118b6b1b3e001a7636293a8f ;
+    prov:value "1.66770362854004"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.67120205793481"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0473408869609759"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:36ff55a8118b6b1b3e001a7636293a8f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0030" ;
+    nidm_coordinateVector: "[26,-90,22]"^^xsd:string .
+
+niiri:cb35f3207972df7107e6d2aea1bfbde2 prov:wasDerivedFrom niiri:983ff16f46a1aa2fb13613f2c2f88011 .
+
+niiri:9545b4314633cb0868f593c5d38febb7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0031" ;
+    prov:atLocation niiri:9803db31221b2c078fe55c084d5d83ed ;
+    prov:value "1.66512632369995"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.66872889854066"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0475855596349387"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:9803db31221b2c078fe55c084d5d83ed
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0031" ;
+    nidm_coordinateVector: "[32,-60,-2]"^^xsd:string .
+
+niiri:9545b4314633cb0868f593c5d38febb7 prov:wasDerivedFrom niiri:a6327d343c9ff6cf00c6cbe83308072b .
+
+niiri:02317feaa78e69f7d7f9737af5644214
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0032" ;
+    prov:atLocation niiri:5d4415f1293150147830ba8d2fe89e88 ;
+    prov:value "1.6600536108017"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.66386211897632"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0480699933329287"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.993657486705384"^^xsd:float .
+
+niiri:5d4415f1293150147830ba8d2fe89e88
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0032" ;
+    nidm_coordinateVector: "[-44,-56,-32]"^^xsd:string .
+
+niiri:02317feaa78e69f7d7f9737af5644214 prov:wasDerivedFrom niiri:92ac4a8cb0a6c243ecb32fc66fd3deab .
+

--- a/spmexport/ex_spm_contrast_mask/config.json
+++ b/spmexport/ex_spm_contrast_mask/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["contrast_mask/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_contrast_mask/nidm.provn
+++ b/spmexport/ex_spm_contrast_mask/nidm.provn
@@ -1,0 +1,445 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:dc265b3f4681d0cbdf40bfb1741fcd71,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:9f4873dc8724bddf712e42767d834d26,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:40f2816759812d9b5773e8b22843ff7e,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:40f2816759812d9b5773e8b22843ff7e, niiri:9f4873dc8724bddf712e42767d834d26, -)
+  wasGeneratedBy(niiri:dc265b3f4681d0cbdf40bfb1741fcd71, niiri:40f2816759812d9b5773e8b22843ff7e, 2016-01-11T10:11:10)
+  bundle niiri:dc265b3f4681d0cbdf40bfb1741fcd71
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_DisplayMaskMap <http://purl.org/nidash/nidm#NIDM_0000020>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+
+    agent(niiri:73856e71cd85f29c845dcd47e6fd1553,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:d2c45297c2b4308a0090e6f05682e0ef,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:7770425c1fda5bbcccf2ba798dabfe46,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:309b8cbbeb7b8628282eb5748b3c2979,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:6d4f652746845571d84967301f954e4b,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:9d9afe40e86a14084e331044de9f84fa',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:309b8cbbeb7b8628282eb5748b3c2979',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:9d9afe40e86a14084e331044de9f84fa,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:c81885f96fe9093297ded3a37f642d59,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:a903f04dfdb0b04d123c49f2bb4526a0,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:a903f04dfdb0b04d123c49f2bb4526a0, niiri:73856e71cd85f29c845dcd47e6fd1553, -)
+    used(niiri:a903f04dfdb0b04d123c49f2bb4526a0, niiri:6d4f652746845571d84967301f954e4b, -)
+    used(niiri:a903f04dfdb0b04d123c49f2bb4526a0, niiri:7770425c1fda5bbcccf2ba798dabfe46, -)
+    used(niiri:a903f04dfdb0b04d123c49f2bb4526a0, niiri:c81885f96fe9093297ded3a37f642d59, -)
+    entity(niiri:8f2e00d2382b1a7614e69b9bc96b0b15,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    entity(niiri:935ad95211ccd5ac37f0aeeeb41a54eb,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
+    wasDerivedFrom(niiri:8f2e00d2382b1a7614e69b9bc96b0b15, niiri:935ad95211ccd5ac37f0aeeeb41a54eb, -, -, -)
+    wasGeneratedBy(niiri:8f2e00d2382b1a7614e69b9bc96b0b15, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
+    entity(niiri:7ecf42b9e909ffb70ace6169d26f4b87,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "121.744659423828" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
+    wasGeneratedBy(niiri:7ecf42b9e909ffb70ace6169d26f4b87, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
+    entity(niiri:e6b2ebbaf8b9da48fa61162a52f0472e,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef'])
+    entity(niiri:a81f1c3b2bb8578c66e094c84d95f8ce,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
+    wasDerivedFrom(niiri:e6b2ebbaf8b9da48fa61162a52f0472e, niiri:a81f1c3b2bb8578c66e094c84d95f8ce, -, -, -)
+    wasGeneratedBy(niiri:e6b2ebbaf8b9da48fa61162a52f0472e, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
+    entity(niiri:7599c79dee642708b0ff7406cc2fad45,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef'])
+    entity(niiri:251258ff5d3ac60578fc277216a050af,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
+    wasDerivedFrom(niiri:7599c79dee642708b0ff7406cc2fad45, niiri:251258ff5d3ac60578fc277216a050af, -, -, -)
+    wasGeneratedBy(niiri:7599c79dee642708b0ff7406cc2fad45, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
+    entity(niiri:ccffb6ed7b41778439cf64b531a10d11,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef'])
+    entity(niiri:634eabe99ed8e72d7ae8abfc9619778f,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
+    wasDerivedFrom(niiri:ccffb6ed7b41778439cf64b531a10d11, niiri:634eabe99ed8e72d7ae8abfc9619778f, -, -, -)
+    wasGeneratedBy(niiri:ccffb6ed7b41778439cf64b531a10d11, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
+    entity(niiri:316761c8d1bf0b16027a1b8cdc4fac27,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
+    entity(niiri:516f43d02318f34ebd03b8059e5e24f8,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
+    wasDerivedFrom(niiri:316761c8d1bf0b16027a1b8cdc4fac27, niiri:516f43d02318f34ebd03b8059e5e24f8, -, -, -)
+    wasGeneratedBy(niiri:316761c8d1bf0b16027a1b8cdc4fac27, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
+    entity(niiri:78e9119d03a0988704bbbe7479967331,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
+    entity(niiri:6b7f1c95bef9d5eb4e6f489ef9dc800e,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
+    wasDerivedFrom(niiri:78e9119d03a0988704bbbe7479967331, niiri:6b7f1c95bef9d5eb4e6f489ef9dc800e, -, -, -)
+    wasGeneratedBy(niiri:78e9119d03a0988704bbbe7479967331, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
+    entity(niiri:b4883919edf3b1325dd80d4f62518d74,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        prov:label = "Contrast: pos vs neg" %% xsd:string,
+        prov:value = "[1, -1, 0]" %% xsd:string])
+    activity(niiri:3e06602588c25ad9f90cba6c2c74974e,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:73856e71cd85f29c845dcd47e6fd1553, -)
+    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:8f2e00d2382b1a7614e69b9bc96b0b15, -)
+    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:316761c8d1bf0b16027a1b8cdc4fac27, -)
+    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:6d4f652746845571d84967301f954e4b, -)
+    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:b4883919edf3b1325dd80d4f62518d74, -)
+    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:e6b2ebbaf8b9da48fa61162a52f0472e, -)
+    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:7599c79dee642708b0ff7406cc2fad45, -)
+    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:ccffb6ed7b41778439cf64b531a10d11, -)
+    entity(niiri:047589c24089fe2835015d8fda752ae3,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: pos vs neg" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
+    entity(niiri:b91d28ec6303cb84a0700d4d0fc56dc0,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
+    wasDerivedFrom(niiri:047589c24089fe2835015d8fda752ae3, niiri:b91d28ec6303cb84a0700d4d0fc56dc0, -, -, -)
+    wasGeneratedBy(niiri:047589c24089fe2835015d8fda752ae3, niiri:3e06602588c25ad9f90cba6c2c74974e, -)
+    entity(niiri:df3e747a4bf63c5e6d8cdcf941740af1,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: pos vs neg" %% xsd:string,
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
+    entity(niiri:455ef80f70e56dc478c28459debbe6a9,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
+    wasDerivedFrom(niiri:df3e747a4bf63c5e6d8cdcf941740af1, niiri:455ef80f70e56dc478c28459debbe6a9, -, -, -)
+    wasGeneratedBy(niiri:df3e747a4bf63c5e6d8cdcf941740af1, niiri:3e06602588c25ad9f90cba6c2c74974e, -)
+    entity(niiri:b59baee2b34fa927b2b76637a3355a4a,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
+    wasGeneratedBy(niiri:b59baee2b34fa927b2b76637a3355a4a, niiri:3e06602588c25ad9f90cba6c2c74974e, -)
+    entity(niiri:0f0fbdc7ba1737de1af9a9f320c03c1a,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
+        prov:value = "0.000999499751574873" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:e675e86d61efac6e5dbfa85e31c02eb4',
+        nidm_equivalentThreshold: = 'niiri:6ef19c727e0caf3bf9f2633e8a583c16'])
+    entity(niiri:e675e86d61efac6e5dbfa85e31c02eb4,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "3.12856968604193" %% xsd:float])
+    entity(niiri:6ef19c727e0caf3bf9f2633e8a583c16,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.999999999998566" %% xsd:float])
+    entity(niiri:f6c0766d53e3c92caa5ff2b5a2bd1934,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:e29340c23f2eaa95405fa5fb9330ef6b',
+        nidm_equivalentThreshold: = 'niiri:baf4b7d454c1692d830ff220f02bf749'])
+    entity(niiri:e29340c23f2eaa95405fa5fb9330ef6b,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:baf4b7d454c1692d830ff220f02bf749,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:a217bc7f43919d5feb8c23658dfe6431,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:a5a8a3ed0cd3bf297321e338bbaa9c5d,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:fa29f8a32fdd4cc314c9e74398b9928e,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:73856e71cd85f29c845dcd47e6fd1553, -)
+    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:0f0fbdc7ba1737de1af9a9f320c03c1a, -)
+    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:f6c0766d53e3c92caa5ff2b5a2bd1934, -)
+    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:047589c24089fe2835015d8fda752ae3, -)
+    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:78e9119d03a0988704bbbe7479967331, -)
+    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:8f2e00d2382b1a7614e69b9bc96b0b15, -)
+    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:a217bc7f43919d5feb8c23658dfe6431, -)
+    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:a5a8a3ed0cd3bf297321e338bbaa9c5d, -)
+    entity(niiri:aa05fc0a0178d64d67c7573ede73e21a,
+        [prov:type = 'nidm_DisplayMaskMap:',
+        prov:location = "DisplayMask_0001.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "DisplayMask_0001.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Display Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62" %% xsd:string])
+    entity(niiri:0a1c819b342dd3d453c7159504dac74c,
+        [prov:type = 'nidm_DisplayMaskMap:',
+        nfo:fileName = "DisplayMask_0001.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62" %% xsd:string])
+    wasDerivedFrom(niiri:aa05fc0a0178d64d67c7573ede73e21a, niiri:0a1c819b342dd3d453c7159504dac74c, -, -, -)
+    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:aa05fc0a0178d64d67c7573ede73e21a, -)
+    entity(niiri:f886b77c81406b1d37a9f9696b5908de,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
+        nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
+        nidm_searchVolumeInResels: = "2650.12011223711" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.01704921884936, 4.07618247398105, 4.38831339907177]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.03409843769872, 8.1523649479621, 8.77662679814353]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "8.23486077915088" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "27.2707251644655" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.05094049746367" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    wasGeneratedBy(niiri:f886b77c81406b1d37a9f9696b5908de, niiri:fa29f8a32fdd4cc314c9e74398b9928e, -)
+    entity(niiri:9fe7122bcd502e668f8a16cf726d0d72,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
+        nidm_pValue: = "NaN" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:e5cc209947f83b56269f8595baba845f',
+        nidm_hasMaximumIntensityProjection: = 'niiri:d733826cb7919e2f2d485b14862a9872',
+        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
+    entity(niiri:e5cc209947f83b56269f8595baba845f,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:d733826cb7919e2f2d485b14862a9872,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:9fe7122bcd502e668f8a16cf726d0d72, niiri:fa29f8a32fdd4cc314c9e74398b9928e, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_contrast_mask/nidm.provn
+++ b/spmexport/ex_spm_contrast_mask/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:8da2092e9c5cb801769d0b385e232e6a,
+  entity(niiri:c06a9f39571e1f67bc5b526ebc1a4b3a,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:b91db0bec92042455fc3d7461ef70278,
+  agent(niiri:4277cc6495cbced735297f8939f859eb,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:8a63018d0fe0b29307668addedf220b8,
+  activity(niiri:ec180f94e0c184a254d0ec463c94711d,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:8a63018d0fe0b29307668addedf220b8, niiri:b91db0bec92042455fc3d7461ef70278, -)
-  wasGeneratedBy(niiri:8da2092e9c5cb801769d0b385e232e6a, niiri:8a63018d0fe0b29307668addedf220b8, 2016-01-11T10:33:25)
-  bundle niiri:8da2092e9c5cb801769d0b385e232e6a
+  wasAssociatedWith(niiri:ec180f94e0c184a254d0ec463c94711d, niiri:4277cc6495cbced735297f8939f859eb, -)
+  wasGeneratedBy(niiri:c06a9f39571e1f67bc5b526ebc1a4b3a, niiri:ec180f94e0c184a254d0ec463c94711d, 2016-01-11T10:43:45)
+  bundle niiri:c06a9f39571e1f67bc5b526ebc1a4b3a
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -120,12 +120,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:984d7168e984d7ee1825dbff00610fe2,
+    agent(niiri:764377a27f95d42e49c0064eb22775fa,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:604151ad3785ac0490c6f4e7cc97b9f4,
+    entity(niiri:6412923fed231d2401c392381339ad18,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -134,153 +134,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:a50da58e4dd0325af19e04cc0f271696,
+    entity(niiri:b60ccb939303d1b9b90656c8feb9bdb9,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:c795dd377205f22eb9b78700adbeb51f,
+    entity(niiri:d26eb12e6c187928bf5ed1dc0f6ed4b6,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:16f111861038e6ae9e34e4670786a60a,
+    entity(niiri:bf9b175d9f41375145e4af6dbceffcac,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:360689ae54d16861b51c542e033af544',
+        dc:description = 'niiri:7579f149870e234e050c500f85e6e2d1',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:c795dd377205f22eb9b78700adbeb51f',
+        nidm_hasDriftModel: = 'niiri:d26eb12e6c187928bf5ed1dc0f6ed4b6',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:360689ae54d16861b51c542e033af544,
+    entity(niiri:7579f149870e234e050c500f85e6e2d1,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:d6bdc1190ce2415d34b44bbc3cd4397c,
+    entity(niiri:fcce69046d89e5c7f5c6bd4bc7fcf48f,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:032ce1df6daf21aef8968c1053a455d2,
+    activity(niiri:da4b8cc476c6af7dcc744d82fbf824bc,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:032ce1df6daf21aef8968c1053a455d2, niiri:984d7168e984d7ee1825dbff00610fe2, -)
-    used(niiri:032ce1df6daf21aef8968c1053a455d2, niiri:16f111861038e6ae9e34e4670786a60a, -)
-    used(niiri:032ce1df6daf21aef8968c1053a455d2, niiri:a50da58e4dd0325af19e04cc0f271696, -)
-    used(niiri:032ce1df6daf21aef8968c1053a455d2, niiri:d6bdc1190ce2415d34b44bbc3cd4397c, -)
-    entity(niiri:dd4f7547ec5fc52c11b3c95fc8352b6f,
+    wasAssociatedWith(niiri:da4b8cc476c6af7dcc744d82fbf824bc, niiri:764377a27f95d42e49c0064eb22775fa, -)
+    used(niiri:da4b8cc476c6af7dcc744d82fbf824bc, niiri:bf9b175d9f41375145e4af6dbceffcac, -)
+    used(niiri:da4b8cc476c6af7dcc744d82fbf824bc, niiri:b60ccb939303d1b9b90656c8feb9bdb9, -)
+    used(niiri:da4b8cc476c6af7dcc744d82fbf824bc, niiri:fcce69046d89e5c7f5c6bd4bc7fcf48f, -)
+    entity(niiri:33c794b7c8714bb65b60a5894c7695c8,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:dea34bf1a708b5204474e9bd7dbdeb80,
+    entity(niiri:493c6b452a9aba5e10dc32865ad7d797,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:dd4f7547ec5fc52c11b3c95fc8352b6f, niiri:dea34bf1a708b5204474e9bd7dbdeb80, -, -, -)
-    wasGeneratedBy(niiri:dd4f7547ec5fc52c11b3c95fc8352b6f, niiri:032ce1df6daf21aef8968c1053a455d2, -)
-    entity(niiri:8cb432009bac65f0c60b4e6ce915333c,
+    wasDerivedFrom(niiri:33c794b7c8714bb65b60a5894c7695c8, niiri:493c6b452a9aba5e10dc32865ad7d797, -, -, -)
+    wasGeneratedBy(niiri:33c794b7c8714bb65b60a5894c7695c8, niiri:da4b8cc476c6af7dcc744d82fbf824bc, -)
+    entity(niiri:ff9740d7c942f700923bf0d6423f3796,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:8cb432009bac65f0c60b4e6ce915333c, niiri:032ce1df6daf21aef8968c1053a455d2, -)
-    entity(niiri:d3bb595f5d8d487461e71a3c089f1288,
+    wasGeneratedBy(niiri:ff9740d7c942f700923bf0d6423f3796, niiri:da4b8cc476c6af7dcc744d82fbf824bc, -)
+    entity(niiri:d62862879cb501953d05a8a7b23bacac,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4'])
-    entity(niiri:29d243f1ba13e9550ab6e765b94e187a,
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18'])
+    entity(niiri:2e53add50cc738c2eb2bbf5db2261ea0,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:d3bb595f5d8d487461e71a3c089f1288, niiri:29d243f1ba13e9550ab6e765b94e187a, -, -, -)
-    wasGeneratedBy(niiri:d3bb595f5d8d487461e71a3c089f1288, niiri:032ce1df6daf21aef8968c1053a455d2, -)
-    entity(niiri:af820f3c39ca14889a21e52b9cdf4e13,
+    wasDerivedFrom(niiri:d62862879cb501953d05a8a7b23bacac, niiri:2e53add50cc738c2eb2bbf5db2261ea0, -, -, -)
+    wasGeneratedBy(niiri:d62862879cb501953d05a8a7b23bacac, niiri:da4b8cc476c6af7dcc744d82fbf824bc, -)
+    entity(niiri:13dc7d34909bdbb052c446c95f97ea83,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4'])
-    entity(niiri:2b157ef526f7b65a4cee54dd340a138b,
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18'])
+    entity(niiri:1429f035a357f84353e0973174333485,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:af820f3c39ca14889a21e52b9cdf4e13, niiri:2b157ef526f7b65a4cee54dd340a138b, -, -, -)
-    wasGeneratedBy(niiri:af820f3c39ca14889a21e52b9cdf4e13, niiri:032ce1df6daf21aef8968c1053a455d2, -)
-    entity(niiri:f28c130e5d1a1f4e3ecec031df15f8fc,
+    wasDerivedFrom(niiri:13dc7d34909bdbb052c446c95f97ea83, niiri:1429f035a357f84353e0973174333485, -, -, -)
+    wasGeneratedBy(niiri:13dc7d34909bdbb052c446c95f97ea83, niiri:da4b8cc476c6af7dcc744d82fbf824bc, -)
+    entity(niiri:9d871e183fed166538e9f8ed7f2041a5,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4'])
-    entity(niiri:74d3c7bc834cbd986257ddeaf5934dc7,
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18'])
+    entity(niiri:d0bf67f0dd670d5fabba2f051423060d,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:f28c130e5d1a1f4e3ecec031df15f8fc, niiri:74d3c7bc834cbd986257ddeaf5934dc7, -, -, -)
-    wasGeneratedBy(niiri:f28c130e5d1a1f4e3ecec031df15f8fc, niiri:032ce1df6daf21aef8968c1053a455d2, -)
-    entity(niiri:c9126b5278cd74f74a3cc84da3a13a37,
+    wasDerivedFrom(niiri:9d871e183fed166538e9f8ed7f2041a5, niiri:d0bf67f0dd670d5fabba2f051423060d, -, -, -)
+    wasGeneratedBy(niiri:9d871e183fed166538e9f8ed7f2041a5, niiri:da4b8cc476c6af7dcc744d82fbf824bc, -)
+    entity(niiri:a3d0092d64af34982390bcf2c60ce79c,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:d7b93f171045f154967d886af8464db0,
+    entity(niiri:4cf3e595d4ec47a4ecdcbacc23b86f79,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:c9126b5278cd74f74a3cc84da3a13a37, niiri:d7b93f171045f154967d886af8464db0, -, -, -)
-    wasGeneratedBy(niiri:c9126b5278cd74f74a3cc84da3a13a37, niiri:032ce1df6daf21aef8968c1053a455d2, -)
-    entity(niiri:83810f5d1d6b8703df151fdfb4eff8ab,
+    wasDerivedFrom(niiri:a3d0092d64af34982390bcf2c60ce79c, niiri:4cf3e595d4ec47a4ecdcbacc23b86f79, -, -, -)
+    wasGeneratedBy(niiri:a3d0092d64af34982390bcf2c60ce79c, niiri:da4b8cc476c6af7dcc744d82fbf824bc, -)
+    entity(niiri:b864ee4870587b4c8b4299a03979a1e4,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:7515d45b26a6862f9461b48a112b135a,
+    entity(niiri:3561b36e56968f1e3ddd6544a509aa9c,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:83810f5d1d6b8703df151fdfb4eff8ab, niiri:7515d45b26a6862f9461b48a112b135a, -, -, -)
-    wasGeneratedBy(niiri:83810f5d1d6b8703df151fdfb4eff8ab, niiri:032ce1df6daf21aef8968c1053a455d2, -)
-    entity(niiri:b5a8ad64303a9f8dd45b1ec2a9b8558a,
+    wasDerivedFrom(niiri:b864ee4870587b4c8b4299a03979a1e4, niiri:3561b36e56968f1e3ddd6544a509aa9c, -, -, -)
+    wasGeneratedBy(niiri:b864ee4870587b4c8b4299a03979a1e4, niiri:da4b8cc476c6af7dcc744d82fbf824bc, -)
+    entity(niiri:981c5bd26f83062fe96c144bffe38491,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:17470629350db82678b9a0e41cb83877,
+    activity(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:17470629350db82678b9a0e41cb83877, niiri:984d7168e984d7ee1825dbff00610fe2, -)
-    used(niiri:17470629350db82678b9a0e41cb83877, niiri:dd4f7547ec5fc52c11b3c95fc8352b6f, -)
-    used(niiri:17470629350db82678b9a0e41cb83877, niiri:c9126b5278cd74f74a3cc84da3a13a37, -)
-    used(niiri:17470629350db82678b9a0e41cb83877, niiri:16f111861038e6ae9e34e4670786a60a, -)
-    used(niiri:17470629350db82678b9a0e41cb83877, niiri:b5a8ad64303a9f8dd45b1ec2a9b8558a, -)
-    used(niiri:17470629350db82678b9a0e41cb83877, niiri:d3bb595f5d8d487461e71a3c089f1288, -)
-    used(niiri:17470629350db82678b9a0e41cb83877, niiri:af820f3c39ca14889a21e52b9cdf4e13, -)
-    used(niiri:17470629350db82678b9a0e41cb83877, niiri:f28c130e5d1a1f4e3ecec031df15f8fc, -)
-    entity(niiri:80a517dfc1d79a9d9ff0858c874000f9,
+    wasAssociatedWith(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, niiri:764377a27f95d42e49c0064eb22775fa, -)
+    used(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, niiri:33c794b7c8714bb65b60a5894c7695c8, -)
+    used(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, niiri:a3d0092d64af34982390bcf2c60ce79c, -)
+    used(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, niiri:bf9b175d9f41375145e4af6dbceffcac, -)
+    used(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, niiri:981c5bd26f83062fe96c144bffe38491, -)
+    used(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, niiri:d62862879cb501953d05a8a7b23bacac, -)
+    used(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, niiri:13dc7d34909bdbb052c446c95f97ea83, -)
+    used(niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, niiri:9d871e183fed166538e9f8ed7f2041a5, -)
+    entity(niiri:f6f265bb04e376f36066cbb7998a60bf,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -290,118 +290,118 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:416c1d9da138f2b21157914a04cf4469,
+    entity(niiri:321dc00b40e95519dcfaa5fa9ae8e76d,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:80a517dfc1d79a9d9ff0858c874000f9, niiri:416c1d9da138f2b21157914a04cf4469, -, -, -)
-    wasGeneratedBy(niiri:80a517dfc1d79a9d9ff0858c874000f9, niiri:17470629350db82678b9a0e41cb83877, -)
-    entity(niiri:ceb24b4408693c41e8da68d09a2dc88d,
+    wasDerivedFrom(niiri:f6f265bb04e376f36066cbb7998a60bf, niiri:321dc00b40e95519dcfaa5fa9ae8e76d, -, -, -)
+    wasGeneratedBy(niiri:f6f265bb04e376f36066cbb7998a60bf, niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, -)
+    entity(niiri:7870e17a18d4f429cf62ba23931814d4,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:ed335d52caa4252ffd4415db85f3abc6,
+    entity(niiri:782e69773c189efd3e452d18a7895071,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:ceb24b4408693c41e8da68d09a2dc88d, niiri:ed335d52caa4252ffd4415db85f3abc6, -, -, -)
-    wasGeneratedBy(niiri:ceb24b4408693c41e8da68d09a2dc88d, niiri:17470629350db82678b9a0e41cb83877, -)
-    entity(niiri:eae5b5885d4cf1bead975525441188a4,
+    wasDerivedFrom(niiri:7870e17a18d4f429cf62ba23931814d4, niiri:782e69773c189efd3e452d18a7895071, -, -, -)
+    wasGeneratedBy(niiri:7870e17a18d4f429cf62ba23931814d4, niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, -)
+    entity(niiri:6b072ed99929b6fe1221c8e3030f6834,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:eae5b5885d4cf1bead975525441188a4, niiri:17470629350db82678b9a0e41cb83877, -)
-    entity(niiri:359106649328e22227982f9186ae05d1,
+    wasGeneratedBy(niiri:6b072ed99929b6fe1221c8e3030f6834, niiri:9f3c1a2748c00dc7f406a3b12aed9c2f, -)
+    entity(niiri:dc719b2df015f2d669f3c26395b4fb0b,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
         prov:value = "0.000999499751574873" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:2a77473ec77fbbeb8aec799ad8fae378',
-        nidm_equivalentThreshold: = 'niiri:8a7dd1f98ad25c84931ff87eac31400c'])
-    entity(niiri:2a77473ec77fbbeb8aec799ad8fae378,
+        nidm_equivalentThreshold: = 'niiri:4dfb90ae072c3f6306aee15016570fa3',
+        nidm_equivalentThreshold: = 'niiri:eb871170bc0255fe0f65a97fc67aa8e4'])
+    entity(niiri:4dfb90ae072c3f6306aee15016570fa3,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12856968604193" %% xsd:float])
-    entity(niiri:8a7dd1f98ad25c84931ff87eac31400c,
+    entity(niiri:eb871170bc0255fe0f65a97fc67aa8e4,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999998566" %% xsd:float])
-    entity(niiri:b392082b96ee307af6ad014dbfe5a244,
+    entity(niiri:ca0b1b9c8f7ca9065ed59d7db82f1893,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:88f2c2569fcd6936cd0fc4e5037e7446',
-        nidm_equivalentThreshold: = 'niiri:1c0f5f3c2723dbf05e045b6ba302128e'])
-    entity(niiri:88f2c2569fcd6936cd0fc4e5037e7446,
+        nidm_equivalentThreshold: = 'niiri:2a87bbcc9722c8a2ca8112c40183a0cb',
+        nidm_equivalentThreshold: = 'niiri:9dc8bebf7604deb38a8f1eca485dc855'])
+    entity(niiri:2a87bbcc9722c8a2ca8112c40183a0cb,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:1c0f5f3c2723dbf05e045b6ba302128e,
+    entity(niiri:9dc8bebf7604deb38a8f1eca485dc855,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:c85bcc1a9f8f5d153c2feb38bff117b3,
+    entity(niiri:f56ec8f9610469eb85f0c651de30962d,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:ba35fd505b40dfd2ebce2f598cfd69cc,
+    entity(niiri:6ba5a7123a5e6790e4942d1d60048257,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:00117ec3afec546e47f98639e5c887ca,
+    activity(niiri:af21179a8cd0915e2b0dd08e2c38a4de,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:00117ec3afec546e47f98639e5c887ca, niiri:984d7168e984d7ee1825dbff00610fe2, -)
-    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:359106649328e22227982f9186ae05d1, -)
-    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:b392082b96ee307af6ad014dbfe5a244, -)
-    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:80a517dfc1d79a9d9ff0858c874000f9, -)
-    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:83810f5d1d6b8703df151fdfb4eff8ab, -)
-    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:dd4f7547ec5fc52c11b3c95fc8352b6f, -)
-    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:c85bcc1a9f8f5d153c2feb38bff117b3, -)
-    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:ba35fd505b40dfd2ebce2f598cfd69cc, -)
-    entity(niiri:a06c1108dbc1970b6cbfbec0d66dca2c,
+    wasAssociatedWith(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:764377a27f95d42e49c0064eb22775fa, -)
+    used(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:dc719b2df015f2d669f3c26395b4fb0b, -)
+    used(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:ca0b1b9c8f7ca9065ed59d7db82f1893, -)
+    used(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:f6f265bb04e376f36066cbb7998a60bf, -)
+    used(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:b864ee4870587b4c8b4299a03979a1e4, -)
+    used(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:33c794b7c8714bb65b60a5894c7695c8, -)
+    used(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:f56ec8f9610469eb85f0c651de30962d, -)
+    used(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:6ba5a7123a5e6790e4942d1d60048257, -)
+    entity(niiri:63b3c158351c75ee0c91d434a3efb13f,
         [prov:type = 'nidm_DisplayMaskMap:',
         prov:location = "DisplayMask_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "DisplayMask_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Display Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62" %% xsd:string])
-    entity(niiri:2169516d50f819b5a3cc4759973af409,
+    entity(niiri:a47824d6d033fc4470b2cfbf5b4609b8,
         [prov:type = 'nidm_DisplayMaskMap:',
         nfo:fileName = "DisplayMask_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62" %% xsd:string])
-    wasDerivedFrom(niiri:a06c1108dbc1970b6cbfbec0d66dca2c, niiri:2169516d50f819b5a3cc4759973af409, -, -, -)
-    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:a06c1108dbc1970b6cbfbec0d66dca2c, -)
-    entity(niiri:ec5bc9615c7007a5fc20e99842caa4a4,
+    wasDerivedFrom(niiri:63b3c158351c75ee0c91d434a3efb13f, niiri:a47824d6d033fc4470b2cfbf5b4609b8, -, -, -)
+    used(niiri:af21179a8cd0915e2b0dd08e2c38a4de, niiri:63b3c158351c75ee0c91d434a3efb13f, -)
+    entity(niiri:57343ab21a8119a72ebb89a38a3bb354,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -417,8 +417,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:ec5bc9615c7007a5fc20e99842caa4a4, niiri:00117ec3afec546e47f98639e5c887ca, -)
-    entity(niiri:025c12df86a668880699d51c9ce3138b,
+    wasGeneratedBy(niiri:57343ab21a8119a72ebb89a38a3bb354, niiri:af21179a8cd0915e2b0dd08e2c38a4de, -)
+    entity(niiri:d1e5f51b914115bbcd75587d4ec489d6,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -426,20 +426,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:71eab44698eccf893972754371c4a961',
-        nidm_hasMaximumIntensityProjection: = 'niiri:9f618f0b5bb815a9c8193b5704f3b55f',
-        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
+        nidm_hasClusterLabelsMap: = 'niiri:7b937b59d0775c2c122d2fa7d8f50a1a',
+        nidm_hasMaximumIntensityProjection: = 'niiri:42b1ac61db1939302cc36658967bb301',
+        nidm_inCoordinateSpace: = 'niiri:6412923fed231d2401c392381339ad18',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:71eab44698eccf893972754371c4a961,
+    entity(niiri:7b937b59d0775c2c122d2fa7d8f50a1a,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:9f618f0b5bb815a9c8193b5704f3b55f,
+    entity(niiri:42b1ac61db1939302cc36658967bb301,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:025c12df86a668880699d51c9ce3138b, niiri:00117ec3afec546e47f98639e5c887ca, -)
+    wasGeneratedBy(niiri:d1e5f51b914115bbcd75587d4ec489d6, niiri:af21179a8cd0915e2b0dd08e2c38a4de, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_contrast_mask/nidm.provn
+++ b/spmexport/ex_spm_contrast_mask/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:dc265b3f4681d0cbdf40bfb1741fcd71,
+  entity(niiri:8da2092e9c5cb801769d0b385e232e6a,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:9f4873dc8724bddf712e42767d834d26,
+  agent(niiri:b91db0bec92042455fc3d7461ef70278,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:40f2816759812d9b5773e8b22843ff7e,
+  activity(niiri:8a63018d0fe0b29307668addedf220b8,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:40f2816759812d9b5773e8b22843ff7e, niiri:9f4873dc8724bddf712e42767d834d26, -)
-  wasGeneratedBy(niiri:dc265b3f4681d0cbdf40bfb1741fcd71, niiri:40f2816759812d9b5773e8b22843ff7e, 2016-01-11T10:11:10)
-  bundle niiri:dc265b3f4681d0cbdf40bfb1741fcd71
+  wasAssociatedWith(niiri:8a63018d0fe0b29307668addedf220b8, niiri:b91db0bec92042455fc3d7461ef70278, -)
+  wasGeneratedBy(niiri:8da2092e9c5cb801769d0b385e232e6a, niiri:8a63018d0fe0b29307668addedf220b8, 2016-01-11T10:33:25)
+  bundle niiri:8da2092e9c5cb801769d0b385e232e6a
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -120,12 +120,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:73856e71cd85f29c845dcd47e6fd1553,
+    agent(niiri:984d7168e984d7ee1825dbff00610fe2,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:d2c45297c2b4308a0090e6f05682e0ef,
+    entity(niiri:604151ad3785ac0490c6f4e7cc97b9f4,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -134,153 +134,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:7770425c1fda5bbcccf2ba798dabfe46,
+    entity(niiri:a50da58e4dd0325af19e04cc0f271696,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:309b8cbbeb7b8628282eb5748b3c2979,
+    entity(niiri:c795dd377205f22eb9b78700adbeb51f,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:6d4f652746845571d84967301f954e4b,
+    entity(niiri:16f111861038e6ae9e34e4670786a60a,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:9d9afe40e86a14084e331044de9f84fa',
+        dc:description = 'niiri:360689ae54d16861b51c542e033af544',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:309b8cbbeb7b8628282eb5748b3c2979',
+        nidm_hasDriftModel: = 'niiri:c795dd377205f22eb9b78700adbeb51f',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:9d9afe40e86a14084e331044de9f84fa,
+    entity(niiri:360689ae54d16861b51c542e033af544,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:c81885f96fe9093297ded3a37f642d59,
+    entity(niiri:d6bdc1190ce2415d34b44bbc3cd4397c,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:a903f04dfdb0b04d123c49f2bb4526a0,
+    activity(niiri:032ce1df6daf21aef8968c1053a455d2,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:a903f04dfdb0b04d123c49f2bb4526a0, niiri:73856e71cd85f29c845dcd47e6fd1553, -)
-    used(niiri:a903f04dfdb0b04d123c49f2bb4526a0, niiri:6d4f652746845571d84967301f954e4b, -)
-    used(niiri:a903f04dfdb0b04d123c49f2bb4526a0, niiri:7770425c1fda5bbcccf2ba798dabfe46, -)
-    used(niiri:a903f04dfdb0b04d123c49f2bb4526a0, niiri:c81885f96fe9093297ded3a37f642d59, -)
-    entity(niiri:8f2e00d2382b1a7614e69b9bc96b0b15,
+    wasAssociatedWith(niiri:032ce1df6daf21aef8968c1053a455d2, niiri:984d7168e984d7ee1825dbff00610fe2, -)
+    used(niiri:032ce1df6daf21aef8968c1053a455d2, niiri:16f111861038e6ae9e34e4670786a60a, -)
+    used(niiri:032ce1df6daf21aef8968c1053a455d2, niiri:a50da58e4dd0325af19e04cc0f271696, -)
+    used(niiri:032ce1df6daf21aef8968c1053a455d2, niiri:d6bdc1190ce2415d34b44bbc3cd4397c, -)
+    entity(niiri:dd4f7547ec5fc52c11b3c95fc8352b6f,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:935ad95211ccd5ac37f0aeeeb41a54eb,
+    entity(niiri:dea34bf1a708b5204474e9bd7dbdeb80,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:8f2e00d2382b1a7614e69b9bc96b0b15, niiri:935ad95211ccd5ac37f0aeeeb41a54eb, -, -, -)
-    wasGeneratedBy(niiri:8f2e00d2382b1a7614e69b9bc96b0b15, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
-    entity(niiri:7ecf42b9e909ffb70ace6169d26f4b87,
+    wasDerivedFrom(niiri:dd4f7547ec5fc52c11b3c95fc8352b6f, niiri:dea34bf1a708b5204474e9bd7dbdeb80, -, -, -)
+    wasGeneratedBy(niiri:dd4f7547ec5fc52c11b3c95fc8352b6f, niiri:032ce1df6daf21aef8968c1053a455d2, -)
+    entity(niiri:8cb432009bac65f0c60b4e6ce915333c,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:7ecf42b9e909ffb70ace6169d26f4b87, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
-    entity(niiri:e6b2ebbaf8b9da48fa61162a52f0472e,
+    wasGeneratedBy(niiri:8cb432009bac65f0c60b4e6ce915333c, niiri:032ce1df6daf21aef8968c1053a455d2, -)
+    entity(niiri:d3bb595f5d8d487461e71a3c089f1288,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef'])
-    entity(niiri:a81f1c3b2bb8578c66e094c84d95f8ce,
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4'])
+    entity(niiri:29d243f1ba13e9550ab6e765b94e187a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:e6b2ebbaf8b9da48fa61162a52f0472e, niiri:a81f1c3b2bb8578c66e094c84d95f8ce, -, -, -)
-    wasGeneratedBy(niiri:e6b2ebbaf8b9da48fa61162a52f0472e, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
-    entity(niiri:7599c79dee642708b0ff7406cc2fad45,
+    wasDerivedFrom(niiri:d3bb595f5d8d487461e71a3c089f1288, niiri:29d243f1ba13e9550ab6e765b94e187a, -, -, -)
+    wasGeneratedBy(niiri:d3bb595f5d8d487461e71a3c089f1288, niiri:032ce1df6daf21aef8968c1053a455d2, -)
+    entity(niiri:af820f3c39ca14889a21e52b9cdf4e13,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef'])
-    entity(niiri:251258ff5d3ac60578fc277216a050af,
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4'])
+    entity(niiri:2b157ef526f7b65a4cee54dd340a138b,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:7599c79dee642708b0ff7406cc2fad45, niiri:251258ff5d3ac60578fc277216a050af, -, -, -)
-    wasGeneratedBy(niiri:7599c79dee642708b0ff7406cc2fad45, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
-    entity(niiri:ccffb6ed7b41778439cf64b531a10d11,
+    wasDerivedFrom(niiri:af820f3c39ca14889a21e52b9cdf4e13, niiri:2b157ef526f7b65a4cee54dd340a138b, -, -, -)
+    wasGeneratedBy(niiri:af820f3c39ca14889a21e52b9cdf4e13, niiri:032ce1df6daf21aef8968c1053a455d2, -)
+    entity(niiri:f28c130e5d1a1f4e3ecec031df15f8fc,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef'])
-    entity(niiri:634eabe99ed8e72d7ae8abfc9619778f,
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4'])
+    entity(niiri:74d3c7bc834cbd986257ddeaf5934dc7,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:ccffb6ed7b41778439cf64b531a10d11, niiri:634eabe99ed8e72d7ae8abfc9619778f, -, -, -)
-    wasGeneratedBy(niiri:ccffb6ed7b41778439cf64b531a10d11, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
-    entity(niiri:316761c8d1bf0b16027a1b8cdc4fac27,
+    wasDerivedFrom(niiri:f28c130e5d1a1f4e3ecec031df15f8fc, niiri:74d3c7bc834cbd986257ddeaf5934dc7, -, -, -)
+    wasGeneratedBy(niiri:f28c130e5d1a1f4e3ecec031df15f8fc, niiri:032ce1df6daf21aef8968c1053a455d2, -)
+    entity(niiri:c9126b5278cd74f74a3cc84da3a13a37,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:516f43d02318f34ebd03b8059e5e24f8,
+    entity(niiri:d7b93f171045f154967d886af8464db0,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:316761c8d1bf0b16027a1b8cdc4fac27, niiri:516f43d02318f34ebd03b8059e5e24f8, -, -, -)
-    wasGeneratedBy(niiri:316761c8d1bf0b16027a1b8cdc4fac27, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
-    entity(niiri:78e9119d03a0988704bbbe7479967331,
+    wasDerivedFrom(niiri:c9126b5278cd74f74a3cc84da3a13a37, niiri:d7b93f171045f154967d886af8464db0, -, -, -)
+    wasGeneratedBy(niiri:c9126b5278cd74f74a3cc84da3a13a37, niiri:032ce1df6daf21aef8968c1053a455d2, -)
+    entity(niiri:83810f5d1d6b8703df151fdfb4eff8ab,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:6b7f1c95bef9d5eb4e6f489ef9dc800e,
+    entity(niiri:7515d45b26a6862f9461b48a112b135a,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:78e9119d03a0988704bbbe7479967331, niiri:6b7f1c95bef9d5eb4e6f489ef9dc800e, -, -, -)
-    wasGeneratedBy(niiri:78e9119d03a0988704bbbe7479967331, niiri:a903f04dfdb0b04d123c49f2bb4526a0, -)
-    entity(niiri:b4883919edf3b1325dd80d4f62518d74,
+    wasDerivedFrom(niiri:83810f5d1d6b8703df151fdfb4eff8ab, niiri:7515d45b26a6862f9461b48a112b135a, -, -, -)
+    wasGeneratedBy(niiri:83810f5d1d6b8703df151fdfb4eff8ab, niiri:032ce1df6daf21aef8968c1053a455d2, -)
+    entity(niiri:b5a8ad64303a9f8dd45b1ec2a9b8558a,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:3e06602588c25ad9f90cba6c2c74974e,
+    activity(niiri:17470629350db82678b9a0e41cb83877,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:73856e71cd85f29c845dcd47e6fd1553, -)
-    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:8f2e00d2382b1a7614e69b9bc96b0b15, -)
-    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:316761c8d1bf0b16027a1b8cdc4fac27, -)
-    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:6d4f652746845571d84967301f954e4b, -)
-    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:b4883919edf3b1325dd80d4f62518d74, -)
-    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:e6b2ebbaf8b9da48fa61162a52f0472e, -)
-    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:7599c79dee642708b0ff7406cc2fad45, -)
-    used(niiri:3e06602588c25ad9f90cba6c2c74974e, niiri:ccffb6ed7b41778439cf64b531a10d11, -)
-    entity(niiri:047589c24089fe2835015d8fda752ae3,
+    wasAssociatedWith(niiri:17470629350db82678b9a0e41cb83877, niiri:984d7168e984d7ee1825dbff00610fe2, -)
+    used(niiri:17470629350db82678b9a0e41cb83877, niiri:dd4f7547ec5fc52c11b3c95fc8352b6f, -)
+    used(niiri:17470629350db82678b9a0e41cb83877, niiri:c9126b5278cd74f74a3cc84da3a13a37, -)
+    used(niiri:17470629350db82678b9a0e41cb83877, niiri:16f111861038e6ae9e34e4670786a60a, -)
+    used(niiri:17470629350db82678b9a0e41cb83877, niiri:b5a8ad64303a9f8dd45b1ec2a9b8558a, -)
+    used(niiri:17470629350db82678b9a0e41cb83877, niiri:d3bb595f5d8d487461e71a3c089f1288, -)
+    used(niiri:17470629350db82678b9a0e41cb83877, niiri:af820f3c39ca14889a21e52b9cdf4e13, -)
+    used(niiri:17470629350db82678b9a0e41cb83877, niiri:f28c130e5d1a1f4e3ecec031df15f8fc, -)
+    entity(niiri:80a517dfc1d79a9d9ff0858c874000f9,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -290,118 +290,118 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:b91d28ec6303cb84a0700d4d0fc56dc0,
+    entity(niiri:416c1d9da138f2b21157914a04cf4469,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:047589c24089fe2835015d8fda752ae3, niiri:b91d28ec6303cb84a0700d4d0fc56dc0, -, -, -)
-    wasGeneratedBy(niiri:047589c24089fe2835015d8fda752ae3, niiri:3e06602588c25ad9f90cba6c2c74974e, -)
-    entity(niiri:df3e747a4bf63c5e6d8cdcf941740af1,
+    wasDerivedFrom(niiri:80a517dfc1d79a9d9ff0858c874000f9, niiri:416c1d9da138f2b21157914a04cf4469, -, -, -)
+    wasGeneratedBy(niiri:80a517dfc1d79a9d9ff0858c874000f9, niiri:17470629350db82678b9a0e41cb83877, -)
+    entity(niiri:ceb24b4408693c41e8da68d09a2dc88d,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:455ef80f70e56dc478c28459debbe6a9,
+    entity(niiri:ed335d52caa4252ffd4415db85f3abc6,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:df3e747a4bf63c5e6d8cdcf941740af1, niiri:455ef80f70e56dc478c28459debbe6a9, -, -, -)
-    wasGeneratedBy(niiri:df3e747a4bf63c5e6d8cdcf941740af1, niiri:3e06602588c25ad9f90cba6c2c74974e, -)
-    entity(niiri:b59baee2b34fa927b2b76637a3355a4a,
+    wasDerivedFrom(niiri:ceb24b4408693c41e8da68d09a2dc88d, niiri:ed335d52caa4252ffd4415db85f3abc6, -, -, -)
+    wasGeneratedBy(niiri:ceb24b4408693c41e8da68d09a2dc88d, niiri:17470629350db82678b9a0e41cb83877, -)
+    entity(niiri:eae5b5885d4cf1bead975525441188a4,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:b59baee2b34fa927b2b76637a3355a4a, niiri:3e06602588c25ad9f90cba6c2c74974e, -)
-    entity(niiri:0f0fbdc7ba1737de1af9a9f320c03c1a,
+    wasGeneratedBy(niiri:eae5b5885d4cf1bead975525441188a4, niiri:17470629350db82678b9a0e41cb83877, -)
+    entity(niiri:359106649328e22227982f9186ae05d1,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
         prov:value = "0.000999499751574873" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:e675e86d61efac6e5dbfa85e31c02eb4',
-        nidm_equivalentThreshold: = 'niiri:6ef19c727e0caf3bf9f2633e8a583c16'])
-    entity(niiri:e675e86d61efac6e5dbfa85e31c02eb4,
+        nidm_equivalentThreshold: = 'niiri:2a77473ec77fbbeb8aec799ad8fae378',
+        nidm_equivalentThreshold: = 'niiri:8a7dd1f98ad25c84931ff87eac31400c'])
+    entity(niiri:2a77473ec77fbbeb8aec799ad8fae378,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12856968604193" %% xsd:float])
-    entity(niiri:6ef19c727e0caf3bf9f2633e8a583c16,
+    entity(niiri:8a7dd1f98ad25c84931ff87eac31400c,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999998566" %% xsd:float])
-    entity(niiri:f6c0766d53e3c92caa5ff2b5a2bd1934,
+    entity(niiri:b392082b96ee307af6ad014dbfe5a244,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:e29340c23f2eaa95405fa5fb9330ef6b',
-        nidm_equivalentThreshold: = 'niiri:baf4b7d454c1692d830ff220f02bf749'])
-    entity(niiri:e29340c23f2eaa95405fa5fb9330ef6b,
+        nidm_equivalentThreshold: = 'niiri:88f2c2569fcd6936cd0fc4e5037e7446',
+        nidm_equivalentThreshold: = 'niiri:1c0f5f3c2723dbf05e045b6ba302128e'])
+    entity(niiri:88f2c2569fcd6936cd0fc4e5037e7446,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:baf4b7d454c1692d830ff220f02bf749,
+    entity(niiri:1c0f5f3c2723dbf05e045b6ba302128e,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:a217bc7f43919d5feb8c23658dfe6431,
+    entity(niiri:c85bcc1a9f8f5d153c2feb38bff117b3,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:a5a8a3ed0cd3bf297321e338bbaa9c5d,
+    entity(niiri:ba35fd505b40dfd2ebce2f598cfd69cc,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:fa29f8a32fdd4cc314c9e74398b9928e,
+    activity(niiri:00117ec3afec546e47f98639e5c887ca,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:73856e71cd85f29c845dcd47e6fd1553, -)
-    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:0f0fbdc7ba1737de1af9a9f320c03c1a, -)
-    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:f6c0766d53e3c92caa5ff2b5a2bd1934, -)
-    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:047589c24089fe2835015d8fda752ae3, -)
-    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:78e9119d03a0988704bbbe7479967331, -)
-    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:8f2e00d2382b1a7614e69b9bc96b0b15, -)
-    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:a217bc7f43919d5feb8c23658dfe6431, -)
-    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:a5a8a3ed0cd3bf297321e338bbaa9c5d, -)
-    entity(niiri:aa05fc0a0178d64d67c7573ede73e21a,
+    wasAssociatedWith(niiri:00117ec3afec546e47f98639e5c887ca, niiri:984d7168e984d7ee1825dbff00610fe2, -)
+    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:359106649328e22227982f9186ae05d1, -)
+    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:b392082b96ee307af6ad014dbfe5a244, -)
+    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:80a517dfc1d79a9d9ff0858c874000f9, -)
+    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:83810f5d1d6b8703df151fdfb4eff8ab, -)
+    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:dd4f7547ec5fc52c11b3c95fc8352b6f, -)
+    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:c85bcc1a9f8f5d153c2feb38bff117b3, -)
+    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:ba35fd505b40dfd2ebce2f598cfd69cc, -)
+    entity(niiri:a06c1108dbc1970b6cbfbec0d66dca2c,
         [prov:type = 'nidm_DisplayMaskMap:',
         prov:location = "DisplayMask_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "DisplayMask_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Display Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62" %% xsd:string])
-    entity(niiri:0a1c819b342dd3d453c7159504dac74c,
+    entity(niiri:2169516d50f819b5a3cc4759973af409,
         [prov:type = 'nidm_DisplayMaskMap:',
         nfo:fileName = "DisplayMask_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62" %% xsd:string])
-    wasDerivedFrom(niiri:aa05fc0a0178d64d67c7573ede73e21a, niiri:0a1c819b342dd3d453c7159504dac74c, -, -, -)
-    used(niiri:fa29f8a32fdd4cc314c9e74398b9928e, niiri:aa05fc0a0178d64d67c7573ede73e21a, -)
-    entity(niiri:f886b77c81406b1d37a9f9696b5908de,
+    wasDerivedFrom(niiri:a06c1108dbc1970b6cbfbec0d66dca2c, niiri:2169516d50f819b5a3cc4759973af409, -, -, -)
+    used(niiri:00117ec3afec546e47f98639e5c887ca, niiri:a06c1108dbc1970b6cbfbec0d66dca2c, -)
+    entity(niiri:ec5bc9615c7007a5fc20e99842caa4a4,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -417,8 +417,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:f886b77c81406b1d37a9f9696b5908de, niiri:fa29f8a32fdd4cc314c9e74398b9928e, -)
-    entity(niiri:9fe7122bcd502e668f8a16cf726d0d72,
+    wasGeneratedBy(niiri:ec5bc9615c7007a5fc20e99842caa4a4, niiri:00117ec3afec546e47f98639e5c887ca, -)
+    entity(niiri:025c12df86a668880699d51c9ce3138b,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -426,20 +426,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:e5cc209947f83b56269f8595baba845f',
-        nidm_hasMaximumIntensityProjection: = 'niiri:d733826cb7919e2f2d485b14862a9872',
-        nidm_inCoordinateSpace: = 'niiri:d2c45297c2b4308a0090e6f05682e0ef',
+        nidm_hasClusterLabelsMap: = 'niiri:71eab44698eccf893972754371c4a961',
+        nidm_hasMaximumIntensityProjection: = 'niiri:9f618f0b5bb815a9c8193b5704f3b55f',
+        nidm_inCoordinateSpace: = 'niiri:604151ad3785ac0490c6f4e7cc97b9f4',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:e5cc209947f83b56269f8595baba845f,
+    entity(niiri:71eab44698eccf893972754371c4a961,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:d733826cb7919e2f2d485b14862a9872,
+    entity(niiri:9f618f0b5bb815a9c8193b5704f3b55f,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:9fe7122bcd502e668f8a16cf726d0d72, niiri:fa29f8a32fdd4cc314c9e74398b9928e, -)
+    wasGeneratedBy(niiri:025c12df86a668880699d51c9ce3138b, niiri:00117ec3afec546e47f98639e5c887ca, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_contrast_mask/nidm.ttl
+++ b/spmexport/ex_spm_contrast_mask/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:8da2092e9c5cb801769d0b385e232e6a
+niiri:c06a9f39571e1f67bc5b526ebc1a4b3a
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:b91db0bec92042455fc3d7461ef70278
+niiri:4277cc6495cbced735297f8939f859eb
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:8a63018d0fe0b29307668addedf220b8
+niiri:ec180f94e0c184a254d0ec463c94711d
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:8a63018d0fe0b29307668addedf220b8 prov:wasAssociatedWith niiri:b91db0bec92042455fc3d7461ef70278 .
+niiri:ec180f94e0c184a254d0ec463c94711d prov:wasAssociatedWith niiri:4277cc6495cbced735297f8939f859eb .
 
 _:blank5 a prov:Generation .
 
-niiri:8da2092e9c5cb801769d0b385e232e6a prov:qualifiedGeneration _:blank5 .
+niiri:c06a9f39571e1f67bc5b526ebc1a4b3a prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:33:25"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:43:45"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -130,12 +130,12 @@ _:blank5 prov:atTime "2016-01-11T10:33:25"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:984d7168e984d7ee1825dbff00610fe2
+niiri:764377a27f95d42e49c0064eb22775fa
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:604151ad3785ac0490c6f4e7cc97b9f4
+niiri:6412923fed231d2401c392381339ad18
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -145,35 +145,35 @@ niiri:604151ad3785ac0490c6f4e7cc97b9f4
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:a50da58e4dd0325af19e04cc0f271696
+niiri:b60ccb939303d1b9b90656c8feb9bdb9
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:c795dd377205f22eb9b78700adbeb51f
+niiri:d26eb12e6c187928bf5ed1dc0f6ed4b6
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:16f111861038e6ae9e34e4670786a60a
+niiri:bf9b175d9f41375145e4af6dbceffcac
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:360689ae54d16861b51c542e033af544 ;
+    dc:description niiri:7579f149870e234e050c500f85e6e2d1 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:c795dd377205f22eb9b78700adbeb51f ;
+    nidm_hasDriftModel: niiri:d26eb12e6c187928bf5ed1dc0f6ed4b6 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:360689ae54d16861b51c542e033af544
+niiri:7579f149870e234e050c500f85e6e2d1
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:d6bdc1190ce2415d34b44bbc3cd4397c
+niiri:fcce69046d89e5c7f5c6bd4bc7fcf48f
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -181,162 +181,162 @@ niiri:d6bdc1190ce2415d34b44bbc3cd4397c
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:032ce1df6daf21aef8968c1053a455d2
+niiri:da4b8cc476c6af7dcc744d82fbf824bc
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:032ce1df6daf21aef8968c1053a455d2 prov:wasAssociatedWith niiri:984d7168e984d7ee1825dbff00610fe2 .
+niiri:da4b8cc476c6af7dcc744d82fbf824bc prov:wasAssociatedWith niiri:764377a27f95d42e49c0064eb22775fa .
 
-niiri:032ce1df6daf21aef8968c1053a455d2 prov:used niiri:16f111861038e6ae9e34e4670786a60a .
+niiri:da4b8cc476c6af7dcc744d82fbf824bc prov:used niiri:bf9b175d9f41375145e4af6dbceffcac .
 
-niiri:032ce1df6daf21aef8968c1053a455d2 prov:used niiri:a50da58e4dd0325af19e04cc0f271696 .
+niiri:da4b8cc476c6af7dcc744d82fbf824bc prov:used niiri:b60ccb939303d1b9b90656c8feb9bdb9 .
 
-niiri:032ce1df6daf21aef8968c1053a455d2 prov:used niiri:d6bdc1190ce2415d34b44bbc3cd4397c .
+niiri:da4b8cc476c6af7dcc744d82fbf824bc prov:used niiri:fcce69046d89e5c7f5c6bd4bc7fcf48f .
 
-niiri:dd4f7547ec5fc52c11b3c95fc8352b6f
+niiri:33c794b7c8714bb65b60a5894c7695c8
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:dea34bf1a708b5204474e9bd7dbdeb80
+niiri:493c6b452a9aba5e10dc32865ad7d797
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:dd4f7547ec5fc52c11b3c95fc8352b6f prov:wasDerivedFrom niiri:dea34bf1a708b5204474e9bd7dbdeb80 .
+niiri:33c794b7c8714bb65b60a5894c7695c8 prov:wasDerivedFrom niiri:493c6b452a9aba5e10dc32865ad7d797 .
 
-niiri:dd4f7547ec5fc52c11b3c95fc8352b6f prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
+niiri:33c794b7c8714bb65b60a5894c7695c8 prov:wasGeneratedBy niiri:da4b8cc476c6af7dcc744d82fbf824bc .
 
-niiri:8cb432009bac65f0c60b4e6ce915333c
+niiri:ff9740d7c942f700923bf0d6423f3796
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:8cb432009bac65f0c60b4e6ce915333c prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
+niiri:ff9740d7c942f700923bf0d6423f3796 prov:wasGeneratedBy niiri:da4b8cc476c6af7dcc744d82fbf824bc .
 
-niiri:d3bb595f5d8d487461e71a3c089f1288
+niiri:d62862879cb501953d05a8a7b23bacac
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 .
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 .
 
-niiri:29d243f1ba13e9550ab6e765b94e187a
+niiri:2e53add50cc738c2eb2bbf5db2261ea0
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:d3bb595f5d8d487461e71a3c089f1288 prov:wasDerivedFrom niiri:29d243f1ba13e9550ab6e765b94e187a .
+niiri:d62862879cb501953d05a8a7b23bacac prov:wasDerivedFrom niiri:2e53add50cc738c2eb2bbf5db2261ea0 .
 
-niiri:d3bb595f5d8d487461e71a3c089f1288 prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
+niiri:d62862879cb501953d05a8a7b23bacac prov:wasGeneratedBy niiri:da4b8cc476c6af7dcc744d82fbf824bc .
 
-niiri:af820f3c39ca14889a21e52b9cdf4e13
+niiri:13dc7d34909bdbb052c446c95f97ea83
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 .
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 .
 
-niiri:2b157ef526f7b65a4cee54dd340a138b
+niiri:1429f035a357f84353e0973174333485
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:af820f3c39ca14889a21e52b9cdf4e13 prov:wasDerivedFrom niiri:2b157ef526f7b65a4cee54dd340a138b .
+niiri:13dc7d34909bdbb052c446c95f97ea83 prov:wasDerivedFrom niiri:1429f035a357f84353e0973174333485 .
 
-niiri:af820f3c39ca14889a21e52b9cdf4e13 prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
+niiri:13dc7d34909bdbb052c446c95f97ea83 prov:wasGeneratedBy niiri:da4b8cc476c6af7dcc744d82fbf824bc .
 
-niiri:f28c130e5d1a1f4e3ecec031df15f8fc
+niiri:9d871e183fed166538e9f8ed7f2041a5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 .
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 .
 
-niiri:74d3c7bc834cbd986257ddeaf5934dc7
+niiri:d0bf67f0dd670d5fabba2f051423060d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:f28c130e5d1a1f4e3ecec031df15f8fc prov:wasDerivedFrom niiri:74d3c7bc834cbd986257ddeaf5934dc7 .
+niiri:9d871e183fed166538e9f8ed7f2041a5 prov:wasDerivedFrom niiri:d0bf67f0dd670d5fabba2f051423060d .
 
-niiri:f28c130e5d1a1f4e3ecec031df15f8fc prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
+niiri:9d871e183fed166538e9f8ed7f2041a5 prov:wasGeneratedBy niiri:da4b8cc476c6af7dcc744d82fbf824bc .
 
-niiri:c9126b5278cd74f74a3cc84da3a13a37
+niiri:a3d0092d64af34982390bcf2c60ce79c
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:d7b93f171045f154967d886af8464db0
+niiri:4cf3e595d4ec47a4ecdcbacc23b86f79
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:c9126b5278cd74f74a3cc84da3a13a37 prov:wasDerivedFrom niiri:d7b93f171045f154967d886af8464db0 .
+niiri:a3d0092d64af34982390bcf2c60ce79c prov:wasDerivedFrom niiri:4cf3e595d4ec47a4ecdcbacc23b86f79 .
 
-niiri:c9126b5278cd74f74a3cc84da3a13a37 prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
+niiri:a3d0092d64af34982390bcf2c60ce79c prov:wasGeneratedBy niiri:da4b8cc476c6af7dcc744d82fbf824bc .
 
-niiri:83810f5d1d6b8703df151fdfb4eff8ab
+niiri:b864ee4870587b4c8b4299a03979a1e4
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:7515d45b26a6862f9461b48a112b135a
+niiri:3561b36e56968f1e3ddd6544a509aa9c
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:83810f5d1d6b8703df151fdfb4eff8ab prov:wasDerivedFrom niiri:7515d45b26a6862f9461b48a112b135a .
+niiri:b864ee4870587b4c8b4299a03979a1e4 prov:wasDerivedFrom niiri:3561b36e56968f1e3ddd6544a509aa9c .
 
-niiri:83810f5d1d6b8703df151fdfb4eff8ab prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
+niiri:b864ee4870587b4c8b4299a03979a1e4 prov:wasGeneratedBy niiri:da4b8cc476c6af7dcc744d82fbf824bc .
 
-niiri:b5a8ad64303a9f8dd45b1ec2a9b8558a
+niiri:981c5bd26f83062fe96c144bffe38491
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:17470629350db82678b9a0e41cb83877
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:17470629350db82678b9a0e41cb83877 prov:wasAssociatedWith niiri:984d7168e984d7ee1825dbff00610fe2 .
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f prov:wasAssociatedWith niiri:764377a27f95d42e49c0064eb22775fa .
 
-niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:dd4f7547ec5fc52c11b3c95fc8352b6f .
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f prov:used niiri:33c794b7c8714bb65b60a5894c7695c8 .
 
-niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:c9126b5278cd74f74a3cc84da3a13a37 .
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f prov:used niiri:a3d0092d64af34982390bcf2c60ce79c .
 
-niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:16f111861038e6ae9e34e4670786a60a .
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f prov:used niiri:bf9b175d9f41375145e4af6dbceffcac .
 
-niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:b5a8ad64303a9f8dd45b1ec2a9b8558a .
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f prov:used niiri:981c5bd26f83062fe96c144bffe38491 .
 
-niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:d3bb595f5d8d487461e71a3c089f1288 .
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f prov:used niiri:d62862879cb501953d05a8a7b23bacac .
 
-niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:af820f3c39ca14889a21e52b9cdf4e13 .
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f prov:used niiri:13dc7d34909bdbb052c446c95f97ea83 .
 
-niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:f28c130e5d1a1f4e3ecec031df15f8fc .
+niiri:9f3c1a2748c00dc7f406a3b12aed9c2f prov:used niiri:9d871e183fed166538e9f8ed7f2041a5 .
 
-niiri:80a517dfc1d79a9d9ff0858c874000f9
+niiri:f6f265bb04e376f36066cbb7998a60bf
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -346,143 +346,143 @@ niiri:80a517dfc1d79a9d9ff0858c874000f9
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:416c1d9da138f2b21157914a04cf4469
+niiri:321dc00b40e95519dcfaa5fa9ae8e76d
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:80a517dfc1d79a9d9ff0858c874000f9 prov:wasDerivedFrom niiri:416c1d9da138f2b21157914a04cf4469 .
+niiri:f6f265bb04e376f36066cbb7998a60bf prov:wasDerivedFrom niiri:321dc00b40e95519dcfaa5fa9ae8e76d .
 
-niiri:80a517dfc1d79a9d9ff0858c874000f9 prov:wasGeneratedBy niiri:17470629350db82678b9a0e41cb83877 .
+niiri:f6f265bb04e376f36066cbb7998a60bf prov:wasGeneratedBy niiri:9f3c1a2748c00dc7f406a3b12aed9c2f .
 
-niiri:ceb24b4408693c41e8da68d09a2dc88d
+niiri:7870e17a18d4f429cf62ba23931814d4
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:ed335d52caa4252ffd4415db85f3abc6
+niiri:782e69773c189efd3e452d18a7895071
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:ceb24b4408693c41e8da68d09a2dc88d prov:wasDerivedFrom niiri:ed335d52caa4252ffd4415db85f3abc6 .
+niiri:7870e17a18d4f429cf62ba23931814d4 prov:wasDerivedFrom niiri:782e69773c189efd3e452d18a7895071 .
 
-niiri:ceb24b4408693c41e8da68d09a2dc88d prov:wasGeneratedBy niiri:17470629350db82678b9a0e41cb83877 .
+niiri:7870e17a18d4f429cf62ba23931814d4 prov:wasGeneratedBy niiri:9f3c1a2748c00dc7f406a3b12aed9c2f .
 
-niiri:eae5b5885d4cf1bead975525441188a4
+niiri:6b072ed99929b6fe1221c8e3030f6834
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:eae5b5885d4cf1bead975525441188a4 prov:wasGeneratedBy niiri:17470629350db82678b9a0e41cb83877 .
+niiri:6b072ed99929b6fe1221c8e3030f6834 prov:wasGeneratedBy niiri:9f3c1a2748c00dc7f406a3b12aed9c2f .
 
-niiri:359106649328e22227982f9186ae05d1
+niiri:dc719b2df015f2d669f3c26395b4fb0b
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
     prov:value "0.000999499751574873"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:2a77473ec77fbbeb8aec799ad8fae378 ;
-    nidm_equivalentThreshold: niiri:8a7dd1f98ad25c84931ff87eac31400c .
+    nidm_equivalentThreshold: niiri:4dfb90ae072c3f6306aee15016570fa3 ;
+    nidm_equivalentThreshold: niiri:eb871170bc0255fe0f65a97fc67aa8e4 .
 
-niiri:2a77473ec77fbbeb8aec799ad8fae378
+niiri:4dfb90ae072c3f6306aee15016570fa3
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12856968604193"^^xsd:float .
 
-niiri:8a7dd1f98ad25c84931ff87eac31400c
+niiri:eb871170bc0255fe0f65a97fc67aa8e4
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999998566"^^xsd:float .
 
-niiri:b392082b96ee307af6ad014dbfe5a244
+niiri:ca0b1b9c8f7ca9065ed59d7db82f1893
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:88f2c2569fcd6936cd0fc4e5037e7446 ;
-    nidm_equivalentThreshold: niiri:1c0f5f3c2723dbf05e045b6ba302128e .
+    nidm_equivalentThreshold: niiri:2a87bbcc9722c8a2ca8112c40183a0cb ;
+    nidm_equivalentThreshold: niiri:9dc8bebf7604deb38a8f1eca485dc855 .
 
-niiri:88f2c2569fcd6936cd0fc4e5037e7446
+niiri:2a87bbcc9722c8a2ca8112c40183a0cb
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:1c0f5f3c2723dbf05e045b6ba302128e
+niiri:9dc8bebf7604deb38a8f1eca485dc855
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:c85bcc1a9f8f5d153c2feb38bff117b3
+niiri:f56ec8f9610469eb85f0c651de30962d
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:ba35fd505b40dfd2ebce2f598cfd69cc
+niiri:6ba5a7123a5e6790e4942d1d60048257
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:00117ec3afec546e47f98639e5c887ca
+niiri:af21179a8cd0915e2b0dd08e2c38a4de
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:wasAssociatedWith niiri:984d7168e984d7ee1825dbff00610fe2 .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:wasAssociatedWith niiri:764377a27f95d42e49c0064eb22775fa .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:359106649328e22227982f9186ae05d1 .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:used niiri:dc719b2df015f2d669f3c26395b4fb0b .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:b392082b96ee307af6ad014dbfe5a244 .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:used niiri:ca0b1b9c8f7ca9065ed59d7db82f1893 .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:80a517dfc1d79a9d9ff0858c874000f9 .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:used niiri:f6f265bb04e376f36066cbb7998a60bf .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:83810f5d1d6b8703df151fdfb4eff8ab .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:used niiri:b864ee4870587b4c8b4299a03979a1e4 .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:dd4f7547ec5fc52c11b3c95fc8352b6f .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:used niiri:33c794b7c8714bb65b60a5894c7695c8 .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:c85bcc1a9f8f5d153c2feb38bff117b3 .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:used niiri:f56ec8f9610469eb85f0c651de30962d .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:ba35fd505b40dfd2ebce2f598cfd69cc .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:used niiri:6ba5a7123a5e6790e4942d1d60048257 .
 
-niiri:a06c1108dbc1970b6cbfbec0d66dca2c
+niiri:63b3c158351c75ee0c91d434a3efb13f
     a prov:Entity, nidm_DisplayMaskMap: ; 
     prov:atLocation "DisplayMask_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "DisplayMask_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Display Mask Map" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62"^^xsd:string .
 
-niiri:2169516d50f819b5a3cc4759973af409
+niiri:a47824d6d033fc4470b2cfbf5b4609b8
     a prov:Entity, nidm_DisplayMaskMap: ; 
     nfo:fileName "DisplayMask_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62"^^xsd:string .
 
-niiri:a06c1108dbc1970b6cbfbec0d66dca2c prov:wasDerivedFrom niiri:2169516d50f819b5a3cc4759973af409 .
+niiri:63b3c158351c75ee0c91d434a3efb13f prov:wasDerivedFrom niiri:a47824d6d033fc4470b2cfbf5b4609b8 .
 
-niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:a06c1108dbc1970b6cbfbec0d66dca2c .
+niiri:af21179a8cd0915e2b0dd08e2c38a4de prov:used niiri:63b3c158351c75ee0c91d434a3efb13f .
 
-niiri:ec5bc9615c7007a5fc20e99842caa4a4
+niiri:57343ab21a8119a72ebb89a38a3bb354
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -499,9 +499,9 @@ niiri:ec5bc9615c7007a5fc20e99842caa4a4
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:ec5bc9615c7007a5fc20e99842caa4a4 prov:wasGeneratedBy niiri:00117ec3afec546e47f98639e5c887ca .
+niiri:57343ab21a8119a72ebb89a38a3bb354 prov:wasGeneratedBy niiri:af21179a8cd0915e2b0dd08e2c38a4de .
 
-niiri:025c12df86a668880699d51c9ce3138b
+niiri:d1e5f51b914115bbcd75587d4ec489d6
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -509,22 +509,22 @@ niiri:025c12df86a668880699d51c9ce3138b
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:71eab44698eccf893972754371c4a961 ;
-    nidm_hasMaximumIntensityProjection: niiri:9f618f0b5bb815a9c8193b5704f3b55f ;
-    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
+    nidm_hasClusterLabelsMap: niiri:7b937b59d0775c2c122d2fa7d8f50a1a ;
+    nidm_hasMaximumIntensityProjection: niiri:42b1ac61db1939302cc36658967bb301 ;
+    nidm_inCoordinateSpace: niiri:6412923fed231d2401c392381339ad18 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:71eab44698eccf893972754371c4a961
+niiri:7b937b59d0775c2c122d2fa7d8f50a1a
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:9f618f0b5bb815a9c8193b5704f3b55f
+niiri:42b1ac61db1939302cc36658967bb301
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:025c12df86a668880699d51c9ce3138b prov:wasGeneratedBy niiri:00117ec3afec546e47f98639e5c887ca .
+niiri:d1e5f51b914115bbcd75587d4ec489d6 prov:wasGeneratedBy niiri:af21179a8cd0915e2b0dd08e2c38a4de .
 

--- a/spmexport/ex_spm_contrast_mask/nidm.ttl
+++ b/spmexport/ex_spm_contrast_mask/nidm.ttl
@@ -1,0 +1,530 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:dc265b3f4681d0cbdf40bfb1741fcd71
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:9f4873dc8724bddf712e42767d834d26
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:40f2816759812d9b5773e8b22843ff7e
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:40f2816759812d9b5773e8b22843ff7e prov:wasAssociatedWith niiri:9f4873dc8724bddf712e42767d834d26 .
+
+_:blank5 a prov:Generation .
+
+niiri:dc265b3f4681d0cbdf40bfb1741fcd71 prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:11:10"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_DisplayMaskMap: <http://purl.org/nidash/nidm#NIDM_0000020> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+
+niiri:73856e71cd85f29c845dcd47e6fd1553
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:d2c45297c2b4308a0090e6f05682e0ef
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:7770425c1fda5bbcccf2ba798dabfe46
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:309b8cbbeb7b8628282eb5748b3c2979
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:6d4f652746845571d84967301f954e4b
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:9d9afe40e86a14084e331044de9f84fa ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:309b8cbbeb7b8628282eb5748b3c2979 ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:9d9afe40e86a14084e331044de9f84fa
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:c81885f96fe9093297ded3a37f642d59
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:a903f04dfdb0b04d123c49f2bb4526a0
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:a903f04dfdb0b04d123c49f2bb4526a0 prov:wasAssociatedWith niiri:73856e71cd85f29c845dcd47e6fd1553 .
+
+niiri:a903f04dfdb0b04d123c49f2bb4526a0 prov:used niiri:6d4f652746845571d84967301f954e4b .
+
+niiri:a903f04dfdb0b04d123c49f2bb4526a0 prov:used niiri:7770425c1fda5bbcccf2ba798dabfe46 .
+
+niiri:a903f04dfdb0b04d123c49f2bb4526a0 prov:used niiri:c81885f96fe9093297ded3a37f642d59 .
+
+niiri:8f2e00d2382b1a7614e69b9bc96b0b15
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:935ad95211ccd5ac37f0aeeeb41a54eb
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
+
+niiri:8f2e00d2382b1a7614e69b9bc96b0b15 prov:wasDerivedFrom niiri:935ad95211ccd5ac37f0aeeeb41a54eb .
+
+niiri:8f2e00d2382b1a7614e69b9bc96b0b15 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+
+niiri:7ecf42b9e909ffb70ace6169d26f4b87
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "121.744659423828"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
+
+niiri:7ecf42b9e909ffb70ace6169d26f4b87 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+
+niiri:e6b2ebbaf8b9da48fa61162a52f0472e
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef .
+
+niiri:a81f1c3b2bb8578c66e094c84d95f8ce
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
+
+niiri:e6b2ebbaf8b9da48fa61162a52f0472e prov:wasDerivedFrom niiri:a81f1c3b2bb8578c66e094c84d95f8ce .
+
+niiri:e6b2ebbaf8b9da48fa61162a52f0472e prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+
+niiri:7599c79dee642708b0ff7406cc2fad45
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef .
+
+niiri:251258ff5d3ac60578fc277216a050af
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
+
+niiri:7599c79dee642708b0ff7406cc2fad45 prov:wasDerivedFrom niiri:251258ff5d3ac60578fc277216a050af .
+
+niiri:7599c79dee642708b0ff7406cc2fad45 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+
+niiri:ccffb6ed7b41778439cf64b531a10d11
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef .
+
+niiri:634eabe99ed8e72d7ae8abfc9619778f
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
+
+niiri:ccffb6ed7b41778439cf64b531a10d11 prov:wasDerivedFrom niiri:634eabe99ed8e72d7ae8abfc9619778f .
+
+niiri:ccffb6ed7b41778439cf64b531a10d11 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+
+niiri:316761c8d1bf0b16027a1b8cdc4fac27
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
+
+niiri:516f43d02318f34ebd03b8059e5e24f8
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
+
+niiri:316761c8d1bf0b16027a1b8cdc4fac27 prov:wasDerivedFrom niiri:516f43d02318f34ebd03b8059e5e24f8 .
+
+niiri:316761c8d1bf0b16027a1b8cdc4fac27 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+
+niiri:78e9119d03a0988704bbbe7479967331
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
+
+niiri:6b7f1c95bef9d5eb4e6f489ef9dc800e
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
+
+niiri:78e9119d03a0988704bbbe7479967331 prov:wasDerivedFrom niiri:6b7f1c95bef9d5eb4e6f489ef9dc800e .
+
+niiri:78e9119d03a0988704bbbe7479967331 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+
+niiri:b4883919edf3b1325dd80d4f62518d74
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    rdfs:label "Contrast: pos vs neg" ;
+    prov:value "[1, -1, 0]"^^xsd:string .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e prov:wasAssociatedWith niiri:73856e71cd85f29c845dcd47e6fd1553 .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:8f2e00d2382b1a7614e69b9bc96b0b15 .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:316761c8d1bf0b16027a1b8cdc4fac27 .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:6d4f652746845571d84967301f954e4b .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:b4883919edf3b1325dd80d4f62518d74 .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:e6b2ebbaf8b9da48fa61162a52f0472e .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:7599c79dee642708b0ff7406cc2fad45 .
+
+niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:ccffb6ed7b41778439cf64b531a10d11 .
+
+niiri:047589c24089fe2835015d8fda752ae3
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: pos vs neg" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
+
+niiri:b91d28ec6303cb84a0700d4d0fc56dc0
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
+
+niiri:047589c24089fe2835015d8fda752ae3 prov:wasDerivedFrom niiri:b91d28ec6303cb84a0700d4d0fc56dc0 .
+
+niiri:047589c24089fe2835015d8fda752ae3 prov:wasGeneratedBy niiri:3e06602588c25ad9f90cba6c2c74974e .
+
+niiri:df3e747a4bf63c5e6d8cdcf941740af1
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: pos vs neg" ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
+
+niiri:455ef80f70e56dc478c28459debbe6a9
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
+
+niiri:df3e747a4bf63c5e6d8cdcf941740af1 prov:wasDerivedFrom niiri:455ef80f70e56dc478c28459debbe6a9 .
+
+niiri:df3e747a4bf63c5e6d8cdcf941740af1 prov:wasGeneratedBy niiri:3e06602588c25ad9f90cba6c2c74974e .
+
+niiri:b59baee2b34fa927b2b76637a3355a4a
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
+
+niiri:b59baee2b34fa927b2b76637a3355a4a prov:wasGeneratedBy niiri:3e06602588c25ad9f90cba6c2c74974e .
+
+niiri:0f0fbdc7ba1737de1af9a9f320c03c1a
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
+    prov:value "0.000999499751574873"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:e675e86d61efac6e5dbfa85e31c02eb4 ;
+    nidm_equivalentThreshold: niiri:6ef19c727e0caf3bf9f2633e8a583c16 .
+
+niiri:e675e86d61efac6e5dbfa85e31c02eb4
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "3.12856968604193"^^xsd:float .
+
+niiri:6ef19c727e0caf3bf9f2633e8a583c16
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.999999999998566"^^xsd:float .
+
+niiri:f6c0766d53e3c92caa5ff2b5a2bd1934
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:e29340c23f2eaa95405fa5fb9330ef6b ;
+    nidm_equivalentThreshold: niiri:baf4b7d454c1692d830ff220f02bf749 .
+
+niiri:e29340c23f2eaa95405fa5fb9330ef6b
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:baf4b7d454c1692d830ff220f02bf749
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:a217bc7f43919d5feb8c23658dfe6431
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:a5a8a3ed0cd3bf297321e338bbaa9c5d
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:wasAssociatedWith niiri:73856e71cd85f29c845dcd47e6fd1553 .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:0f0fbdc7ba1737de1af9a9f320c03c1a .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:f6c0766d53e3c92caa5ff2b5a2bd1934 .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:047589c24089fe2835015d8fda752ae3 .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:78e9119d03a0988704bbbe7479967331 .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:8f2e00d2382b1a7614e69b9bc96b0b15 .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:a217bc7f43919d5feb8c23658dfe6431 .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:a5a8a3ed0cd3bf297321e338bbaa9c5d .
+
+niiri:aa05fc0a0178d64d67c7573ede73e21a
+    a prov:Entity, nidm_DisplayMaskMap: ; 
+    prov:atLocation "DisplayMask_0001.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "DisplayMask_0001.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Display Mask Map" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62"^^xsd:string .
+
+niiri:0a1c819b342dd3d453c7159504dac74c
+    a prov:Entity, nidm_DisplayMaskMap: ; 
+    nfo:fileName "DisplayMask_0001.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62"^^xsd:string .
+
+niiri:aa05fc0a0178d64d67c7573ede73e21a prov:wasDerivedFrom niiri:0a1c819b342dd3d453c7159504dac74c .
+
+niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:aa05fc0a0178d64d67c7573ede73e21a .
+
+niiri:f886b77c81406b1d37a9f9696b5908de
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
+    nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
+    nidm_searchVolumeInResels: "2650.12011223711"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.01704921884936, 4.07618247398105, 4.38831339907177]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.03409843769872, 8.1523649479621, 8.77662679814353]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "8.23486077915088"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "27.2707251644655"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.05094049746367"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:f886b77c81406b1d37a9f9696b5908de prov:wasGeneratedBy niiri:fa29f8a32fdd4cc314c9e74398b9928e .
+
+niiri:9fe7122bcd502e668f8a16cf726d0d72
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
+    nidm_pValue: "NaN"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:e5cc209947f83b56269f8595baba845f ;
+    nidm_hasMaximumIntensityProjection: niiri:d733826cb7919e2f2d485b14862a9872 ;
+    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
+
+niiri:e5cc209947f83b56269f8595baba845f
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:d733826cb7919e2f2d485b14862a9872
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:9fe7122bcd502e668f8a16cf726d0d72 prov:wasGeneratedBy niiri:fa29f8a32fdd4cc314c9e74398b9928e .
+

--- a/spmexport/ex_spm_contrast_mask/nidm.ttl
+++ b/spmexport/ex_spm_contrast_mask/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:dc265b3f4681d0cbdf40bfb1741fcd71
+niiri:8da2092e9c5cb801769d0b385e232e6a
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:9f4873dc8724bddf712e42767d834d26
+niiri:b91db0bec92042455fc3d7461ef70278
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:40f2816759812d9b5773e8b22843ff7e
+niiri:8a63018d0fe0b29307668addedf220b8
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:40f2816759812d9b5773e8b22843ff7e prov:wasAssociatedWith niiri:9f4873dc8724bddf712e42767d834d26 .
+niiri:8a63018d0fe0b29307668addedf220b8 prov:wasAssociatedWith niiri:b91db0bec92042455fc3d7461ef70278 .
 
 _:blank5 a prov:Generation .
 
-niiri:dc265b3f4681d0cbdf40bfb1741fcd71 prov:qualifiedGeneration _:blank5 .
+niiri:8da2092e9c5cb801769d0b385e232e6a prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:11:10"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:33:25"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -130,12 +130,12 @@ _:blank5 prov:atTime "2016-01-11T10:11:10"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:73856e71cd85f29c845dcd47e6fd1553
+niiri:984d7168e984d7ee1825dbff00610fe2
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:d2c45297c2b4308a0090e6f05682e0ef
+niiri:604151ad3785ac0490c6f4e7cc97b9f4
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -145,35 +145,35 @@ niiri:d2c45297c2b4308a0090e6f05682e0ef
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:7770425c1fda5bbcccf2ba798dabfe46
+niiri:a50da58e4dd0325af19e04cc0f271696
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:309b8cbbeb7b8628282eb5748b3c2979
+niiri:c795dd377205f22eb9b78700adbeb51f
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:6d4f652746845571d84967301f954e4b
+niiri:16f111861038e6ae9e34e4670786a60a
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:9d9afe40e86a14084e331044de9f84fa ;
+    dc:description niiri:360689ae54d16861b51c542e033af544 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:309b8cbbeb7b8628282eb5748b3c2979 ;
+    nidm_hasDriftModel: niiri:c795dd377205f22eb9b78700adbeb51f ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:9d9afe40e86a14084e331044de9f84fa
+niiri:360689ae54d16861b51c542e033af544
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:c81885f96fe9093297ded3a37f642d59
+niiri:d6bdc1190ce2415d34b44bbc3cd4397c
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -181,162 +181,162 @@ niiri:c81885f96fe9093297ded3a37f642d59
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:a903f04dfdb0b04d123c49f2bb4526a0
+niiri:032ce1df6daf21aef8968c1053a455d2
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:a903f04dfdb0b04d123c49f2bb4526a0 prov:wasAssociatedWith niiri:73856e71cd85f29c845dcd47e6fd1553 .
+niiri:032ce1df6daf21aef8968c1053a455d2 prov:wasAssociatedWith niiri:984d7168e984d7ee1825dbff00610fe2 .
 
-niiri:a903f04dfdb0b04d123c49f2bb4526a0 prov:used niiri:6d4f652746845571d84967301f954e4b .
+niiri:032ce1df6daf21aef8968c1053a455d2 prov:used niiri:16f111861038e6ae9e34e4670786a60a .
 
-niiri:a903f04dfdb0b04d123c49f2bb4526a0 prov:used niiri:7770425c1fda5bbcccf2ba798dabfe46 .
+niiri:032ce1df6daf21aef8968c1053a455d2 prov:used niiri:a50da58e4dd0325af19e04cc0f271696 .
 
-niiri:a903f04dfdb0b04d123c49f2bb4526a0 prov:used niiri:c81885f96fe9093297ded3a37f642d59 .
+niiri:032ce1df6daf21aef8968c1053a455d2 prov:used niiri:d6bdc1190ce2415d34b44bbc3cd4397c .
 
-niiri:8f2e00d2382b1a7614e69b9bc96b0b15
+niiri:dd4f7547ec5fc52c11b3c95fc8352b6f
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:935ad95211ccd5ac37f0aeeeb41a54eb
+niiri:dea34bf1a708b5204474e9bd7dbdeb80
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:8f2e00d2382b1a7614e69b9bc96b0b15 prov:wasDerivedFrom niiri:935ad95211ccd5ac37f0aeeeb41a54eb .
+niiri:dd4f7547ec5fc52c11b3c95fc8352b6f prov:wasDerivedFrom niiri:dea34bf1a708b5204474e9bd7dbdeb80 .
 
-niiri:8f2e00d2382b1a7614e69b9bc96b0b15 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+niiri:dd4f7547ec5fc52c11b3c95fc8352b6f prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
 
-niiri:7ecf42b9e909ffb70ace6169d26f4b87
+niiri:8cb432009bac65f0c60b4e6ce915333c
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:7ecf42b9e909ffb70ace6169d26f4b87 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+niiri:8cb432009bac65f0c60b4e6ce915333c prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
 
-niiri:e6b2ebbaf8b9da48fa61162a52f0472e
+niiri:d3bb595f5d8d487461e71a3c089f1288
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef .
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 .
 
-niiri:a81f1c3b2bb8578c66e094c84d95f8ce
+niiri:29d243f1ba13e9550ab6e765b94e187a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:e6b2ebbaf8b9da48fa61162a52f0472e prov:wasDerivedFrom niiri:a81f1c3b2bb8578c66e094c84d95f8ce .
+niiri:d3bb595f5d8d487461e71a3c089f1288 prov:wasDerivedFrom niiri:29d243f1ba13e9550ab6e765b94e187a .
 
-niiri:e6b2ebbaf8b9da48fa61162a52f0472e prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+niiri:d3bb595f5d8d487461e71a3c089f1288 prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
 
-niiri:7599c79dee642708b0ff7406cc2fad45
+niiri:af820f3c39ca14889a21e52b9cdf4e13
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef .
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 .
 
-niiri:251258ff5d3ac60578fc277216a050af
+niiri:2b157ef526f7b65a4cee54dd340a138b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:7599c79dee642708b0ff7406cc2fad45 prov:wasDerivedFrom niiri:251258ff5d3ac60578fc277216a050af .
+niiri:af820f3c39ca14889a21e52b9cdf4e13 prov:wasDerivedFrom niiri:2b157ef526f7b65a4cee54dd340a138b .
 
-niiri:7599c79dee642708b0ff7406cc2fad45 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+niiri:af820f3c39ca14889a21e52b9cdf4e13 prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
 
-niiri:ccffb6ed7b41778439cf64b531a10d11
+niiri:f28c130e5d1a1f4e3ecec031df15f8fc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef .
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 .
 
-niiri:634eabe99ed8e72d7ae8abfc9619778f
+niiri:74d3c7bc834cbd986257ddeaf5934dc7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:ccffb6ed7b41778439cf64b531a10d11 prov:wasDerivedFrom niiri:634eabe99ed8e72d7ae8abfc9619778f .
+niiri:f28c130e5d1a1f4e3ecec031df15f8fc prov:wasDerivedFrom niiri:74d3c7bc834cbd986257ddeaf5934dc7 .
 
-niiri:ccffb6ed7b41778439cf64b531a10d11 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+niiri:f28c130e5d1a1f4e3ecec031df15f8fc prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
 
-niiri:316761c8d1bf0b16027a1b8cdc4fac27
+niiri:c9126b5278cd74f74a3cc84da3a13a37
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:516f43d02318f34ebd03b8059e5e24f8
+niiri:d7b93f171045f154967d886af8464db0
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:316761c8d1bf0b16027a1b8cdc4fac27 prov:wasDerivedFrom niiri:516f43d02318f34ebd03b8059e5e24f8 .
+niiri:c9126b5278cd74f74a3cc84da3a13a37 prov:wasDerivedFrom niiri:d7b93f171045f154967d886af8464db0 .
 
-niiri:316761c8d1bf0b16027a1b8cdc4fac27 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+niiri:c9126b5278cd74f74a3cc84da3a13a37 prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
 
-niiri:78e9119d03a0988704bbbe7479967331
+niiri:83810f5d1d6b8703df151fdfb4eff8ab
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:6b7f1c95bef9d5eb4e6f489ef9dc800e
+niiri:7515d45b26a6862f9461b48a112b135a
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:78e9119d03a0988704bbbe7479967331 prov:wasDerivedFrom niiri:6b7f1c95bef9d5eb4e6f489ef9dc800e .
+niiri:83810f5d1d6b8703df151fdfb4eff8ab prov:wasDerivedFrom niiri:7515d45b26a6862f9461b48a112b135a .
 
-niiri:78e9119d03a0988704bbbe7479967331 prov:wasGeneratedBy niiri:a903f04dfdb0b04d123c49f2bb4526a0 .
+niiri:83810f5d1d6b8703df151fdfb4eff8ab prov:wasGeneratedBy niiri:032ce1df6daf21aef8968c1053a455d2 .
 
-niiri:b4883919edf3b1325dd80d4f62518d74
+niiri:b5a8ad64303a9f8dd45b1ec2a9b8558a
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e
+niiri:17470629350db82678b9a0e41cb83877
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e prov:wasAssociatedWith niiri:73856e71cd85f29c845dcd47e6fd1553 .
+niiri:17470629350db82678b9a0e41cb83877 prov:wasAssociatedWith niiri:984d7168e984d7ee1825dbff00610fe2 .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:8f2e00d2382b1a7614e69b9bc96b0b15 .
+niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:dd4f7547ec5fc52c11b3c95fc8352b6f .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:316761c8d1bf0b16027a1b8cdc4fac27 .
+niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:c9126b5278cd74f74a3cc84da3a13a37 .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:6d4f652746845571d84967301f954e4b .
+niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:16f111861038e6ae9e34e4670786a60a .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:b4883919edf3b1325dd80d4f62518d74 .
+niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:b5a8ad64303a9f8dd45b1ec2a9b8558a .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:e6b2ebbaf8b9da48fa61162a52f0472e .
+niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:d3bb595f5d8d487461e71a3c089f1288 .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:7599c79dee642708b0ff7406cc2fad45 .
+niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:af820f3c39ca14889a21e52b9cdf4e13 .
 
-niiri:3e06602588c25ad9f90cba6c2c74974e prov:used niiri:ccffb6ed7b41778439cf64b531a10d11 .
+niiri:17470629350db82678b9a0e41cb83877 prov:used niiri:f28c130e5d1a1f4e3ecec031df15f8fc .
 
-niiri:047589c24089fe2835015d8fda752ae3
+niiri:80a517dfc1d79a9d9ff0858c874000f9
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -346,143 +346,143 @@ niiri:047589c24089fe2835015d8fda752ae3
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:b91d28ec6303cb84a0700d4d0fc56dc0
+niiri:416c1d9da138f2b21157914a04cf4469
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:047589c24089fe2835015d8fda752ae3 prov:wasDerivedFrom niiri:b91d28ec6303cb84a0700d4d0fc56dc0 .
+niiri:80a517dfc1d79a9d9ff0858c874000f9 prov:wasDerivedFrom niiri:416c1d9da138f2b21157914a04cf4469 .
 
-niiri:047589c24089fe2835015d8fda752ae3 prov:wasGeneratedBy niiri:3e06602588c25ad9f90cba6c2c74974e .
+niiri:80a517dfc1d79a9d9ff0858c874000f9 prov:wasGeneratedBy niiri:17470629350db82678b9a0e41cb83877 .
 
-niiri:df3e747a4bf63c5e6d8cdcf941740af1
+niiri:ceb24b4408693c41e8da68d09a2dc88d
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:455ef80f70e56dc478c28459debbe6a9
+niiri:ed335d52caa4252ffd4415db85f3abc6
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:df3e747a4bf63c5e6d8cdcf941740af1 prov:wasDerivedFrom niiri:455ef80f70e56dc478c28459debbe6a9 .
+niiri:ceb24b4408693c41e8da68d09a2dc88d prov:wasDerivedFrom niiri:ed335d52caa4252ffd4415db85f3abc6 .
 
-niiri:df3e747a4bf63c5e6d8cdcf941740af1 prov:wasGeneratedBy niiri:3e06602588c25ad9f90cba6c2c74974e .
+niiri:ceb24b4408693c41e8da68d09a2dc88d prov:wasGeneratedBy niiri:17470629350db82678b9a0e41cb83877 .
 
-niiri:b59baee2b34fa927b2b76637a3355a4a
+niiri:eae5b5885d4cf1bead975525441188a4
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:b59baee2b34fa927b2b76637a3355a4a prov:wasGeneratedBy niiri:3e06602588c25ad9f90cba6c2c74974e .
+niiri:eae5b5885d4cf1bead975525441188a4 prov:wasGeneratedBy niiri:17470629350db82678b9a0e41cb83877 .
 
-niiri:0f0fbdc7ba1737de1af9a9f320c03c1a
+niiri:359106649328e22227982f9186ae05d1
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
     prov:value "0.000999499751574873"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:e675e86d61efac6e5dbfa85e31c02eb4 ;
-    nidm_equivalentThreshold: niiri:6ef19c727e0caf3bf9f2633e8a583c16 .
+    nidm_equivalentThreshold: niiri:2a77473ec77fbbeb8aec799ad8fae378 ;
+    nidm_equivalentThreshold: niiri:8a7dd1f98ad25c84931ff87eac31400c .
 
-niiri:e675e86d61efac6e5dbfa85e31c02eb4
+niiri:2a77473ec77fbbeb8aec799ad8fae378
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12856968604193"^^xsd:float .
 
-niiri:6ef19c727e0caf3bf9f2633e8a583c16
+niiri:8a7dd1f98ad25c84931ff87eac31400c
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999998566"^^xsd:float .
 
-niiri:f6c0766d53e3c92caa5ff2b5a2bd1934
+niiri:b392082b96ee307af6ad014dbfe5a244
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:e29340c23f2eaa95405fa5fb9330ef6b ;
-    nidm_equivalentThreshold: niiri:baf4b7d454c1692d830ff220f02bf749 .
+    nidm_equivalentThreshold: niiri:88f2c2569fcd6936cd0fc4e5037e7446 ;
+    nidm_equivalentThreshold: niiri:1c0f5f3c2723dbf05e045b6ba302128e .
 
-niiri:e29340c23f2eaa95405fa5fb9330ef6b
+niiri:88f2c2569fcd6936cd0fc4e5037e7446
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:baf4b7d454c1692d830ff220f02bf749
+niiri:1c0f5f3c2723dbf05e045b6ba302128e
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:a217bc7f43919d5feb8c23658dfe6431
+niiri:c85bcc1a9f8f5d153c2feb38bff117b3
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:a5a8a3ed0cd3bf297321e338bbaa9c5d
+niiri:ba35fd505b40dfd2ebce2f598cfd69cc
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e
+niiri:00117ec3afec546e47f98639e5c887ca
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:wasAssociatedWith niiri:73856e71cd85f29c845dcd47e6fd1553 .
+niiri:00117ec3afec546e47f98639e5c887ca prov:wasAssociatedWith niiri:984d7168e984d7ee1825dbff00610fe2 .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:0f0fbdc7ba1737de1af9a9f320c03c1a .
+niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:359106649328e22227982f9186ae05d1 .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:f6c0766d53e3c92caa5ff2b5a2bd1934 .
+niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:b392082b96ee307af6ad014dbfe5a244 .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:047589c24089fe2835015d8fda752ae3 .
+niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:80a517dfc1d79a9d9ff0858c874000f9 .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:78e9119d03a0988704bbbe7479967331 .
+niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:83810f5d1d6b8703df151fdfb4eff8ab .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:8f2e00d2382b1a7614e69b9bc96b0b15 .
+niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:dd4f7547ec5fc52c11b3c95fc8352b6f .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:a217bc7f43919d5feb8c23658dfe6431 .
+niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:c85bcc1a9f8f5d153c2feb38bff117b3 .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:a5a8a3ed0cd3bf297321e338bbaa9c5d .
+niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:ba35fd505b40dfd2ebce2f598cfd69cc .
 
-niiri:aa05fc0a0178d64d67c7573ede73e21a
+niiri:a06c1108dbc1970b6cbfbec0d66dca2c
     a prov:Entity, nidm_DisplayMaskMap: ; 
     prov:atLocation "DisplayMask_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "DisplayMask_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Display Mask Map" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62"^^xsd:string .
 
-niiri:0a1c819b342dd3d453c7159504dac74c
+niiri:2169516d50f819b5a3cc4759973af409
     a prov:Entity, nidm_DisplayMaskMap: ; 
     nfo:fileName "DisplayMask_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "8d1f94c1d9b0ce7b1f03926e525434308c56d084d2803724edc0163aa504867984395e0f370bb62b4ba45ea42c39118556f6a1420890cc0e2422cb510f837e62"^^xsd:string .
 
-niiri:aa05fc0a0178d64d67c7573ede73e21a prov:wasDerivedFrom niiri:0a1c819b342dd3d453c7159504dac74c .
+niiri:a06c1108dbc1970b6cbfbec0d66dca2c prov:wasDerivedFrom niiri:2169516d50f819b5a3cc4759973af409 .
 
-niiri:fa29f8a32fdd4cc314c9e74398b9928e prov:used niiri:aa05fc0a0178d64d67c7573ede73e21a .
+niiri:00117ec3afec546e47f98639e5c887ca prov:used niiri:a06c1108dbc1970b6cbfbec0d66dca2c .
 
-niiri:f886b77c81406b1d37a9f9696b5908de
+niiri:ec5bc9615c7007a5fc20e99842caa4a4
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -499,9 +499,9 @@ niiri:f886b77c81406b1d37a9f9696b5908de
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:f886b77c81406b1d37a9f9696b5908de prov:wasGeneratedBy niiri:fa29f8a32fdd4cc314c9e74398b9928e .
+niiri:ec5bc9615c7007a5fc20e99842caa4a4 prov:wasGeneratedBy niiri:00117ec3afec546e47f98639e5c887ca .
 
-niiri:9fe7122bcd502e668f8a16cf726d0d72
+niiri:025c12df86a668880699d51c9ce3138b
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -509,22 +509,22 @@ niiri:9fe7122bcd502e668f8a16cf726d0d72
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:e5cc209947f83b56269f8595baba845f ;
-    nidm_hasMaximumIntensityProjection: niiri:d733826cb7919e2f2d485b14862a9872 ;
-    nidm_inCoordinateSpace: niiri:d2c45297c2b4308a0090e6f05682e0ef ;
+    nidm_hasClusterLabelsMap: niiri:71eab44698eccf893972754371c4a961 ;
+    nidm_hasMaximumIntensityProjection: niiri:9f618f0b5bb815a9c8193b5704f3b55f ;
+    nidm_inCoordinateSpace: niiri:604151ad3785ac0490c6f4e7cc97b9f4 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:e5cc209947f83b56269f8595baba845f
+niiri:71eab44698eccf893972754371c4a961
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:d733826cb7919e2f2d485b14862a9872
+niiri:9f618f0b5bb815a9c8193b5704f3b55f
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:9fe7122bcd502e668f8a16cf726d0d72 prov:wasGeneratedBy niiri:fa29f8a32fdd4cc314c9e74398b9928e .
+niiri:025c12df86a668880699d51c9ce3138b prov:wasGeneratedBy niiri:00117ec3afec546e47f98639e5c887ca .
 

--- a/spmexport/ex_spm_covariate/config.json
+++ b/spmexport/ex_spm_covariate/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["covariate/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_covariate/nidm.provn
+++ b/spmexport/ex_spm_covariate/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:31d6c1a45e08732f9d39d4fd32cea085,
+  entity(niiri:3ccf008c518c3f0ebe9dea04f0edfbc4,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:8cf1ef035df283fda3a56583da8cbd77,
+  agent(niiri:97c0efb1395126dbff029ae881c33b9d,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:a33cfd1828738469b4829a177a32ea49,
+  activity(niiri:4ee63714952ef11034b1653f40760c75,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:a33cfd1828738469b4829a177a32ea49, niiri:8cf1ef035df283fda3a56583da8cbd77, -)
-  wasGeneratedBy(niiri:31d6c1a45e08732f9d39d4fd32cea085, niiri:a33cfd1828738469b4829a177a32ea49, 2016-01-11T10:11:15)
-  bundle niiri:31d6c1a45e08732f9d39d4fd32cea085
+  wasAssociatedWith(niiri:4ee63714952ef11034b1653f40760c75, niiri:97c0efb1395126dbff029ae881c33b9d, -)
+  wasGeneratedBy(niiri:3ccf008c518c3f0ebe9dea04f0edfbc4, niiri:4ee63714952ef11034b1653f40760c75, 2016-01-11T10:33:30)
+  bundle niiri:3ccf008c518c3f0ebe9dea04f0edfbc4
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -118,12 +118,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:d515e4539ba77e4aaafcb479a1267ad1,
+    agent(niiri:7cd23874d74598fb93575d0ca339d267,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:29ca7f31a8b4fa610180435e7362a7d0,
+    entity(niiri:e7538b8eeead984e7d4168b9eb1e2185,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -132,132 +132,132 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:cbf0821fd0582df876cb99f6e1c69ac8,
+    entity(niiri:f0df94187254dffcef42f57c9a34f591,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "false" %% xsd:boolean])
-    entity(niiri:f49fb0ce586d5bba164b397ad004843d,
+    entity(niiri:8cc550f78b4df2ff508e85441d0a1fd0,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:41a74f856bbb8085011a19fe078fabce',
+        dc:description = 'niiri:83ee7456b6dda22712d37e10cc39a213',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"mean\", \"Subject ID Covariate\"]" %% xsd:string])
-    entity(niiri:41a74f856bbb8085011a19fe078fabce,
+    entity(niiri:83ee7456b6dda22712d37e10cc39a213,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:6a6716cb24609f317367c274cd3a3012,
+    entity(niiri:dc642cee82597b23a6938238a2d15373,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'nidm_IndependentError:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean])
-    activity(niiri:fc1b05994ad6f530ee7e2818c82ace02,
+    activity(niiri:169c4819223a8702ebf9447665c6a242,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_OLS:'])
-    wasAssociatedWith(niiri:fc1b05994ad6f530ee7e2818c82ace02, niiri:d515e4539ba77e4aaafcb479a1267ad1, -)
-    used(niiri:fc1b05994ad6f530ee7e2818c82ace02, niiri:f49fb0ce586d5bba164b397ad004843d, -)
-    used(niiri:fc1b05994ad6f530ee7e2818c82ace02, niiri:cbf0821fd0582df876cb99f6e1c69ac8, -)
-    used(niiri:fc1b05994ad6f530ee7e2818c82ace02, niiri:6a6716cb24609f317367c274cd3a3012, -)
-    entity(niiri:a0e2e4659c44ec8283f603e4d63d4cb7,
+    wasAssociatedWith(niiri:169c4819223a8702ebf9447665c6a242, niiri:7cd23874d74598fb93575d0ca339d267, -)
+    used(niiri:169c4819223a8702ebf9447665c6a242, niiri:8cc550f78b4df2ff508e85441d0a1fd0, -)
+    used(niiri:169c4819223a8702ebf9447665c6a242, niiri:f0df94187254dffcef42f57c9a34f591, -)
+    used(niiri:169c4819223a8702ebf9447665c6a242, niiri:dc642cee82597b23a6938238a2d15373, -)
+    entity(niiri:43e01138ea166419cf89ae0c1b960c02,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         crypto:sha512 = "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f" %% xsd:string])
-    entity(niiri:c48268f2a6a23bf1f723deea7bbdb5b6,
+    entity(niiri:aa7e9876de1332712a7a6718e06772c7,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "e06c7e91d23253a8dffd3bb366d05851340e63a972bc08812d42cb46ea31fdad3063cca9559c6a372781a84a7a50c17cf4bbf65c515ce00580f79372cc763807" %% xsd:string])
-    wasDerivedFrom(niiri:a0e2e4659c44ec8283f603e4d63d4cb7, niiri:c48268f2a6a23bf1f723deea7bbdb5b6, -, -, -)
-    wasGeneratedBy(niiri:a0e2e4659c44ec8283f603e4d63d4cb7, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
-    entity(niiri:26f92bdc36b3170ba40be9cc15a7dc6e,
+    wasDerivedFrom(niiri:43e01138ea166419cf89ae0c1b960c02, niiri:aa7e9876de1332712a7a6718e06772c7, -, -, -)
+    wasGeneratedBy(niiri:43e01138ea166419cf89ae0c1b960c02, niiri:169c4819223a8702ebf9447665c6a242, -)
+    entity(niiri:165ea688a4bf64576aaa4b9aefc18471,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "0.0173736633732915" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         crypto:sha512 = "98952e02ac3f45da846d94deb554fad9126d6ba05b8ba745f176150b7b18bf2edee7efff67e7362f6704114b42ec7cb1d68fcde6005a829d52921961a4dad470" %% xsd:string])
-    wasGeneratedBy(niiri:26f92bdc36b3170ba40be9cc15a7dc6e, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
-    entity(niiri:2623a47371135f56c2aecb37063cac44,
+    wasGeneratedBy(niiri:165ea688a4bf64576aaa4b9aefc18471, niiri:169c4819223a8702ebf9447665c6a242, -)
+    entity(niiri:f2d25df0f1d380a37ffc86ec505d0987,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0'])
-    entity(niiri:51246b06ba783f764ebdcafdef38e2e3,
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185'])
+    entity(niiri:1d80b51894720953bd75f667c1e8d960,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "edde9f432759a7f2dad9ef0d3cb847eae532656aa81a7c08c76d939fe426e2e85329d56d0d279bf546773319599dd0bdf75b484d25083c8a2ac7ccb694a30e86" %% xsd:string])
-    wasDerivedFrom(niiri:2623a47371135f56c2aecb37063cac44, niiri:51246b06ba783f764ebdcafdef38e2e3, -, -, -)
-    wasGeneratedBy(niiri:2623a47371135f56c2aecb37063cac44, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
-    entity(niiri:9a291bb486326720055fc2883364893a,
+    wasDerivedFrom(niiri:f2d25df0f1d380a37ffc86ec505d0987, niiri:1d80b51894720953bd75f667c1e8d960, -, -, -)
+    wasGeneratedBy(niiri:f2d25df0f1d380a37ffc86ec505d0987, niiri:169c4819223a8702ebf9447665c6a242, -)
+    entity(niiri:f89edafcbb5a3cc6c1e71d9a08caf49e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0'])
-    entity(niiri:0575f791e06f7944f37a4249570f2201,
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185'])
+    entity(niiri:e06126279c6b3cc3de4edddb8525281c,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "f54847aa8325ebc7e962e70e87b4ecc5cfc95e840fa0229889bfab2345836d6b6032c0d29f89f2bc95abc2581dfd7ad2af5833031d4c2974513717c3f0ec29f8" %% xsd:string])
-    wasDerivedFrom(niiri:9a291bb486326720055fc2883364893a, niiri:0575f791e06f7944f37a4249570f2201, -, -, -)
-    wasGeneratedBy(niiri:9a291bb486326720055fc2883364893a, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
-    entity(niiri:b9cbdd666979ec7a12ae681547b560f7,
+    wasDerivedFrom(niiri:f89edafcbb5a3cc6c1e71d9a08caf49e, niiri:e06126279c6b3cc3de4edddb8525281c, -, -, -)
+    wasGeneratedBy(niiri:f89edafcbb5a3cc6c1e71d9a08caf49e, niiri:169c4819223a8702ebf9447665c6a242, -)
+    entity(niiri:0dcb05747e20cb33a44bc7d7ca0576cb,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         crypto:sha512 = "693dd1daf261efafb742c7da149cccc8b7383b49e672358dd29c6bcd31a6ee983270e23c3f118d86b0758d86162d77033926cb1ae0f653efb0b7102c922ca40b" %% xsd:string])
-    entity(niiri:51db014e8a30d126f73e7f235977299f,
+    entity(niiri:b6f9383af3eb3dc8144e7261991f9fb1,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "afca09bea5ebf5bceda101c9cb4d803de2cc2307b72a539454ce04e72ad6f655304b653779a287d3f38fca841819bf8126c51cb0a095e8710882e87d5eb7c565" %% xsd:string])
-    wasDerivedFrom(niiri:b9cbdd666979ec7a12ae681547b560f7, niiri:51db014e8a30d126f73e7f235977299f, -, -, -)
-    wasGeneratedBy(niiri:b9cbdd666979ec7a12ae681547b560f7, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
-    entity(niiri:4b89f205af8d9f723bc3dd1382c941ba,
+    wasDerivedFrom(niiri:0dcb05747e20cb33a44bc7d7ca0576cb, niiri:b6f9383af3eb3dc8144e7261991f9fb1, -, -, -)
+    wasGeneratedBy(niiri:0dcb05747e20cb33a44bc7d7ca0576cb, niiri:169c4819223a8702ebf9447665c6a242, -)
+    entity(niiri:dcbee28f8fa480eb84e376111f7b6875,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         crypto:sha512 = "58dcbf304825e142d28af1f78351fa5fa758ea20a597f7c117967af6a2d051d80f69686dc6858c0d6b1b677ff279e00d600772ce8175eae7a54dbedd0848bfd5" %% xsd:string])
-    entity(niiri:d5024dc0bc94c982918144fd5349aa97,
+    entity(niiri:4cb25d713c24e1d3d5fa873ee3dbfceb,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "42b06ae2316603cd1635234bdc474edf4cfac04b7ffe7acfe80221ee4cb3ecc0e6b514f5ebf1391df5ced6eb2fd5a91cd62a58ce1c4318ed4514eb8e1b41729b" %% xsd:string])
-    wasDerivedFrom(niiri:4b89f205af8d9f723bc3dd1382c941ba, niiri:d5024dc0bc94c982918144fd5349aa97, -, -, -)
-    wasGeneratedBy(niiri:4b89f205af8d9f723bc3dd1382c941ba, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
-    entity(niiri:43cb4a137447d784b18f0327f0c441f9,
+    wasDerivedFrom(niiri:dcbee28f8fa480eb84e376111f7b6875, niiri:4cb25d713c24e1d3d5fa873ee3dbfceb, -, -, -)
+    wasGeneratedBy(niiri:dcbee28f8fa480eb84e376111f7b6875, niiri:169c4819223a8702ebf9447665c6a242, -)
+    entity(niiri:1d97aaaad1a6968e4783cd6214ee5179,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         prov:label = "Contrast: mr vs plain" %% xsd:string,
         prov:value = "[1, 0]" %% xsd:string])
-    activity(niiri:8106d8f378522cc994936b6c1d2b0f47,
+    activity(niiri:54a8d8c7177e25879aa8c042805dfebe,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:d515e4539ba77e4aaafcb479a1267ad1, -)
-    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:a0e2e4659c44ec8283f603e4d63d4cb7, -)
-    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:b9cbdd666979ec7a12ae681547b560f7, -)
-    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:f49fb0ce586d5bba164b397ad004843d, -)
-    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:43cb4a137447d784b18f0327f0c441f9, -)
-    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:2623a47371135f56c2aecb37063cac44, -)
-    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:9a291bb486326720055fc2883364893a, -)
-    entity(niiri:7180fa05eac2a8815661ff232ad535d2,
+    wasAssociatedWith(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:7cd23874d74598fb93575d0ca339d267, -)
+    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:43e01138ea166419cf89ae0c1b960c02, -)
+    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:0dcb05747e20cb33a44bc7d7ca0576cb, -)
+    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:8cc550f78b4df2ff508e85441d0a1fd0, -)
+    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:1d97aaaad1a6968e4783cd6214ee5179, -)
+    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:f2d25df0f1d380a37ffc86ec505d0987, -)
+    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:f89edafcbb5a3cc6c1e71d9a08caf49e, -)
+    entity(niiri:78c3a55d6161c2415d14067b8c63d784,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -267,103 +267,103 @@ document
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "11" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         crypto:sha512 = "370387f786b51f404f6ca9acd10c4e35fbac46e4f5ec42750cf05c4236bda63dc8c003dea0989fd6c397d05d2e46bf0e0685ef08fa143418c0f1fdc3e7fe0d8b" %% xsd:string])
-    entity(niiri:a909b2437ec845db0a946d87fcdbf110,
+    entity(niiri:40a16c560c78731e96db83110db91267,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "489d1d288d622546f52d846311adfd3c6b7a5a604e0356335c997c6c7c2cfdf648e312383d151343007194e94ae8e681af5c7c1c0f69754126dd9561cbcf622b" %% xsd:string])
-    wasDerivedFrom(niiri:7180fa05eac2a8815661ff232ad535d2, niiri:a909b2437ec845db0a946d87fcdbf110, -, -, -)
-    wasGeneratedBy(niiri:7180fa05eac2a8815661ff232ad535d2, niiri:8106d8f378522cc994936b6c1d2b0f47, -)
-    entity(niiri:f88a91a1a09378bbfdb3dd220962cbd0,
+    wasDerivedFrom(niiri:78c3a55d6161c2415d14067b8c63d784, niiri:40a16c560c78731e96db83110db91267, -, -, -)
+    wasGeneratedBy(niiri:78c3a55d6161c2415d14067b8c63d784, niiri:54a8d8c7177e25879aa8c042805dfebe, -)
+    entity(niiri:3becd9191b28badb59abfebfeab96ef5,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: mr vs plain" %% xsd:string,
         nidm_contrastName: = "mr vs plain" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         crypto:sha512 = "ab6e3d990747f48517f1cf7eb1dd7dd0e973d4f5b7f468963c982c906f3dfcafa7c056c8f34d9f54c10330a67ab92b7f7ab3d95781a568b7fbaddf9f17746216" %% xsd:string])
-    entity(niiri:1282ac0f2eeb5bc9dde3259940a5b967,
+    entity(niiri:78c411926e48aaf00a21986fb6b38f41,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "9dc48e80c35ac0d74eb3131bab4e8cac2db2df834fef3c5cb6ddb5d91082d573d885a8e703a03652b5745f3f52b0e3397feb130f3ebccae549142ce88c29cb59" %% xsd:string])
-    wasDerivedFrom(niiri:f88a91a1a09378bbfdb3dd220962cbd0, niiri:1282ac0f2eeb5bc9dde3259940a5b967, -, -, -)
-    wasGeneratedBy(niiri:f88a91a1a09378bbfdb3dd220962cbd0, niiri:8106d8f378522cc994936b6c1d2b0f47, -)
-    entity(niiri:c68b99924630158595413c4285a41ec7,
+    wasDerivedFrom(niiri:3becd9191b28badb59abfebfeab96ef5, niiri:78c411926e48aaf00a21986fb6b38f41, -, -, -)
+    wasGeneratedBy(niiri:3becd9191b28badb59abfebfeab96ef5, niiri:54a8d8c7177e25879aa8c042805dfebe, -)
+    entity(niiri:e74be4649036d7e5c6372c0258817b2b,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         crypto:sha512 = "a36854cf6dd56807c2a335d31d64f3f265785b7b573115e7cfaec97da31078aad22aa084ac09c3a550605f550228a781457821df43845b7a92c8b375bc9ac9dc" %% xsd:string])
-    wasGeneratedBy(niiri:c68b99924630158595413c4285a41ec7, niiri:8106d8f378522cc994936b6c1d2b0f47, -)
-    entity(niiri:98a24053ecc198c682c361b35db9d066,
+    wasGeneratedBy(niiri:e74be4649036d7e5c6372c0258817b2b, niiri:54a8d8c7177e25879aa8c042805dfebe, -)
+    entity(niiri:5fc89d76faab61ee021d9cc78f0fd0b5,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500148243682" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:7d4015daee5ad33cd195777edd7b45e7',
-        nidm_equivalentThreshold: = 'niiri:2e33ccc4e77256ac0c3122164affbf0f'])
-    entity(niiri:7d4015daee5ad33cd195777edd7b45e7,
+        nidm_equivalentThreshold: = 'niiri:550ff496a1f20b888585d452cf21e219',
+        nidm_equivalentThreshold: = 'niiri:268cc3d07350375a06d59e1c72255036'])
+    entity(niiri:550ff496a1f20b888585d452cf21e219,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.02470104841152" %% xsd:float])
-    entity(niiri:2e33ccc4e77256ac0c3122164affbf0f,
+    entity(niiri:268cc3d07350375a06d59e1c72255036,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999999987" %% xsd:float])
-    entity(niiri:97c3deab28ad09270d41f36ac051abf0,
+    entity(niiri:fb431b6d009d90dc5f369aadeb468547,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:dc2315d702ea7d63764b08840958382b',
-        nidm_equivalentThreshold: = 'niiri:3a2b050a6e9b6bf8427850e20e551ae4'])
-    entity(niiri:dc2315d702ea7d63764b08840958382b,
+        nidm_equivalentThreshold: = 'niiri:bbb30eb0dc56085d0bb3b8f32e1aa7d8',
+        nidm_equivalentThreshold: = 'niiri:6af35793d4c30300501f6e4843ea64f9'])
+    entity(niiri:bbb30eb0dc56085d0bb3b8f32e1aa7d8,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:3a2b050a6e9b6bf8427850e20e551ae4,
+    entity(niiri:6af35793d4c30300501f6e4843ea64f9,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:b96cd6ef89bc01300f460e26e2535619,
+    entity(niiri:e3fc10780da51f8073baec6993b81559,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:a6afd19740d69851bcebb4de3abcb4e7,
+    entity(niiri:a7fcffe68706a024505ad48123a3a597,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:58ea1c58f6fd442a5f0b30714b02f548,
+    activity(niiri:f74ee55215d923c382e467dc5985637f,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:d515e4539ba77e4aaafcb479a1267ad1, -)
-    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:98a24053ecc198c682c361b35db9d066, -)
-    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:97c3deab28ad09270d41f36ac051abf0, -)
-    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:7180fa05eac2a8815661ff232ad535d2, -)
-    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:4b89f205af8d9f723bc3dd1382c941ba, -)
-    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:a0e2e4659c44ec8283f603e4d63d4cb7, -)
-    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:b96cd6ef89bc01300f460e26e2535619, -)
-    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:a6afd19740d69851bcebb4de3abcb4e7, -)
-    entity(niiri:af00c4dc59502bf1fe7721773eb5a850,
+    wasAssociatedWith(niiri:f74ee55215d923c382e467dc5985637f, niiri:7cd23874d74598fb93575d0ca339d267, -)
+    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:5fc89d76faab61ee021d9cc78f0fd0b5, -)
+    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:fb431b6d009d90dc5f369aadeb468547, -)
+    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:78c3a55d6161c2415d14067b8c63d784, -)
+    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:dcbee28f8fa480eb84e376111f7b6875, -)
+    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:43e01138ea166419cf89ae0c1b960c02, -)
+    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:e3fc10780da51f8073baec6993b81559, -)
+    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:a7fcffe68706a024505ad48123a3a597, -)
+    entity(niiri:4210503ffa69b7e56d701bcba7b1b2df,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         nidm_searchVolumeInVoxels: = "162104" %% xsd:int,
         nidm_searchVolumeInUnits: = "1296832" %% xsd:float,
         nidm_reselSizeInVoxels: = "95.2875561406722" %% xsd:float,
@@ -379,8 +379,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f" %% xsd:string])
-    wasGeneratedBy(niiri:af00c4dc59502bf1fe7721773eb5a850, niiri:58ea1c58f6fd442a5f0b30714b02f548, -)
-    entity(niiri:d60a0c55d948a11dac535e382316f31f,
+    wasGeneratedBy(niiri:4210503ffa69b7e56d701bcba7b1b2df, niiri:f74ee55215d923c382e467dc5985637f, -)
+    entity(niiri:ff2b188fd5ef195057b9076462d97f0c,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -388,22 +388,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "29" %% xsd:int,
         nidm_pValue: = "0.722893095431427" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:aae74d51171ea0af243cd165c716a211',
-        nidm_hasMaximumIntensityProjection: = 'niiri:93a498407930e7c2f57870d6e06e32d4',
-        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_hasClusterLabelsMap: = 'niiri:3fe999af53b6ff1062dd11597b4540ec',
+        nidm_hasMaximumIntensityProjection: = 'niiri:ec2532bdcd7e520faba8a90cf9625856',
+        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
         crypto:sha512 = "2bbcc39452bb1127d7205b05c820b5d31d5e2daa43e4ba6ccaf43c229aa7d708af405aff650daa9a08b3582c5aa013e32a6535188542c9c1fc3fa24fcc03c59c" %% xsd:string])
-    entity(niiri:aae74d51171ea0af243cd165c716a211,
+    entity(niiri:3fe999af53b6ff1062dd11597b4540ec,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:93a498407930e7c2f57870d6e06e32d4,
+    entity(niiri:ec2532bdcd7e520faba8a90cf9625856,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:d60a0c55d948a11dac535e382316f31f, niiri:58ea1c58f6fd442a5f0b30714b02f548, -)
-    entity(niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b,
+    wasGeneratedBy(niiri:ff2b188fd5ef195057b9076462d97f0c, niiri:f74ee55215d923c382e467dc5985637f, -)
+    entity(niiri:be91aa057bdd9d8651b94a428f9d7e04,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -412,8 +412,8 @@ document
         nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:02bd1b0dd4f143323060712eeb0b3401,
+    wasDerivedFrom(niiri:be91aa057bdd9d8651b94a428f9d7e04, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:8c1f835fe33bb35a741db5d71610f74d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -422,8 +422,8 @@ document
         nidm_pValueFWER: = "0.999549488736845" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:02bd1b0dd4f143323060712eeb0b3401, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:4feafd8d4a6ff76500cde244ec4a9ac0,
+    wasDerivedFrom(niiri:8c1f835fe33bb35a741db5d71610f74d, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:427a5e18f5920cd494cd57b5222b9804,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -432,8 +432,8 @@ document
         nidm_pValueFWER: = "0.998828548616846" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:4feafd8d4a6ff76500cde244ec4a9ac0, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:6267cdb89b255ce524220439e2d056f1,
+    wasDerivedFrom(niiri:427a5e18f5920cd494cd57b5222b9804, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:8cd69d4c2bcb674537c0f59674d850f8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -442,8 +442,8 @@ document
         nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:6267cdb89b255ce524220439e2d056f1, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:dccae6a3d4de3910d04419b8bb7c8d62,
+    wasDerivedFrom(niiri:8cd69d4c2bcb674537c0f59674d850f8, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:1c094c13c4622d206afcab0831c06c8e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -452,8 +452,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:dccae6a3d4de3910d04419b8bb7c8d62, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:8a59a0d3509f23181ea020ba988244a4,
+    wasDerivedFrom(niiri:1c094c13c4622d206afcab0831c06c8e, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:d03fb3a214226f8e359063dd56622b80,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -462,8 +462,8 @@ document
         nidm_pValueFWER: = "0.93333931168142" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:8a59a0d3509f23181ea020ba988244a4, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:26f9f618c22ef5edf5685712623da454,
+    wasDerivedFrom(niiri:d03fb3a214226f8e359063dd56622b80, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:08acd9d5e3c86a5597634b63f9ca5b76,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -472,8 +472,8 @@ document
         nidm_pValueFWER: = "0.990653977132472" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:26f9f618c22ef5edf5685712623da454, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:d2f346a025c15c9fc9c31510f24b5886,
+    wasDerivedFrom(niiri:08acd9d5e3c86a5597634b63f9ca5b76, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:33fdb3dcbde308077cb41f61bbb538d4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -482,8 +482,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:d2f346a025c15c9fc9c31510f24b5886, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:d2e202f26f07d353e876c8513aaac055,
+    wasDerivedFrom(niiri:33fdb3dcbde308077cb41f61bbb538d4, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:a1dfe524338b100e2c0b4aac79347135,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -492,8 +492,8 @@ document
         nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:d2e202f26f07d353e876c8513aaac055, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:d0abf7f944018518c8b2f88645568e05,
+    wasDerivedFrom(niiri:a1dfe524338b100e2c0b4aac79347135, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:398e18e13e41fd86f9c91a0c37179f94,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -502,8 +502,8 @@ document
         nidm_pValueFWER: = "0.999857085744802" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:d0abf7f944018518c8b2f88645568e05, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:71dd070abfb1b28ce2b0e47fb4f49daf,
+    wasDerivedFrom(niiri:398e18e13e41fd86f9c91a0c37179f94, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:fc5a20643a49d6b48c632806b9fb3669,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -512,8 +512,8 @@ document
         nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:71dd070abfb1b28ce2b0e47fb4f49daf, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:354b333049efc8a35bffb5e871d5df51,
+    wasDerivedFrom(niiri:fc5a20643a49d6b48c632806b9fb3669, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:7977d3c2d53495076863f90a7414369f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -522,8 +522,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:354b333049efc8a35bffb5e871d5df51, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:dfcda071a872154b10c43f862bf52d69,
+    wasDerivedFrom(niiri:7977d3c2d53495076863f90a7414369f, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:e6d67f5c8f427474527d0d727f3dce58,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -532,8 +532,8 @@ document
         nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:dfcda071a872154b10c43f862bf52d69, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:9f93d2b40c1f794cb34e0ae17e04bd0c,
+    wasDerivedFrom(niiri:e6d67f5c8f427474527d0d727f3dce58, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:9ba6b697c18c9fa2a070f1ac777899c3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -542,8 +542,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:9f93d2b40c1f794cb34e0ae17e04bd0c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:899db6b982fa96374440fc31d77225c7,
+    wasDerivedFrom(niiri:9ba6b697c18c9fa2a070f1ac777899c3, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:17cf04133d00b334b009343c68cc794f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -552,8 +552,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:899db6b982fa96374440fc31d77225c7, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:d19f972dfab2b23346202c34e5574f29,
+    wasDerivedFrom(niiri:17cf04133d00b334b009343c68cc794f, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:715dbdcf861d88449d6bf9fd80be68c2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -562,8 +562,8 @@ document
         nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:d19f972dfab2b23346202c34e5574f29, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:c8e45b2b37dac3869716ea38f6f82aa2,
+    wasDerivedFrom(niiri:715dbdcf861d88449d6bf9fd80be68c2, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:a722ba5c3f48104c4bffaa9f1bc96e93,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -572,8 +572,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:c8e45b2b37dac3869716ea38f6f82aa2, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:f4fe3e2f741c280bd998a6eaf285b07c,
+    wasDerivedFrom(niiri:a722ba5c3f48104c4bffaa9f1bc96e93, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:0aa4b1a84fee2649d333d5561003c8bf,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -582,8 +582,8 @@ document
         nidm_pValueFWER: = "0.999964783142854" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:f4fe3e2f741c280bd998a6eaf285b07c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:f18795394da513a451940bf5032734eb,
+    wasDerivedFrom(niiri:0aa4b1a84fee2649d333d5561003c8bf, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:5b1d37cc88f4111dc6ae2a4f48520a59,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -592,8 +592,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:f18795394da513a451940bf5032734eb, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:350e81fc1b83d10ae96dfefb3bab3615,
+    wasDerivedFrom(niiri:5b1d37cc88f4111dc6ae2a4f48520a59, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:7a1feca53667470e0f2534f053958e05,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -602,8 +602,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:350e81fc1b83d10ae96dfefb3bab3615, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b,
+    wasDerivedFrom(niiri:7a1feca53667470e0f2534f053958e05, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:bda46dfc41022916ad6faceac091ba3d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -612,8 +612,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:3e2d682ff8be1f7b5e4954125d52dc9c,
+    wasDerivedFrom(niiri:bda46dfc41022916ad6faceac091ba3d, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:0c786e61d78880c4e546692954781ced,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -622,8 +622,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:3e2d682ff8be1f7b5e4954125d52dc9c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:9a3e77b28376a93d769c670fd53a30cb,
+    wasDerivedFrom(niiri:0c786e61d78880c4e546692954781ced, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:b9a4c4c2b5a9793a35534927d9578f48,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -632,8 +632,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:9a3e77b28376a93d769c670fd53a30cb, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:0cff727da02fc982bbc0f11d56d44db2,
+    wasDerivedFrom(niiri:b9a4c4c2b5a9793a35534927d9578f48, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:f4849377c56edcbca1dc5384795946ce,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -642,8 +642,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:0cff727da02fc982bbc0f11d56d44db2, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:8fb299584020cc344c3c2c82de2f748c,
+    wasDerivedFrom(niiri:f4849377c56edcbca1dc5384795946ce, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:6ad64a79d36f37c1cd1b1433a1aef9ca,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -652,8 +652,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:8fb299584020cc344c3c2c82de2f748c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:6e2110d791417b070202a6783afba19c,
+    wasDerivedFrom(niiri:6ad64a79d36f37c1cd1b1433a1aef9ca, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:50d65ffbbedadcbcef20b8bacaa5bf32,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -662,8 +662,8 @@ document
         nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:6e2110d791417b070202a6783afba19c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:b0fbdf26b837fa676d008fcff5a30ee9,
+    wasDerivedFrom(niiri:50d65ffbbedadcbcef20b8bacaa5bf32, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:57ec9ce901bb55b112e2f594ad471e7a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -672,8 +672,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:b0fbdf26b837fa676d008fcff5a30ee9, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:5167e145ebaf9f5693dffbc09df2f2f8,
+    wasDerivedFrom(niiri:57ec9ce901bb55b112e2f594ad471e7a, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:1318d2cd1289a2678d066b7cca2986f1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -682,8 +682,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:5167e145ebaf9f5693dffbc09df2f2f8, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:17c3abf712c940e8e07c2fa7b3493dc1,
+    wasDerivedFrom(niiri:1318d2cd1289a2678d066b7cca2986f1, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -692,441 +692,441 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:17c3abf712c940e8e07c2fa7b3493dc1, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
-    entity(niiri:70a79fb5d0fafa6b4641330f8f8b12aa,
+    wasDerivedFrom(niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
+    entity(niiri:da098c4cc640a214fd988ad023eb1a86,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:654d6238fa35ad568af3286425629272',
+        prov:location = 'niiri:ba3f25e2c5e1f415cd2525e4abcdb621',
         prov:value = "6.37317276000977" %% xsd:float,
         nidm_equivalentZStatistic: = "4.04320073372639" %% xsd:float,
         nidm_pValueUncorrected: = "2.63632212645915e-05" %% xsd:float,
         nidm_pValueFWER: = "0.958902832016109" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:654d6238fa35ad568af3286425629272,
+    entity(niiri:ba3f25e2c5e1f415cd2525e4abcdb621,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[28,-36,38]" %% xsd:string])
-    wasDerivedFrom(niiri:70a79fb5d0fafa6b4641330f8f8b12aa, niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b, -, -, -)
-    entity(niiri:81a8683173d0ed24bd3d2f6be8ec0f77,
+    wasDerivedFrom(niiri:da098c4cc640a214fd988ad023eb1a86, niiri:be91aa057bdd9d8651b94a428f9d7e04, -, -, -)
+    entity(niiri:3f041463e58131d17c3adb62ae04b812,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:eacbf2fc9ec48207e00dc693c683bf1f',
+        prov:location = 'niiri:96c5c034a22620ddcd2779d651b4b97e',
         prov:value = "5.69066715240479" %% xsd:float,
         nidm_equivalentZStatistic: = "3.8079805415517" %% xsd:float,
         nidm_pValueUncorrected: = "7.00531473561972e-05" %% xsd:float,
         nidm_pValueFWER: = "0.997756103851125" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:eacbf2fc9ec48207e00dc693c683bf1f,
+    entity(niiri:96c5c034a22620ddcd2779d651b4b97e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[10,-48,16]" %% xsd:string])
-    wasDerivedFrom(niiri:81a8683173d0ed24bd3d2f6be8ec0f77, niiri:02bd1b0dd4f143323060712eeb0b3401, -, -, -)
-    entity(niiri:b6d7f661e892640001af0eea6f38dc9e,
+    wasDerivedFrom(niiri:3f041463e58131d17c3adb62ae04b812, niiri:8c1f835fe33bb35a741db5d71610f74d, -, -, -)
+    entity(niiri:7b61b8562a0fa2a8fc1be01625db2383,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:79a643a3d5d92c1658b5fb52ce02a6d1',
+        prov:location = 'niiri:709ff8ac6d109875a6c00824a37dec97',
         prov:value = "5.404944896698" %% xsd:float,
         nidm_equivalentZStatistic: = "3.70067578615084" %% xsd:float,
         nidm_pValueUncorrected: = "0.000107513031460726" %% xsd:float,
         nidm_pValueFWER: = "0.999684183052173" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:79a643a3d5d92c1658b5fb52ce02a6d1,
+    entity(niiri:709ff8ac6d109875a6c00824a37dec97,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[-34,-6,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:b6d7f661e892640001af0eea6f38dc9e, niiri:4feafd8d4a6ff76500cde244ec4a9ac0, -, -, -)
-    entity(niiri:640d2f1d4cb2fff0fb98dd63f4292b5e,
+    wasDerivedFrom(niiri:7b61b8562a0fa2a8fc1be01625db2383, niiri:427a5e18f5920cd494cd57b5222b9804, -, -, -)
+    entity(niiri:1e33617f26a669bbc5d4a8e1a84861df,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:26366fb427147de255e4516551b308e9',
+        prov:location = 'niiri:ef91d2750f81ce9286534c4378095103',
         prov:value = "5.20687818527222" %% xsd:float,
         nidm_equivalentZStatistic: = "3.62288194485815" %% xsd:float,
         nidm_pValueUncorrected: = "0.000145669405598126" %% xsd:float,
         nidm_pValueFWER: = "0.999944545222406" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:26366fb427147de255e4516551b308e9,
+    entity(niiri:ef91d2750f81ce9286534c4378095103,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[-28,-80,24]" %% xsd:string])
-    wasDerivedFrom(niiri:640d2f1d4cb2fff0fb98dd63f4292b5e, niiri:6267cdb89b255ce524220439e2d056f1, -, -, -)
-    entity(niiri:aaba7d880bfd3cc9e40f6e040f3df3ca,
+    wasDerivedFrom(niiri:1e33617f26a669bbc5d4a8e1a84861df, niiri:8cd69d4c2bcb674537c0f59674d850f8, -, -, -)
+    entity(niiri:f9aa7f4153c94329f57f5a213c31ad9d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:ceafb447ebc334cf0885953cb12180dc',
+        prov:location = 'niiri:a01b0efba27795b5259e72e8b06cc19e',
         prov:value = "4.90865421295166" %% xsd:float,
         nidm_equivalentZStatistic: = "3.50007991972101" %% xsd:float,
         nidm_pValueUncorrected: = "0.000232559344231609" %% xsd:float,
         nidm_pValueFWER: = "0.999998126675029" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:ceafb447ebc334cf0885953cb12180dc,
+    entity(niiri:a01b0efba27795b5259e72e8b06cc19e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[-12,-32,28]" %% xsd:string])
-    wasDerivedFrom(niiri:aaba7d880bfd3cc9e40f6e040f3df3ca, niiri:dccae6a3d4de3910d04419b8bb7c8d62, -, -, -)
-    entity(niiri:c9d9194d3fc86fceb8cbb0ad72e5e116,
+    wasDerivedFrom(niiri:f9aa7f4153c94329f57f5a213c31ad9d, niiri:1c094c13c4622d206afcab0831c06c8e, -, -, -)
+    entity(niiri:afa5a345b8d55093f5d0ff485e694dbf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:39876766efea7749fdb1e3ec89516c50',
+        prov:location = 'niiri:2f8f1cfad3185761941c0d73d52f473c',
         prov:value = "4.84440040588379" %% xsd:float,
         nidm_equivalentZStatistic: = "3.47268080874189" %% xsd:float,
         nidm_pValueUncorrected: = "0.000257643895570592" %% xsd:float,
         nidm_pValueFWER: = "0.999999219649123" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:39876766efea7749fdb1e3ec89516c50,
+    entity(niiri:2f8f1cfad3185761941c0d73d52f473c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[-18,-76,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:c9d9194d3fc86fceb8cbb0ad72e5e116, niiri:8a59a0d3509f23181ea020ba988244a4, -, -, -)
-    entity(niiri:7361b36fbc686ac319529770f44965bb,
+    wasDerivedFrom(niiri:afa5a345b8d55093f5d0ff485e694dbf, niiri:d03fb3a214226f8e359063dd56622b80, -, -, -)
+    entity(niiri:60a2332e10d9170f38d2463aeabd0113,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:d6b455e1b17b09ffb45f2319ae5feaa7',
+        prov:location = 'niiri:8c54f00fb0e08af1fb95533f64c42abe',
         prov:value = "4.84136772155762" %% xsd:float,
         nidm_equivalentZStatistic: = "3.47137907963827" %% xsd:float,
         nidm_pValueUncorrected: = "0.000258896237096851" %% xsd:float,
         nidm_pValueFWER: = "0.999999252321799" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:d6b455e1b17b09ffb45f2319ae5feaa7,
+    entity(niiri:8c54f00fb0e08af1fb95533f64c42abe,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[32,16,40]" %% xsd:string])
-    wasDerivedFrom(niiri:7361b36fbc686ac319529770f44965bb, niiri:26f9f618c22ef5edf5685712623da454, -, -, -)
-    entity(niiri:71afea378b2be0836e3b1e53b4c621c4,
+    wasDerivedFrom(niiri:60a2332e10d9170f38d2463aeabd0113, niiri:08acd9d5e3c86a5597634b63f9ca5b76, -, -, -)
+    entity(niiri:79e0ce1a82f0e80e09c1b5064a2d60b2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:a1d44e4d1e3f9e624a75e1de128e43a4',
+        prov:location = 'niiri:80f6cd9cf5fcdd939d578cbb14fba341',
         prov:value = "4.78605508804321" %% xsd:float,
         nidm_equivalentZStatistic: = "3.4475005479143" %% xsd:float,
         nidm_pValueUncorrected: = "0.000282899629741595" %% xsd:float,
         nidm_pValueFWER: = "0.999999665309186" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:a1d44e4d1e3f9e624a75e1de128e43a4,
+    entity(niiri:80f6cd9cf5fcdd939d578cbb14fba341,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[-26,-78,46]" %% xsd:string])
-    wasDerivedFrom(niiri:71afea378b2be0836e3b1e53b4c621c4, niiri:d2f346a025c15c9fc9c31510f24b5886, -, -, -)
-    entity(niiri:8d7d3064a7e3b5bf7e85fffe64b06bc6,
+    wasDerivedFrom(niiri:79e0ce1a82f0e80e09c1b5064a2d60b2, niiri:33fdb3dcbde308077cb41f61bbb538d4, -, -, -)
+    entity(niiri:33896a562b3020901f0a9129b329ca9f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:6d9c75885354734cf3570762871d32aa',
+        prov:location = 'niiri:46882cfa883eb6417029f9e14cfcd78d',
         prov:value = "4.75920820236206" %% xsd:float,
         nidm_equivalentZStatistic: = "3.43581665930553" %% xsd:float,
         nidm_pValueUncorrected: = "0.000295385308778928" %% xsd:float,
         nidm_pValueFWER: = "0.999999777160537" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:6d9c75885354734cf3570762871d32aa,
+    entity(niiri:46882cfa883eb6417029f9e14cfcd78d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[-50,-2,42]" %% xsd:string])
-    wasDerivedFrom(niiri:8d7d3064a7e3b5bf7e85fffe64b06bc6, niiri:d2e202f26f07d353e876c8513aaac055, -, -, -)
-    entity(niiri:00f11aa6a9bf3c67963ec8004894a193,
+    wasDerivedFrom(niiri:33896a562b3020901f0a9129b329ca9f, niiri:a1dfe524338b100e2c0b4aac79347135, -, -, -)
+    entity(niiri:0a36f87ab7a0b75562073c6947d4f7b1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:cfe98ef5194606348538a89c7dce71b0',
+        prov:location = 'niiri:7573b7d12c8d035c9d5d8631ccb22a9f',
         prov:value = "4.70320177078247" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41124192966355" %% xsd:float,
         nidm_pValueUncorrected: = "0.000323338426391984" %% xsd:float,
         nidm_pValueFWER: = "0.999999908044234" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:cfe98ef5194606348538a89c7dce71b0,
+    entity(niiri:7573b7d12c8d035c9d5d8631ccb22a9f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[22,-34,34]" %% xsd:string])
-    wasDerivedFrom(niiri:00f11aa6a9bf3c67963ec8004894a193, niiri:d0abf7f944018518c8b2f88645568e05, -, -, -)
-    entity(niiri:057cb92551aa371b6f6dc683d506bf96,
+    wasDerivedFrom(niiri:0a36f87ab7a0b75562073c6947d4f7b1, niiri:398e18e13e41fd86f9c91a0c37179f94, -, -, -)
+    entity(niiri:6eab38ddecebcaaa0bf86b72dc12049c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:a7a44c477f5330dc6c8b7bbe1aa3f387',
+        prov:location = 'niiri:7f68e73a36ee3f3687de8c6c9b97a7fe',
         prov:value = "4.65910387039185" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39169946109688" %% xsd:float,
         nidm_pValueUncorrected: = "0.000347302923845438" %% xsd:float,
         nidm_pValueFWER: = "0.999999955827132" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:a7a44c477f5330dc6c8b7bbe1aa3f387,
+    entity(niiri:7f68e73a36ee3f3687de8c6c9b97a7fe,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[-20,-44,-36]" %% xsd:string])
-    wasDerivedFrom(niiri:057cb92551aa371b6f6dc683d506bf96, niiri:71dd070abfb1b28ce2b0e47fb4f49daf, -, -, -)
-    entity(niiri:32caa29266a76db202d1c2c5c68c7445,
+    wasDerivedFrom(niiri:6eab38ddecebcaaa0bf86b72dc12049c, niiri:fc5a20643a49d6b48c632806b9fb3669, -, -, -)
+    entity(niiri:8dff42675f00ab4b9ddd2b53dc34917f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:5e965e5ef7f2d1914d1b1f52d8cbddea',
+        prov:location = 'niiri:7eab74d15593b8c8ffc29b17ea34173f',
         prov:value = "4.63754796981812" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38208413500926" %% xsd:float,
         nidm_pValueUncorrected: = "0.00035969054090712" %% xsd:float,
         nidm_pValueFWER: = "0.999999969503" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:5e965e5ef7f2d1914d1b1f52d8cbddea,
+    entity(niiri:7eab74d15593b8c8ffc29b17ea34173f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[34,-22,26]" %% xsd:string])
-    wasDerivedFrom(niiri:32caa29266a76db202d1c2c5c68c7445, niiri:354b333049efc8a35bffb5e871d5df51, -, -, -)
-    entity(niiri:4c62c0e8cf4e83463b2cd8ef62f9c602,
+    wasDerivedFrom(niiri:8dff42675f00ab4b9ddd2b53dc34917f, niiri:7977d3c2d53495076863f90a7414369f, -, -, -)
+    entity(niiri:69505c505831c5f7ad6ff3002082e4c0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:b3021dc8859525200429834fc6310f99',
+        prov:location = 'niiri:dc677f45978a7877a700f4d03cf0e7ce',
         prov:value = "4.61526584625244" %% xsd:float,
         nidm_equivalentZStatistic: = "3.37210130568973" %% xsd:float,
         nidm_pValueUncorrected: = "0.000372985020458683" %% xsd:float,
         nidm_pValueFWER: = "0.999999979383511" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:b3021dc8859525200429834fc6310f99,
+    entity(niiri:dc677f45978a7877a700f4d03cf0e7ce,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[-8,-24,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:4c62c0e8cf4e83463b2cd8ef62f9c602, niiri:dfcda071a872154b10c43f862bf52d69, -, -, -)
-    entity(niiri:8a73d008087b3fa9d94106936d72a9cf,
+    wasDerivedFrom(niiri:69505c505831c5f7ad6ff3002082e4c0, niiri:e6d67f5c8f427474527d0d727f3dce58, -, -, -)
+    entity(niiri:07fc7144bacb9a33351978163ec7665f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:f56aea2994cdd430b079943b1299d6ba',
+        prov:location = 'niiri:2aa908545a5498195b685e803d760c2a',
         prov:value = "4.51868915557861" %% xsd:float,
         nidm_equivalentZStatistic: = "3.32831433156359" %% xsd:float,
         nidm_pValueUncorrected: = "0.000436866114896683" %% xsd:float,
         nidm_pValueFWER: = "0.999999996599993" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:f56aea2994cdd430b079943b1299d6ba,
+    entity(niiri:2aa908545a5498195b685e803d760c2a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[10,-12,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:8a73d008087b3fa9d94106936d72a9cf, niiri:9f93d2b40c1f794cb34e0ae17e04bd0c, -, -, -)
-    entity(niiri:a96fc8bfcb9cf24f47dbdf7bfe7afd17,
+    wasDerivedFrom(niiri:07fc7144bacb9a33351978163ec7665f, niiri:9ba6b697c18c9fa2a070f1ac777899c3, -, -, -)
+    entity(niiri:2a7de24428d3d14a74344f3a2ed53ab9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:ac7a10e1bead2a7d7fd42038f3949443',
+        prov:location = 'niiri:402ce4265cfb6d8f4eccfcd7202c27c6',
         prov:value = "4.45568466186523" %% xsd:float,
         nidm_equivalentZStatistic: = "3.2992865242182" %% xsd:float,
         nidm_pValueUncorrected: = "0.000484654601471068" %% xsd:float,
         nidm_pValueFWER: = "0.999999999048352" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:ac7a10e1bead2a7d7fd42038f3949443,
+    entity(niiri:402ce4265cfb6d8f4eccfcd7202c27c6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[16,-48,-46]" %% xsd:string])
-    wasDerivedFrom(niiri:a96fc8bfcb9cf24f47dbdf7bfe7afd17, niiri:899db6b982fa96374440fc31d77225c7, -, -, -)
-    entity(niiri:3d6d68b50c110bd970cae436330e36d9,
+    wasDerivedFrom(niiri:2a7de24428d3d14a74344f3a2ed53ab9, niiri:17cf04133d00b334b009343c68cc794f, -, -, -)
+    entity(niiri:71a4d25f7fb9dd5f2ff89ce4a6426ed6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:daf43d66330a2ead30991863c01caec5',
+        prov:location = 'niiri:170bf99fa55adf19b4bcf6bac2226035',
         prov:value = "4.42093467712402" %% xsd:float,
         nidm_equivalentZStatistic: = "3.28311730425125" %% xsd:float,
         nidm_pValueUncorrected: = "0.000513329675929763" %% xsd:float,
         nidm_pValueFWER: = "0.999999999544708" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:daf43d66330a2ead30991863c01caec5,
+    entity(niiri:170bf99fa55adf19b4bcf6bac2226035,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[-20,52,16]" %% xsd:string])
-    wasDerivedFrom(niiri:3d6d68b50c110bd970cae436330e36d9, niiri:d19f972dfab2b23346202c34e5574f29, -, -, -)
-    entity(niiri:00d1711e3ed46fde327d5581de9dd791,
+    wasDerivedFrom(niiri:71a4d25f7fb9dd5f2ff89ce4a6426ed6, niiri:715dbdcf861d88449d6bf9fd80be68c2, -, -, -)
+    entity(niiri:3fe2b2a2a97891aa0347dc4a8041143b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:ae59229032d7c40d79b030470e5f23b9',
+        prov:location = 'niiri:a810311fe07f257dbdaf36cba74972bf',
         prov:value = "4.41627073287964" %% xsd:float,
         nidm_equivalentZStatistic: = "3.28093847762164" %% xsd:float,
         nidm_pValueUncorrected: = "0.00051731154621093" %% xsd:float,
         nidm_pValueFWER: = "0.999999999588405" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:ae59229032d7c40d79b030470e5f23b9,
+    entity(niiri:a810311fe07f257dbdaf36cba74972bf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[10,62,20]" %% xsd:string])
-    wasDerivedFrom(niiri:00d1711e3ed46fde327d5581de9dd791, niiri:c8e45b2b37dac3869716ea38f6f82aa2, -, -, -)
-    entity(niiri:7e851910d726d6995c852ed218ac5570,
+    wasDerivedFrom(niiri:3fe2b2a2a97891aa0347dc4a8041143b, niiri:a722ba5c3f48104c4bffaa9f1bc96e93, -, -, -)
+    entity(niiri:771d0950142ef5727aa4539533181ebe,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:a01d789cee79784cca55a545db21ce87',
+        prov:location = 'niiri:01971ac462b6f6a68ddf7a4bcb329cd1',
         prov:value = "4.39752912521362" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27216223374679" %% xsd:float,
         nidm_pValueUncorrected: = "0.000533641570346299" %% xsd:float,
         nidm_pValueFWER: = "0.999999999726897" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:a01d789cee79784cca55a545db21ce87,
+    entity(niiri:01971ac462b6f6a68ddf7a4bcb329cd1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[50,-66,38]" %% xsd:string])
-    wasDerivedFrom(niiri:7e851910d726d6995c852ed218ac5570, niiri:f4fe3e2f741c280bd998a6eaf285b07c, -, -, -)
-    entity(niiri:9fe2a624ae89ae7fa855b69eec31ebbd,
+    wasDerivedFrom(niiri:771d0950142ef5727aa4539533181ebe, niiri:0aa4b1a84fee2649d333d5561003c8bf, -, -, -)
+    entity(niiri:8fa040e1a3007565edd3ecf0c6827522,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:88780e43a9ab7fafa2461b5df7d58e73',
+        prov:location = 'niiri:386b7d31755630d505a2b693dea28f77',
         prov:value = "4.30746841430664" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22951851195682" %% xsd:float,
         nidm_pValueUncorrected: = "0.000619994267038626" %% xsd:float,
         nidm_pValueFWER: = "0.999999999965896" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:88780e43a9ab7fafa2461b5df7d58e73,
+    entity(niiri:386b7d31755630d505a2b693dea28f77,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[-4,-4,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:9fe2a624ae89ae7fa855b69eec31ebbd, niiri:f18795394da513a451940bf5032734eb, -, -, -)
-    entity(niiri:a74e55a109a945b087544cc3e5a316c8,
+    wasDerivedFrom(niiri:8fa040e1a3007565edd3ecf0c6827522, niiri:5b1d37cc88f4111dc6ae2a4f48520a59, -, -, -)
+    entity(niiri:2c9566f77e7f82b34e22874819f8c710,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:f763f5cde1a933a22512bd1463316cc3',
+        prov:location = 'niiri:170fb7ed6d4143e9075bf54c54eb7793',
         prov:value = "4.29710006713867" %% xsd:float,
         nidm_equivalentZStatistic: = "3.2245585560768" %% xsd:float,
         nidm_pValueUncorrected: = "0.000630835257803941" %% xsd:float,
         nidm_pValueFWER: = "0.999999999973481" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:f763f5cde1a933a22512bd1463316cc3,
+    entity(niiri:170fb7ed6d4143e9075bf54c54eb7793,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[-20,-56,14]" %% xsd:string])
-    wasDerivedFrom(niiri:a74e55a109a945b087544cc3e5a316c8, niiri:350e81fc1b83d10ae96dfefb3bab3615, -, -, -)
-    entity(niiri:f450448fe12d0362b602a56046e2eca2,
+    wasDerivedFrom(niiri:2c9566f77e7f82b34e22874819f8c710, niiri:7a1feca53667470e0f2534f053958e05, -, -, -)
+    entity(niiri:b0fa3c1d2ceac260635bee3e4a36167b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:c65359940d6cccd84bad6f3231507649',
+        prov:location = 'niiri:a83c51a65ddebc4a61818ab017d3f959',
         prov:value = "4.28621673583984" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21934090215671" %% xsd:float,
         nidm_pValueUncorrected: = "0.000642428185358868" %% xsd:float,
         nidm_pValueFWER: = "0.999999999979691" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:c65359940d6cccd84bad6f3231507649,
+    entity(niiri:a83c51a65ddebc4a61818ab017d3f959,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[32,24,30]" %% xsd:string])
-    wasDerivedFrom(niiri:f450448fe12d0362b602a56046e2eca2, niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b, -, -, -)
-    entity(niiri:eb48ceb96e89cae6a5b3a0ba68de877a,
+    wasDerivedFrom(niiri:b0fa3c1d2ceac260635bee3e4a36167b, niiri:bda46dfc41022916ad6faceac091ba3d, -, -, -)
+    entity(niiri:69ba9d52a63ad25b2c1f23f677985988,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:135e25c43b8fa91ac5f365849500911d',
+        prov:location = 'niiri:2a05164883101591007a84904b255170',
         prov:value = "4.28483486175537" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21867757532573" %% xsd:float,
         nidm_pValueUncorrected: = "0.000643916016166424" %% xsd:float,
         nidm_pValueFWER: = "0.999999999980371" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:135e25c43b8fa91ac5f365849500911d,
+    entity(niiri:2a05164883101591007a84904b255170,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[-18,-48,12]" %% xsd:string])
-    wasDerivedFrom(niiri:eb48ceb96e89cae6a5b3a0ba68de877a, niiri:3e2d682ff8be1f7b5e4954125d52dc9c, -, -, -)
-    entity(niiri:a02879441932ceb79462d5b20fa110d6,
+    wasDerivedFrom(niiri:69ba9d52a63ad25b2c1f23f677985988, niiri:0c786e61d78880c4e546692954781ced, -, -, -)
+    entity(niiri:8af718e4eb7ee27c7d2b1f62ae1f4fc8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:006c681558a6a4b518e9cfbba9778dc6',
+        prov:location = 'niiri:9327092d5f9ad138d37b770b39d5e356',
         prov:value = "4.27967262268066" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21619793589097" %% xsd:float,
         nidm_pValueUncorrected: = "0.000649506017056822" %% xsd:float,
         nidm_pValueFWER: = "0.999999999982724" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:006c681558a6a4b518e9cfbba9778dc6,
+    entity(niiri:9327092d5f9ad138d37b770b39d5e356,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-26,-80,16]" %% xsd:string])
-    wasDerivedFrom(niiri:a02879441932ceb79462d5b20fa110d6, niiri:9a3e77b28376a93d769c670fd53a30cb, -, -, -)
-    entity(niiri:2dfef592e2c3fe76668cd44d20d63b01,
+    wasDerivedFrom(niiri:8af718e4eb7ee27c7d2b1f62ae1f4fc8, niiri:b9a4c4c2b5a9793a35534927d9578f48, -, -, -)
+    entity(niiri:49c4aad3b156440f8fd3346227c812bb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:6219f06a8442157e1456fc904d88c25a',
+        prov:location = 'niiri:219d1a9528adbd1b3e9fad127c12ba45',
         prov:value = "4.27626991271973" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21456203610231" %% xsd:float,
         nidm_pValueUncorrected: = "0.000653218409537804" %% xsd:float,
         nidm_pValueFWER: = "0.999999999984125" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:6219f06a8442157e1456fc904d88c25a,
+    entity(niiri:219d1a9528adbd1b3e9fad127c12ba45,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[22,-42,-44]" %% xsd:string])
-    wasDerivedFrom(niiri:2dfef592e2c3fe76668cd44d20d63b01, niiri:0cff727da02fc982bbc0f11d56d44db2, -, -, -)
-    entity(niiri:0fa6e1dc1111a03b5e4039ea1ac7bb00,
+    wasDerivedFrom(niiri:49c4aad3b156440f8fd3346227c812bb, niiri:f4849377c56edcbca1dc5384795946ce, -, -, -)
+    entity(niiri:86047a3e6b7ffa4a1d1b9a29cb05f3c8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:512c7eaa981cfb72974cfb868f502dd3',
+        prov:location = 'niiri:29a67515a2b3cfc85dfdfd1fc059f75c',
         prov:value = "4.25063323974609" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20220005940261" %% xsd:float,
         nidm_pValueUncorrected: = "0.000681911226584231" %% xsd:float,
         nidm_pValueFWER: = "0.999999999991679" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:512c7eaa981cfb72974cfb868f502dd3,
+    entity(niiri:29a67515a2b3cfc85dfdfd1fc059f75c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[20,28,6]" %% xsd:string])
-    wasDerivedFrom(niiri:0fa6e1dc1111a03b5e4039ea1ac7bb00, niiri:8fb299584020cc344c3c2c82de2f748c, -, -, -)
-    entity(niiri:ced62c2013b6703081946558916b11da,
+    wasDerivedFrom(niiri:86047a3e6b7ffa4a1d1b9a29cb05f3c8, niiri:6ad64a79d36f37c1cd1b1433a1aef9ca, -, -, -)
+    entity(niiri:2d96bb4e97bbf9cdca301464aea060d7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:a829e3773a01f331491ad7d37354892f',
+        prov:location = 'niiri:17e914d0522a7782b8946f4570a112a0',
         prov:value = "4.22958660125732" %% xsd:float,
         nidm_equivalentZStatistic: = "3.19200261281843" %% xsd:float,
         nidm_pValueUncorrected: = "0.000706450272937809" %% xsd:float,
         nidm_pValueFWER: = "0.999999999995163" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:a829e3773a01f331491ad7d37354892f,
+    entity(niiri:17e914d0522a7782b8946f4570a112a0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[44,26,40]" %% xsd:string])
-    wasDerivedFrom(niiri:ced62c2013b6703081946558916b11da, niiri:6e2110d791417b070202a6783afba19c, -, -, -)
-    entity(niiri:e47ab6c45400adc2077bdd0ae11df79c,
+    wasDerivedFrom(niiri:2d96bb4e97bbf9cdca301464aea060d7, niiri:50d65ffbbedadcbcef20b8bacaa5bf32, -, -, -)
+    entity(niiri:b544c89d1296f2203fb8e262999b2903,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:aa889a8c10c7df77f4c657a1ba5d6cc2',
+        prov:location = 'niiri:7ab866ab624608ae371a87356ccbb246',
         prov:value = "4.13231182098389" %% xsd:float,
         nidm_equivalentZStatistic: = "3.14429239999158" %% xsd:float,
         nidm_pValueUncorrected: = "0.000832444966141432" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999966" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:aa889a8c10c7df77f4c657a1ba5d6cc2,
+    entity(niiri:7ab866ab624608ae371a87356ccbb246,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[-32,-78,44]" %% xsd:string])
-    wasDerivedFrom(niiri:e47ab6c45400adc2077bdd0ae11df79c, niiri:b0fbdf26b837fa676d008fcff5a30ee9, -, -, -)
-    entity(niiri:2b415d5e579030f0e97fe16ff764d1af,
+    wasDerivedFrom(niiri:b544c89d1296f2203fb8e262999b2903, niiri:57ec9ce901bb55b112e2f594ad471e7a, -, -, -)
+    entity(niiri:e8fc125bac22d26604b604112b05554d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:1a87f060e179e8d5d5fad75dee9e561e',
+        prov:location = 'niiri:0e198fd93d34f6f23b1574200bd77922',
         prov:value = "4.0775408744812" %% xsd:float,
         nidm_equivalentZStatistic: = "3.11700347232274" %% xsd:float,
         nidm_pValueUncorrected: = "0.000913497101264649" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999932" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:1a87f060e179e8d5d5fad75dee9e561e,
+    entity(niiri:0e198fd93d34f6f23b1574200bd77922,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[4,-54,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:2b415d5e579030f0e97fe16ff764d1af, niiri:5167e145ebaf9f5693dffbc09df2f2f8, -, -, -)
-    entity(niiri:a4068ca93949e6e3223a16b3e3bfeb42,
+    wasDerivedFrom(niiri:e8fc125bac22d26604b604112b05554d, niiri:1318d2cd1289a2678d066b7cca2986f1, -, -, -)
+    entity(niiri:93ad18b2412733cb3a43ab2edf151f7d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:e82cbbcc7b634200287898ef5f614f70',
+        prov:location = 'niiri:65f92900970c3f35426b598b6b9b186c',
         prov:value = "4.07394027709961" %% xsd:float,
         nidm_equivalentZStatistic: = "3.11519863095218" %% xsd:float,
         nidm_pValueUncorrected: = "0.000919105401866016" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999939" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:e82cbbcc7b634200287898ef5f614f70,
+    entity(niiri:65f92900970c3f35426b598b6b9b186c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[34,14,56]" %% xsd:string])
-    wasDerivedFrom(niiri:a4068ca93949e6e3223a16b3e3bfeb42, niiri:17c3abf712c940e8e07c2fa7b3493dc1, -, -, -)
+    wasDerivedFrom(niiri:93ad18b2412733cb3a43ab2edf151f7d, niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_covariate/nidm.provn
+++ b/spmexport/ex_spm_covariate/nidm.provn
@@ -1,0 +1,1132 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:31d6c1a45e08732f9d39d4fd32cea085,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:8cf1ef035df283fda3a56583da8cbd77,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:a33cfd1828738469b4829a177a32ea49,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:a33cfd1828738469b4829a177a32ea49, niiri:8cf1ef035df283fda3a56583da8cbd77, -)
+  wasGeneratedBy(niiri:31d6c1a45e08732f9d39d4fd32cea085, niiri:a33cfd1828738469b4829a177a32ea49, 2016-01-11T10:11:15)
+  bundle niiri:31d6c1a45e08732f9d39d4fd32cea085
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix nidm_IndependentError <http://purl.org/nidash/nidm#NIDM_0000048>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_OLS <http://purl.obolibrary.org/obo/STATO_0000370>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+    prefix nidm_SupraThresholdCluster <http://purl.org/nidash/nidm#NIDM_0000070>
+    prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
+    prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+    prefix nidm_qValueFDR <http://purl.org/nidash/nidm#NIDM_0000119>
+    prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
+    prefix nidm_Peak <http://purl.org/nidash/nidm#NIDM_0000062>
+    prefix nidm_equivalentZStatistic <http://purl.org/nidash/nidm#NIDM_0000092>
+    prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
+    prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
+
+    agent(niiri:d515e4539ba77e4aaafcb479a1267ad1,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:29ca7f31a8b4fa610180435e7362a7d0,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:cbf0821fd0582df876cb99f6e1c69ac8,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "false" %% xsd:boolean])
+    entity(niiri:f49fb0ce586d5bba164b397ad004843d,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:41a74f856bbb8085011a19fe078fabce',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"mean\", \"Subject ID Covariate\"]" %% xsd:string])
+    entity(niiri:41a74f856bbb8085011a19fe078fabce,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:6a6716cb24609f317367c274cd3a3012,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'nidm_IndependentError:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean])
+    activity(niiri:fc1b05994ad6f530ee7e2818c82ace02,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_OLS:'])
+    wasAssociatedWith(niiri:fc1b05994ad6f530ee7e2818c82ace02, niiri:d515e4539ba77e4aaafcb479a1267ad1, -)
+    used(niiri:fc1b05994ad6f530ee7e2818c82ace02, niiri:f49fb0ce586d5bba164b397ad004843d, -)
+    used(niiri:fc1b05994ad6f530ee7e2818c82ace02, niiri:cbf0821fd0582df876cb99f6e1c69ac8, -)
+    used(niiri:fc1b05994ad6f530ee7e2818c82ace02, niiri:6a6716cb24609f317367c274cd3a3012, -)
+    entity(niiri:a0e2e4659c44ec8283f603e4d63d4cb7,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        crypto:sha512 = "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f" %% xsd:string])
+    entity(niiri:c48268f2a6a23bf1f723deea7bbdb5b6,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "e06c7e91d23253a8dffd3bb366d05851340e63a972bc08812d42cb46ea31fdad3063cca9559c6a372781a84a7a50c17cf4bbf65c515ce00580f79372cc763807" %% xsd:string])
+    wasDerivedFrom(niiri:a0e2e4659c44ec8283f603e4d63d4cb7, niiri:c48268f2a6a23bf1f723deea7bbdb5b6, -, -, -)
+    wasGeneratedBy(niiri:a0e2e4659c44ec8283f603e4d63d4cb7, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
+    entity(niiri:26f92bdc36b3170ba40be9cc15a7dc6e,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "0.0173736633732915" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        crypto:sha512 = "98952e02ac3f45da846d94deb554fad9126d6ba05b8ba745f176150b7b18bf2edee7efff67e7362f6704114b42ec7cb1d68fcde6005a829d52921961a4dad470" %% xsd:string])
+    wasGeneratedBy(niiri:26f92bdc36b3170ba40be9cc15a7dc6e, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
+    entity(niiri:2623a47371135f56c2aecb37063cac44,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0'])
+    entity(niiri:51246b06ba783f764ebdcafdef38e2e3,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "edde9f432759a7f2dad9ef0d3cb847eae532656aa81a7c08c76d939fe426e2e85329d56d0d279bf546773319599dd0bdf75b484d25083c8a2ac7ccb694a30e86" %% xsd:string])
+    wasDerivedFrom(niiri:2623a47371135f56c2aecb37063cac44, niiri:51246b06ba783f764ebdcafdef38e2e3, -, -, -)
+    wasGeneratedBy(niiri:2623a47371135f56c2aecb37063cac44, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
+    entity(niiri:9a291bb486326720055fc2883364893a,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0'])
+    entity(niiri:0575f791e06f7944f37a4249570f2201,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "f54847aa8325ebc7e962e70e87b4ecc5cfc95e840fa0229889bfab2345836d6b6032c0d29f89f2bc95abc2581dfd7ad2af5833031d4c2974513717c3f0ec29f8" %% xsd:string])
+    wasDerivedFrom(niiri:9a291bb486326720055fc2883364893a, niiri:0575f791e06f7944f37a4249570f2201, -, -, -)
+    wasGeneratedBy(niiri:9a291bb486326720055fc2883364893a, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
+    entity(niiri:b9cbdd666979ec7a12ae681547b560f7,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        crypto:sha512 = "693dd1daf261efafb742c7da149cccc8b7383b49e672358dd29c6bcd31a6ee983270e23c3f118d86b0758d86162d77033926cb1ae0f653efb0b7102c922ca40b" %% xsd:string])
+    entity(niiri:51db014e8a30d126f73e7f235977299f,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "afca09bea5ebf5bceda101c9cb4d803de2cc2307b72a539454ce04e72ad6f655304b653779a287d3f38fca841819bf8126c51cb0a095e8710882e87d5eb7c565" %% xsd:string])
+    wasDerivedFrom(niiri:b9cbdd666979ec7a12ae681547b560f7, niiri:51db014e8a30d126f73e7f235977299f, -, -, -)
+    wasGeneratedBy(niiri:b9cbdd666979ec7a12ae681547b560f7, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
+    entity(niiri:4b89f205af8d9f723bc3dd1382c941ba,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        crypto:sha512 = "58dcbf304825e142d28af1f78351fa5fa758ea20a597f7c117967af6a2d051d80f69686dc6858c0d6b1b677ff279e00d600772ce8175eae7a54dbedd0848bfd5" %% xsd:string])
+    entity(niiri:d5024dc0bc94c982918144fd5349aa97,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "42b06ae2316603cd1635234bdc474edf4cfac04b7ffe7acfe80221ee4cb3ecc0e6b514f5ebf1391df5ced6eb2fd5a91cd62a58ce1c4318ed4514eb8e1b41729b" %% xsd:string])
+    wasDerivedFrom(niiri:4b89f205af8d9f723bc3dd1382c941ba, niiri:d5024dc0bc94c982918144fd5349aa97, -, -, -)
+    wasGeneratedBy(niiri:4b89f205af8d9f723bc3dd1382c941ba, niiri:fc1b05994ad6f530ee7e2818c82ace02, -)
+    entity(niiri:43cb4a137447d784b18f0327f0c441f9,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        prov:label = "Contrast: mr vs plain" %% xsd:string,
+        prov:value = "[1, 0]" %% xsd:string])
+    activity(niiri:8106d8f378522cc994936b6c1d2b0f47,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:d515e4539ba77e4aaafcb479a1267ad1, -)
+    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:a0e2e4659c44ec8283f603e4d63d4cb7, -)
+    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:b9cbdd666979ec7a12ae681547b560f7, -)
+    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:f49fb0ce586d5bba164b397ad004843d, -)
+    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:43cb4a137447d784b18f0327f0c441f9, -)
+    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:2623a47371135f56c2aecb37063cac44, -)
+    used(niiri:8106d8f378522cc994936b6c1d2b0f47, niiri:9a291bb486326720055fc2883364893a, -)
+    entity(niiri:7180fa05eac2a8815661ff232ad535d2,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: mr vs plain" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "11" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        crypto:sha512 = "370387f786b51f404f6ca9acd10c4e35fbac46e4f5ec42750cf05c4236bda63dc8c003dea0989fd6c397d05d2e46bf0e0685ef08fa143418c0f1fdc3e7fe0d8b" %% xsd:string])
+    entity(niiri:a909b2437ec845db0a946d87fcdbf110,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "489d1d288d622546f52d846311adfd3c6b7a5a604e0356335c997c6c7c2cfdf648e312383d151343007194e94ae8e681af5c7c1c0f69754126dd9561cbcf622b" %% xsd:string])
+    wasDerivedFrom(niiri:7180fa05eac2a8815661ff232ad535d2, niiri:a909b2437ec845db0a946d87fcdbf110, -, -, -)
+    wasGeneratedBy(niiri:7180fa05eac2a8815661ff232ad535d2, niiri:8106d8f378522cc994936b6c1d2b0f47, -)
+    entity(niiri:f88a91a1a09378bbfdb3dd220962cbd0,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: mr vs plain" %% xsd:string,
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        crypto:sha512 = "ab6e3d990747f48517f1cf7eb1dd7dd0e973d4f5b7f468963c982c906f3dfcafa7c056c8f34d9f54c10330a67ab92b7f7ab3d95781a568b7fbaddf9f17746216" %% xsd:string])
+    entity(niiri:1282ac0f2eeb5bc9dde3259940a5b967,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "9dc48e80c35ac0d74eb3131bab4e8cac2db2df834fef3c5cb6ddb5d91082d573d885a8e703a03652b5745f3f52b0e3397feb130f3ebccae549142ce88c29cb59" %% xsd:string])
+    wasDerivedFrom(niiri:f88a91a1a09378bbfdb3dd220962cbd0, niiri:1282ac0f2eeb5bc9dde3259940a5b967, -, -, -)
+    wasGeneratedBy(niiri:f88a91a1a09378bbfdb3dd220962cbd0, niiri:8106d8f378522cc994936b6c1d2b0f47, -)
+    entity(niiri:c68b99924630158595413c4285a41ec7,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        crypto:sha512 = "a36854cf6dd56807c2a335d31d64f3f265785b7b573115e7cfaec97da31078aad22aa084ac09c3a550605f550228a781457821df43845b7a92c8b375bc9ac9dc" %% xsd:string])
+    wasGeneratedBy(niiri:c68b99924630158595413c4285a41ec7, niiri:8106d8f378522cc994936b6c1d2b0f47, -)
+    entity(niiri:98a24053ecc198c682c361b35db9d066,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
+        prov:value = "0.000999500148243682" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:7d4015daee5ad33cd195777edd7b45e7',
+        nidm_equivalentThreshold: = 'niiri:2e33ccc4e77256ac0c3122164affbf0f'])
+    entity(niiri:7d4015daee5ad33cd195777edd7b45e7,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "4.02470104841152" %% xsd:float])
+    entity(niiri:2e33ccc4e77256ac0c3122164affbf0f,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.999999999999987" %% xsd:float])
+    entity(niiri:97c3deab28ad09270d41f36ac051abf0,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:dc2315d702ea7d63764b08840958382b',
+        nidm_equivalentThreshold: = 'niiri:3a2b050a6e9b6bf8427850e20e551ae4'])
+    entity(niiri:dc2315d702ea7d63764b08840958382b,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:3a2b050a6e9b6bf8427850e20e551ae4,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:b96cd6ef89bc01300f460e26e2535619,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:a6afd19740d69851bcebb4de3abcb4e7,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:58ea1c58f6fd442a5f0b30714b02f548,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:d515e4539ba77e4aaafcb479a1267ad1, -)
+    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:98a24053ecc198c682c361b35db9d066, -)
+    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:97c3deab28ad09270d41f36ac051abf0, -)
+    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:7180fa05eac2a8815661ff232ad535d2, -)
+    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:4b89f205af8d9f723bc3dd1382c941ba, -)
+    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:a0e2e4659c44ec8283f603e4d63d4cb7, -)
+    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:b96cd6ef89bc01300f460e26e2535619, -)
+    used(niiri:58ea1c58f6fd442a5f0b30714b02f548, niiri:a6afd19740d69851bcebb4de3abcb4e7, -)
+    entity(niiri:af00c4dc59502bf1fe7721773eb5a850,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        nidm_searchVolumeInVoxels: = "162104" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1296832" %% xsd:float,
+        nidm_reselSizeInVoxels: = "95.2875561406722" %% xsd:float,
+        nidm_searchVolumeInResels: = "1563.13170399827" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[4, 44.8383200236172, 622.676579140049, 1563.13170399827]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.39048281781903, 4.50910789991045, 4.81319302824617]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.78096563563806, 9.01821579982091, 9.62638605649234]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "5.48622463035775" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "31.9486171281883" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "10.182499224951" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f" %% xsd:string])
+    wasGeneratedBy(niiri:af00c4dc59502bf1fe7721773eb5a850, niiri:58ea1c58f6fd442a5f0b30714b02f548, -)
+    entity(niiri:d60a0c55d948a11dac535e382316f31f,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "29" %% xsd:int,
+        nidm_pValue: = "0.722893095431427" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:aae74d51171ea0af243cd165c716a211',
+        nidm_hasMaximumIntensityProjection: = 'niiri:93a498407930e7c2f57870d6e06e32d4',
+        nidm_inCoordinateSpace: = 'niiri:29ca7f31a8b4fa610180435e7362a7d0',
+        crypto:sha512 = "2bbcc39452bb1127d7205b05c820b5d31d5e2daa43e4ba6ccaf43c229aa7d708af405aff650daa9a08b3582c5aa013e32a6535188542c9c1fc3fa24fcc03c59c" %% xsd:string])
+    entity(niiri:aae74d51171ea0af243cd165c716a211,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:93a498407930e7c2f57870d6e06e32d4,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:d60a0c55d948a11dac535e382316f31f, niiri:58ea1c58f6fd442a5f0b30714b02f548, -)
+    entity(niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0419781990640502" %% xsd:float,
+        nidm_pValueUncorrected: = "0.375546258337659" %% xsd:float,
+        nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "1" %% xsd:int])
+    wasDerivedFrom(niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:02bd1b0dd4f143323060712eeb0b3401,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0734618483620879" %% xsd:float,
+        nidm_pValueUncorrected: = "0.24117248796276" %% xsd:float,
+        nidm_pValueFWER: = "0.999549488736845" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "2" %% xsd:int])
+    wasDerivedFrom(niiri:02bd1b0dd4f143323060712eeb0b3401, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:4feafd8d4a6ff76500cde244ec4a9ac0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0839563981281005" %% xsd:float,
+        nidm_pValueUncorrected: = "0.211261469422963" %% xsd:float,
+        nidm_pValueFWER: = "0.998828548616846" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "3" %% xsd:int])
+    wasDerivedFrom(niiri:4feafd8d4a6ff76500cde244ec4a9ac0, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:6267cdb89b255ce524220439e2d056f1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0419781990640502" %% xsd:float,
+        nidm_pValueUncorrected: = "0.375546258337659" %% xsd:float,
+        nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "4" %% xsd:int])
+    wasDerivedFrom(niiri:6267cdb89b255ce524220439e2d056f1, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:dccae6a3d4de3910d04419b8bb7c8d62,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0209890995320251" %% xsd:float,
+        nidm_pValueUncorrected: = "0.539578649702376" %% xsd:float,
+        nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "5" %% xsd:int])
+    wasDerivedFrom(niiri:dccae6a3d4de3910d04419b8bb7c8d62, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:8a59a0d3509f23181ea020ba988244a4,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "16" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.167912796256201" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0847654804425067" %% xsd:float,
+        nidm_pValueFWER: = "0.93333931168142" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "6" %% xsd:int])
+    wasDerivedFrom(niiri:8a59a0d3509f23181ea020ba988244a4, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:26f9f618c22ef5edf5685712623da454,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.115440047426138" %% xsd:float,
+        nidm_pValueUncorrected: = "0.146259988943696" %% xsd:float,
+        nidm_pValueFWER: = "0.990653977132472" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "7" %% xsd:int])
+    wasDerivedFrom(niiri:26f9f618c22ef5edf5685712623da454, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:d2f346a025c15c9fc9c31510f24b5886,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "8" %% xsd:int])
+    wasDerivedFrom(niiri:d2f346a025c15c9fc9c31510f24b5886, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:d2e202f26f07d353e876c8513aaac055,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0314836492980377" %% xsd:float,
+        nidm_pValueUncorrected: = "0.445545852347923" %% xsd:float,
+        nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "9" %% xsd:int])
+    wasDerivedFrom(niiri:d2e202f26f07d353e876c8513aaac055, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:d0abf7f944018518c8b2f88645568e05,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0629672985960754" %% xsd:float,
+        nidm_pValueUncorrected: = "0.277109512628503" %% xsd:float,
+        nidm_pValueFWER: = "0.999857085744802" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "10" %% xsd:int])
+    wasDerivedFrom(niiri:d0abf7f944018518c8b2f88645568e05, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:71dd070abfb1b28ce2b0e47fb4f49daf,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0314836492980377" %% xsd:float,
+        nidm_pValueUncorrected: = "0.445545852347923" %% xsd:float,
+        nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "11" %% xsd:int])
+    wasDerivedFrom(niiri:71dd070abfb1b28ce2b0e47fb4f49daf, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:354b333049efc8a35bffb5e871d5df51,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "12" %% xsd:int])
+    wasDerivedFrom(niiri:354b333049efc8a35bffb5e871d5df51, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:dfcda071a872154b10c43f862bf52d69,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0419781990640502" %% xsd:float,
+        nidm_pValueUncorrected: = "0.375546258337659" %% xsd:float,
+        nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "13" %% xsd:int])
+    wasDerivedFrom(niiri:dfcda071a872154b10c43f862bf52d69, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:9f93d2b40c1f794cb34e0ae17e04bd0c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "14" %% xsd:int])
+    wasDerivedFrom(niiri:9f93d2b40c1f794cb34e0ae17e04bd0c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:899db6b982fa96374440fc31d77225c7,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "15" %% xsd:int])
+    wasDerivedFrom(niiri:899db6b982fa96374440fc31d77225c7, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:d19f972dfab2b23346202c34e5574f29,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0314836492980377" %% xsd:float,
+        nidm_pValueUncorrected: = "0.445545852347923" %% xsd:float,
+        nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "16" %% xsd:int])
+    wasDerivedFrom(niiri:d19f972dfab2b23346202c34e5574f29, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:c8e45b2b37dac3869716ea38f6f82aa2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0209890995320251" %% xsd:float,
+        nidm_pValueUncorrected: = "0.539578649702376" %% xsd:float,
+        nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "17" %% xsd:int])
+    wasDerivedFrom(niiri:c8e45b2b37dac3869716ea38f6f82aa2, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:f4fe3e2f741c280bd998a6eaf285b07c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0524727488300628" %% xsd:float,
+        nidm_pValueUncorrected: = "0.320952410949864" %% xsd:float,
+        nidm_pValueFWER: = "0.999964783142854" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "18" %% xsd:int])
+    wasDerivedFrom(niiri:f4fe3e2f741c280bd998a6eaf285b07c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:f18795394da513a451940bf5032734eb,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0209890995320251" %% xsd:float,
+        nidm_pValueUncorrected: = "0.539578649702376" %% xsd:float,
+        nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "19" %% xsd:int])
+    wasDerivedFrom(niiri:f18795394da513a451940bf5032734eb, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:350e81fc1b83d10ae96dfefb3bab3615,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "20" %% xsd:int])
+    wasDerivedFrom(niiri:350e81fc1b83d10ae96dfefb3bab3615, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "21" %% xsd:int])
+    wasDerivedFrom(niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:3e2d682ff8be1f7b5e4954125d52dc9c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0209890995320251" %% xsd:float,
+        nidm_pValueUncorrected: = "0.539578649702376" %% xsd:float,
+        nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "22" %% xsd:int])
+    wasDerivedFrom(niiri:3e2d682ff8be1f7b5e4954125d52dc9c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:9a3e77b28376a93d769c670fd53a30cb,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0209890995320251" %% xsd:float,
+        nidm_pValueUncorrected: = "0.539578649702376" %% xsd:float,
+        nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "23" %% xsd:int])
+    wasDerivedFrom(niiri:9a3e77b28376a93d769c670fd53a30cb, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:0cff727da02fc982bbc0f11d56d44db2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "24" %% xsd:int])
+    wasDerivedFrom(niiri:0cff727da02fc982bbc0f11d56d44db2, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:8fb299584020cc344c3c2c82de2f748c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "25" %% xsd:int])
+    wasDerivedFrom(niiri:8fb299584020cc344c3c2c82de2f748c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:6e2110d791417b070202a6783afba19c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0314836492980377" %% xsd:float,
+        nidm_pValueUncorrected: = "0.445545852347923" %% xsd:float,
+        nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "26" %% xsd:int])
+    wasDerivedFrom(niiri:6e2110d791417b070202a6783afba19c, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:b0fbdf26b837fa676d008fcff5a30ee9,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "27" %% xsd:int])
+    wasDerivedFrom(niiri:b0fbdf26b837fa676d008fcff5a30ee9, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:5167e145ebaf9f5693dffbc09df2f2f8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "28" %% xsd:int])
+    wasDerivedFrom(niiri:5167e145ebaf9f5693dffbc09df2f2f8, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:17c3abf712c940e8e07c2fa7b3493dc1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0104945497660126" %% xsd:float,
+        nidm_pValueUncorrected: = "0.677961565790583" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "29" %% xsd:int])
+    wasDerivedFrom(niiri:17c3abf712c940e8e07c2fa7b3493dc1, niiri:d60a0c55d948a11dac535e382316f31f, -, -, -)
+    entity(niiri:70a79fb5d0fafa6b4641330f8f8b12aa,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0001" %% xsd:string,
+        prov:location = 'niiri:654d6238fa35ad568af3286425629272',
+        prov:value = "6.37317276000977" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.04320073372639" %% xsd:float,
+        nidm_pValueUncorrected: = "2.63632212645915e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.958902832016109" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:654d6238fa35ad568af3286425629272,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0001" %% xsd:string,
+        nidm_coordinateVector: = "[28,-36,38]" %% xsd:string])
+    wasDerivedFrom(niiri:70a79fb5d0fafa6b4641330f8f8b12aa, niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b, -, -, -)
+    entity(niiri:81a8683173d0ed24bd3d2f6be8ec0f77,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0002" %% xsd:string,
+        prov:location = 'niiri:eacbf2fc9ec48207e00dc693c683bf1f',
+        prov:value = "5.69066715240479" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.8079805415517" %% xsd:float,
+        nidm_pValueUncorrected: = "7.00531473561972e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.997756103851125" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:eacbf2fc9ec48207e00dc693c683bf1f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0002" %% xsd:string,
+        nidm_coordinateVector: = "[10,-48,16]" %% xsd:string])
+    wasDerivedFrom(niiri:81a8683173d0ed24bd3d2f6be8ec0f77, niiri:02bd1b0dd4f143323060712eeb0b3401, -, -, -)
+    entity(niiri:b6d7f661e892640001af0eea6f38dc9e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0003" %% xsd:string,
+        prov:location = 'niiri:79a643a3d5d92c1658b5fb52ce02a6d1',
+        prov:value = "5.404944896698" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.70067578615084" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000107513031460726" %% xsd:float,
+        nidm_pValueFWER: = "0.999684183052173" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:79a643a3d5d92c1658b5fb52ce02a6d1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0003" %% xsd:string,
+        nidm_coordinateVector: = "[-34,-6,-32]" %% xsd:string])
+    wasDerivedFrom(niiri:b6d7f661e892640001af0eea6f38dc9e, niiri:4feafd8d4a6ff76500cde244ec4a9ac0, -, -, -)
+    entity(niiri:640d2f1d4cb2fff0fb98dd63f4292b5e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0004" %% xsd:string,
+        prov:location = 'niiri:26366fb427147de255e4516551b308e9',
+        prov:value = "5.20687818527222" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.62288194485815" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000145669405598126" %% xsd:float,
+        nidm_pValueFWER: = "0.999944545222406" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:26366fb427147de255e4516551b308e9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0004" %% xsd:string,
+        nidm_coordinateVector: = "[-28,-80,24]" %% xsd:string])
+    wasDerivedFrom(niiri:640d2f1d4cb2fff0fb98dd63f4292b5e, niiri:6267cdb89b255ce524220439e2d056f1, -, -, -)
+    entity(niiri:aaba7d880bfd3cc9e40f6e040f3df3ca,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0005" %% xsd:string,
+        prov:location = 'niiri:ceafb447ebc334cf0885953cb12180dc',
+        prov:value = "4.90865421295166" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.50007991972101" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000232559344231609" %% xsd:float,
+        nidm_pValueFWER: = "0.999998126675029" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:ceafb447ebc334cf0885953cb12180dc,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0005" %% xsd:string,
+        nidm_coordinateVector: = "[-12,-32,28]" %% xsd:string])
+    wasDerivedFrom(niiri:aaba7d880bfd3cc9e40f6e040f3df3ca, niiri:dccae6a3d4de3910d04419b8bb7c8d62, -, -, -)
+    entity(niiri:c9d9194d3fc86fceb8cbb0ad72e5e116,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0006" %% xsd:string,
+        prov:location = 'niiri:39876766efea7749fdb1e3ec89516c50',
+        prov:value = "4.84440040588379" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.47268080874189" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000257643895570592" %% xsd:float,
+        nidm_pValueFWER: = "0.999999219649123" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:39876766efea7749fdb1e3ec89516c50,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0006" %% xsd:string,
+        nidm_coordinateVector: = "[-18,-76,-12]" %% xsd:string])
+    wasDerivedFrom(niiri:c9d9194d3fc86fceb8cbb0ad72e5e116, niiri:8a59a0d3509f23181ea020ba988244a4, -, -, -)
+    entity(niiri:7361b36fbc686ac319529770f44965bb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0007" %% xsd:string,
+        prov:location = 'niiri:d6b455e1b17b09ffb45f2319ae5feaa7',
+        prov:value = "4.84136772155762" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.47137907963827" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000258896237096851" %% xsd:float,
+        nidm_pValueFWER: = "0.999999252321799" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:d6b455e1b17b09ffb45f2319ae5feaa7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0007" %% xsd:string,
+        nidm_coordinateVector: = "[32,16,40]" %% xsd:string])
+    wasDerivedFrom(niiri:7361b36fbc686ac319529770f44965bb, niiri:26f9f618c22ef5edf5685712623da454, -, -, -)
+    entity(niiri:71afea378b2be0836e3b1e53b4c621c4,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0008" %% xsd:string,
+        prov:location = 'niiri:a1d44e4d1e3f9e624a75e1de128e43a4',
+        prov:value = "4.78605508804321" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.4475005479143" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000282899629741595" %% xsd:float,
+        nidm_pValueFWER: = "0.999999665309186" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:a1d44e4d1e3f9e624a75e1de128e43a4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0008" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-78,46]" %% xsd:string])
+    wasDerivedFrom(niiri:71afea378b2be0836e3b1e53b4c621c4, niiri:d2f346a025c15c9fc9c31510f24b5886, -, -, -)
+    entity(niiri:8d7d3064a7e3b5bf7e85fffe64b06bc6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0009" %% xsd:string,
+        prov:location = 'niiri:6d9c75885354734cf3570762871d32aa',
+        prov:value = "4.75920820236206" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.43581665930553" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000295385308778928" %% xsd:float,
+        nidm_pValueFWER: = "0.999999777160537" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:6d9c75885354734cf3570762871d32aa,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0009" %% xsd:string,
+        nidm_coordinateVector: = "[-50,-2,42]" %% xsd:string])
+    wasDerivedFrom(niiri:8d7d3064a7e3b5bf7e85fffe64b06bc6, niiri:d2e202f26f07d353e876c8513aaac055, -, -, -)
+    entity(niiri:00f11aa6a9bf3c67963ec8004894a193,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0010" %% xsd:string,
+        prov:location = 'niiri:cfe98ef5194606348538a89c7dce71b0',
+        prov:value = "4.70320177078247" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.41124192966355" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000323338426391984" %% xsd:float,
+        nidm_pValueFWER: = "0.999999908044234" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:cfe98ef5194606348538a89c7dce71b0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0010" %% xsd:string,
+        nidm_coordinateVector: = "[22,-34,34]" %% xsd:string])
+    wasDerivedFrom(niiri:00f11aa6a9bf3c67963ec8004894a193, niiri:d0abf7f944018518c8b2f88645568e05, -, -, -)
+    entity(niiri:057cb92551aa371b6f6dc683d506bf96,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0011" %% xsd:string,
+        prov:location = 'niiri:a7a44c477f5330dc6c8b7bbe1aa3f387',
+        prov:value = "4.65910387039185" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.39169946109688" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000347302923845438" %% xsd:float,
+        nidm_pValueFWER: = "0.999999955827132" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:a7a44c477f5330dc6c8b7bbe1aa3f387,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0011" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-44,-36]" %% xsd:string])
+    wasDerivedFrom(niiri:057cb92551aa371b6f6dc683d506bf96, niiri:71dd070abfb1b28ce2b0e47fb4f49daf, -, -, -)
+    entity(niiri:32caa29266a76db202d1c2c5c68c7445,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0012" %% xsd:string,
+        prov:location = 'niiri:5e965e5ef7f2d1914d1b1f52d8cbddea',
+        prov:value = "4.63754796981812" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.38208413500926" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00035969054090712" %% xsd:float,
+        nidm_pValueFWER: = "0.999999969503" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:5e965e5ef7f2d1914d1b1f52d8cbddea,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0012" %% xsd:string,
+        nidm_coordinateVector: = "[34,-22,26]" %% xsd:string])
+    wasDerivedFrom(niiri:32caa29266a76db202d1c2c5c68c7445, niiri:354b333049efc8a35bffb5e871d5df51, -, -, -)
+    entity(niiri:4c62c0e8cf4e83463b2cd8ef62f9c602,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0013" %% xsd:string,
+        prov:location = 'niiri:b3021dc8859525200429834fc6310f99',
+        prov:value = "4.61526584625244" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.37210130568973" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000372985020458683" %% xsd:float,
+        nidm_pValueFWER: = "0.999999979383511" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:b3021dc8859525200429834fc6310f99,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0013" %% xsd:string,
+        nidm_coordinateVector: = "[-8,-24,-20]" %% xsd:string])
+    wasDerivedFrom(niiri:4c62c0e8cf4e83463b2cd8ef62f9c602, niiri:dfcda071a872154b10c43f862bf52d69, -, -, -)
+    entity(niiri:8a73d008087b3fa9d94106936d72a9cf,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0014" %% xsd:string,
+        prov:location = 'niiri:f56aea2994cdd430b079943b1299d6ba',
+        prov:value = "4.51868915557861" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.32831433156359" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000436866114896683" %% xsd:float,
+        nidm_pValueFWER: = "0.999999996599993" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:f56aea2994cdd430b079943b1299d6ba,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0014" %% xsd:string,
+        nidm_coordinateVector: = "[10,-12,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:8a73d008087b3fa9d94106936d72a9cf, niiri:9f93d2b40c1f794cb34e0ae17e04bd0c, -, -, -)
+    entity(niiri:a96fc8bfcb9cf24f47dbdf7bfe7afd17,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0015" %% xsd:string,
+        prov:location = 'niiri:ac7a10e1bead2a7d7fd42038f3949443',
+        prov:value = "4.45568466186523" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.2992865242182" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000484654601471068" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999048352" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:ac7a10e1bead2a7d7fd42038f3949443,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0015" %% xsd:string,
+        nidm_coordinateVector: = "[16,-48,-46]" %% xsd:string])
+    wasDerivedFrom(niiri:a96fc8bfcb9cf24f47dbdf7bfe7afd17, niiri:899db6b982fa96374440fc31d77225c7, -, -, -)
+    entity(niiri:3d6d68b50c110bd970cae436330e36d9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0016" %% xsd:string,
+        prov:location = 'niiri:daf43d66330a2ead30991863c01caec5',
+        prov:value = "4.42093467712402" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.28311730425125" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000513329675929763" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999544708" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:daf43d66330a2ead30991863c01caec5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0016" %% xsd:string,
+        nidm_coordinateVector: = "[-20,52,16]" %% xsd:string])
+    wasDerivedFrom(niiri:3d6d68b50c110bd970cae436330e36d9, niiri:d19f972dfab2b23346202c34e5574f29, -, -, -)
+    entity(niiri:00d1711e3ed46fde327d5581de9dd791,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0017" %% xsd:string,
+        prov:location = 'niiri:ae59229032d7c40d79b030470e5f23b9',
+        prov:value = "4.41627073287964" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.28093847762164" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00051731154621093" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999588405" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:ae59229032d7c40d79b030470e5f23b9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0017" %% xsd:string,
+        nidm_coordinateVector: = "[10,62,20]" %% xsd:string])
+    wasDerivedFrom(niiri:00d1711e3ed46fde327d5581de9dd791, niiri:c8e45b2b37dac3869716ea38f6f82aa2, -, -, -)
+    entity(niiri:7e851910d726d6995c852ed218ac5570,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0018" %% xsd:string,
+        prov:location = 'niiri:a01d789cee79784cca55a545db21ce87',
+        prov:value = "4.39752912521362" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.27216223374679" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000533641570346299" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999726897" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:a01d789cee79784cca55a545db21ce87,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0018" %% xsd:string,
+        nidm_coordinateVector: = "[50,-66,38]" %% xsd:string])
+    wasDerivedFrom(niiri:7e851910d726d6995c852ed218ac5570, niiri:f4fe3e2f741c280bd998a6eaf285b07c, -, -, -)
+    entity(niiri:9fe2a624ae89ae7fa855b69eec31ebbd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0019" %% xsd:string,
+        prov:location = 'niiri:88780e43a9ab7fafa2461b5df7d58e73',
+        prov:value = "4.30746841430664" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.22951851195682" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000619994267038626" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999965896" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:88780e43a9ab7fafa2461b5df7d58e73,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0019" %% xsd:string,
+        nidm_coordinateVector: = "[-4,-4,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:9fe2a624ae89ae7fa855b69eec31ebbd, niiri:f18795394da513a451940bf5032734eb, -, -, -)
+    entity(niiri:a74e55a109a945b087544cc3e5a316c8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0020" %% xsd:string,
+        prov:location = 'niiri:f763f5cde1a933a22512bd1463316cc3',
+        prov:value = "4.29710006713867" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.2245585560768" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000630835257803941" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999973481" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:f763f5cde1a933a22512bd1463316cc3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0020" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-56,14]" %% xsd:string])
+    wasDerivedFrom(niiri:a74e55a109a945b087544cc3e5a316c8, niiri:350e81fc1b83d10ae96dfefb3bab3615, -, -, -)
+    entity(niiri:f450448fe12d0362b602a56046e2eca2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0021" %% xsd:string,
+        prov:location = 'niiri:c65359940d6cccd84bad6f3231507649',
+        prov:value = "4.28621673583984" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.21934090215671" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000642428185358868" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999979691" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:c65359940d6cccd84bad6f3231507649,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0021" %% xsd:string,
+        nidm_coordinateVector: = "[32,24,30]" %% xsd:string])
+    wasDerivedFrom(niiri:f450448fe12d0362b602a56046e2eca2, niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b, -, -, -)
+    entity(niiri:eb48ceb96e89cae6a5b3a0ba68de877a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0022" %% xsd:string,
+        prov:location = 'niiri:135e25c43b8fa91ac5f365849500911d',
+        prov:value = "4.28483486175537" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.21867757532573" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000643916016166424" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999980371" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:135e25c43b8fa91ac5f365849500911d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0022" %% xsd:string,
+        nidm_coordinateVector: = "[-18,-48,12]" %% xsd:string])
+    wasDerivedFrom(niiri:eb48ceb96e89cae6a5b3a0ba68de877a, niiri:3e2d682ff8be1f7b5e4954125d52dc9c, -, -, -)
+    entity(niiri:a02879441932ceb79462d5b20fa110d6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0023" %% xsd:string,
+        prov:location = 'niiri:006c681558a6a4b518e9cfbba9778dc6',
+        prov:value = "4.27967262268066" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.21619793589097" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000649506017056822" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999982724" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:006c681558a6a4b518e9cfbba9778dc6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0023" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-80,16]" %% xsd:string])
+    wasDerivedFrom(niiri:a02879441932ceb79462d5b20fa110d6, niiri:9a3e77b28376a93d769c670fd53a30cb, -, -, -)
+    entity(niiri:2dfef592e2c3fe76668cd44d20d63b01,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0024" %% xsd:string,
+        prov:location = 'niiri:6219f06a8442157e1456fc904d88c25a',
+        prov:value = "4.27626991271973" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.21456203610231" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000653218409537804" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999984125" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:6219f06a8442157e1456fc904d88c25a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0024" %% xsd:string,
+        nidm_coordinateVector: = "[22,-42,-44]" %% xsd:string])
+    wasDerivedFrom(niiri:2dfef592e2c3fe76668cd44d20d63b01, niiri:0cff727da02fc982bbc0f11d56d44db2, -, -, -)
+    entity(niiri:0fa6e1dc1111a03b5e4039ea1ac7bb00,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0025" %% xsd:string,
+        prov:location = 'niiri:512c7eaa981cfb72974cfb868f502dd3',
+        prov:value = "4.25063323974609" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.20220005940261" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000681911226584231" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999991679" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:512c7eaa981cfb72974cfb868f502dd3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0025" %% xsd:string,
+        nidm_coordinateVector: = "[20,28,6]" %% xsd:string])
+    wasDerivedFrom(niiri:0fa6e1dc1111a03b5e4039ea1ac7bb00, niiri:8fb299584020cc344c3c2c82de2f748c, -, -, -)
+    entity(niiri:ced62c2013b6703081946558916b11da,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0026" %% xsd:string,
+        prov:location = 'niiri:a829e3773a01f331491ad7d37354892f',
+        prov:value = "4.22958660125732" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.19200261281843" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000706450272937809" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999995163" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:a829e3773a01f331491ad7d37354892f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0026" %% xsd:string,
+        nidm_coordinateVector: = "[44,26,40]" %% xsd:string])
+    wasDerivedFrom(niiri:ced62c2013b6703081946558916b11da, niiri:6e2110d791417b070202a6783afba19c, -, -, -)
+    entity(niiri:e47ab6c45400adc2077bdd0ae11df79c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0027" %% xsd:string,
+        prov:location = 'niiri:aa889a8c10c7df77f4c657a1ba5d6cc2',
+        prov:value = "4.13231182098389" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.14429239999158" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000832444966141432" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999999966" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:aa889a8c10c7df77f4c657a1ba5d6cc2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0027" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-78,44]" %% xsd:string])
+    wasDerivedFrom(niiri:e47ab6c45400adc2077bdd0ae11df79c, niiri:b0fbdf26b837fa676d008fcff5a30ee9, -, -, -)
+    entity(niiri:2b415d5e579030f0e97fe16ff764d1af,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0028" %% xsd:string,
+        prov:location = 'niiri:1a87f060e179e8d5d5fad75dee9e561e',
+        prov:value = "4.0775408744812" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.11700347232274" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000913497101264649" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999932" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:1a87f060e179e8d5d5fad75dee9e561e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0028" %% xsd:string,
+        nidm_coordinateVector: = "[4,-54,-42]" %% xsd:string])
+    wasDerivedFrom(niiri:2b415d5e579030f0e97fe16ff764d1af, niiri:5167e145ebaf9f5693dffbc09df2f2f8, -, -, -)
+    entity(niiri:a4068ca93949e6e3223a16b3e3bfeb42,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0029" %% xsd:string,
+        prov:location = 'niiri:e82cbbcc7b634200287898ef5f614f70',
+        prov:value = "4.07394027709961" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.11519863095218" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000919105401866016" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999939" %% xsd:float,
+        nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
+    entity(niiri:e82cbbcc7b634200287898ef5f614f70,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0029" %% xsd:string,
+        nidm_coordinateVector: = "[34,14,56]" %% xsd:string])
+    wasDerivedFrom(niiri:a4068ca93949e6e3223a16b3e3bfeb42, niiri:17c3abf712c940e8e07c2fa7b3493dc1, -, -, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_covariate/nidm.provn
+++ b/spmexport/ex_spm_covariate/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:3ccf008c518c3f0ebe9dea04f0edfbc4,
+  entity(niiri:45de040124eabad18bf082b06af4cf9f,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:97c0efb1395126dbff029ae881c33b9d,
+  agent(niiri:bcc842a0d3d70beef6bcd40987b89d9d,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:4ee63714952ef11034b1653f40760c75,
+  activity(niiri:ef77e9af7b05e8005ba66d95bd38ec8f,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:4ee63714952ef11034b1653f40760c75, niiri:97c0efb1395126dbff029ae881c33b9d, -)
-  wasGeneratedBy(niiri:3ccf008c518c3f0ebe9dea04f0edfbc4, niiri:4ee63714952ef11034b1653f40760c75, 2016-01-11T10:33:30)
-  bundle niiri:3ccf008c518c3f0ebe9dea04f0edfbc4
+  wasAssociatedWith(niiri:ef77e9af7b05e8005ba66d95bd38ec8f, niiri:bcc842a0d3d70beef6bcd40987b89d9d, -)
+  wasGeneratedBy(niiri:45de040124eabad18bf082b06af4cf9f, niiri:ef77e9af7b05e8005ba66d95bd38ec8f, 2016-01-11T10:43:50)
+  bundle niiri:45de040124eabad18bf082b06af4cf9f
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -118,12 +118,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:7cd23874d74598fb93575d0ca339d267,
+    agent(niiri:2945a1d97a29c6969fdbf0eb195dc093,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:e7538b8eeead984e7d4168b9eb1e2185,
+    entity(niiri:409379fe70cecdcc9766ed27de979ed5,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -132,132 +132,132 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:f0df94187254dffcef42f57c9a34f591,
+    entity(niiri:760b84bdceecebaf15e2cf5a556d75af,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "false" %% xsd:boolean])
-    entity(niiri:8cc550f78b4df2ff508e85441d0a1fd0,
+    entity(niiri:e85d0cb7b322cd23c6939609e5b47e7f,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:83ee7456b6dda22712d37e10cc39a213',
+        dc:description = 'niiri:1d81cc1b6e5d65b95679161506c7dc05',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"mean\", \"Subject ID Covariate\"]" %% xsd:string])
-    entity(niiri:83ee7456b6dda22712d37e10cc39a213,
+    entity(niiri:1d81cc1b6e5d65b95679161506c7dc05,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:dc642cee82597b23a6938238a2d15373,
+    entity(niiri:492d2e071c9917615b83dd40cee0a85c,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'nidm_IndependentError:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean])
-    activity(niiri:169c4819223a8702ebf9447665c6a242,
+    activity(niiri:72cae3a8761174eff45f2a684fd4d0b1,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_OLS:'])
-    wasAssociatedWith(niiri:169c4819223a8702ebf9447665c6a242, niiri:7cd23874d74598fb93575d0ca339d267, -)
-    used(niiri:169c4819223a8702ebf9447665c6a242, niiri:8cc550f78b4df2ff508e85441d0a1fd0, -)
-    used(niiri:169c4819223a8702ebf9447665c6a242, niiri:f0df94187254dffcef42f57c9a34f591, -)
-    used(niiri:169c4819223a8702ebf9447665c6a242, niiri:dc642cee82597b23a6938238a2d15373, -)
-    entity(niiri:43e01138ea166419cf89ae0c1b960c02,
+    wasAssociatedWith(niiri:72cae3a8761174eff45f2a684fd4d0b1, niiri:2945a1d97a29c6969fdbf0eb195dc093, -)
+    used(niiri:72cae3a8761174eff45f2a684fd4d0b1, niiri:e85d0cb7b322cd23c6939609e5b47e7f, -)
+    used(niiri:72cae3a8761174eff45f2a684fd4d0b1, niiri:760b84bdceecebaf15e2cf5a556d75af, -)
+    used(niiri:72cae3a8761174eff45f2a684fd4d0b1, niiri:492d2e071c9917615b83dd40cee0a85c, -)
+    entity(niiri:1195cb378c9921f7f84d3b3470aa3123,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         crypto:sha512 = "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f" %% xsd:string])
-    entity(niiri:aa7e9876de1332712a7a6718e06772c7,
+    entity(niiri:a7fa345aa6718eea856fe11c365866b0,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "e06c7e91d23253a8dffd3bb366d05851340e63a972bc08812d42cb46ea31fdad3063cca9559c6a372781a84a7a50c17cf4bbf65c515ce00580f79372cc763807" %% xsd:string])
-    wasDerivedFrom(niiri:43e01138ea166419cf89ae0c1b960c02, niiri:aa7e9876de1332712a7a6718e06772c7, -, -, -)
-    wasGeneratedBy(niiri:43e01138ea166419cf89ae0c1b960c02, niiri:169c4819223a8702ebf9447665c6a242, -)
-    entity(niiri:165ea688a4bf64576aaa4b9aefc18471,
+    wasDerivedFrom(niiri:1195cb378c9921f7f84d3b3470aa3123, niiri:a7fa345aa6718eea856fe11c365866b0, -, -, -)
+    wasGeneratedBy(niiri:1195cb378c9921f7f84d3b3470aa3123, niiri:72cae3a8761174eff45f2a684fd4d0b1, -)
+    entity(niiri:0e03e7b35877063654d10de129520638,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "0.0173736633732915" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         crypto:sha512 = "98952e02ac3f45da846d94deb554fad9126d6ba05b8ba745f176150b7b18bf2edee7efff67e7362f6704114b42ec7cb1d68fcde6005a829d52921961a4dad470" %% xsd:string])
-    wasGeneratedBy(niiri:165ea688a4bf64576aaa4b9aefc18471, niiri:169c4819223a8702ebf9447665c6a242, -)
-    entity(niiri:f2d25df0f1d380a37ffc86ec505d0987,
+    wasGeneratedBy(niiri:0e03e7b35877063654d10de129520638, niiri:72cae3a8761174eff45f2a684fd4d0b1, -)
+    entity(niiri:d80b2820da42c9396e5e6b207065df30,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185'])
-    entity(niiri:1d80b51894720953bd75f667c1e8d960,
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5'])
+    entity(niiri:8befeb0a5fd1f97a7809dd988bc128f6,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "edde9f432759a7f2dad9ef0d3cb847eae532656aa81a7c08c76d939fe426e2e85329d56d0d279bf546773319599dd0bdf75b484d25083c8a2ac7ccb694a30e86" %% xsd:string])
-    wasDerivedFrom(niiri:f2d25df0f1d380a37ffc86ec505d0987, niiri:1d80b51894720953bd75f667c1e8d960, -, -, -)
-    wasGeneratedBy(niiri:f2d25df0f1d380a37ffc86ec505d0987, niiri:169c4819223a8702ebf9447665c6a242, -)
-    entity(niiri:f89edafcbb5a3cc6c1e71d9a08caf49e,
+    wasDerivedFrom(niiri:d80b2820da42c9396e5e6b207065df30, niiri:8befeb0a5fd1f97a7809dd988bc128f6, -, -, -)
+    wasGeneratedBy(niiri:d80b2820da42c9396e5e6b207065df30, niiri:72cae3a8761174eff45f2a684fd4d0b1, -)
+    entity(niiri:d1b7bb7f417814f80571c1d2468e4000,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185'])
-    entity(niiri:e06126279c6b3cc3de4edddb8525281c,
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5'])
+    entity(niiri:5d2dab2c3a026180cfd3a0dc830cf861,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "f54847aa8325ebc7e962e70e87b4ecc5cfc95e840fa0229889bfab2345836d6b6032c0d29f89f2bc95abc2581dfd7ad2af5833031d4c2974513717c3f0ec29f8" %% xsd:string])
-    wasDerivedFrom(niiri:f89edafcbb5a3cc6c1e71d9a08caf49e, niiri:e06126279c6b3cc3de4edddb8525281c, -, -, -)
-    wasGeneratedBy(niiri:f89edafcbb5a3cc6c1e71d9a08caf49e, niiri:169c4819223a8702ebf9447665c6a242, -)
-    entity(niiri:0dcb05747e20cb33a44bc7d7ca0576cb,
+    wasDerivedFrom(niiri:d1b7bb7f417814f80571c1d2468e4000, niiri:5d2dab2c3a026180cfd3a0dc830cf861, -, -, -)
+    wasGeneratedBy(niiri:d1b7bb7f417814f80571c1d2468e4000, niiri:72cae3a8761174eff45f2a684fd4d0b1, -)
+    entity(niiri:434990a2699db93362c651c0e066e61a,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         crypto:sha512 = "693dd1daf261efafb742c7da149cccc8b7383b49e672358dd29c6bcd31a6ee983270e23c3f118d86b0758d86162d77033926cb1ae0f653efb0b7102c922ca40b" %% xsd:string])
-    entity(niiri:b6f9383af3eb3dc8144e7261991f9fb1,
+    entity(niiri:122e25e1184c88c89124dde1d88e6cac,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "afca09bea5ebf5bceda101c9cb4d803de2cc2307b72a539454ce04e72ad6f655304b653779a287d3f38fca841819bf8126c51cb0a095e8710882e87d5eb7c565" %% xsd:string])
-    wasDerivedFrom(niiri:0dcb05747e20cb33a44bc7d7ca0576cb, niiri:b6f9383af3eb3dc8144e7261991f9fb1, -, -, -)
-    wasGeneratedBy(niiri:0dcb05747e20cb33a44bc7d7ca0576cb, niiri:169c4819223a8702ebf9447665c6a242, -)
-    entity(niiri:dcbee28f8fa480eb84e376111f7b6875,
+    wasDerivedFrom(niiri:434990a2699db93362c651c0e066e61a, niiri:122e25e1184c88c89124dde1d88e6cac, -, -, -)
+    wasGeneratedBy(niiri:434990a2699db93362c651c0e066e61a, niiri:72cae3a8761174eff45f2a684fd4d0b1, -)
+    entity(niiri:d305d0a8c1202e6daffd93b008bf5ffe,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         crypto:sha512 = "58dcbf304825e142d28af1f78351fa5fa758ea20a597f7c117967af6a2d051d80f69686dc6858c0d6b1b677ff279e00d600772ce8175eae7a54dbedd0848bfd5" %% xsd:string])
-    entity(niiri:4cb25d713c24e1d3d5fa873ee3dbfceb,
+    entity(niiri:322e9eaec41c80c26e1532dbfd6e16e0,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "42b06ae2316603cd1635234bdc474edf4cfac04b7ffe7acfe80221ee4cb3ecc0e6b514f5ebf1391df5ced6eb2fd5a91cd62a58ce1c4318ed4514eb8e1b41729b" %% xsd:string])
-    wasDerivedFrom(niiri:dcbee28f8fa480eb84e376111f7b6875, niiri:4cb25d713c24e1d3d5fa873ee3dbfceb, -, -, -)
-    wasGeneratedBy(niiri:dcbee28f8fa480eb84e376111f7b6875, niiri:169c4819223a8702ebf9447665c6a242, -)
-    entity(niiri:1d97aaaad1a6968e4783cd6214ee5179,
+    wasDerivedFrom(niiri:d305d0a8c1202e6daffd93b008bf5ffe, niiri:322e9eaec41c80c26e1532dbfd6e16e0, -, -, -)
+    wasGeneratedBy(niiri:d305d0a8c1202e6daffd93b008bf5ffe, niiri:72cae3a8761174eff45f2a684fd4d0b1, -)
+    entity(niiri:2c4731e21194b47e12dbaa51f4774b19,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         prov:label = "Contrast: mr vs plain" %% xsd:string,
         prov:value = "[1, 0]" %% xsd:string])
-    activity(niiri:54a8d8c7177e25879aa8c042805dfebe,
+    activity(niiri:f6ee4e8755ba4fdf9b24d704a16de570,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:7cd23874d74598fb93575d0ca339d267, -)
-    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:43e01138ea166419cf89ae0c1b960c02, -)
-    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:0dcb05747e20cb33a44bc7d7ca0576cb, -)
-    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:8cc550f78b4df2ff508e85441d0a1fd0, -)
-    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:1d97aaaad1a6968e4783cd6214ee5179, -)
-    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:f2d25df0f1d380a37ffc86ec505d0987, -)
-    used(niiri:54a8d8c7177e25879aa8c042805dfebe, niiri:f89edafcbb5a3cc6c1e71d9a08caf49e, -)
-    entity(niiri:78c3a55d6161c2415d14067b8c63d784,
+    wasAssociatedWith(niiri:f6ee4e8755ba4fdf9b24d704a16de570, niiri:2945a1d97a29c6969fdbf0eb195dc093, -)
+    used(niiri:f6ee4e8755ba4fdf9b24d704a16de570, niiri:1195cb378c9921f7f84d3b3470aa3123, -)
+    used(niiri:f6ee4e8755ba4fdf9b24d704a16de570, niiri:434990a2699db93362c651c0e066e61a, -)
+    used(niiri:f6ee4e8755ba4fdf9b24d704a16de570, niiri:e85d0cb7b322cd23c6939609e5b47e7f, -)
+    used(niiri:f6ee4e8755ba4fdf9b24d704a16de570, niiri:2c4731e21194b47e12dbaa51f4774b19, -)
+    used(niiri:f6ee4e8755ba4fdf9b24d704a16de570, niiri:d80b2820da42c9396e5e6b207065df30, -)
+    used(niiri:f6ee4e8755ba4fdf9b24d704a16de570, niiri:d1b7bb7f417814f80571c1d2468e4000, -)
+    entity(niiri:5b25a9567dcc3b650c8a24dae9143e2a,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -267,103 +267,103 @@ document
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "11" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         crypto:sha512 = "370387f786b51f404f6ca9acd10c4e35fbac46e4f5ec42750cf05c4236bda63dc8c003dea0989fd6c397d05d2e46bf0e0685ef08fa143418c0f1fdc3e7fe0d8b" %% xsd:string])
-    entity(niiri:40a16c560c78731e96db83110db91267,
+    entity(niiri:5af84637cd56e9820875877b470b1ed9,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "489d1d288d622546f52d846311adfd3c6b7a5a604e0356335c997c6c7c2cfdf648e312383d151343007194e94ae8e681af5c7c1c0f69754126dd9561cbcf622b" %% xsd:string])
-    wasDerivedFrom(niiri:78c3a55d6161c2415d14067b8c63d784, niiri:40a16c560c78731e96db83110db91267, -, -, -)
-    wasGeneratedBy(niiri:78c3a55d6161c2415d14067b8c63d784, niiri:54a8d8c7177e25879aa8c042805dfebe, -)
-    entity(niiri:3becd9191b28badb59abfebfeab96ef5,
+    wasDerivedFrom(niiri:5b25a9567dcc3b650c8a24dae9143e2a, niiri:5af84637cd56e9820875877b470b1ed9, -, -, -)
+    wasGeneratedBy(niiri:5b25a9567dcc3b650c8a24dae9143e2a, niiri:f6ee4e8755ba4fdf9b24d704a16de570, -)
+    entity(niiri:6d499cb898fe23d15aa58d3eab006246,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: mr vs plain" %% xsd:string,
         nidm_contrastName: = "mr vs plain" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         crypto:sha512 = "ab6e3d990747f48517f1cf7eb1dd7dd0e973d4f5b7f468963c982c906f3dfcafa7c056c8f34d9f54c10330a67ab92b7f7ab3d95781a568b7fbaddf9f17746216" %% xsd:string])
-    entity(niiri:78c411926e48aaf00a21986fb6b38f41,
+    entity(niiri:d242c1285ba53499604f20d0affe4f65,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "9dc48e80c35ac0d74eb3131bab4e8cac2db2df834fef3c5cb6ddb5d91082d573d885a8e703a03652b5745f3f52b0e3397feb130f3ebccae549142ce88c29cb59" %% xsd:string])
-    wasDerivedFrom(niiri:3becd9191b28badb59abfebfeab96ef5, niiri:78c411926e48aaf00a21986fb6b38f41, -, -, -)
-    wasGeneratedBy(niiri:3becd9191b28badb59abfebfeab96ef5, niiri:54a8d8c7177e25879aa8c042805dfebe, -)
-    entity(niiri:e74be4649036d7e5c6372c0258817b2b,
+    wasDerivedFrom(niiri:6d499cb898fe23d15aa58d3eab006246, niiri:d242c1285ba53499604f20d0affe4f65, -, -, -)
+    wasGeneratedBy(niiri:6d499cb898fe23d15aa58d3eab006246, niiri:f6ee4e8755ba4fdf9b24d704a16de570, -)
+    entity(niiri:34a7586b80f7bf5ce094767d3ba869ab,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         crypto:sha512 = "a36854cf6dd56807c2a335d31d64f3f265785b7b573115e7cfaec97da31078aad22aa084ac09c3a550605f550228a781457821df43845b7a92c8b375bc9ac9dc" %% xsd:string])
-    wasGeneratedBy(niiri:e74be4649036d7e5c6372c0258817b2b, niiri:54a8d8c7177e25879aa8c042805dfebe, -)
-    entity(niiri:5fc89d76faab61ee021d9cc78f0fd0b5,
+    wasGeneratedBy(niiri:34a7586b80f7bf5ce094767d3ba869ab, niiri:f6ee4e8755ba4fdf9b24d704a16de570, -)
+    entity(niiri:68e44305e604cf88c0d764b51cb9fe97,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500148243682" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:550ff496a1f20b888585d452cf21e219',
-        nidm_equivalentThreshold: = 'niiri:268cc3d07350375a06d59e1c72255036'])
-    entity(niiri:550ff496a1f20b888585d452cf21e219,
+        nidm_equivalentThreshold: = 'niiri:2223afd924dcb113734f5902000d3753',
+        nidm_equivalentThreshold: = 'niiri:5fc7d7e81dd2b8f2b501110577cfd4ba'])
+    entity(niiri:2223afd924dcb113734f5902000d3753,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.02470104841152" %% xsd:float])
-    entity(niiri:268cc3d07350375a06d59e1c72255036,
+    entity(niiri:5fc7d7e81dd2b8f2b501110577cfd4ba,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999999987" %% xsd:float])
-    entity(niiri:fb431b6d009d90dc5f369aadeb468547,
+    entity(niiri:1a36474c8ecdb3f7acb6a0e94b5c25bc,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:bbb30eb0dc56085d0bb3b8f32e1aa7d8',
-        nidm_equivalentThreshold: = 'niiri:6af35793d4c30300501f6e4843ea64f9'])
-    entity(niiri:bbb30eb0dc56085d0bb3b8f32e1aa7d8,
+        nidm_equivalentThreshold: = 'niiri:63a8882dc3fb7ed503d53c8d4d7c9008',
+        nidm_equivalentThreshold: = 'niiri:5be7edeaa9ac59ad8714d616ca536732'])
+    entity(niiri:63a8882dc3fb7ed503d53c8d4d7c9008,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:6af35793d4c30300501f6e4843ea64f9,
+    entity(niiri:5be7edeaa9ac59ad8714d616ca536732,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:e3fc10780da51f8073baec6993b81559,
+    entity(niiri:ee437a13fde8be91f28ac815bfbe3422,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:a7fcffe68706a024505ad48123a3a597,
+    entity(niiri:5eeb434f1becae361edcf7a5c6cc4062,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:f74ee55215d923c382e467dc5985637f,
+    activity(niiri:a0391f9b196095c360c805f7bed84e2e,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:f74ee55215d923c382e467dc5985637f, niiri:7cd23874d74598fb93575d0ca339d267, -)
-    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:5fc89d76faab61ee021d9cc78f0fd0b5, -)
-    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:fb431b6d009d90dc5f369aadeb468547, -)
-    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:78c3a55d6161c2415d14067b8c63d784, -)
-    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:dcbee28f8fa480eb84e376111f7b6875, -)
-    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:43e01138ea166419cf89ae0c1b960c02, -)
-    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:e3fc10780da51f8073baec6993b81559, -)
-    used(niiri:f74ee55215d923c382e467dc5985637f, niiri:a7fcffe68706a024505ad48123a3a597, -)
-    entity(niiri:4210503ffa69b7e56d701bcba7b1b2df,
+    wasAssociatedWith(niiri:a0391f9b196095c360c805f7bed84e2e, niiri:2945a1d97a29c6969fdbf0eb195dc093, -)
+    used(niiri:a0391f9b196095c360c805f7bed84e2e, niiri:68e44305e604cf88c0d764b51cb9fe97, -)
+    used(niiri:a0391f9b196095c360c805f7bed84e2e, niiri:1a36474c8ecdb3f7acb6a0e94b5c25bc, -)
+    used(niiri:a0391f9b196095c360c805f7bed84e2e, niiri:5b25a9567dcc3b650c8a24dae9143e2a, -)
+    used(niiri:a0391f9b196095c360c805f7bed84e2e, niiri:d305d0a8c1202e6daffd93b008bf5ffe, -)
+    used(niiri:a0391f9b196095c360c805f7bed84e2e, niiri:1195cb378c9921f7f84d3b3470aa3123, -)
+    used(niiri:a0391f9b196095c360c805f7bed84e2e, niiri:ee437a13fde8be91f28ac815bfbe3422, -)
+    used(niiri:a0391f9b196095c360c805f7bed84e2e, niiri:5eeb434f1becae361edcf7a5c6cc4062, -)
+    entity(niiri:6194b4183f7a41c54d073c56dc64f4d5,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         nidm_searchVolumeInVoxels: = "162104" %% xsd:int,
         nidm_searchVolumeInUnits: = "1296832" %% xsd:float,
         nidm_reselSizeInVoxels: = "95.2875561406722" %% xsd:float,
@@ -379,8 +379,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f" %% xsd:string])
-    wasGeneratedBy(niiri:4210503ffa69b7e56d701bcba7b1b2df, niiri:f74ee55215d923c382e467dc5985637f, -)
-    entity(niiri:ff2b188fd5ef195057b9076462d97f0c,
+    wasGeneratedBy(niiri:6194b4183f7a41c54d073c56dc64f4d5, niiri:a0391f9b196095c360c805f7bed84e2e, -)
+    entity(niiri:603e00a935726a95290a8c8be9f450ba,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -388,22 +388,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "29" %% xsd:int,
         nidm_pValue: = "0.722893095431427" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:3fe999af53b6ff1062dd11597b4540ec',
-        nidm_hasMaximumIntensityProjection: = 'niiri:ec2532bdcd7e520faba8a90cf9625856',
-        nidm_inCoordinateSpace: = 'niiri:e7538b8eeead984e7d4168b9eb1e2185',
+        nidm_hasClusterLabelsMap: = 'niiri:441086d357ed3f71cb532625cad214bc',
+        nidm_hasMaximumIntensityProjection: = 'niiri:27fe9e4be467254559329cf4e39595d2',
+        nidm_inCoordinateSpace: = 'niiri:409379fe70cecdcc9766ed27de979ed5',
         crypto:sha512 = "2bbcc39452bb1127d7205b05c820b5d31d5e2daa43e4ba6ccaf43c229aa7d708af405aff650daa9a08b3582c5aa013e32a6535188542c9c1fc3fa24fcc03c59c" %% xsd:string])
-    entity(niiri:3fe999af53b6ff1062dd11597b4540ec,
+    entity(niiri:441086d357ed3f71cb532625cad214bc,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:ec2532bdcd7e520faba8a90cf9625856,
+    entity(niiri:27fe9e4be467254559329cf4e39595d2,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:ff2b188fd5ef195057b9076462d97f0c, niiri:f74ee55215d923c382e467dc5985637f, -)
-    entity(niiri:be91aa057bdd9d8651b94a428f9d7e04,
+    wasGeneratedBy(niiri:603e00a935726a95290a8c8be9f450ba, niiri:a0391f9b196095c360c805f7bed84e2e, -)
+    entity(niiri:f5f1d4e01916e6d7ca48255a18330b17,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -412,8 +412,8 @@ document
         nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:be91aa057bdd9d8651b94a428f9d7e04, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:8c1f835fe33bb35a741db5d71610f74d,
+    wasDerivedFrom(niiri:f5f1d4e01916e6d7ca48255a18330b17, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:3b69500b101d653d5a95b9cd8e1d8c26,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -422,8 +422,8 @@ document
         nidm_pValueFWER: = "0.999549488736845" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:8c1f835fe33bb35a741db5d71610f74d, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:427a5e18f5920cd494cd57b5222b9804,
+    wasDerivedFrom(niiri:3b69500b101d653d5a95b9cd8e1d8c26, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:b150dfb21a962c7e0e9abd29a9e66209,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -432,8 +432,8 @@ document
         nidm_pValueFWER: = "0.998828548616846" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:427a5e18f5920cd494cd57b5222b9804, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:8cd69d4c2bcb674537c0f59674d850f8,
+    wasDerivedFrom(niiri:b150dfb21a962c7e0e9abd29a9e66209, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:573fad7099031cdb5c6aaf454eebae12,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -442,8 +442,8 @@ document
         nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:8cd69d4c2bcb674537c0f59674d850f8, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:1c094c13c4622d206afcab0831c06c8e,
+    wasDerivedFrom(niiri:573fad7099031cdb5c6aaf454eebae12, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:17c644af5b5b69ce4e55ce54602fbe9b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -452,8 +452,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:1c094c13c4622d206afcab0831c06c8e, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:d03fb3a214226f8e359063dd56622b80,
+    wasDerivedFrom(niiri:17c644af5b5b69ce4e55ce54602fbe9b, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:426152dfa5cb1a1dc5a196231796f1b9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -462,8 +462,8 @@ document
         nidm_pValueFWER: = "0.93333931168142" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:d03fb3a214226f8e359063dd56622b80, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:08acd9d5e3c86a5597634b63f9ca5b76,
+    wasDerivedFrom(niiri:426152dfa5cb1a1dc5a196231796f1b9, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:3bb14948c48d4d39919bbb810b678d69,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -472,8 +472,8 @@ document
         nidm_pValueFWER: = "0.990653977132472" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:08acd9d5e3c86a5597634b63f9ca5b76, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:33fdb3dcbde308077cb41f61bbb538d4,
+    wasDerivedFrom(niiri:3bb14948c48d4d39919bbb810b678d69, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:b134ec4fcd225723830f850e07a638db,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -482,8 +482,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:33fdb3dcbde308077cb41f61bbb538d4, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:a1dfe524338b100e2c0b4aac79347135,
+    wasDerivedFrom(niiri:b134ec4fcd225723830f850e07a638db, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:49e454729692bc106178637c8a22c617,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -492,8 +492,8 @@ document
         nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:a1dfe524338b100e2c0b4aac79347135, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:398e18e13e41fd86f9c91a0c37179f94,
+    wasDerivedFrom(niiri:49e454729692bc106178637c8a22c617, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:1e8f7a14eb802923b15d73f67fed2575,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -502,8 +502,8 @@ document
         nidm_pValueFWER: = "0.999857085744802" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:398e18e13e41fd86f9c91a0c37179f94, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:fc5a20643a49d6b48c632806b9fb3669,
+    wasDerivedFrom(niiri:1e8f7a14eb802923b15d73f67fed2575, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:1b36259af3067ed47d1d36c7f3e5ae9f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -512,8 +512,8 @@ document
         nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:fc5a20643a49d6b48c632806b9fb3669, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:7977d3c2d53495076863f90a7414369f,
+    wasDerivedFrom(niiri:1b36259af3067ed47d1d36c7f3e5ae9f, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:daf9bb1cc9f9b0e02d75aa15c8b779c7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -522,8 +522,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:7977d3c2d53495076863f90a7414369f, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:e6d67f5c8f427474527d0d727f3dce58,
+    wasDerivedFrom(niiri:daf9bb1cc9f9b0e02d75aa15c8b779c7, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:347d8082d0347a8c8c0664045f8487c2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -532,8 +532,8 @@ document
         nidm_pValueFWER: = "0.99999384461729" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:e6d67f5c8f427474527d0d727f3dce58, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:9ba6b697c18c9fa2a070f1ac777899c3,
+    wasDerivedFrom(niiri:347d8082d0347a8c8c0664045f8487c2, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:ce8982e550edd698ed8c7acdaac90be2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -542,8 +542,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:9ba6b697c18c9fa2a070f1ac777899c3, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:17cf04133d00b334b009343c68cc794f,
+    wasDerivedFrom(niiri:ce8982e550edd698ed8c7acdaac90be2, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:177ff2c2e855c609bb6a99b368bab6b4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -552,8 +552,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:17cf04133d00b334b009343c68cc794f, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:715dbdcf861d88449d6bf9fd80be68c2,
+    wasDerivedFrom(niiri:177ff2c2e855c609bb6a99b368bab6b4, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:301c22bdebf70b67d36aa2cc2edd7c6e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -562,8 +562,8 @@ document
         nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:715dbdcf861d88449d6bf9fd80be68c2, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:a722ba5c3f48104c4bffaa9f1bc96e93,
+    wasDerivedFrom(niiri:301c22bdebf70b67d36aa2cc2edd7c6e, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:a4f97ce3e351468a0b599542e9fe1960,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -572,8 +572,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:a722ba5c3f48104c4bffaa9f1bc96e93, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:0aa4b1a84fee2649d333d5561003c8bf,
+    wasDerivedFrom(niiri:a4f97ce3e351468a0b599542e9fe1960, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:9eeed673f0f6da15d5140c5984d28a3c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -582,8 +582,8 @@ document
         nidm_pValueFWER: = "0.999964783142854" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:0aa4b1a84fee2649d333d5561003c8bf, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:5b1d37cc88f4111dc6ae2a4f48520a59,
+    wasDerivedFrom(niiri:9eeed673f0f6da15d5140c5984d28a3c, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:6d6f7c13ffe51614573bd56d21ff26a7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -592,8 +592,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:5b1d37cc88f4111dc6ae2a4f48520a59, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:7a1feca53667470e0f2534f053958e05,
+    wasDerivedFrom(niiri:6d6f7c13ffe51614573bd56d21ff26a7, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:c7b43074794c90965e68f71cc444780a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -602,8 +602,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:7a1feca53667470e0f2534f053958e05, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:bda46dfc41022916ad6faceac091ba3d,
+    wasDerivedFrom(niiri:c7b43074794c90965e68f71cc444780a, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:c41d10c310919c8cbe2d4327dda739c9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -612,8 +612,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:bda46dfc41022916ad6faceac091ba3d, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:0c786e61d78880c4e546692954781ced,
+    wasDerivedFrom(niiri:c41d10c310919c8cbe2d4327dda739c9, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:8cd4eb873cc68bc694b905aebcc585c9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -622,8 +622,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:0c786e61d78880c4e546692954781ced, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:b9a4c4c2b5a9793a35534927d9578f48,
+    wasDerivedFrom(niiri:8cd4eb873cc68bc694b905aebcc585c9, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:93093df2bfed236a073657264fcfd67a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -632,8 +632,8 @@ document
         nidm_pValueFWER: = "0.999999967394723" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:b9a4c4c2b5a9793a35534927d9578f48, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:f4849377c56edcbca1dc5384795946ce,
+    wasDerivedFrom(niiri:93093df2bfed236a073657264fcfd67a, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:f78564c27b61dd4e46b3be31141d54a7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -642,8 +642,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:f4849377c56edcbca1dc5384795946ce, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:6ad64a79d36f37c1cd1b1433a1aef9ca,
+    wasDerivedFrom(niiri:f78564c27b61dd4e46b3be31141d54a7, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:f395049f71ae2e104b9b26062c56431a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -652,8 +652,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:6ad64a79d36f37c1cd1b1433a1aef9ca, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:50d65ffbbedadcbcef20b8bacaa5bf32,
+    wasDerivedFrom(niiri:f395049f71ae2e104b9b26062c56431a, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:b3217b4acb17a2036c4b69c3b751a912,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -662,8 +662,8 @@ document
         nidm_pValueFWER: = "0.999999342337431" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:50d65ffbbedadcbcef20b8bacaa5bf32, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:57ec9ce901bb55b112e2f594ad471e7a,
+    wasDerivedFrom(niiri:b3217b4acb17a2036c4b69c3b751a912, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:9178c692ea33d50b8bc90323fbe1561d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -672,8 +672,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:57ec9ce901bb55b112e2f594ad471e7a, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:1318d2cd1289a2678d066b7cca2986f1,
+    wasDerivedFrom(niiri:9178c692ea33d50b8bc90323fbe1561d, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:1b4bb4acb913740f6b3863891a7115fa,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -682,8 +682,8 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:1318d2cd1289a2678d066b7cca2986f1, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea,
+    wasDerivedFrom(niiri:1b4bb4acb913740f6b3863891a7115fa, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:6d4c71c4ef585e41f24f639435b05026,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -692,441 +692,441 @@ document
         nidm_pValueFWER: = "0.999999999608069" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea, niiri:ff2b188fd5ef195057b9076462d97f0c, -, -, -)
-    entity(niiri:da098c4cc640a214fd988ad023eb1a86,
+    wasDerivedFrom(niiri:6d4c71c4ef585e41f24f639435b05026, niiri:603e00a935726a95290a8c8be9f450ba, -, -, -)
+    entity(niiri:e2cfe5ed77eeb785cbdfcadbf53cc939,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:ba3f25e2c5e1f415cd2525e4abcdb621',
+        prov:location = 'niiri:5f9a71f50fd0545689636058d7b3c54a',
         prov:value = "6.37317276000977" %% xsd:float,
         nidm_equivalentZStatistic: = "4.04320073372639" %% xsd:float,
         nidm_pValueUncorrected: = "2.63632212645915e-05" %% xsd:float,
         nidm_pValueFWER: = "0.958902832016109" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:ba3f25e2c5e1f415cd2525e4abcdb621,
+    entity(niiri:5f9a71f50fd0545689636058d7b3c54a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[28,-36,38]" %% xsd:string])
-    wasDerivedFrom(niiri:da098c4cc640a214fd988ad023eb1a86, niiri:be91aa057bdd9d8651b94a428f9d7e04, -, -, -)
-    entity(niiri:3f041463e58131d17c3adb62ae04b812,
+    wasDerivedFrom(niiri:e2cfe5ed77eeb785cbdfcadbf53cc939, niiri:f5f1d4e01916e6d7ca48255a18330b17, -, -, -)
+    entity(niiri:d6deaaace8f041e7c21070e3e51ad1f7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:96c5c034a22620ddcd2779d651b4b97e',
+        prov:location = 'niiri:befaea8bb8709990399405a4dd53e15d',
         prov:value = "5.69066715240479" %% xsd:float,
         nidm_equivalentZStatistic: = "3.8079805415517" %% xsd:float,
         nidm_pValueUncorrected: = "7.00531473561972e-05" %% xsd:float,
         nidm_pValueFWER: = "0.997756103851125" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:96c5c034a22620ddcd2779d651b4b97e,
+    entity(niiri:befaea8bb8709990399405a4dd53e15d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[10,-48,16]" %% xsd:string])
-    wasDerivedFrom(niiri:3f041463e58131d17c3adb62ae04b812, niiri:8c1f835fe33bb35a741db5d71610f74d, -, -, -)
-    entity(niiri:7b61b8562a0fa2a8fc1be01625db2383,
+    wasDerivedFrom(niiri:d6deaaace8f041e7c21070e3e51ad1f7, niiri:3b69500b101d653d5a95b9cd8e1d8c26, -, -, -)
+    entity(niiri:808815ce2b1dbc4f7d41f4aa99e3424c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:709ff8ac6d109875a6c00824a37dec97',
+        prov:location = 'niiri:a8e9b7b4871a6d92e701777264d774df',
         prov:value = "5.404944896698" %% xsd:float,
         nidm_equivalentZStatistic: = "3.70067578615084" %% xsd:float,
         nidm_pValueUncorrected: = "0.000107513031460726" %% xsd:float,
         nidm_pValueFWER: = "0.999684183052173" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:709ff8ac6d109875a6c00824a37dec97,
+    entity(niiri:a8e9b7b4871a6d92e701777264d774df,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[-34,-6,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:7b61b8562a0fa2a8fc1be01625db2383, niiri:427a5e18f5920cd494cd57b5222b9804, -, -, -)
-    entity(niiri:1e33617f26a669bbc5d4a8e1a84861df,
+    wasDerivedFrom(niiri:808815ce2b1dbc4f7d41f4aa99e3424c, niiri:b150dfb21a962c7e0e9abd29a9e66209, -, -, -)
+    entity(niiri:4151ef564a41037621a331a0a83294e2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:ef91d2750f81ce9286534c4378095103',
+        prov:location = 'niiri:9d61098f81fb83b7ce5bd351f33c5408',
         prov:value = "5.20687818527222" %% xsd:float,
         nidm_equivalentZStatistic: = "3.62288194485815" %% xsd:float,
         nidm_pValueUncorrected: = "0.000145669405598126" %% xsd:float,
         nidm_pValueFWER: = "0.999944545222406" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:ef91d2750f81ce9286534c4378095103,
+    entity(niiri:9d61098f81fb83b7ce5bd351f33c5408,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[-28,-80,24]" %% xsd:string])
-    wasDerivedFrom(niiri:1e33617f26a669bbc5d4a8e1a84861df, niiri:8cd69d4c2bcb674537c0f59674d850f8, -, -, -)
-    entity(niiri:f9aa7f4153c94329f57f5a213c31ad9d,
+    wasDerivedFrom(niiri:4151ef564a41037621a331a0a83294e2, niiri:573fad7099031cdb5c6aaf454eebae12, -, -, -)
+    entity(niiri:de00a0adf87aa924896cf169dcdd412b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:a01b0efba27795b5259e72e8b06cc19e',
+        prov:location = 'niiri:20e542b21d056af04265ebcd2ab4f619',
         prov:value = "4.90865421295166" %% xsd:float,
         nidm_equivalentZStatistic: = "3.50007991972101" %% xsd:float,
         nidm_pValueUncorrected: = "0.000232559344231609" %% xsd:float,
         nidm_pValueFWER: = "0.999998126675029" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:a01b0efba27795b5259e72e8b06cc19e,
+    entity(niiri:20e542b21d056af04265ebcd2ab4f619,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[-12,-32,28]" %% xsd:string])
-    wasDerivedFrom(niiri:f9aa7f4153c94329f57f5a213c31ad9d, niiri:1c094c13c4622d206afcab0831c06c8e, -, -, -)
-    entity(niiri:afa5a345b8d55093f5d0ff485e694dbf,
+    wasDerivedFrom(niiri:de00a0adf87aa924896cf169dcdd412b, niiri:17c644af5b5b69ce4e55ce54602fbe9b, -, -, -)
+    entity(niiri:df65340173edc841ee99d737a7cb58fb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:2f8f1cfad3185761941c0d73d52f473c',
+        prov:location = 'niiri:c520b70ebbf65091d2c03a8ab0531b2a',
         prov:value = "4.84440040588379" %% xsd:float,
         nidm_equivalentZStatistic: = "3.47268080874189" %% xsd:float,
         nidm_pValueUncorrected: = "0.000257643895570592" %% xsd:float,
         nidm_pValueFWER: = "0.999999219649123" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:2f8f1cfad3185761941c0d73d52f473c,
+    entity(niiri:c520b70ebbf65091d2c03a8ab0531b2a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[-18,-76,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:afa5a345b8d55093f5d0ff485e694dbf, niiri:d03fb3a214226f8e359063dd56622b80, -, -, -)
-    entity(niiri:60a2332e10d9170f38d2463aeabd0113,
+    wasDerivedFrom(niiri:df65340173edc841ee99d737a7cb58fb, niiri:426152dfa5cb1a1dc5a196231796f1b9, -, -, -)
+    entity(niiri:e0b16b87724af90af0fc9b76cb42b530,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:8c54f00fb0e08af1fb95533f64c42abe',
+        prov:location = 'niiri:254f2a6f22601b8d930470c21aaff838',
         prov:value = "4.84136772155762" %% xsd:float,
         nidm_equivalentZStatistic: = "3.47137907963827" %% xsd:float,
         nidm_pValueUncorrected: = "0.000258896237096851" %% xsd:float,
         nidm_pValueFWER: = "0.999999252321799" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:8c54f00fb0e08af1fb95533f64c42abe,
+    entity(niiri:254f2a6f22601b8d930470c21aaff838,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[32,16,40]" %% xsd:string])
-    wasDerivedFrom(niiri:60a2332e10d9170f38d2463aeabd0113, niiri:08acd9d5e3c86a5597634b63f9ca5b76, -, -, -)
-    entity(niiri:79e0ce1a82f0e80e09c1b5064a2d60b2,
+    wasDerivedFrom(niiri:e0b16b87724af90af0fc9b76cb42b530, niiri:3bb14948c48d4d39919bbb810b678d69, -, -, -)
+    entity(niiri:0a67ef9acb1f1ff9deae962c3f59e058,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:80f6cd9cf5fcdd939d578cbb14fba341',
+        prov:location = 'niiri:f4ab90a76994db235ca411f9aae6ecb5',
         prov:value = "4.78605508804321" %% xsd:float,
         nidm_equivalentZStatistic: = "3.4475005479143" %% xsd:float,
         nidm_pValueUncorrected: = "0.000282899629741595" %% xsd:float,
         nidm_pValueFWER: = "0.999999665309186" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:80f6cd9cf5fcdd939d578cbb14fba341,
+    entity(niiri:f4ab90a76994db235ca411f9aae6ecb5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[-26,-78,46]" %% xsd:string])
-    wasDerivedFrom(niiri:79e0ce1a82f0e80e09c1b5064a2d60b2, niiri:33fdb3dcbde308077cb41f61bbb538d4, -, -, -)
-    entity(niiri:33896a562b3020901f0a9129b329ca9f,
+    wasDerivedFrom(niiri:0a67ef9acb1f1ff9deae962c3f59e058, niiri:b134ec4fcd225723830f850e07a638db, -, -, -)
+    entity(niiri:3dd0f864a494cf502a0434e761e33ca5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:46882cfa883eb6417029f9e14cfcd78d',
+        prov:location = 'niiri:10fe67cdad3e4f781e2c7e43edd65095',
         prov:value = "4.75920820236206" %% xsd:float,
         nidm_equivalentZStatistic: = "3.43581665930553" %% xsd:float,
         nidm_pValueUncorrected: = "0.000295385308778928" %% xsd:float,
         nidm_pValueFWER: = "0.999999777160537" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:46882cfa883eb6417029f9e14cfcd78d,
+    entity(niiri:10fe67cdad3e4f781e2c7e43edd65095,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[-50,-2,42]" %% xsd:string])
-    wasDerivedFrom(niiri:33896a562b3020901f0a9129b329ca9f, niiri:a1dfe524338b100e2c0b4aac79347135, -, -, -)
-    entity(niiri:0a36f87ab7a0b75562073c6947d4f7b1,
+    wasDerivedFrom(niiri:3dd0f864a494cf502a0434e761e33ca5, niiri:49e454729692bc106178637c8a22c617, -, -, -)
+    entity(niiri:3d4492db78b206abfae38aa443db976d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:7573b7d12c8d035c9d5d8631ccb22a9f',
+        prov:location = 'niiri:66e160264c8d2ad9e63e0993ef7db059',
         prov:value = "4.70320177078247" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41124192966355" %% xsd:float,
         nidm_pValueUncorrected: = "0.000323338426391984" %% xsd:float,
         nidm_pValueFWER: = "0.999999908044234" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:7573b7d12c8d035c9d5d8631ccb22a9f,
+    entity(niiri:66e160264c8d2ad9e63e0993ef7db059,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[22,-34,34]" %% xsd:string])
-    wasDerivedFrom(niiri:0a36f87ab7a0b75562073c6947d4f7b1, niiri:398e18e13e41fd86f9c91a0c37179f94, -, -, -)
-    entity(niiri:6eab38ddecebcaaa0bf86b72dc12049c,
+    wasDerivedFrom(niiri:3d4492db78b206abfae38aa443db976d, niiri:1e8f7a14eb802923b15d73f67fed2575, -, -, -)
+    entity(niiri:f72ddbae1cb1b90cdbae2561e91e7dd6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:7f68e73a36ee3f3687de8c6c9b97a7fe',
+        prov:location = 'niiri:c90170c4b1ea8d90df2f75d439bd1458',
         prov:value = "4.65910387039185" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39169946109688" %% xsd:float,
         nidm_pValueUncorrected: = "0.000347302923845438" %% xsd:float,
         nidm_pValueFWER: = "0.999999955827132" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:7f68e73a36ee3f3687de8c6c9b97a7fe,
+    entity(niiri:c90170c4b1ea8d90df2f75d439bd1458,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[-20,-44,-36]" %% xsd:string])
-    wasDerivedFrom(niiri:6eab38ddecebcaaa0bf86b72dc12049c, niiri:fc5a20643a49d6b48c632806b9fb3669, -, -, -)
-    entity(niiri:8dff42675f00ab4b9ddd2b53dc34917f,
+    wasDerivedFrom(niiri:f72ddbae1cb1b90cdbae2561e91e7dd6, niiri:1b36259af3067ed47d1d36c7f3e5ae9f, -, -, -)
+    entity(niiri:d3292a0cd20db9459beffd1223b81b88,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:7eab74d15593b8c8ffc29b17ea34173f',
+        prov:location = 'niiri:1dbfcefb9aa3c60bd7bf1c4397bd0869',
         prov:value = "4.63754796981812" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38208413500926" %% xsd:float,
         nidm_pValueUncorrected: = "0.00035969054090712" %% xsd:float,
         nidm_pValueFWER: = "0.999999969503" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:7eab74d15593b8c8ffc29b17ea34173f,
+    entity(niiri:1dbfcefb9aa3c60bd7bf1c4397bd0869,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[34,-22,26]" %% xsd:string])
-    wasDerivedFrom(niiri:8dff42675f00ab4b9ddd2b53dc34917f, niiri:7977d3c2d53495076863f90a7414369f, -, -, -)
-    entity(niiri:69505c505831c5f7ad6ff3002082e4c0,
+    wasDerivedFrom(niiri:d3292a0cd20db9459beffd1223b81b88, niiri:daf9bb1cc9f9b0e02d75aa15c8b779c7, -, -, -)
+    entity(niiri:82bbc3be044d029a5cff801aca3fe5de,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:dc677f45978a7877a700f4d03cf0e7ce',
+        prov:location = 'niiri:31a39306eff8328690edee3d6e2f49ca',
         prov:value = "4.61526584625244" %% xsd:float,
         nidm_equivalentZStatistic: = "3.37210130568973" %% xsd:float,
         nidm_pValueUncorrected: = "0.000372985020458683" %% xsd:float,
         nidm_pValueFWER: = "0.999999979383511" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:dc677f45978a7877a700f4d03cf0e7ce,
+    entity(niiri:31a39306eff8328690edee3d6e2f49ca,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[-8,-24,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:69505c505831c5f7ad6ff3002082e4c0, niiri:e6d67f5c8f427474527d0d727f3dce58, -, -, -)
-    entity(niiri:07fc7144bacb9a33351978163ec7665f,
+    wasDerivedFrom(niiri:82bbc3be044d029a5cff801aca3fe5de, niiri:347d8082d0347a8c8c0664045f8487c2, -, -, -)
+    entity(niiri:cf7b82d2756ddb040ecfdf69ad8ee9d4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:2aa908545a5498195b685e803d760c2a',
+        prov:location = 'niiri:3711399f5ab94dade9a21c0b0dcbcccc',
         prov:value = "4.51868915557861" %% xsd:float,
         nidm_equivalentZStatistic: = "3.32831433156359" %% xsd:float,
         nidm_pValueUncorrected: = "0.000436866114896683" %% xsd:float,
         nidm_pValueFWER: = "0.999999996599993" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:2aa908545a5498195b685e803d760c2a,
+    entity(niiri:3711399f5ab94dade9a21c0b0dcbcccc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[10,-12,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:07fc7144bacb9a33351978163ec7665f, niiri:9ba6b697c18c9fa2a070f1ac777899c3, -, -, -)
-    entity(niiri:2a7de24428d3d14a74344f3a2ed53ab9,
+    wasDerivedFrom(niiri:cf7b82d2756ddb040ecfdf69ad8ee9d4, niiri:ce8982e550edd698ed8c7acdaac90be2, -, -, -)
+    entity(niiri:3d1403940f81e99c4b7eb7ed3ba9d7d4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:402ce4265cfb6d8f4eccfcd7202c27c6',
+        prov:location = 'niiri:217ec3b736b83b2a5614463d4fe0ce06',
         prov:value = "4.45568466186523" %% xsd:float,
         nidm_equivalentZStatistic: = "3.2992865242182" %% xsd:float,
         nidm_pValueUncorrected: = "0.000484654601471068" %% xsd:float,
         nidm_pValueFWER: = "0.999999999048352" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:402ce4265cfb6d8f4eccfcd7202c27c6,
+    entity(niiri:217ec3b736b83b2a5614463d4fe0ce06,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[16,-48,-46]" %% xsd:string])
-    wasDerivedFrom(niiri:2a7de24428d3d14a74344f3a2ed53ab9, niiri:17cf04133d00b334b009343c68cc794f, -, -, -)
-    entity(niiri:71a4d25f7fb9dd5f2ff89ce4a6426ed6,
+    wasDerivedFrom(niiri:3d1403940f81e99c4b7eb7ed3ba9d7d4, niiri:177ff2c2e855c609bb6a99b368bab6b4, -, -, -)
+    entity(niiri:16189a2299f27429558ef4834d1c5aa3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:170bf99fa55adf19b4bcf6bac2226035',
+        prov:location = 'niiri:c622ec0e155af693ff91a96a7779c4fd',
         prov:value = "4.42093467712402" %% xsd:float,
         nidm_equivalentZStatistic: = "3.28311730425125" %% xsd:float,
         nidm_pValueUncorrected: = "0.000513329675929763" %% xsd:float,
         nidm_pValueFWER: = "0.999999999544708" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:170bf99fa55adf19b4bcf6bac2226035,
+    entity(niiri:c622ec0e155af693ff91a96a7779c4fd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[-20,52,16]" %% xsd:string])
-    wasDerivedFrom(niiri:71a4d25f7fb9dd5f2ff89ce4a6426ed6, niiri:715dbdcf861d88449d6bf9fd80be68c2, -, -, -)
-    entity(niiri:3fe2b2a2a97891aa0347dc4a8041143b,
+    wasDerivedFrom(niiri:16189a2299f27429558ef4834d1c5aa3, niiri:301c22bdebf70b67d36aa2cc2edd7c6e, -, -, -)
+    entity(niiri:6575ec06f88b0f953f6f9390d533ab50,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:a810311fe07f257dbdaf36cba74972bf',
+        prov:location = 'niiri:49105cd40a656ff8ef0d2174017d9cd0',
         prov:value = "4.41627073287964" %% xsd:float,
         nidm_equivalentZStatistic: = "3.28093847762164" %% xsd:float,
         nidm_pValueUncorrected: = "0.00051731154621093" %% xsd:float,
         nidm_pValueFWER: = "0.999999999588405" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:a810311fe07f257dbdaf36cba74972bf,
+    entity(niiri:49105cd40a656ff8ef0d2174017d9cd0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[10,62,20]" %% xsd:string])
-    wasDerivedFrom(niiri:3fe2b2a2a97891aa0347dc4a8041143b, niiri:a722ba5c3f48104c4bffaa9f1bc96e93, -, -, -)
-    entity(niiri:771d0950142ef5727aa4539533181ebe,
+    wasDerivedFrom(niiri:6575ec06f88b0f953f6f9390d533ab50, niiri:a4f97ce3e351468a0b599542e9fe1960, -, -, -)
+    entity(niiri:cb6956a4299b4a7cb665e732f724b204,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:01971ac462b6f6a68ddf7a4bcb329cd1',
+        prov:location = 'niiri:8320eca97390d2908a4112000203d93e',
         prov:value = "4.39752912521362" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27216223374679" %% xsd:float,
         nidm_pValueUncorrected: = "0.000533641570346299" %% xsd:float,
         nidm_pValueFWER: = "0.999999999726897" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:01971ac462b6f6a68ddf7a4bcb329cd1,
+    entity(niiri:8320eca97390d2908a4112000203d93e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[50,-66,38]" %% xsd:string])
-    wasDerivedFrom(niiri:771d0950142ef5727aa4539533181ebe, niiri:0aa4b1a84fee2649d333d5561003c8bf, -, -, -)
-    entity(niiri:8fa040e1a3007565edd3ecf0c6827522,
+    wasDerivedFrom(niiri:cb6956a4299b4a7cb665e732f724b204, niiri:9eeed673f0f6da15d5140c5984d28a3c, -, -, -)
+    entity(niiri:ca5152e1ac133ad18f0df30171300f28,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:386b7d31755630d505a2b693dea28f77',
+        prov:location = 'niiri:426dc744c165e7364d33cb64d542a2ce',
         prov:value = "4.30746841430664" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22951851195682" %% xsd:float,
         nidm_pValueUncorrected: = "0.000619994267038626" %% xsd:float,
         nidm_pValueFWER: = "0.999999999965896" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:386b7d31755630d505a2b693dea28f77,
+    entity(niiri:426dc744c165e7364d33cb64d542a2ce,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[-4,-4,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:8fa040e1a3007565edd3ecf0c6827522, niiri:5b1d37cc88f4111dc6ae2a4f48520a59, -, -, -)
-    entity(niiri:2c9566f77e7f82b34e22874819f8c710,
+    wasDerivedFrom(niiri:ca5152e1ac133ad18f0df30171300f28, niiri:6d6f7c13ffe51614573bd56d21ff26a7, -, -, -)
+    entity(niiri:c1c03fa6f2753370070c650d1c5fbff1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:170fb7ed6d4143e9075bf54c54eb7793',
+        prov:location = 'niiri:141e560c1bc04b4fd8ba5c5e9c02cb39',
         prov:value = "4.29710006713867" %% xsd:float,
         nidm_equivalentZStatistic: = "3.2245585560768" %% xsd:float,
         nidm_pValueUncorrected: = "0.000630835257803941" %% xsd:float,
         nidm_pValueFWER: = "0.999999999973481" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:170fb7ed6d4143e9075bf54c54eb7793,
+    entity(niiri:141e560c1bc04b4fd8ba5c5e9c02cb39,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[-20,-56,14]" %% xsd:string])
-    wasDerivedFrom(niiri:2c9566f77e7f82b34e22874819f8c710, niiri:7a1feca53667470e0f2534f053958e05, -, -, -)
-    entity(niiri:b0fa3c1d2ceac260635bee3e4a36167b,
+    wasDerivedFrom(niiri:c1c03fa6f2753370070c650d1c5fbff1, niiri:c7b43074794c90965e68f71cc444780a, -, -, -)
+    entity(niiri:9c6a7cfe9f8d38c24e14824830f49bc0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:a83c51a65ddebc4a61818ab017d3f959',
+        prov:location = 'niiri:9c52154aad7501a924f3f043ae4c5959',
         prov:value = "4.28621673583984" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21934090215671" %% xsd:float,
         nidm_pValueUncorrected: = "0.000642428185358868" %% xsd:float,
         nidm_pValueFWER: = "0.999999999979691" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:a83c51a65ddebc4a61818ab017d3f959,
+    entity(niiri:9c52154aad7501a924f3f043ae4c5959,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[32,24,30]" %% xsd:string])
-    wasDerivedFrom(niiri:b0fa3c1d2ceac260635bee3e4a36167b, niiri:bda46dfc41022916ad6faceac091ba3d, -, -, -)
-    entity(niiri:69ba9d52a63ad25b2c1f23f677985988,
+    wasDerivedFrom(niiri:9c6a7cfe9f8d38c24e14824830f49bc0, niiri:c41d10c310919c8cbe2d4327dda739c9, -, -, -)
+    entity(niiri:5b4f6b80a53d3311dcd2f5da199517cb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:2a05164883101591007a84904b255170',
+        prov:location = 'niiri:a3acd33b50384b2692990584f551bf0c',
         prov:value = "4.28483486175537" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21867757532573" %% xsd:float,
         nidm_pValueUncorrected: = "0.000643916016166424" %% xsd:float,
         nidm_pValueFWER: = "0.999999999980371" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:2a05164883101591007a84904b255170,
+    entity(niiri:a3acd33b50384b2692990584f551bf0c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[-18,-48,12]" %% xsd:string])
-    wasDerivedFrom(niiri:69ba9d52a63ad25b2c1f23f677985988, niiri:0c786e61d78880c4e546692954781ced, -, -, -)
-    entity(niiri:8af718e4eb7ee27c7d2b1f62ae1f4fc8,
+    wasDerivedFrom(niiri:5b4f6b80a53d3311dcd2f5da199517cb, niiri:8cd4eb873cc68bc694b905aebcc585c9, -, -, -)
+    entity(niiri:5ec228b3171198ace9fbb6146df6c678,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:9327092d5f9ad138d37b770b39d5e356',
+        prov:location = 'niiri:79ac7b96bcbf87780aeb0400b85d2fda',
         prov:value = "4.27967262268066" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21619793589097" %% xsd:float,
         nidm_pValueUncorrected: = "0.000649506017056822" %% xsd:float,
         nidm_pValueFWER: = "0.999999999982724" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:9327092d5f9ad138d37b770b39d5e356,
+    entity(niiri:79ac7b96bcbf87780aeb0400b85d2fda,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-26,-80,16]" %% xsd:string])
-    wasDerivedFrom(niiri:8af718e4eb7ee27c7d2b1f62ae1f4fc8, niiri:b9a4c4c2b5a9793a35534927d9578f48, -, -, -)
-    entity(niiri:49c4aad3b156440f8fd3346227c812bb,
+    wasDerivedFrom(niiri:5ec228b3171198ace9fbb6146df6c678, niiri:93093df2bfed236a073657264fcfd67a, -, -, -)
+    entity(niiri:2264e18ba802faabecfa101c08d27996,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:219d1a9528adbd1b3e9fad127c12ba45',
+        prov:location = 'niiri:3252fcc9f4cd6d0bcc7abf7abb6602a7',
         prov:value = "4.27626991271973" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21456203610231" %% xsd:float,
         nidm_pValueUncorrected: = "0.000653218409537804" %% xsd:float,
         nidm_pValueFWER: = "0.999999999984125" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:219d1a9528adbd1b3e9fad127c12ba45,
+    entity(niiri:3252fcc9f4cd6d0bcc7abf7abb6602a7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[22,-42,-44]" %% xsd:string])
-    wasDerivedFrom(niiri:49c4aad3b156440f8fd3346227c812bb, niiri:f4849377c56edcbca1dc5384795946ce, -, -, -)
-    entity(niiri:86047a3e6b7ffa4a1d1b9a29cb05f3c8,
+    wasDerivedFrom(niiri:2264e18ba802faabecfa101c08d27996, niiri:f78564c27b61dd4e46b3be31141d54a7, -, -, -)
+    entity(niiri:711c3bc552e3a66a9412d6fd2fb775b1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:29a67515a2b3cfc85dfdfd1fc059f75c',
+        prov:location = 'niiri:7a1fc6df95484bec6ca7395446f3a1b7',
         prov:value = "4.25063323974609" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20220005940261" %% xsd:float,
         nidm_pValueUncorrected: = "0.000681911226584231" %% xsd:float,
         nidm_pValueFWER: = "0.999999999991679" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:29a67515a2b3cfc85dfdfd1fc059f75c,
+    entity(niiri:7a1fc6df95484bec6ca7395446f3a1b7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[20,28,6]" %% xsd:string])
-    wasDerivedFrom(niiri:86047a3e6b7ffa4a1d1b9a29cb05f3c8, niiri:6ad64a79d36f37c1cd1b1433a1aef9ca, -, -, -)
-    entity(niiri:2d96bb4e97bbf9cdca301464aea060d7,
+    wasDerivedFrom(niiri:711c3bc552e3a66a9412d6fd2fb775b1, niiri:f395049f71ae2e104b9b26062c56431a, -, -, -)
+    entity(niiri:32e250f6dc9d5c3442b08814c9443fe3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:17e914d0522a7782b8946f4570a112a0',
+        prov:location = 'niiri:51125b6d7abce3d3c78c487bc9fa5969',
         prov:value = "4.22958660125732" %% xsd:float,
         nidm_equivalentZStatistic: = "3.19200261281843" %% xsd:float,
         nidm_pValueUncorrected: = "0.000706450272937809" %% xsd:float,
         nidm_pValueFWER: = "0.999999999995163" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:17e914d0522a7782b8946f4570a112a0,
+    entity(niiri:51125b6d7abce3d3c78c487bc9fa5969,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[44,26,40]" %% xsd:string])
-    wasDerivedFrom(niiri:2d96bb4e97bbf9cdca301464aea060d7, niiri:50d65ffbbedadcbcef20b8bacaa5bf32, -, -, -)
-    entity(niiri:b544c89d1296f2203fb8e262999b2903,
+    wasDerivedFrom(niiri:32e250f6dc9d5c3442b08814c9443fe3, niiri:b3217b4acb17a2036c4b69c3b751a912, -, -, -)
+    entity(niiri:a1810948e0e400ebc306b2b756f74a0e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:7ab866ab624608ae371a87356ccbb246',
+        prov:location = 'niiri:04f8840d371d916d2ac43250d8e09c75',
         prov:value = "4.13231182098389" %% xsd:float,
         nidm_equivalentZStatistic: = "3.14429239999158" %% xsd:float,
         nidm_pValueUncorrected: = "0.000832444966141432" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999966" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:7ab866ab624608ae371a87356ccbb246,
+    entity(niiri:04f8840d371d916d2ac43250d8e09c75,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[-32,-78,44]" %% xsd:string])
-    wasDerivedFrom(niiri:b544c89d1296f2203fb8e262999b2903, niiri:57ec9ce901bb55b112e2f594ad471e7a, -, -, -)
-    entity(niiri:e8fc125bac22d26604b604112b05554d,
+    wasDerivedFrom(niiri:a1810948e0e400ebc306b2b756f74a0e, niiri:9178c692ea33d50b8bc90323fbe1561d, -, -, -)
+    entity(niiri:4869211d5caf0eddb9fd6e1b3246e3b0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:0e198fd93d34f6f23b1574200bd77922',
+        prov:location = 'niiri:02fad55253b907bb3460b724ad605ff8',
         prov:value = "4.0775408744812" %% xsd:float,
         nidm_equivalentZStatistic: = "3.11700347232274" %% xsd:float,
         nidm_pValueUncorrected: = "0.000913497101264649" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999932" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:0e198fd93d34f6f23b1574200bd77922,
+    entity(niiri:02fad55253b907bb3460b724ad605ff8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[4,-54,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:e8fc125bac22d26604b604112b05554d, niiri:1318d2cd1289a2678d066b7cca2986f1, -, -, -)
-    entity(niiri:93ad18b2412733cb3a43ab2edf151f7d,
+    wasDerivedFrom(niiri:4869211d5caf0eddb9fd6e1b3246e3b0, niiri:1b4bb4acb913740f6b3863891a7115fa, -, -, -)
+    entity(niiri:01d1363c9790021850fa9adcadeff99a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:65f92900970c3f35426b598b6b9b186c',
+        prov:location = 'niiri:ae86be3809cd578b07a064930d2ad838',
         prov:value = "4.07394027709961" %% xsd:float,
         nidm_equivalentZStatistic: = "3.11519863095218" %% xsd:float,
         nidm_pValueUncorrected: = "0.000919105401866016" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999939" %% xsd:float,
         nidm_qValueFDR: = "0.882167584555376" %% xsd:float])
-    entity(niiri:65f92900970c3f35426b598b6b9b186c,
+    entity(niiri:ae86be3809cd578b07a064930d2ad838,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[34,14,56]" %% xsd:string])
-    wasDerivedFrom(niiri:93ad18b2412733cb3a43ab2edf151f7d, niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea, -, -, -)
+    wasDerivedFrom(niiri:01d1363c9790021850fa9adcadeff99a, niiri:6d4c71c4ef585e41f24f639435b05026, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_covariate/nidm.ttl
+++ b/spmexport/ex_spm_covariate/nidm.ttl
@@ -1,0 +1,1323 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:31d6c1a45e08732f9d39d4fd32cea085
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:8cf1ef035df283fda3a56583da8cbd77
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:a33cfd1828738469b4829a177a32ea49
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:a33cfd1828738469b4829a177a32ea49 prov:wasAssociatedWith niiri:8cf1ef035df283fda3a56583da8cbd77 .
+
+_:blank5 a prov:Generation .
+
+niiri:31d6c1a45e08732f9d39d4fd32cea085 prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:11:15"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_OLS: <http://purl.obolibrary.org/obo/STATO_0000370> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070> .
+@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
+@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .
+@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .
+@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082> .
+@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .
+@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092> .
+@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
+@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
+
+niiri:d515e4539ba77e4aaafcb479a1267ad1
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:29ca7f31a8b4fa610180435e7362a7d0
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:cbf0821fd0582df876cb99f6e1c69ac8
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "false"^^xsd:boolean .
+
+niiri:f49fb0ce586d5bba164b397ad004843d
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:41a74f856bbb8085011a19fe078fabce ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"mean\", \"Subject ID Covariate\"]"^^xsd:string .
+
+niiri:41a74f856bbb8085011a19fe078fabce
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:6a6716cb24609f317367c274cd3a3012
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: nidm_IndependentError: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean .
+
+niiri:fc1b05994ad6f530ee7e2818c82ace02
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_OLS: .
+
+niiri:fc1b05994ad6f530ee7e2818c82ace02 prov:wasAssociatedWith niiri:d515e4539ba77e4aaafcb479a1267ad1 .
+
+niiri:fc1b05994ad6f530ee7e2818c82ace02 prov:used niiri:f49fb0ce586d5bba164b397ad004843d .
+
+niiri:fc1b05994ad6f530ee7e2818c82ace02 prov:used niiri:cbf0821fd0582df876cb99f6e1c69ac8 .
+
+niiri:fc1b05994ad6f530ee7e2818c82ace02 prov:used niiri:6a6716cb24609f317367c274cd3a3012 .
+
+niiri:a0e2e4659c44ec8283f603e4d63d4cb7
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    crypto:sha512 "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f"^^xsd:string .
+
+niiri:c48268f2a6a23bf1f723deea7bbdb5b6
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "e06c7e91d23253a8dffd3bb366d05851340e63a972bc08812d42cb46ea31fdad3063cca9559c6a372781a84a7a50c17cf4bbf65c515ce00580f79372cc763807"^^xsd:string .
+
+niiri:a0e2e4659c44ec8283f603e4d63d4cb7 prov:wasDerivedFrom niiri:c48268f2a6a23bf1f723deea7bbdb5b6 .
+
+niiri:a0e2e4659c44ec8283f603e4d63d4cb7 prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+
+niiri:26f92bdc36b3170ba40be9cc15a7dc6e
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "0.0173736633732915"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    crypto:sha512 "98952e02ac3f45da846d94deb554fad9126d6ba05b8ba745f176150b7b18bf2edee7efff67e7362f6704114b42ec7cb1d68fcde6005a829d52921961a4dad470"^^xsd:string .
+
+niiri:26f92bdc36b3170ba40be9cc15a7dc6e prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+
+niiri:2623a47371135f56c2aecb37063cac44
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 .
+
+niiri:51246b06ba783f764ebdcafdef38e2e3
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "edde9f432759a7f2dad9ef0d3cb847eae532656aa81a7c08c76d939fe426e2e85329d56d0d279bf546773319599dd0bdf75b484d25083c8a2ac7ccb694a30e86"^^xsd:string .
+
+niiri:2623a47371135f56c2aecb37063cac44 prov:wasDerivedFrom niiri:51246b06ba783f764ebdcafdef38e2e3 .
+
+niiri:2623a47371135f56c2aecb37063cac44 prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+
+niiri:9a291bb486326720055fc2883364893a
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 .
+
+niiri:0575f791e06f7944f37a4249570f2201
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "f54847aa8325ebc7e962e70e87b4ecc5cfc95e840fa0229889bfab2345836d6b6032c0d29f89f2bc95abc2581dfd7ad2af5833031d4c2974513717c3f0ec29f8"^^xsd:string .
+
+niiri:9a291bb486326720055fc2883364893a prov:wasDerivedFrom niiri:0575f791e06f7944f37a4249570f2201 .
+
+niiri:9a291bb486326720055fc2883364893a prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+
+niiri:b9cbdd666979ec7a12ae681547b560f7
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    crypto:sha512 "693dd1daf261efafb742c7da149cccc8b7383b49e672358dd29c6bcd31a6ee983270e23c3f118d86b0758d86162d77033926cb1ae0f653efb0b7102c922ca40b"^^xsd:string .
+
+niiri:51db014e8a30d126f73e7f235977299f
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "afca09bea5ebf5bceda101c9cb4d803de2cc2307b72a539454ce04e72ad6f655304b653779a287d3f38fca841819bf8126c51cb0a095e8710882e87d5eb7c565"^^xsd:string .
+
+niiri:b9cbdd666979ec7a12ae681547b560f7 prov:wasDerivedFrom niiri:51db014e8a30d126f73e7f235977299f .
+
+niiri:b9cbdd666979ec7a12ae681547b560f7 prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+
+niiri:4b89f205af8d9f723bc3dd1382c941ba
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    crypto:sha512 "58dcbf304825e142d28af1f78351fa5fa758ea20a597f7c117967af6a2d051d80f69686dc6858c0d6b1b677ff279e00d600772ce8175eae7a54dbedd0848bfd5"^^xsd:string .
+
+niiri:d5024dc0bc94c982918144fd5349aa97
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "42b06ae2316603cd1635234bdc474edf4cfac04b7ffe7acfe80221ee4cb3ecc0e6b514f5ebf1391df5ced6eb2fd5a91cd62a58ce1c4318ed4514eb8e1b41729b"^^xsd:string .
+
+niiri:4b89f205af8d9f723bc3dd1382c941ba prov:wasDerivedFrom niiri:d5024dc0bc94c982918144fd5349aa97 .
+
+niiri:4b89f205af8d9f723bc3dd1382c941ba prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+
+niiri:43cb4a137447d784b18f0327f0c441f9
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    rdfs:label "Contrast: mr vs plain" ;
+    prov:value "[1, 0]"^^xsd:string .
+
+niiri:8106d8f378522cc994936b6c1d2b0f47
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:8106d8f378522cc994936b6c1d2b0f47 prov:wasAssociatedWith niiri:d515e4539ba77e4aaafcb479a1267ad1 .
+
+niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:a0e2e4659c44ec8283f603e4d63d4cb7 .
+
+niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:b9cbdd666979ec7a12ae681547b560f7 .
+
+niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:f49fb0ce586d5bba164b397ad004843d .
+
+niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:43cb4a137447d784b18f0327f0c441f9 .
+
+niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:2623a47371135f56c2aecb37063cac44 .
+
+niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:9a291bb486326720055fc2883364893a .
+
+niiri:7180fa05eac2a8815661ff232ad535d2
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: mr vs plain" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "11"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    crypto:sha512 "370387f786b51f404f6ca9acd10c4e35fbac46e4f5ec42750cf05c4236bda63dc8c003dea0989fd6c397d05d2e46bf0e0685ef08fa143418c0f1fdc3e7fe0d8b"^^xsd:string .
+
+niiri:a909b2437ec845db0a946d87fcdbf110
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "489d1d288d622546f52d846311adfd3c6b7a5a604e0356335c997c6c7c2cfdf648e312383d151343007194e94ae8e681af5c7c1c0f69754126dd9561cbcf622b"^^xsd:string .
+
+niiri:7180fa05eac2a8815661ff232ad535d2 prov:wasDerivedFrom niiri:a909b2437ec845db0a946d87fcdbf110 .
+
+niiri:7180fa05eac2a8815661ff232ad535d2 prov:wasGeneratedBy niiri:8106d8f378522cc994936b6c1d2b0f47 .
+
+niiri:f88a91a1a09378bbfdb3dd220962cbd0
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: mr vs plain" ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    crypto:sha512 "ab6e3d990747f48517f1cf7eb1dd7dd0e973d4f5b7f468963c982c906f3dfcafa7c056c8f34d9f54c10330a67ab92b7f7ab3d95781a568b7fbaddf9f17746216"^^xsd:string .
+
+niiri:1282ac0f2eeb5bc9dde3259940a5b967
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "9dc48e80c35ac0d74eb3131bab4e8cac2db2df834fef3c5cb6ddb5d91082d573d885a8e703a03652b5745f3f52b0e3397feb130f3ebccae549142ce88c29cb59"^^xsd:string .
+
+niiri:f88a91a1a09378bbfdb3dd220962cbd0 prov:wasDerivedFrom niiri:1282ac0f2eeb5bc9dde3259940a5b967 .
+
+niiri:f88a91a1a09378bbfdb3dd220962cbd0 prov:wasGeneratedBy niiri:8106d8f378522cc994936b6c1d2b0f47 .
+
+niiri:c68b99924630158595413c4285a41ec7
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    crypto:sha512 "a36854cf6dd56807c2a335d31d64f3f265785b7b573115e7cfaec97da31078aad22aa084ac09c3a550605f550228a781457821df43845b7a92c8b375bc9ac9dc"^^xsd:string .
+
+niiri:c68b99924630158595413c4285a41ec7 prov:wasGeneratedBy niiri:8106d8f378522cc994936b6c1d2b0f47 .
+
+niiri:98a24053ecc198c682c361b35db9d066
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    prov:value "0.000999500148243682"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:7d4015daee5ad33cd195777edd7b45e7 ;
+    nidm_equivalentThreshold: niiri:2e33ccc4e77256ac0c3122164affbf0f .
+
+niiri:7d4015daee5ad33cd195777edd7b45e7
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "4.02470104841152"^^xsd:float .
+
+niiri:2e33ccc4e77256ac0c3122164affbf0f
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.999999999999987"^^xsd:float .
+
+niiri:97c3deab28ad09270d41f36ac051abf0
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:dc2315d702ea7d63764b08840958382b ;
+    nidm_equivalentThreshold: niiri:3a2b050a6e9b6bf8427850e20e551ae4 .
+
+niiri:dc2315d702ea7d63764b08840958382b
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:3a2b050a6e9b6bf8427850e20e551ae4
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:b96cd6ef89bc01300f460e26e2535619
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:a6afd19740d69851bcebb4de3abcb4e7
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:wasAssociatedWith niiri:d515e4539ba77e4aaafcb479a1267ad1 .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:98a24053ecc198c682c361b35db9d066 .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:97c3deab28ad09270d41f36ac051abf0 .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:7180fa05eac2a8815661ff232ad535d2 .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:4b89f205af8d9f723bc3dd1382c941ba .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:a0e2e4659c44ec8283f603e4d63d4cb7 .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:b96cd6ef89bc01300f460e26e2535619 .
+
+niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:a6afd19740d69851bcebb4de3abcb4e7 .
+
+niiri:af00c4dc59502bf1fe7721773eb5a850
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_searchVolumeInVoxels: "162104"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1296832"^^xsd:float ;
+    nidm_reselSizeInVoxels: "95.2875561406722"^^xsd:float ;
+    nidm_searchVolumeInResels: "1563.13170399827"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[4, 44.8383200236172, 622.676579140049, 1563.13170399827]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.39048281781903, 4.50910789991045, 4.81319302824617]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.78096563563806, 9.01821579982091, 9.62638605649234]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "5.48622463035775"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "31.9486171281883"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "10.182499224951"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f"^^xsd:string .
+
+niiri:af00c4dc59502bf1fe7721773eb5a850 prov:wasGeneratedBy niiri:58ea1c58f6fd442a5f0b30714b02f548 .
+
+niiri:d60a0c55d948a11dac535e382316f31f
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "29"^^xsd:int ;
+    nidm_pValue: "0.722893095431427"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:aae74d51171ea0af243cd165c716a211 ;
+    nidm_hasMaximumIntensityProjection: niiri:93a498407930e7c2f57870d6e06e32d4 ;
+    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    crypto:sha512 "2bbcc39452bb1127d7205b05c820b5d31d5e2daa43e4ba6ccaf43c229aa7d708af405aff650daa9a08b3582c5aa013e32a6535188542c9c1fc3fa24fcc03c59c"^^xsd:string .
+
+niiri:aae74d51171ea0af243cd165c716a211
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:93a498407930e7c2f57870d6e06e32d4
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:d60a0c55d948a11dac535e382316f31f prov:wasGeneratedBy niiri:58ea1c58f6fd442a5f0b30714b02f548 .
+
+niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0001" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0419781990640502"^^xsd:float ;
+    nidm_pValueUncorrected: "0.375546258337659"^^xsd:float ;
+    nidm_pValueFWER: "0.99999384461729"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "1"^^xsd:int .
+
+niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:02bd1b0dd4f143323060712eeb0b3401
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0002" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0734618483620879"^^xsd:float ;
+    nidm_pValueUncorrected: "0.24117248796276"^^xsd:float ;
+    nidm_pValueFWER: "0.999549488736845"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "2"^^xsd:int .
+
+niiri:02bd1b0dd4f143323060712eeb0b3401 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:4feafd8d4a6ff76500cde244ec4a9ac0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0003" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0839563981281005"^^xsd:float ;
+    nidm_pValueUncorrected: "0.211261469422963"^^xsd:float ;
+    nidm_pValueFWER: "0.998828548616846"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "3"^^xsd:int .
+
+niiri:4feafd8d4a6ff76500cde244ec4a9ac0 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:6267cdb89b255ce524220439e2d056f1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0004" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0419781990640502"^^xsd:float ;
+    nidm_pValueUncorrected: "0.375546258337659"^^xsd:float ;
+    nidm_pValueFWER: "0.99999384461729"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "4"^^xsd:int .
+
+niiri:6267cdb89b255ce524220439e2d056f1 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:dccae6a3d4de3910d04419b8bb7c8d62
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0005" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0209890995320251"^^xsd:float ;
+    nidm_pValueUncorrected: "0.539578649702376"^^xsd:float ;
+    nidm_pValueFWER: "0.999999967394723"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "5"^^xsd:int .
+
+niiri:dccae6a3d4de3910d04419b8bb7c8d62 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:8a59a0d3509f23181ea020ba988244a4
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0006" ;
+    nidm_clusterSizeInVoxels: "16"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.167912796256201"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0847654804425067"^^xsd:float ;
+    nidm_pValueFWER: "0.93333931168142"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "6"^^xsd:int .
+
+niiri:8a59a0d3509f23181ea020ba988244a4 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:26f9f618c22ef5edf5685712623da454
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0007" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.115440047426138"^^xsd:float ;
+    nidm_pValueUncorrected: "0.146259988943696"^^xsd:float ;
+    nidm_pValueFWER: "0.990653977132472"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "7"^^xsd:int .
+
+niiri:26f9f618c22ef5edf5685712623da454 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:d2f346a025c15c9fc9c31510f24b5886
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0008" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "8"^^xsd:int .
+
+niiri:d2f346a025c15c9fc9c31510f24b5886 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:d2e202f26f07d353e876c8513aaac055
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0009" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0314836492980377"^^xsd:float ;
+    nidm_pValueUncorrected: "0.445545852347923"^^xsd:float ;
+    nidm_pValueFWER: "0.999999342337431"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "9"^^xsd:int .
+
+niiri:d2e202f26f07d353e876c8513aaac055 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:d0abf7f944018518c8b2f88645568e05
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0010" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0629672985960754"^^xsd:float ;
+    nidm_pValueUncorrected: "0.277109512628503"^^xsd:float ;
+    nidm_pValueFWER: "0.999857085744802"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "10"^^xsd:int .
+
+niiri:d0abf7f944018518c8b2f88645568e05 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:71dd070abfb1b28ce2b0e47fb4f49daf
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0011" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0314836492980377"^^xsd:float ;
+    nidm_pValueUncorrected: "0.445545852347923"^^xsd:float ;
+    nidm_pValueFWER: "0.999999342337431"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "11"^^xsd:int .
+
+niiri:71dd070abfb1b28ce2b0e47fb4f49daf prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:354b333049efc8a35bffb5e871d5df51
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0012" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "12"^^xsd:int .
+
+niiri:354b333049efc8a35bffb5e871d5df51 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:dfcda071a872154b10c43f862bf52d69
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0013" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0419781990640502"^^xsd:float ;
+    nidm_pValueUncorrected: "0.375546258337659"^^xsd:float ;
+    nidm_pValueFWER: "0.99999384461729"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "13"^^xsd:int .
+
+niiri:dfcda071a872154b10c43f862bf52d69 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:9f93d2b40c1f794cb34e0ae17e04bd0c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0014" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "14"^^xsd:int .
+
+niiri:9f93d2b40c1f794cb34e0ae17e04bd0c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:899db6b982fa96374440fc31d77225c7
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0015" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "15"^^xsd:int .
+
+niiri:899db6b982fa96374440fc31d77225c7 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:d19f972dfab2b23346202c34e5574f29
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0016" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0314836492980377"^^xsd:float ;
+    nidm_pValueUncorrected: "0.445545852347923"^^xsd:float ;
+    nidm_pValueFWER: "0.999999342337431"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "16"^^xsd:int .
+
+niiri:d19f972dfab2b23346202c34e5574f29 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:c8e45b2b37dac3869716ea38f6f82aa2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0017" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0209890995320251"^^xsd:float ;
+    nidm_pValueUncorrected: "0.539578649702376"^^xsd:float ;
+    nidm_pValueFWER: "0.999999967394723"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "17"^^xsd:int .
+
+niiri:c8e45b2b37dac3869716ea38f6f82aa2 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:f4fe3e2f741c280bd998a6eaf285b07c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0018" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0524727488300628"^^xsd:float ;
+    nidm_pValueUncorrected: "0.320952410949864"^^xsd:float ;
+    nidm_pValueFWER: "0.999964783142854"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "18"^^xsd:int .
+
+niiri:f4fe3e2f741c280bd998a6eaf285b07c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:f18795394da513a451940bf5032734eb
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0019" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0209890995320251"^^xsd:float ;
+    nidm_pValueUncorrected: "0.539578649702376"^^xsd:float ;
+    nidm_pValueFWER: "0.999999967394723"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "19"^^xsd:int .
+
+niiri:f18795394da513a451940bf5032734eb prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:350e81fc1b83d10ae96dfefb3bab3615
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0020" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "20"^^xsd:int .
+
+niiri:350e81fc1b83d10ae96dfefb3bab3615 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0021" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "21"^^xsd:int .
+
+niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:3e2d682ff8be1f7b5e4954125d52dc9c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0022" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0209890995320251"^^xsd:float ;
+    nidm_pValueUncorrected: "0.539578649702376"^^xsd:float ;
+    nidm_pValueFWER: "0.999999967394723"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "22"^^xsd:int .
+
+niiri:3e2d682ff8be1f7b5e4954125d52dc9c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:9a3e77b28376a93d769c670fd53a30cb
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0023" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0209890995320251"^^xsd:float ;
+    nidm_pValueUncorrected: "0.539578649702376"^^xsd:float ;
+    nidm_pValueFWER: "0.999999967394723"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "23"^^xsd:int .
+
+niiri:9a3e77b28376a93d769c670fd53a30cb prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:0cff727da02fc982bbc0f11d56d44db2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0024" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "24"^^xsd:int .
+
+niiri:0cff727da02fc982bbc0f11d56d44db2 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:8fb299584020cc344c3c2c82de2f748c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0025" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "25"^^xsd:int .
+
+niiri:8fb299584020cc344c3c2c82de2f748c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:6e2110d791417b070202a6783afba19c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0026" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0314836492980377"^^xsd:float ;
+    nidm_pValueUncorrected: "0.445545852347923"^^xsd:float ;
+    nidm_pValueFWER: "0.999999342337431"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "26"^^xsd:int .
+
+niiri:6e2110d791417b070202a6783afba19c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:b0fbdf26b837fa676d008fcff5a30ee9
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0027" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "27"^^xsd:int .
+
+niiri:b0fbdf26b837fa676d008fcff5a30ee9 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:5167e145ebaf9f5693dffbc09df2f2f8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0028" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "28"^^xsd:int .
+
+niiri:5167e145ebaf9f5693dffbc09df2f2f8 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:17c3abf712c940e8e07c2fa7b3493dc1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0029" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0104945497660126"^^xsd:float ;
+    nidm_pValueUncorrected: "0.677961565790583"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999608069"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "29"^^xsd:int .
+
+niiri:17c3abf712c940e8e07c2fa7b3493dc1 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+
+niiri:70a79fb5d0fafa6b4641330f8f8b12aa
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0001" ;
+    prov:atLocation niiri:654d6238fa35ad568af3286425629272 ;
+    prov:value "6.37317276000977"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.04320073372639"^^xsd:float ;
+    nidm_pValueUncorrected: "2.63632212645915e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.958902832016109"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:654d6238fa35ad568af3286425629272
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0001" ;
+    nidm_coordinateVector: "[28,-36,38]"^^xsd:string .
+
+niiri:70a79fb5d0fafa6b4641330f8f8b12aa prov:wasDerivedFrom niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b .
+
+niiri:81a8683173d0ed24bd3d2f6be8ec0f77
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0002" ;
+    prov:atLocation niiri:eacbf2fc9ec48207e00dc693c683bf1f ;
+    prov:value "5.69066715240479"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.8079805415517"^^xsd:float ;
+    nidm_pValueUncorrected: "7.00531473561972e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.997756103851125"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:eacbf2fc9ec48207e00dc693c683bf1f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0002" ;
+    nidm_coordinateVector: "[10,-48,16]"^^xsd:string .
+
+niiri:81a8683173d0ed24bd3d2f6be8ec0f77 prov:wasDerivedFrom niiri:02bd1b0dd4f143323060712eeb0b3401 .
+
+niiri:b6d7f661e892640001af0eea6f38dc9e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0003" ;
+    prov:atLocation niiri:79a643a3d5d92c1658b5fb52ce02a6d1 ;
+    prov:value "5.404944896698"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.70067578615084"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000107513031460726"^^xsd:float ;
+    nidm_pValueFWER: "0.999684183052173"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:79a643a3d5d92c1658b5fb52ce02a6d1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0003" ;
+    nidm_coordinateVector: "[-34,-6,-32]"^^xsd:string .
+
+niiri:b6d7f661e892640001af0eea6f38dc9e prov:wasDerivedFrom niiri:4feafd8d4a6ff76500cde244ec4a9ac0 .
+
+niiri:640d2f1d4cb2fff0fb98dd63f4292b5e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0004" ;
+    prov:atLocation niiri:26366fb427147de255e4516551b308e9 ;
+    prov:value "5.20687818527222"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.62288194485815"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000145669405598126"^^xsd:float ;
+    nidm_pValueFWER: "0.999944545222406"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:26366fb427147de255e4516551b308e9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0004" ;
+    nidm_coordinateVector: "[-28,-80,24]"^^xsd:string .
+
+niiri:640d2f1d4cb2fff0fb98dd63f4292b5e prov:wasDerivedFrom niiri:6267cdb89b255ce524220439e2d056f1 .
+
+niiri:aaba7d880bfd3cc9e40f6e040f3df3ca
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0005" ;
+    prov:atLocation niiri:ceafb447ebc334cf0885953cb12180dc ;
+    prov:value "4.90865421295166"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.50007991972101"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000232559344231609"^^xsd:float ;
+    nidm_pValueFWER: "0.999998126675029"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:ceafb447ebc334cf0885953cb12180dc
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0005" ;
+    nidm_coordinateVector: "[-12,-32,28]"^^xsd:string .
+
+niiri:aaba7d880bfd3cc9e40f6e040f3df3ca prov:wasDerivedFrom niiri:dccae6a3d4de3910d04419b8bb7c8d62 .
+
+niiri:c9d9194d3fc86fceb8cbb0ad72e5e116
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0006" ;
+    prov:atLocation niiri:39876766efea7749fdb1e3ec89516c50 ;
+    prov:value "4.84440040588379"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.47268080874189"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000257643895570592"^^xsd:float ;
+    nidm_pValueFWER: "0.999999219649123"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:39876766efea7749fdb1e3ec89516c50
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0006" ;
+    nidm_coordinateVector: "[-18,-76,-12]"^^xsd:string .
+
+niiri:c9d9194d3fc86fceb8cbb0ad72e5e116 prov:wasDerivedFrom niiri:8a59a0d3509f23181ea020ba988244a4 .
+
+niiri:7361b36fbc686ac319529770f44965bb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0007" ;
+    prov:atLocation niiri:d6b455e1b17b09ffb45f2319ae5feaa7 ;
+    prov:value "4.84136772155762"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.47137907963827"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000258896237096851"^^xsd:float ;
+    nidm_pValueFWER: "0.999999252321799"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:d6b455e1b17b09ffb45f2319ae5feaa7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0007" ;
+    nidm_coordinateVector: "[32,16,40]"^^xsd:string .
+
+niiri:7361b36fbc686ac319529770f44965bb prov:wasDerivedFrom niiri:26f9f618c22ef5edf5685712623da454 .
+
+niiri:71afea378b2be0836e3b1e53b4c621c4
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0008" ;
+    prov:atLocation niiri:a1d44e4d1e3f9e624a75e1de128e43a4 ;
+    prov:value "4.78605508804321"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.4475005479143"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000282899629741595"^^xsd:float ;
+    nidm_pValueFWER: "0.999999665309186"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:a1d44e4d1e3f9e624a75e1de128e43a4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0008" ;
+    nidm_coordinateVector: "[-26,-78,46]"^^xsd:string .
+
+niiri:71afea378b2be0836e3b1e53b4c621c4 prov:wasDerivedFrom niiri:d2f346a025c15c9fc9c31510f24b5886 .
+
+niiri:8d7d3064a7e3b5bf7e85fffe64b06bc6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0009" ;
+    prov:atLocation niiri:6d9c75885354734cf3570762871d32aa ;
+    prov:value "4.75920820236206"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.43581665930553"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000295385308778928"^^xsd:float ;
+    nidm_pValueFWER: "0.999999777160537"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:6d9c75885354734cf3570762871d32aa
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0009" ;
+    nidm_coordinateVector: "[-50,-2,42]"^^xsd:string .
+
+niiri:8d7d3064a7e3b5bf7e85fffe64b06bc6 prov:wasDerivedFrom niiri:d2e202f26f07d353e876c8513aaac055 .
+
+niiri:00f11aa6a9bf3c67963ec8004894a193
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0010" ;
+    prov:atLocation niiri:cfe98ef5194606348538a89c7dce71b0 ;
+    prov:value "4.70320177078247"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.41124192966355"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000323338426391984"^^xsd:float ;
+    nidm_pValueFWER: "0.999999908044234"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:cfe98ef5194606348538a89c7dce71b0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0010" ;
+    nidm_coordinateVector: "[22,-34,34]"^^xsd:string .
+
+niiri:00f11aa6a9bf3c67963ec8004894a193 prov:wasDerivedFrom niiri:d0abf7f944018518c8b2f88645568e05 .
+
+niiri:057cb92551aa371b6f6dc683d506bf96
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0011" ;
+    prov:atLocation niiri:a7a44c477f5330dc6c8b7bbe1aa3f387 ;
+    prov:value "4.65910387039185"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.39169946109688"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000347302923845438"^^xsd:float ;
+    nidm_pValueFWER: "0.999999955827132"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:a7a44c477f5330dc6c8b7bbe1aa3f387
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0011" ;
+    nidm_coordinateVector: "[-20,-44,-36]"^^xsd:string .
+
+niiri:057cb92551aa371b6f6dc683d506bf96 prov:wasDerivedFrom niiri:71dd070abfb1b28ce2b0e47fb4f49daf .
+
+niiri:32caa29266a76db202d1c2c5c68c7445
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0012" ;
+    prov:atLocation niiri:5e965e5ef7f2d1914d1b1f52d8cbddea ;
+    prov:value "4.63754796981812"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.38208413500926"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00035969054090712"^^xsd:float ;
+    nidm_pValueFWER: "0.999999969503"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:5e965e5ef7f2d1914d1b1f52d8cbddea
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0012" ;
+    nidm_coordinateVector: "[34,-22,26]"^^xsd:string .
+
+niiri:32caa29266a76db202d1c2c5c68c7445 prov:wasDerivedFrom niiri:354b333049efc8a35bffb5e871d5df51 .
+
+niiri:4c62c0e8cf4e83463b2cd8ef62f9c602
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0013" ;
+    prov:atLocation niiri:b3021dc8859525200429834fc6310f99 ;
+    prov:value "4.61526584625244"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.37210130568973"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000372985020458683"^^xsd:float ;
+    nidm_pValueFWER: "0.999999979383511"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:b3021dc8859525200429834fc6310f99
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0013" ;
+    nidm_coordinateVector: "[-8,-24,-20]"^^xsd:string .
+
+niiri:4c62c0e8cf4e83463b2cd8ef62f9c602 prov:wasDerivedFrom niiri:dfcda071a872154b10c43f862bf52d69 .
+
+niiri:8a73d008087b3fa9d94106936d72a9cf
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0014" ;
+    prov:atLocation niiri:f56aea2994cdd430b079943b1299d6ba ;
+    prov:value "4.51868915557861"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.32831433156359"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000436866114896683"^^xsd:float ;
+    nidm_pValueFWER: "0.999999996599993"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:f56aea2994cdd430b079943b1299d6ba
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0014" ;
+    nidm_coordinateVector: "[10,-12,-8]"^^xsd:string .
+
+niiri:8a73d008087b3fa9d94106936d72a9cf prov:wasDerivedFrom niiri:9f93d2b40c1f794cb34e0ae17e04bd0c .
+
+niiri:a96fc8bfcb9cf24f47dbdf7bfe7afd17
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0015" ;
+    prov:atLocation niiri:ac7a10e1bead2a7d7fd42038f3949443 ;
+    prov:value "4.45568466186523"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.2992865242182"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000484654601471068"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999048352"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:ac7a10e1bead2a7d7fd42038f3949443
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0015" ;
+    nidm_coordinateVector: "[16,-48,-46]"^^xsd:string .
+
+niiri:a96fc8bfcb9cf24f47dbdf7bfe7afd17 prov:wasDerivedFrom niiri:899db6b982fa96374440fc31d77225c7 .
+
+niiri:3d6d68b50c110bd970cae436330e36d9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0016" ;
+    prov:atLocation niiri:daf43d66330a2ead30991863c01caec5 ;
+    prov:value "4.42093467712402"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.28311730425125"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000513329675929763"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999544708"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:daf43d66330a2ead30991863c01caec5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0016" ;
+    nidm_coordinateVector: "[-20,52,16]"^^xsd:string .
+
+niiri:3d6d68b50c110bd970cae436330e36d9 prov:wasDerivedFrom niiri:d19f972dfab2b23346202c34e5574f29 .
+
+niiri:00d1711e3ed46fde327d5581de9dd791
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0017" ;
+    prov:atLocation niiri:ae59229032d7c40d79b030470e5f23b9 ;
+    prov:value "4.41627073287964"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.28093847762164"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00051731154621093"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999588405"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:ae59229032d7c40d79b030470e5f23b9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0017" ;
+    nidm_coordinateVector: "[10,62,20]"^^xsd:string .
+
+niiri:00d1711e3ed46fde327d5581de9dd791 prov:wasDerivedFrom niiri:c8e45b2b37dac3869716ea38f6f82aa2 .
+
+niiri:7e851910d726d6995c852ed218ac5570
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0018" ;
+    prov:atLocation niiri:a01d789cee79784cca55a545db21ce87 ;
+    prov:value "4.39752912521362"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.27216223374679"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000533641570346299"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999726897"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:a01d789cee79784cca55a545db21ce87
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0018" ;
+    nidm_coordinateVector: "[50,-66,38]"^^xsd:string .
+
+niiri:7e851910d726d6995c852ed218ac5570 prov:wasDerivedFrom niiri:f4fe3e2f741c280bd998a6eaf285b07c .
+
+niiri:9fe2a624ae89ae7fa855b69eec31ebbd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0019" ;
+    prov:atLocation niiri:88780e43a9ab7fafa2461b5df7d58e73 ;
+    prov:value "4.30746841430664"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.22951851195682"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000619994267038626"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999965896"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:88780e43a9ab7fafa2461b5df7d58e73
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0019" ;
+    nidm_coordinateVector: "[-4,-4,-8]"^^xsd:string .
+
+niiri:9fe2a624ae89ae7fa855b69eec31ebbd prov:wasDerivedFrom niiri:f18795394da513a451940bf5032734eb .
+
+niiri:a74e55a109a945b087544cc3e5a316c8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0020" ;
+    prov:atLocation niiri:f763f5cde1a933a22512bd1463316cc3 ;
+    prov:value "4.29710006713867"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.2245585560768"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000630835257803941"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999973481"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:f763f5cde1a933a22512bd1463316cc3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0020" ;
+    nidm_coordinateVector: "[-20,-56,14]"^^xsd:string .
+
+niiri:a74e55a109a945b087544cc3e5a316c8 prov:wasDerivedFrom niiri:350e81fc1b83d10ae96dfefb3bab3615 .
+
+niiri:f450448fe12d0362b602a56046e2eca2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0021" ;
+    prov:atLocation niiri:c65359940d6cccd84bad6f3231507649 ;
+    prov:value "4.28621673583984"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.21934090215671"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000642428185358868"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999979691"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:c65359940d6cccd84bad6f3231507649
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0021" ;
+    nidm_coordinateVector: "[32,24,30]"^^xsd:string .
+
+niiri:f450448fe12d0362b602a56046e2eca2 prov:wasDerivedFrom niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b .
+
+niiri:eb48ceb96e89cae6a5b3a0ba68de877a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0022" ;
+    prov:atLocation niiri:135e25c43b8fa91ac5f365849500911d ;
+    prov:value "4.28483486175537"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.21867757532573"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000643916016166424"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999980371"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:135e25c43b8fa91ac5f365849500911d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0022" ;
+    nidm_coordinateVector: "[-18,-48,12]"^^xsd:string .
+
+niiri:eb48ceb96e89cae6a5b3a0ba68de877a prov:wasDerivedFrom niiri:3e2d682ff8be1f7b5e4954125d52dc9c .
+
+niiri:a02879441932ceb79462d5b20fa110d6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0023" ;
+    prov:atLocation niiri:006c681558a6a4b518e9cfbba9778dc6 ;
+    prov:value "4.27967262268066"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.21619793589097"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000649506017056822"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999982724"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:006c681558a6a4b518e9cfbba9778dc6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0023" ;
+    nidm_coordinateVector: "[-26,-80,16]"^^xsd:string .
+
+niiri:a02879441932ceb79462d5b20fa110d6 prov:wasDerivedFrom niiri:9a3e77b28376a93d769c670fd53a30cb .
+
+niiri:2dfef592e2c3fe76668cd44d20d63b01
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0024" ;
+    prov:atLocation niiri:6219f06a8442157e1456fc904d88c25a ;
+    prov:value "4.27626991271973"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.21456203610231"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000653218409537804"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999984125"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:6219f06a8442157e1456fc904d88c25a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0024" ;
+    nidm_coordinateVector: "[22,-42,-44]"^^xsd:string .
+
+niiri:2dfef592e2c3fe76668cd44d20d63b01 prov:wasDerivedFrom niiri:0cff727da02fc982bbc0f11d56d44db2 .
+
+niiri:0fa6e1dc1111a03b5e4039ea1ac7bb00
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0025" ;
+    prov:atLocation niiri:512c7eaa981cfb72974cfb868f502dd3 ;
+    prov:value "4.25063323974609"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.20220005940261"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000681911226584231"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999991679"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:512c7eaa981cfb72974cfb868f502dd3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0025" ;
+    nidm_coordinateVector: "[20,28,6]"^^xsd:string .
+
+niiri:0fa6e1dc1111a03b5e4039ea1ac7bb00 prov:wasDerivedFrom niiri:8fb299584020cc344c3c2c82de2f748c .
+
+niiri:ced62c2013b6703081946558916b11da
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0026" ;
+    prov:atLocation niiri:a829e3773a01f331491ad7d37354892f ;
+    prov:value "4.22958660125732"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.19200261281843"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000706450272937809"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999995163"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:a829e3773a01f331491ad7d37354892f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0026" ;
+    nidm_coordinateVector: "[44,26,40]"^^xsd:string .
+
+niiri:ced62c2013b6703081946558916b11da prov:wasDerivedFrom niiri:6e2110d791417b070202a6783afba19c .
+
+niiri:e47ab6c45400adc2077bdd0ae11df79c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0027" ;
+    prov:atLocation niiri:aa889a8c10c7df77f4c657a1ba5d6cc2 ;
+    prov:value "4.13231182098389"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.14429239999158"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000832444966141432"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999999966"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:aa889a8c10c7df77f4c657a1ba5d6cc2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0027" ;
+    nidm_coordinateVector: "[-32,-78,44]"^^xsd:string .
+
+niiri:e47ab6c45400adc2077bdd0ae11df79c prov:wasDerivedFrom niiri:b0fbdf26b837fa676d008fcff5a30ee9 .
+
+niiri:2b415d5e579030f0e97fe16ff764d1af
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0028" ;
+    prov:atLocation niiri:1a87f060e179e8d5d5fad75dee9e561e ;
+    prov:value "4.0775408744812"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.11700347232274"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000913497101264649"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999932"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:1a87f060e179e8d5d5fad75dee9e561e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0028" ;
+    nidm_coordinateVector: "[4,-54,-42]"^^xsd:string .
+
+niiri:2b415d5e579030f0e97fe16ff764d1af prov:wasDerivedFrom niiri:5167e145ebaf9f5693dffbc09df2f2f8 .
+
+niiri:a4068ca93949e6e3223a16b3e3bfeb42
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0029" ;
+    prov:atLocation niiri:e82cbbcc7b634200287898ef5f614f70 ;
+    prov:value "4.07394027709961"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.11519863095218"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000919105401866016"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999939"^^xsd:float ;
+    nidm_qValueFDR: "0.882167584555376"^^xsd:float .
+
+niiri:e82cbbcc7b634200287898ef5f614f70
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0029" ;
+    nidm_coordinateVector: "[34,14,56]"^^xsd:string .
+
+niiri:a4068ca93949e6e3223a16b3e3bfeb42 prov:wasDerivedFrom niiri:17c3abf712c940e8e07c2fa7b3493dc1 .
+

--- a/spmexport/ex_spm_covariate/nidm.ttl
+++ b/spmexport/ex_spm_covariate/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:3ccf008c518c3f0ebe9dea04f0edfbc4
+niiri:45de040124eabad18bf082b06af4cf9f
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:97c0efb1395126dbff029ae881c33b9d
+niiri:bcc842a0d3d70beef6bcd40987b89d9d
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:4ee63714952ef11034b1653f40760c75
+niiri:ef77e9af7b05e8005ba66d95bd38ec8f
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:4ee63714952ef11034b1653f40760c75 prov:wasAssociatedWith niiri:97c0efb1395126dbff029ae881c33b9d .
+niiri:ef77e9af7b05e8005ba66d95bd38ec8f prov:wasAssociatedWith niiri:bcc842a0d3d70beef6bcd40987b89d9d .
 
 _:blank5 a prov:Generation .
 
-niiri:3ccf008c518c3f0ebe9dea04f0edfbc4 prov:qualifiedGeneration _:blank5 .
+niiri:45de040124eabad18bf082b06af4cf9f prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:33:30"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:43:50"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -128,12 +128,12 @@ _:blank5 prov:atTime "2016-01-11T10:33:30"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:7cd23874d74598fb93575d0ca339d267
+niiri:2945a1d97a29c6969fdbf0eb195dc093
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:e7538b8eeead984e7d4168b9eb1e2185
+niiri:409379fe70cecdcc9766ed27de979ed5
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -143,171 +143,171 @@ niiri:e7538b8eeead984e7d4168b9eb1e2185
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:f0df94187254dffcef42f57c9a34f591
+niiri:760b84bdceecebaf15e2cf5a556d75af
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean .
 
-niiri:8cc550f78b4df2ff508e85441d0a1fd0
+niiri:e85d0cb7b322cd23c6939609e5b47e7f
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:83ee7456b6dda22712d37e10cc39a213 ;
+    dc:description niiri:1d81cc1b6e5d65b95679161506c7dc05 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"mean\", \"Subject ID Covariate\"]"^^xsd:string .
 
-niiri:83ee7456b6dda22712d37e10cc39a213
+niiri:1d81cc1b6e5d65b95679161506c7dc05
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:dc642cee82597b23a6938238a2d15373
+niiri:492d2e071c9917615b83dd40cee0a85c
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean .
 
-niiri:169c4819223a8702ebf9447665c6a242
+niiri:72cae3a8761174eff45f2a684fd4d0b1
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_OLS: .
 
-niiri:169c4819223a8702ebf9447665c6a242 prov:wasAssociatedWith niiri:7cd23874d74598fb93575d0ca339d267 .
+niiri:72cae3a8761174eff45f2a684fd4d0b1 prov:wasAssociatedWith niiri:2945a1d97a29c6969fdbf0eb195dc093 .
 
-niiri:169c4819223a8702ebf9447665c6a242 prov:used niiri:8cc550f78b4df2ff508e85441d0a1fd0 .
+niiri:72cae3a8761174eff45f2a684fd4d0b1 prov:used niiri:e85d0cb7b322cd23c6939609e5b47e7f .
 
-niiri:169c4819223a8702ebf9447665c6a242 prov:used niiri:f0df94187254dffcef42f57c9a34f591 .
+niiri:72cae3a8761174eff45f2a684fd4d0b1 prov:used niiri:760b84bdceecebaf15e2cf5a556d75af .
 
-niiri:169c4819223a8702ebf9447665c6a242 prov:used niiri:dc642cee82597b23a6938238a2d15373 .
+niiri:72cae3a8761174eff45f2a684fd4d0b1 prov:used niiri:492d2e071c9917615b83dd40cee0a85c .
 
-niiri:43e01138ea166419cf89ae0c1b960c02
+niiri:1195cb378c9921f7f84d3b3470aa3123
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     crypto:sha512 "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f"^^xsd:string .
 
-niiri:aa7e9876de1332712a7a6718e06772c7
+niiri:a7fa345aa6718eea856fe11c365866b0
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "e06c7e91d23253a8dffd3bb366d05851340e63a972bc08812d42cb46ea31fdad3063cca9559c6a372781a84a7a50c17cf4bbf65c515ce00580f79372cc763807"^^xsd:string .
 
-niiri:43e01138ea166419cf89ae0c1b960c02 prov:wasDerivedFrom niiri:aa7e9876de1332712a7a6718e06772c7 .
+niiri:1195cb378c9921f7f84d3b3470aa3123 prov:wasDerivedFrom niiri:a7fa345aa6718eea856fe11c365866b0 .
 
-niiri:43e01138ea166419cf89ae0c1b960c02 prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
+niiri:1195cb378c9921f7f84d3b3470aa3123 prov:wasGeneratedBy niiri:72cae3a8761174eff45f2a684fd4d0b1 .
 
-niiri:165ea688a4bf64576aaa4b9aefc18471
+niiri:0e03e7b35877063654d10de129520638
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "0.0173736633732915"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     crypto:sha512 "98952e02ac3f45da846d94deb554fad9126d6ba05b8ba745f176150b7b18bf2edee7efff67e7362f6704114b42ec7cb1d68fcde6005a829d52921961a4dad470"^^xsd:string .
 
-niiri:165ea688a4bf64576aaa4b9aefc18471 prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
+niiri:0e03e7b35877063654d10de129520638 prov:wasGeneratedBy niiri:72cae3a8761174eff45f2a684fd4d0b1 .
 
-niiri:f2d25df0f1d380a37ffc86ec505d0987
+niiri:d80b2820da42c9396e5e6b207065df30
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 .
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 .
 
-niiri:1d80b51894720953bd75f667c1e8d960
+niiri:8befeb0a5fd1f97a7809dd988bc128f6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "edde9f432759a7f2dad9ef0d3cb847eae532656aa81a7c08c76d939fe426e2e85329d56d0d279bf546773319599dd0bdf75b484d25083c8a2ac7ccb694a30e86"^^xsd:string .
 
-niiri:f2d25df0f1d380a37ffc86ec505d0987 prov:wasDerivedFrom niiri:1d80b51894720953bd75f667c1e8d960 .
+niiri:d80b2820da42c9396e5e6b207065df30 prov:wasDerivedFrom niiri:8befeb0a5fd1f97a7809dd988bc128f6 .
 
-niiri:f2d25df0f1d380a37ffc86ec505d0987 prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
+niiri:d80b2820da42c9396e5e6b207065df30 prov:wasGeneratedBy niiri:72cae3a8761174eff45f2a684fd4d0b1 .
 
-niiri:f89edafcbb5a3cc6c1e71d9a08caf49e
+niiri:d1b7bb7f417814f80571c1d2468e4000
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 .
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 .
 
-niiri:e06126279c6b3cc3de4edddb8525281c
+niiri:5d2dab2c3a026180cfd3a0dc830cf861
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "f54847aa8325ebc7e962e70e87b4ecc5cfc95e840fa0229889bfab2345836d6b6032c0d29f89f2bc95abc2581dfd7ad2af5833031d4c2974513717c3f0ec29f8"^^xsd:string .
 
-niiri:f89edafcbb5a3cc6c1e71d9a08caf49e prov:wasDerivedFrom niiri:e06126279c6b3cc3de4edddb8525281c .
+niiri:d1b7bb7f417814f80571c1d2468e4000 prov:wasDerivedFrom niiri:5d2dab2c3a026180cfd3a0dc830cf861 .
 
-niiri:f89edafcbb5a3cc6c1e71d9a08caf49e prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
+niiri:d1b7bb7f417814f80571c1d2468e4000 prov:wasGeneratedBy niiri:72cae3a8761174eff45f2a684fd4d0b1 .
 
-niiri:0dcb05747e20cb33a44bc7d7ca0576cb
+niiri:434990a2699db93362c651c0e066e61a
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     crypto:sha512 "693dd1daf261efafb742c7da149cccc8b7383b49e672358dd29c6bcd31a6ee983270e23c3f118d86b0758d86162d77033926cb1ae0f653efb0b7102c922ca40b"^^xsd:string .
 
-niiri:b6f9383af3eb3dc8144e7261991f9fb1
+niiri:122e25e1184c88c89124dde1d88e6cac
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "afca09bea5ebf5bceda101c9cb4d803de2cc2307b72a539454ce04e72ad6f655304b653779a287d3f38fca841819bf8126c51cb0a095e8710882e87d5eb7c565"^^xsd:string .
 
-niiri:0dcb05747e20cb33a44bc7d7ca0576cb prov:wasDerivedFrom niiri:b6f9383af3eb3dc8144e7261991f9fb1 .
+niiri:434990a2699db93362c651c0e066e61a prov:wasDerivedFrom niiri:122e25e1184c88c89124dde1d88e6cac .
 
-niiri:0dcb05747e20cb33a44bc7d7ca0576cb prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
+niiri:434990a2699db93362c651c0e066e61a prov:wasGeneratedBy niiri:72cae3a8761174eff45f2a684fd4d0b1 .
 
-niiri:dcbee28f8fa480eb84e376111f7b6875
+niiri:d305d0a8c1202e6daffd93b008bf5ffe
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     crypto:sha512 "58dcbf304825e142d28af1f78351fa5fa758ea20a597f7c117967af6a2d051d80f69686dc6858c0d6b1b677ff279e00d600772ce8175eae7a54dbedd0848bfd5"^^xsd:string .
 
-niiri:4cb25d713c24e1d3d5fa873ee3dbfceb
+niiri:322e9eaec41c80c26e1532dbfd6e16e0
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "42b06ae2316603cd1635234bdc474edf4cfac04b7ffe7acfe80221ee4cb3ecc0e6b514f5ebf1391df5ced6eb2fd5a91cd62a58ce1c4318ed4514eb8e1b41729b"^^xsd:string .
 
-niiri:dcbee28f8fa480eb84e376111f7b6875 prov:wasDerivedFrom niiri:4cb25d713c24e1d3d5fa873ee3dbfceb .
+niiri:d305d0a8c1202e6daffd93b008bf5ffe prov:wasDerivedFrom niiri:322e9eaec41c80c26e1532dbfd6e16e0 .
 
-niiri:dcbee28f8fa480eb84e376111f7b6875 prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
+niiri:d305d0a8c1202e6daffd93b008bf5ffe prov:wasGeneratedBy niiri:72cae3a8761174eff45f2a684fd4d0b1 .
 
-niiri:1d97aaaad1a6968e4783cd6214ee5179
+niiri:2c4731e21194b47e12dbaa51f4774b19
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     rdfs:label "Contrast: mr vs plain" ;
     prov:value "[1, 0]"^^xsd:string .
 
-niiri:54a8d8c7177e25879aa8c042805dfebe
+niiri:f6ee4e8755ba4fdf9b24d704a16de570
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:54a8d8c7177e25879aa8c042805dfebe prov:wasAssociatedWith niiri:7cd23874d74598fb93575d0ca339d267 .
+niiri:f6ee4e8755ba4fdf9b24d704a16de570 prov:wasAssociatedWith niiri:2945a1d97a29c6969fdbf0eb195dc093 .
 
-niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:43e01138ea166419cf89ae0c1b960c02 .
+niiri:f6ee4e8755ba4fdf9b24d704a16de570 prov:used niiri:1195cb378c9921f7f84d3b3470aa3123 .
 
-niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:0dcb05747e20cb33a44bc7d7ca0576cb .
+niiri:f6ee4e8755ba4fdf9b24d704a16de570 prov:used niiri:434990a2699db93362c651c0e066e61a .
 
-niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:8cc550f78b4df2ff508e85441d0a1fd0 .
+niiri:f6ee4e8755ba4fdf9b24d704a16de570 prov:used niiri:e85d0cb7b322cd23c6939609e5b47e7f .
 
-niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:1d97aaaad1a6968e4783cd6214ee5179 .
+niiri:f6ee4e8755ba4fdf9b24d704a16de570 prov:used niiri:2c4731e21194b47e12dbaa51f4774b19 .
 
-niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:f2d25df0f1d380a37ffc86ec505d0987 .
+niiri:f6ee4e8755ba4fdf9b24d704a16de570 prov:used niiri:d80b2820da42c9396e5e6b207065df30 .
 
-niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:f89edafcbb5a3cc6c1e71d9a08caf49e .
+niiri:f6ee4e8755ba4fdf9b24d704a16de570 prov:used niiri:d1b7bb7f417814f80571c1d2468e4000 .
 
-niiri:78c3a55d6161c2415d14067b8c63d784
+niiri:5b25a9567dcc3b650c8a24dae9143e2a
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -317,124 +317,124 @@ niiri:78c3a55d6161c2415d14067b8c63d784
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "11"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     crypto:sha512 "370387f786b51f404f6ca9acd10c4e35fbac46e4f5ec42750cf05c4236bda63dc8c003dea0989fd6c397d05d2e46bf0e0685ef08fa143418c0f1fdc3e7fe0d8b"^^xsd:string .
 
-niiri:40a16c560c78731e96db83110db91267
+niiri:5af84637cd56e9820875877b470b1ed9
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "489d1d288d622546f52d846311adfd3c6b7a5a604e0356335c997c6c7c2cfdf648e312383d151343007194e94ae8e681af5c7c1c0f69754126dd9561cbcf622b"^^xsd:string .
 
-niiri:78c3a55d6161c2415d14067b8c63d784 prov:wasDerivedFrom niiri:40a16c560c78731e96db83110db91267 .
+niiri:5b25a9567dcc3b650c8a24dae9143e2a prov:wasDerivedFrom niiri:5af84637cd56e9820875877b470b1ed9 .
 
-niiri:78c3a55d6161c2415d14067b8c63d784 prov:wasGeneratedBy niiri:54a8d8c7177e25879aa8c042805dfebe .
+niiri:5b25a9567dcc3b650c8a24dae9143e2a prov:wasGeneratedBy niiri:f6ee4e8755ba4fdf9b24d704a16de570 .
 
-niiri:3becd9191b28badb59abfebfeab96ef5
+niiri:6d499cb898fe23d15aa58d3eab006246
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: mr vs plain" ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     crypto:sha512 "ab6e3d990747f48517f1cf7eb1dd7dd0e973d4f5b7f468963c982c906f3dfcafa7c056c8f34d9f54c10330a67ab92b7f7ab3d95781a568b7fbaddf9f17746216"^^xsd:string .
 
-niiri:78c411926e48aaf00a21986fb6b38f41
+niiri:d242c1285ba53499604f20d0affe4f65
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "9dc48e80c35ac0d74eb3131bab4e8cac2db2df834fef3c5cb6ddb5d91082d573d885a8e703a03652b5745f3f52b0e3397feb130f3ebccae549142ce88c29cb59"^^xsd:string .
 
-niiri:3becd9191b28badb59abfebfeab96ef5 prov:wasDerivedFrom niiri:78c411926e48aaf00a21986fb6b38f41 .
+niiri:6d499cb898fe23d15aa58d3eab006246 prov:wasDerivedFrom niiri:d242c1285ba53499604f20d0affe4f65 .
 
-niiri:3becd9191b28badb59abfebfeab96ef5 prov:wasGeneratedBy niiri:54a8d8c7177e25879aa8c042805dfebe .
+niiri:6d499cb898fe23d15aa58d3eab006246 prov:wasGeneratedBy niiri:f6ee4e8755ba4fdf9b24d704a16de570 .
 
-niiri:e74be4649036d7e5c6372c0258817b2b
+niiri:34a7586b80f7bf5ce094767d3ba869ab
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     crypto:sha512 "a36854cf6dd56807c2a335d31d64f3f265785b7b573115e7cfaec97da31078aad22aa084ac09c3a550605f550228a781457821df43845b7a92c8b375bc9ac9dc"^^xsd:string .
 
-niiri:e74be4649036d7e5c6372c0258817b2b prov:wasGeneratedBy niiri:54a8d8c7177e25879aa8c042805dfebe .
+niiri:34a7586b80f7bf5ce094767d3ba869ab prov:wasGeneratedBy niiri:f6ee4e8755ba4fdf9b24d704a16de570 .
 
-niiri:5fc89d76faab61ee021d9cc78f0fd0b5
+niiri:68e44305e604cf88c0d764b51cb9fe97
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500148243682"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:550ff496a1f20b888585d452cf21e219 ;
-    nidm_equivalentThreshold: niiri:268cc3d07350375a06d59e1c72255036 .
+    nidm_equivalentThreshold: niiri:2223afd924dcb113734f5902000d3753 ;
+    nidm_equivalentThreshold: niiri:5fc7d7e81dd2b8f2b501110577cfd4ba .
 
-niiri:550ff496a1f20b888585d452cf21e219
+niiri:2223afd924dcb113734f5902000d3753
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.02470104841152"^^xsd:float .
 
-niiri:268cc3d07350375a06d59e1c72255036
+niiri:5fc7d7e81dd2b8f2b501110577cfd4ba
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999999987"^^xsd:float .
 
-niiri:fb431b6d009d90dc5f369aadeb468547
+niiri:1a36474c8ecdb3f7acb6a0e94b5c25bc
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:bbb30eb0dc56085d0bb3b8f32e1aa7d8 ;
-    nidm_equivalentThreshold: niiri:6af35793d4c30300501f6e4843ea64f9 .
+    nidm_equivalentThreshold: niiri:63a8882dc3fb7ed503d53c8d4d7c9008 ;
+    nidm_equivalentThreshold: niiri:5be7edeaa9ac59ad8714d616ca536732 .
 
-niiri:bbb30eb0dc56085d0bb3b8f32e1aa7d8
+niiri:63a8882dc3fb7ed503d53c8d4d7c9008
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:6af35793d4c30300501f6e4843ea64f9
+niiri:5be7edeaa9ac59ad8714d616ca536732
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:e3fc10780da51f8073baec6993b81559
+niiri:ee437a13fde8be91f28ac815bfbe3422
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:a7fcffe68706a024505ad48123a3a597
+niiri:5eeb434f1becae361edcf7a5c6cc4062
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:f74ee55215d923c382e467dc5985637f
+niiri:a0391f9b196095c360c805f7bed84e2e
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:f74ee55215d923c382e467dc5985637f prov:wasAssociatedWith niiri:7cd23874d74598fb93575d0ca339d267 .
+niiri:a0391f9b196095c360c805f7bed84e2e prov:wasAssociatedWith niiri:2945a1d97a29c6969fdbf0eb195dc093 .
 
-niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:5fc89d76faab61ee021d9cc78f0fd0b5 .
+niiri:a0391f9b196095c360c805f7bed84e2e prov:used niiri:68e44305e604cf88c0d764b51cb9fe97 .
 
-niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:fb431b6d009d90dc5f369aadeb468547 .
+niiri:a0391f9b196095c360c805f7bed84e2e prov:used niiri:1a36474c8ecdb3f7acb6a0e94b5c25bc .
 
-niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:78c3a55d6161c2415d14067b8c63d784 .
+niiri:a0391f9b196095c360c805f7bed84e2e prov:used niiri:5b25a9567dcc3b650c8a24dae9143e2a .
 
-niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:dcbee28f8fa480eb84e376111f7b6875 .
+niiri:a0391f9b196095c360c805f7bed84e2e prov:used niiri:d305d0a8c1202e6daffd93b008bf5ffe .
 
-niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:43e01138ea166419cf89ae0c1b960c02 .
+niiri:a0391f9b196095c360c805f7bed84e2e prov:used niiri:1195cb378c9921f7f84d3b3470aa3123 .
 
-niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:e3fc10780da51f8073baec6993b81559 .
+niiri:a0391f9b196095c360c805f7bed84e2e prov:used niiri:ee437a13fde8be91f28ac815bfbe3422 .
 
-niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:a7fcffe68706a024505ad48123a3a597 .
+niiri:a0391f9b196095c360c805f7bed84e2e prov:used niiri:5eeb434f1becae361edcf7a5c6cc4062 .
 
-niiri:4210503ffa69b7e56d701bcba7b1b2df
+niiri:6194b4183f7a41c54d073c56dc64f4d5
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     nidm_searchVolumeInVoxels: "162104"^^xsd:int ;
     nidm_searchVolumeInUnits: "1296832"^^xsd:float ;
     nidm_reselSizeInVoxels: "95.2875561406722"^^xsd:float ;
@@ -451,9 +451,9 @@ niiri:4210503ffa69b7e56d701bcba7b1b2df
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f"^^xsd:string .
 
-niiri:4210503ffa69b7e56d701bcba7b1b2df prov:wasGeneratedBy niiri:f74ee55215d923c382e467dc5985637f .
+niiri:6194b4183f7a41c54d073c56dc64f4d5 prov:wasGeneratedBy niiri:a0391f9b196095c360c805f7bed84e2e .
 
-niiri:ff2b188fd5ef195057b9076462d97f0c
+niiri:603e00a935726a95290a8c8be9f450ba
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -461,26 +461,26 @@ niiri:ff2b188fd5ef195057b9076462d97f0c
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "29"^^xsd:int ;
     nidm_pValue: "0.722893095431427"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:3fe999af53b6ff1062dd11597b4540ec ;
-    nidm_hasMaximumIntensityProjection: niiri:ec2532bdcd7e520faba8a90cf9625856 ;
-    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
+    nidm_hasClusterLabelsMap: niiri:441086d357ed3f71cb532625cad214bc ;
+    nidm_hasMaximumIntensityProjection: niiri:27fe9e4be467254559329cf4e39595d2 ;
+    nidm_inCoordinateSpace: niiri:409379fe70cecdcc9766ed27de979ed5 ;
     crypto:sha512 "2bbcc39452bb1127d7205b05c820b5d31d5e2daa43e4ba6ccaf43c229aa7d708af405aff650daa9a08b3582c5aa013e32a6535188542c9c1fc3fa24fcc03c59c"^^xsd:string .
 
-niiri:3fe999af53b6ff1062dd11597b4540ec
+niiri:441086d357ed3f71cb532625cad214bc
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:ec2532bdcd7e520faba8a90cf9625856
+niiri:27fe9e4be467254559329cf4e39595d2
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:ff2b188fd5ef195057b9076462d97f0c prov:wasGeneratedBy niiri:f74ee55215d923c382e467dc5985637f .
+niiri:603e00a935726a95290a8c8be9f450ba prov:wasGeneratedBy niiri:a0391f9b196095c360c805f7bed84e2e .
 
-niiri:be91aa057bdd9d8651b94a428f9d7e04
+niiri:f5f1d4e01916e6d7ca48255a18330b17
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -490,9 +490,9 @@ niiri:be91aa057bdd9d8651b94a428f9d7e04
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:be91aa057bdd9d8651b94a428f9d7e04 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:f5f1d4e01916e6d7ca48255a18330b17 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:8c1f835fe33bb35a741db5d71610f74d
+niiri:3b69500b101d653d5a95b9cd8e1d8c26
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -502,9 +502,9 @@ niiri:8c1f835fe33bb35a741db5d71610f74d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:8c1f835fe33bb35a741db5d71610f74d prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:3b69500b101d653d5a95b9cd8e1d8c26 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:427a5e18f5920cd494cd57b5222b9804
+niiri:b150dfb21a962c7e0e9abd29a9e66209
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -514,9 +514,9 @@ niiri:427a5e18f5920cd494cd57b5222b9804
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:427a5e18f5920cd494cd57b5222b9804 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:b150dfb21a962c7e0e9abd29a9e66209 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:8cd69d4c2bcb674537c0f59674d850f8
+niiri:573fad7099031cdb5c6aaf454eebae12
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -526,9 +526,9 @@ niiri:8cd69d4c2bcb674537c0f59674d850f8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:8cd69d4c2bcb674537c0f59674d850f8 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:573fad7099031cdb5c6aaf454eebae12 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:1c094c13c4622d206afcab0831c06c8e
+niiri:17c644af5b5b69ce4e55ce54602fbe9b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -538,9 +538,9 @@ niiri:1c094c13c4622d206afcab0831c06c8e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:1c094c13c4622d206afcab0831c06c8e prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:17c644af5b5b69ce4e55ce54602fbe9b prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:d03fb3a214226f8e359063dd56622b80
+niiri:426152dfa5cb1a1dc5a196231796f1b9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -550,9 +550,9 @@ niiri:d03fb3a214226f8e359063dd56622b80
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:d03fb3a214226f8e359063dd56622b80 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:426152dfa5cb1a1dc5a196231796f1b9 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:08acd9d5e3c86a5597634b63f9ca5b76
+niiri:3bb14948c48d4d39919bbb810b678d69
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -562,9 +562,9 @@ niiri:08acd9d5e3c86a5597634b63f9ca5b76
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:08acd9d5e3c86a5597634b63f9ca5b76 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:3bb14948c48d4d39919bbb810b678d69 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:33fdb3dcbde308077cb41f61bbb538d4
+niiri:b134ec4fcd225723830f850e07a638db
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -574,9 +574,9 @@ niiri:33fdb3dcbde308077cb41f61bbb538d4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:33fdb3dcbde308077cb41f61bbb538d4 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:b134ec4fcd225723830f850e07a638db prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:a1dfe524338b100e2c0b4aac79347135
+niiri:49e454729692bc106178637c8a22c617
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -586,9 +586,9 @@ niiri:a1dfe524338b100e2c0b4aac79347135
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:a1dfe524338b100e2c0b4aac79347135 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:49e454729692bc106178637c8a22c617 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:398e18e13e41fd86f9c91a0c37179f94
+niiri:1e8f7a14eb802923b15d73f67fed2575
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -598,9 +598,9 @@ niiri:398e18e13e41fd86f9c91a0c37179f94
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:398e18e13e41fd86f9c91a0c37179f94 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:1e8f7a14eb802923b15d73f67fed2575 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:fc5a20643a49d6b48c632806b9fb3669
+niiri:1b36259af3067ed47d1d36c7f3e5ae9f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -610,9 +610,9 @@ niiri:fc5a20643a49d6b48c632806b9fb3669
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:fc5a20643a49d6b48c632806b9fb3669 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:1b36259af3067ed47d1d36c7f3e5ae9f prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:7977d3c2d53495076863f90a7414369f
+niiri:daf9bb1cc9f9b0e02d75aa15c8b779c7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -622,9 +622,9 @@ niiri:7977d3c2d53495076863f90a7414369f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:7977d3c2d53495076863f90a7414369f prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:daf9bb1cc9f9b0e02d75aa15c8b779c7 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:e6d67f5c8f427474527d0d727f3dce58
+niiri:347d8082d0347a8c8c0664045f8487c2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -634,9 +634,9 @@ niiri:e6d67f5c8f427474527d0d727f3dce58
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:e6d67f5c8f427474527d0d727f3dce58 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:347d8082d0347a8c8c0664045f8487c2 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:9ba6b697c18c9fa2a070f1ac777899c3
+niiri:ce8982e550edd698ed8c7acdaac90be2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -646,9 +646,9 @@ niiri:9ba6b697c18c9fa2a070f1ac777899c3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:9ba6b697c18c9fa2a070f1ac777899c3 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:ce8982e550edd698ed8c7acdaac90be2 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:17cf04133d00b334b009343c68cc794f
+niiri:177ff2c2e855c609bb6a99b368bab6b4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -658,9 +658,9 @@ niiri:17cf04133d00b334b009343c68cc794f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:17cf04133d00b334b009343c68cc794f prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:177ff2c2e855c609bb6a99b368bab6b4 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:715dbdcf861d88449d6bf9fd80be68c2
+niiri:301c22bdebf70b67d36aa2cc2edd7c6e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -670,9 +670,9 @@ niiri:715dbdcf861d88449d6bf9fd80be68c2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:715dbdcf861d88449d6bf9fd80be68c2 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:301c22bdebf70b67d36aa2cc2edd7c6e prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:a722ba5c3f48104c4bffaa9f1bc96e93
+niiri:a4f97ce3e351468a0b599542e9fe1960
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -682,9 +682,9 @@ niiri:a722ba5c3f48104c4bffaa9f1bc96e93
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:a722ba5c3f48104c4bffaa9f1bc96e93 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:a4f97ce3e351468a0b599542e9fe1960 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:0aa4b1a84fee2649d333d5561003c8bf
+niiri:9eeed673f0f6da15d5140c5984d28a3c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -694,9 +694,9 @@ niiri:0aa4b1a84fee2649d333d5561003c8bf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:0aa4b1a84fee2649d333d5561003c8bf prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:9eeed673f0f6da15d5140c5984d28a3c prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:5b1d37cc88f4111dc6ae2a4f48520a59
+niiri:6d6f7c13ffe51614573bd56d21ff26a7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -706,9 +706,9 @@ niiri:5b1d37cc88f4111dc6ae2a4f48520a59
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:5b1d37cc88f4111dc6ae2a4f48520a59 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:6d6f7c13ffe51614573bd56d21ff26a7 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:7a1feca53667470e0f2534f053958e05
+niiri:c7b43074794c90965e68f71cc444780a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -718,9 +718,9 @@ niiri:7a1feca53667470e0f2534f053958e05
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:7a1feca53667470e0f2534f053958e05 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:c7b43074794c90965e68f71cc444780a prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:bda46dfc41022916ad6faceac091ba3d
+niiri:c41d10c310919c8cbe2d4327dda739c9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -730,9 +730,9 @@ niiri:bda46dfc41022916ad6faceac091ba3d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:bda46dfc41022916ad6faceac091ba3d prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:c41d10c310919c8cbe2d4327dda739c9 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:0c786e61d78880c4e546692954781ced
+niiri:8cd4eb873cc68bc694b905aebcc585c9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -742,9 +742,9 @@ niiri:0c786e61d78880c4e546692954781ced
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:0c786e61d78880c4e546692954781ced prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:8cd4eb873cc68bc694b905aebcc585c9 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:b9a4c4c2b5a9793a35534927d9578f48
+niiri:93093df2bfed236a073657264fcfd67a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -754,9 +754,9 @@ niiri:b9a4c4c2b5a9793a35534927d9578f48
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:b9a4c4c2b5a9793a35534927d9578f48 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:93093df2bfed236a073657264fcfd67a prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:f4849377c56edcbca1dc5384795946ce
+niiri:f78564c27b61dd4e46b3be31141d54a7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -766,9 +766,9 @@ niiri:f4849377c56edcbca1dc5384795946ce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:f4849377c56edcbca1dc5384795946ce prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:f78564c27b61dd4e46b3be31141d54a7 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:6ad64a79d36f37c1cd1b1433a1aef9ca
+niiri:f395049f71ae2e104b9b26062c56431a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -778,9 +778,9 @@ niiri:6ad64a79d36f37c1cd1b1433a1aef9ca
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:6ad64a79d36f37c1cd1b1433a1aef9ca prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:f395049f71ae2e104b9b26062c56431a prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:50d65ffbbedadcbcef20b8bacaa5bf32
+niiri:b3217b4acb17a2036c4b69c3b751a912
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -790,9 +790,9 @@ niiri:50d65ffbbedadcbcef20b8bacaa5bf32
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:50d65ffbbedadcbcef20b8bacaa5bf32 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:b3217b4acb17a2036c4b69c3b751a912 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:57ec9ce901bb55b112e2f594ad471e7a
+niiri:9178c692ea33d50b8bc90323fbe1561d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -802,9 +802,9 @@ niiri:57ec9ce901bb55b112e2f594ad471e7a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:57ec9ce901bb55b112e2f594ad471e7a prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:9178c692ea33d50b8bc90323fbe1561d prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:1318d2cd1289a2678d066b7cca2986f1
+niiri:1b4bb4acb913740f6b3863891a7115fa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -814,9 +814,9 @@ niiri:1318d2cd1289a2678d066b7cca2986f1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:1318d2cd1289a2678d066b7cca2986f1 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:1b4bb4acb913740f6b3863891a7115fa prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea
+niiri:6d4c71c4ef585e41f24f639435b05026
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -826,498 +826,498 @@ niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
+niiri:6d4c71c4ef585e41f24f639435b05026 prov:wasDerivedFrom niiri:603e00a935726a95290a8c8be9f450ba .
 
-niiri:da098c4cc640a214fd988ad023eb1a86
+niiri:e2cfe5ed77eeb785cbdfcadbf53cc939
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:ba3f25e2c5e1f415cd2525e4abcdb621 ;
+    prov:atLocation niiri:5f9a71f50fd0545689636058d7b3c54a ;
     prov:value "6.37317276000977"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04320073372639"^^xsd:float ;
     nidm_pValueUncorrected: "2.63632212645915e-05"^^xsd:float ;
     nidm_pValueFWER: "0.958902832016109"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:ba3f25e2c5e1f415cd2525e4abcdb621
+niiri:5f9a71f50fd0545689636058d7b3c54a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[28,-36,38]"^^xsd:string .
 
-niiri:da098c4cc640a214fd988ad023eb1a86 prov:wasDerivedFrom niiri:be91aa057bdd9d8651b94a428f9d7e04 .
+niiri:e2cfe5ed77eeb785cbdfcadbf53cc939 prov:wasDerivedFrom niiri:f5f1d4e01916e6d7ca48255a18330b17 .
 
-niiri:3f041463e58131d17c3adb62ae04b812
+niiri:d6deaaace8f041e7c21070e3e51ad1f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:96c5c034a22620ddcd2779d651b4b97e ;
+    prov:atLocation niiri:befaea8bb8709990399405a4dd53e15d ;
     prov:value "5.69066715240479"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8079805415517"^^xsd:float ;
     nidm_pValueUncorrected: "7.00531473561972e-05"^^xsd:float ;
     nidm_pValueFWER: "0.997756103851125"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:96c5c034a22620ddcd2779d651b4b97e
+niiri:befaea8bb8709990399405a4dd53e15d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[10,-48,16]"^^xsd:string .
 
-niiri:3f041463e58131d17c3adb62ae04b812 prov:wasDerivedFrom niiri:8c1f835fe33bb35a741db5d71610f74d .
+niiri:d6deaaace8f041e7c21070e3e51ad1f7 prov:wasDerivedFrom niiri:3b69500b101d653d5a95b9cd8e1d8c26 .
 
-niiri:7b61b8562a0fa2a8fc1be01625db2383
+niiri:808815ce2b1dbc4f7d41f4aa99e3424c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:709ff8ac6d109875a6c00824a37dec97 ;
+    prov:atLocation niiri:a8e9b7b4871a6d92e701777264d774df ;
     prov:value "5.404944896698"^^xsd:float ;
     nidm_equivalentZStatistic: "3.70067578615084"^^xsd:float ;
     nidm_pValueUncorrected: "0.000107513031460726"^^xsd:float ;
     nidm_pValueFWER: "0.999684183052173"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:709ff8ac6d109875a6c00824a37dec97
+niiri:a8e9b7b4871a6d92e701777264d774df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-34,-6,-32]"^^xsd:string .
 
-niiri:7b61b8562a0fa2a8fc1be01625db2383 prov:wasDerivedFrom niiri:427a5e18f5920cd494cd57b5222b9804 .
+niiri:808815ce2b1dbc4f7d41f4aa99e3424c prov:wasDerivedFrom niiri:b150dfb21a962c7e0e9abd29a9e66209 .
 
-niiri:1e33617f26a669bbc5d4a8e1a84861df
+niiri:4151ef564a41037621a331a0a83294e2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:ef91d2750f81ce9286534c4378095103 ;
+    prov:atLocation niiri:9d61098f81fb83b7ce5bd351f33c5408 ;
     prov:value "5.20687818527222"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62288194485815"^^xsd:float ;
     nidm_pValueUncorrected: "0.000145669405598126"^^xsd:float ;
     nidm_pValueFWER: "0.999944545222406"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:ef91d2750f81ce9286534c4378095103
+niiri:9d61098f81fb83b7ce5bd351f33c5408
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-28,-80,24]"^^xsd:string .
 
-niiri:1e33617f26a669bbc5d4a8e1a84861df prov:wasDerivedFrom niiri:8cd69d4c2bcb674537c0f59674d850f8 .
+niiri:4151ef564a41037621a331a0a83294e2 prov:wasDerivedFrom niiri:573fad7099031cdb5c6aaf454eebae12 .
 
-niiri:f9aa7f4153c94329f57f5a213c31ad9d
+niiri:de00a0adf87aa924896cf169dcdd412b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:a01b0efba27795b5259e72e8b06cc19e ;
+    prov:atLocation niiri:20e542b21d056af04265ebcd2ab4f619 ;
     prov:value "4.90865421295166"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50007991972101"^^xsd:float ;
     nidm_pValueUncorrected: "0.000232559344231609"^^xsd:float ;
     nidm_pValueFWER: "0.999998126675029"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:a01b0efba27795b5259e72e8b06cc19e
+niiri:20e542b21d056af04265ebcd2ab4f619
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[-12,-32,28]"^^xsd:string .
 
-niiri:f9aa7f4153c94329f57f5a213c31ad9d prov:wasDerivedFrom niiri:1c094c13c4622d206afcab0831c06c8e .
+niiri:de00a0adf87aa924896cf169dcdd412b prov:wasDerivedFrom niiri:17c644af5b5b69ce4e55ce54602fbe9b .
 
-niiri:afa5a345b8d55093f5d0ff485e694dbf
+niiri:df65340173edc841ee99d737a7cb58fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:2f8f1cfad3185761941c0d73d52f473c ;
+    prov:atLocation niiri:c520b70ebbf65091d2c03a8ab0531b2a ;
     prov:value "4.84440040588379"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47268080874189"^^xsd:float ;
     nidm_pValueUncorrected: "0.000257643895570592"^^xsd:float ;
     nidm_pValueFWER: "0.999999219649123"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:2f8f1cfad3185761941c0d73d52f473c
+niiri:c520b70ebbf65091d2c03a8ab0531b2a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[-18,-76,-12]"^^xsd:string .
 
-niiri:afa5a345b8d55093f5d0ff485e694dbf prov:wasDerivedFrom niiri:d03fb3a214226f8e359063dd56622b80 .
+niiri:df65340173edc841ee99d737a7cb58fb prov:wasDerivedFrom niiri:426152dfa5cb1a1dc5a196231796f1b9 .
 
-niiri:60a2332e10d9170f38d2463aeabd0113
+niiri:e0b16b87724af90af0fc9b76cb42b530
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:8c54f00fb0e08af1fb95533f64c42abe ;
+    prov:atLocation niiri:254f2a6f22601b8d930470c21aaff838 ;
     prov:value "4.84136772155762"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47137907963827"^^xsd:float ;
     nidm_pValueUncorrected: "0.000258896237096851"^^xsd:float ;
     nidm_pValueFWER: "0.999999252321799"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:8c54f00fb0e08af1fb95533f64c42abe
+niiri:254f2a6f22601b8d930470c21aaff838
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[32,16,40]"^^xsd:string .
 
-niiri:60a2332e10d9170f38d2463aeabd0113 prov:wasDerivedFrom niiri:08acd9d5e3c86a5597634b63f9ca5b76 .
+niiri:e0b16b87724af90af0fc9b76cb42b530 prov:wasDerivedFrom niiri:3bb14948c48d4d39919bbb810b678d69 .
 
-niiri:79e0ce1a82f0e80e09c1b5064a2d60b2
+niiri:0a67ef9acb1f1ff9deae962c3f59e058
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:80f6cd9cf5fcdd939d578cbb14fba341 ;
+    prov:atLocation niiri:f4ab90a76994db235ca411f9aae6ecb5 ;
     prov:value "4.78605508804321"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4475005479143"^^xsd:float ;
     nidm_pValueUncorrected: "0.000282899629741595"^^xsd:float ;
     nidm_pValueFWER: "0.999999665309186"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:80f6cd9cf5fcdd939d578cbb14fba341
+niiri:f4ab90a76994db235ca411f9aae6ecb5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-26,-78,46]"^^xsd:string .
 
-niiri:79e0ce1a82f0e80e09c1b5064a2d60b2 prov:wasDerivedFrom niiri:33fdb3dcbde308077cb41f61bbb538d4 .
+niiri:0a67ef9acb1f1ff9deae962c3f59e058 prov:wasDerivedFrom niiri:b134ec4fcd225723830f850e07a638db .
 
-niiri:33896a562b3020901f0a9129b329ca9f
+niiri:3dd0f864a494cf502a0434e761e33ca5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:46882cfa883eb6417029f9e14cfcd78d ;
+    prov:atLocation niiri:10fe67cdad3e4f781e2c7e43edd65095 ;
     prov:value "4.75920820236206"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43581665930553"^^xsd:float ;
     nidm_pValueUncorrected: "0.000295385308778928"^^xsd:float ;
     nidm_pValueFWER: "0.999999777160537"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:46882cfa883eb6417029f9e14cfcd78d
+niiri:10fe67cdad3e4f781e2c7e43edd65095
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-50,-2,42]"^^xsd:string .
 
-niiri:33896a562b3020901f0a9129b329ca9f prov:wasDerivedFrom niiri:a1dfe524338b100e2c0b4aac79347135 .
+niiri:3dd0f864a494cf502a0434e761e33ca5 prov:wasDerivedFrom niiri:49e454729692bc106178637c8a22c617 .
 
-niiri:0a36f87ab7a0b75562073c6947d4f7b1
+niiri:3d4492db78b206abfae38aa443db976d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:7573b7d12c8d035c9d5d8631ccb22a9f ;
+    prov:atLocation niiri:66e160264c8d2ad9e63e0993ef7db059 ;
     prov:value "4.70320177078247"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41124192966355"^^xsd:float ;
     nidm_pValueUncorrected: "0.000323338426391984"^^xsd:float ;
     nidm_pValueFWER: "0.999999908044234"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:7573b7d12c8d035c9d5d8631ccb22a9f
+niiri:66e160264c8d2ad9e63e0993ef7db059
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[22,-34,34]"^^xsd:string .
 
-niiri:0a36f87ab7a0b75562073c6947d4f7b1 prov:wasDerivedFrom niiri:398e18e13e41fd86f9c91a0c37179f94 .
+niiri:3d4492db78b206abfae38aa443db976d prov:wasDerivedFrom niiri:1e8f7a14eb802923b15d73f67fed2575 .
 
-niiri:6eab38ddecebcaaa0bf86b72dc12049c
+niiri:f72ddbae1cb1b90cdbae2561e91e7dd6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:7f68e73a36ee3f3687de8c6c9b97a7fe ;
+    prov:atLocation niiri:c90170c4b1ea8d90df2f75d439bd1458 ;
     prov:value "4.65910387039185"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39169946109688"^^xsd:float ;
     nidm_pValueUncorrected: "0.000347302923845438"^^xsd:float ;
     nidm_pValueFWER: "0.999999955827132"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:7f68e73a36ee3f3687de8c6c9b97a7fe
+niiri:c90170c4b1ea8d90df2f75d439bd1458
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-20,-44,-36]"^^xsd:string .
 
-niiri:6eab38ddecebcaaa0bf86b72dc12049c prov:wasDerivedFrom niiri:fc5a20643a49d6b48c632806b9fb3669 .
+niiri:f72ddbae1cb1b90cdbae2561e91e7dd6 prov:wasDerivedFrom niiri:1b36259af3067ed47d1d36c7f3e5ae9f .
 
-niiri:8dff42675f00ab4b9ddd2b53dc34917f
+niiri:d3292a0cd20db9459beffd1223b81b88
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:7eab74d15593b8c8ffc29b17ea34173f ;
+    prov:atLocation niiri:1dbfcefb9aa3c60bd7bf1c4397bd0869 ;
     prov:value "4.63754796981812"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38208413500926"^^xsd:float ;
     nidm_pValueUncorrected: "0.00035969054090712"^^xsd:float ;
     nidm_pValueFWER: "0.999999969503"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:7eab74d15593b8c8ffc29b17ea34173f
+niiri:1dbfcefb9aa3c60bd7bf1c4397bd0869
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[34,-22,26]"^^xsd:string .
 
-niiri:8dff42675f00ab4b9ddd2b53dc34917f prov:wasDerivedFrom niiri:7977d3c2d53495076863f90a7414369f .
+niiri:d3292a0cd20db9459beffd1223b81b88 prov:wasDerivedFrom niiri:daf9bb1cc9f9b0e02d75aa15c8b779c7 .
 
-niiri:69505c505831c5f7ad6ff3002082e4c0
+niiri:82bbc3be044d029a5cff801aca3fe5de
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:dc677f45978a7877a700f4d03cf0e7ce ;
+    prov:atLocation niiri:31a39306eff8328690edee3d6e2f49ca ;
     prov:value "4.61526584625244"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37210130568973"^^xsd:float ;
     nidm_pValueUncorrected: "0.000372985020458683"^^xsd:float ;
     nidm_pValueFWER: "0.999999979383511"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:dc677f45978a7877a700f4d03cf0e7ce
+niiri:31a39306eff8328690edee3d6e2f49ca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-8,-24,-20]"^^xsd:string .
 
-niiri:69505c505831c5f7ad6ff3002082e4c0 prov:wasDerivedFrom niiri:e6d67f5c8f427474527d0d727f3dce58 .
+niiri:82bbc3be044d029a5cff801aca3fe5de prov:wasDerivedFrom niiri:347d8082d0347a8c8c0664045f8487c2 .
 
-niiri:07fc7144bacb9a33351978163ec7665f
+niiri:cf7b82d2756ddb040ecfdf69ad8ee9d4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:2aa908545a5498195b685e803d760c2a ;
+    prov:atLocation niiri:3711399f5ab94dade9a21c0b0dcbcccc ;
     prov:value "4.51868915557861"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32831433156359"^^xsd:float ;
     nidm_pValueUncorrected: "0.000436866114896683"^^xsd:float ;
     nidm_pValueFWER: "0.999999996599993"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:2aa908545a5498195b685e803d760c2a
+niiri:3711399f5ab94dade9a21c0b0dcbcccc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[10,-12,-8]"^^xsd:string .
 
-niiri:07fc7144bacb9a33351978163ec7665f prov:wasDerivedFrom niiri:9ba6b697c18c9fa2a070f1ac777899c3 .
+niiri:cf7b82d2756ddb040ecfdf69ad8ee9d4 prov:wasDerivedFrom niiri:ce8982e550edd698ed8c7acdaac90be2 .
 
-niiri:2a7de24428d3d14a74344f3a2ed53ab9
+niiri:3d1403940f81e99c4b7eb7ed3ba9d7d4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:402ce4265cfb6d8f4eccfcd7202c27c6 ;
+    prov:atLocation niiri:217ec3b736b83b2a5614463d4fe0ce06 ;
     prov:value "4.45568466186523"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2992865242182"^^xsd:float ;
     nidm_pValueUncorrected: "0.000484654601471068"^^xsd:float ;
     nidm_pValueFWER: "0.999999999048352"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:402ce4265cfb6d8f4eccfcd7202c27c6
+niiri:217ec3b736b83b2a5614463d4fe0ce06
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[16,-48,-46]"^^xsd:string .
 
-niiri:2a7de24428d3d14a74344f3a2ed53ab9 prov:wasDerivedFrom niiri:17cf04133d00b334b009343c68cc794f .
+niiri:3d1403940f81e99c4b7eb7ed3ba9d7d4 prov:wasDerivedFrom niiri:177ff2c2e855c609bb6a99b368bab6b4 .
 
-niiri:71a4d25f7fb9dd5f2ff89ce4a6426ed6
+niiri:16189a2299f27429558ef4834d1c5aa3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:170bf99fa55adf19b4bcf6bac2226035 ;
+    prov:atLocation niiri:c622ec0e155af693ff91a96a7779c4fd ;
     prov:value "4.42093467712402"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28311730425125"^^xsd:float ;
     nidm_pValueUncorrected: "0.000513329675929763"^^xsd:float ;
     nidm_pValueFWER: "0.999999999544708"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:170bf99fa55adf19b4bcf6bac2226035
+niiri:c622ec0e155af693ff91a96a7779c4fd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-20,52,16]"^^xsd:string .
 
-niiri:71a4d25f7fb9dd5f2ff89ce4a6426ed6 prov:wasDerivedFrom niiri:715dbdcf861d88449d6bf9fd80be68c2 .
+niiri:16189a2299f27429558ef4834d1c5aa3 prov:wasDerivedFrom niiri:301c22bdebf70b67d36aa2cc2edd7c6e .
 
-niiri:3fe2b2a2a97891aa0347dc4a8041143b
+niiri:6575ec06f88b0f953f6f9390d533ab50
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:a810311fe07f257dbdaf36cba74972bf ;
+    prov:atLocation niiri:49105cd40a656ff8ef0d2174017d9cd0 ;
     prov:value "4.41627073287964"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28093847762164"^^xsd:float ;
     nidm_pValueUncorrected: "0.00051731154621093"^^xsd:float ;
     nidm_pValueFWER: "0.999999999588405"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:a810311fe07f257dbdaf36cba74972bf
+niiri:49105cd40a656ff8ef0d2174017d9cd0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[10,62,20]"^^xsd:string .
 
-niiri:3fe2b2a2a97891aa0347dc4a8041143b prov:wasDerivedFrom niiri:a722ba5c3f48104c4bffaa9f1bc96e93 .
+niiri:6575ec06f88b0f953f6f9390d533ab50 prov:wasDerivedFrom niiri:a4f97ce3e351468a0b599542e9fe1960 .
 
-niiri:771d0950142ef5727aa4539533181ebe
+niiri:cb6956a4299b4a7cb665e732f724b204
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:01971ac462b6f6a68ddf7a4bcb329cd1 ;
+    prov:atLocation niiri:8320eca97390d2908a4112000203d93e ;
     prov:value "4.39752912521362"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27216223374679"^^xsd:float ;
     nidm_pValueUncorrected: "0.000533641570346299"^^xsd:float ;
     nidm_pValueFWER: "0.999999999726897"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:01971ac462b6f6a68ddf7a4bcb329cd1
+niiri:8320eca97390d2908a4112000203d93e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[50,-66,38]"^^xsd:string .
 
-niiri:771d0950142ef5727aa4539533181ebe prov:wasDerivedFrom niiri:0aa4b1a84fee2649d333d5561003c8bf .
+niiri:cb6956a4299b4a7cb665e732f724b204 prov:wasDerivedFrom niiri:9eeed673f0f6da15d5140c5984d28a3c .
 
-niiri:8fa040e1a3007565edd3ecf0c6827522
+niiri:ca5152e1ac133ad18f0df30171300f28
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:386b7d31755630d505a2b693dea28f77 ;
+    prov:atLocation niiri:426dc744c165e7364d33cb64d542a2ce ;
     prov:value "4.30746841430664"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22951851195682"^^xsd:float ;
     nidm_pValueUncorrected: "0.000619994267038626"^^xsd:float ;
     nidm_pValueFWER: "0.999999999965896"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:386b7d31755630d505a2b693dea28f77
+niiri:426dc744c165e7364d33cb64d542a2ce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-4,-4,-8]"^^xsd:string .
 
-niiri:8fa040e1a3007565edd3ecf0c6827522 prov:wasDerivedFrom niiri:5b1d37cc88f4111dc6ae2a4f48520a59 .
+niiri:ca5152e1ac133ad18f0df30171300f28 prov:wasDerivedFrom niiri:6d6f7c13ffe51614573bd56d21ff26a7 .
 
-niiri:2c9566f77e7f82b34e22874819f8c710
+niiri:c1c03fa6f2753370070c650d1c5fbff1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:170fb7ed6d4143e9075bf54c54eb7793 ;
+    prov:atLocation niiri:141e560c1bc04b4fd8ba5c5e9c02cb39 ;
     prov:value "4.29710006713867"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2245585560768"^^xsd:float ;
     nidm_pValueUncorrected: "0.000630835257803941"^^xsd:float ;
     nidm_pValueFWER: "0.999999999973481"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:170fb7ed6d4143e9075bf54c54eb7793
+niiri:141e560c1bc04b4fd8ba5c5e9c02cb39
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-20,-56,14]"^^xsd:string .
 
-niiri:2c9566f77e7f82b34e22874819f8c710 prov:wasDerivedFrom niiri:7a1feca53667470e0f2534f053958e05 .
+niiri:c1c03fa6f2753370070c650d1c5fbff1 prov:wasDerivedFrom niiri:c7b43074794c90965e68f71cc444780a .
 
-niiri:b0fa3c1d2ceac260635bee3e4a36167b
+niiri:9c6a7cfe9f8d38c24e14824830f49bc0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:a83c51a65ddebc4a61818ab017d3f959 ;
+    prov:atLocation niiri:9c52154aad7501a924f3f043ae4c5959 ;
     prov:value "4.28621673583984"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21934090215671"^^xsd:float ;
     nidm_pValueUncorrected: "0.000642428185358868"^^xsd:float ;
     nidm_pValueFWER: "0.999999999979691"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:a83c51a65ddebc4a61818ab017d3f959
+niiri:9c52154aad7501a924f3f043ae4c5959
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[32,24,30]"^^xsd:string .
 
-niiri:b0fa3c1d2ceac260635bee3e4a36167b prov:wasDerivedFrom niiri:bda46dfc41022916ad6faceac091ba3d .
+niiri:9c6a7cfe9f8d38c24e14824830f49bc0 prov:wasDerivedFrom niiri:c41d10c310919c8cbe2d4327dda739c9 .
 
-niiri:69ba9d52a63ad25b2c1f23f677985988
+niiri:5b4f6b80a53d3311dcd2f5da199517cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:2a05164883101591007a84904b255170 ;
+    prov:atLocation niiri:a3acd33b50384b2692990584f551bf0c ;
     prov:value "4.28483486175537"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21867757532573"^^xsd:float ;
     nidm_pValueUncorrected: "0.000643916016166424"^^xsd:float ;
     nidm_pValueFWER: "0.999999999980371"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:2a05164883101591007a84904b255170
+niiri:a3acd33b50384b2692990584f551bf0c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-18,-48,12]"^^xsd:string .
 
-niiri:69ba9d52a63ad25b2c1f23f677985988 prov:wasDerivedFrom niiri:0c786e61d78880c4e546692954781ced .
+niiri:5b4f6b80a53d3311dcd2f5da199517cb prov:wasDerivedFrom niiri:8cd4eb873cc68bc694b905aebcc585c9 .
 
-niiri:8af718e4eb7ee27c7d2b1f62ae1f4fc8
+niiri:5ec228b3171198ace9fbb6146df6c678
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:9327092d5f9ad138d37b770b39d5e356 ;
+    prov:atLocation niiri:79ac7b96bcbf87780aeb0400b85d2fda ;
     prov:value "4.27967262268066"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21619793589097"^^xsd:float ;
     nidm_pValueUncorrected: "0.000649506017056822"^^xsd:float ;
     nidm_pValueFWER: "0.999999999982724"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:9327092d5f9ad138d37b770b39d5e356
+niiri:79ac7b96bcbf87780aeb0400b85d2fda
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-26,-80,16]"^^xsd:string .
 
-niiri:8af718e4eb7ee27c7d2b1f62ae1f4fc8 prov:wasDerivedFrom niiri:b9a4c4c2b5a9793a35534927d9578f48 .
+niiri:5ec228b3171198ace9fbb6146df6c678 prov:wasDerivedFrom niiri:93093df2bfed236a073657264fcfd67a .
 
-niiri:49c4aad3b156440f8fd3346227c812bb
+niiri:2264e18ba802faabecfa101c08d27996
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:219d1a9528adbd1b3e9fad127c12ba45 ;
+    prov:atLocation niiri:3252fcc9f4cd6d0bcc7abf7abb6602a7 ;
     prov:value "4.27626991271973"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21456203610231"^^xsd:float ;
     nidm_pValueUncorrected: "0.000653218409537804"^^xsd:float ;
     nidm_pValueFWER: "0.999999999984125"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:219d1a9528adbd1b3e9fad127c12ba45
+niiri:3252fcc9f4cd6d0bcc7abf7abb6602a7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[22,-42,-44]"^^xsd:string .
 
-niiri:49c4aad3b156440f8fd3346227c812bb prov:wasDerivedFrom niiri:f4849377c56edcbca1dc5384795946ce .
+niiri:2264e18ba802faabecfa101c08d27996 prov:wasDerivedFrom niiri:f78564c27b61dd4e46b3be31141d54a7 .
 
-niiri:86047a3e6b7ffa4a1d1b9a29cb05f3c8
+niiri:711c3bc552e3a66a9412d6fd2fb775b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:29a67515a2b3cfc85dfdfd1fc059f75c ;
+    prov:atLocation niiri:7a1fc6df95484bec6ca7395446f3a1b7 ;
     prov:value "4.25063323974609"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20220005940261"^^xsd:float ;
     nidm_pValueUncorrected: "0.000681911226584231"^^xsd:float ;
     nidm_pValueFWER: "0.999999999991679"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:29a67515a2b3cfc85dfdfd1fc059f75c
+niiri:7a1fc6df95484bec6ca7395446f3a1b7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[20,28,6]"^^xsd:string .
 
-niiri:86047a3e6b7ffa4a1d1b9a29cb05f3c8 prov:wasDerivedFrom niiri:6ad64a79d36f37c1cd1b1433a1aef9ca .
+niiri:711c3bc552e3a66a9412d6fd2fb775b1 prov:wasDerivedFrom niiri:f395049f71ae2e104b9b26062c56431a .
 
-niiri:2d96bb4e97bbf9cdca301464aea060d7
+niiri:32e250f6dc9d5c3442b08814c9443fe3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:17e914d0522a7782b8946f4570a112a0 ;
+    prov:atLocation niiri:51125b6d7abce3d3c78c487bc9fa5969 ;
     prov:value "4.22958660125732"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19200261281843"^^xsd:float ;
     nidm_pValueUncorrected: "0.000706450272937809"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995163"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:17e914d0522a7782b8946f4570a112a0
+niiri:51125b6d7abce3d3c78c487bc9fa5969
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[44,26,40]"^^xsd:string .
 
-niiri:2d96bb4e97bbf9cdca301464aea060d7 prov:wasDerivedFrom niiri:50d65ffbbedadcbcef20b8bacaa5bf32 .
+niiri:32e250f6dc9d5c3442b08814c9443fe3 prov:wasDerivedFrom niiri:b3217b4acb17a2036c4b69c3b751a912 .
 
-niiri:b544c89d1296f2203fb8e262999b2903
+niiri:a1810948e0e400ebc306b2b756f74a0e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:7ab866ab624608ae371a87356ccbb246 ;
+    prov:atLocation niiri:04f8840d371d916d2ac43250d8e09c75 ;
     prov:value "4.13231182098389"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14429239999158"^^xsd:float ;
     nidm_pValueUncorrected: "0.000832444966141432"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999966"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:7ab866ab624608ae371a87356ccbb246
+niiri:04f8840d371d916d2ac43250d8e09c75
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-32,-78,44]"^^xsd:string .
 
-niiri:b544c89d1296f2203fb8e262999b2903 prov:wasDerivedFrom niiri:57ec9ce901bb55b112e2f594ad471e7a .
+niiri:a1810948e0e400ebc306b2b756f74a0e prov:wasDerivedFrom niiri:9178c692ea33d50b8bc90323fbe1561d .
 
-niiri:e8fc125bac22d26604b604112b05554d
+niiri:4869211d5caf0eddb9fd6e1b3246e3b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:0e198fd93d34f6f23b1574200bd77922 ;
+    prov:atLocation niiri:02fad55253b907bb3460b724ad605ff8 ;
     prov:value "4.0775408744812"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11700347232274"^^xsd:float ;
     nidm_pValueUncorrected: "0.000913497101264649"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999932"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:0e198fd93d34f6f23b1574200bd77922
+niiri:02fad55253b907bb3460b724ad605ff8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[4,-54,-42]"^^xsd:string .
 
-niiri:e8fc125bac22d26604b604112b05554d prov:wasDerivedFrom niiri:1318d2cd1289a2678d066b7cca2986f1 .
+niiri:4869211d5caf0eddb9fd6e1b3246e3b0 prov:wasDerivedFrom niiri:1b4bb4acb913740f6b3863891a7115fa .
 
-niiri:93ad18b2412733cb3a43ab2edf151f7d
+niiri:01d1363c9790021850fa9adcadeff99a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:65f92900970c3f35426b598b6b9b186c ;
+    prov:atLocation niiri:ae86be3809cd578b07a064930d2ad838 ;
     prov:value "4.07394027709961"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11519863095218"^^xsd:float ;
     nidm_pValueUncorrected: "0.000919105401866016"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999939"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:65f92900970c3f35426b598b6b9b186c
+niiri:ae86be3809cd578b07a064930d2ad838
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[34,14,56]"^^xsd:string .
 
-niiri:93ad18b2412733cb3a43ab2edf151f7d prov:wasDerivedFrom niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea .
+niiri:01d1363c9790021850fa9adcadeff99a prov:wasDerivedFrom niiri:6d4c71c4ef585e41f24f639435b05026 .
 

--- a/spmexport/ex_spm_covariate/nidm.ttl
+++ b/spmexport/ex_spm_covariate/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:31d6c1a45e08732f9d39d4fd32cea085
+niiri:3ccf008c518c3f0ebe9dea04f0edfbc4
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:8cf1ef035df283fda3a56583da8cbd77
+niiri:97c0efb1395126dbff029ae881c33b9d
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:a33cfd1828738469b4829a177a32ea49
+niiri:4ee63714952ef11034b1653f40760c75
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:a33cfd1828738469b4829a177a32ea49 prov:wasAssociatedWith niiri:8cf1ef035df283fda3a56583da8cbd77 .
+niiri:4ee63714952ef11034b1653f40760c75 prov:wasAssociatedWith niiri:97c0efb1395126dbff029ae881c33b9d .
 
 _:blank5 a prov:Generation .
 
-niiri:31d6c1a45e08732f9d39d4fd32cea085 prov:qualifiedGeneration _:blank5 .
+niiri:3ccf008c518c3f0ebe9dea04f0edfbc4 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:11:15"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:33:30"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -128,12 +128,12 @@ _:blank5 prov:atTime "2016-01-11T10:11:15"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:d515e4539ba77e4aaafcb479a1267ad1
+niiri:7cd23874d74598fb93575d0ca339d267
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:29ca7f31a8b4fa610180435e7362a7d0
+niiri:e7538b8eeead984e7d4168b9eb1e2185
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -143,171 +143,171 @@ niiri:29ca7f31a8b4fa610180435e7362a7d0
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:cbf0821fd0582df876cb99f6e1c69ac8
+niiri:f0df94187254dffcef42f57c9a34f591
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean .
 
-niiri:f49fb0ce586d5bba164b397ad004843d
+niiri:8cc550f78b4df2ff508e85441d0a1fd0
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:41a74f856bbb8085011a19fe078fabce ;
+    dc:description niiri:83ee7456b6dda22712d37e10cc39a213 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"mean\", \"Subject ID Covariate\"]"^^xsd:string .
 
-niiri:41a74f856bbb8085011a19fe078fabce
+niiri:83ee7456b6dda22712d37e10cc39a213
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:6a6716cb24609f317367c274cd3a3012
+niiri:dc642cee82597b23a6938238a2d15373
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean .
 
-niiri:fc1b05994ad6f530ee7e2818c82ace02
+niiri:169c4819223a8702ebf9447665c6a242
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_OLS: .
 
-niiri:fc1b05994ad6f530ee7e2818c82ace02 prov:wasAssociatedWith niiri:d515e4539ba77e4aaafcb479a1267ad1 .
+niiri:169c4819223a8702ebf9447665c6a242 prov:wasAssociatedWith niiri:7cd23874d74598fb93575d0ca339d267 .
 
-niiri:fc1b05994ad6f530ee7e2818c82ace02 prov:used niiri:f49fb0ce586d5bba164b397ad004843d .
+niiri:169c4819223a8702ebf9447665c6a242 prov:used niiri:8cc550f78b4df2ff508e85441d0a1fd0 .
 
-niiri:fc1b05994ad6f530ee7e2818c82ace02 prov:used niiri:cbf0821fd0582df876cb99f6e1c69ac8 .
+niiri:169c4819223a8702ebf9447665c6a242 prov:used niiri:f0df94187254dffcef42f57c9a34f591 .
 
-niiri:fc1b05994ad6f530ee7e2818c82ace02 prov:used niiri:6a6716cb24609f317367c274cd3a3012 .
+niiri:169c4819223a8702ebf9447665c6a242 prov:used niiri:dc642cee82597b23a6938238a2d15373 .
 
-niiri:a0e2e4659c44ec8283f603e4d63d4cb7
+niiri:43e01138ea166419cf89ae0c1b960c02
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     crypto:sha512 "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f"^^xsd:string .
 
-niiri:c48268f2a6a23bf1f723deea7bbdb5b6
+niiri:aa7e9876de1332712a7a6718e06772c7
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "e06c7e91d23253a8dffd3bb366d05851340e63a972bc08812d42cb46ea31fdad3063cca9559c6a372781a84a7a50c17cf4bbf65c515ce00580f79372cc763807"^^xsd:string .
 
-niiri:a0e2e4659c44ec8283f603e4d63d4cb7 prov:wasDerivedFrom niiri:c48268f2a6a23bf1f723deea7bbdb5b6 .
+niiri:43e01138ea166419cf89ae0c1b960c02 prov:wasDerivedFrom niiri:aa7e9876de1332712a7a6718e06772c7 .
 
-niiri:a0e2e4659c44ec8283f603e4d63d4cb7 prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+niiri:43e01138ea166419cf89ae0c1b960c02 prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
 
-niiri:26f92bdc36b3170ba40be9cc15a7dc6e
+niiri:165ea688a4bf64576aaa4b9aefc18471
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "0.0173736633732915"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     crypto:sha512 "98952e02ac3f45da846d94deb554fad9126d6ba05b8ba745f176150b7b18bf2edee7efff67e7362f6704114b42ec7cb1d68fcde6005a829d52921961a4dad470"^^xsd:string .
 
-niiri:26f92bdc36b3170ba40be9cc15a7dc6e prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+niiri:165ea688a4bf64576aaa4b9aefc18471 prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
 
-niiri:2623a47371135f56c2aecb37063cac44
+niiri:f2d25df0f1d380a37ffc86ec505d0987
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 .
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 .
 
-niiri:51246b06ba783f764ebdcafdef38e2e3
+niiri:1d80b51894720953bd75f667c1e8d960
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "edde9f432759a7f2dad9ef0d3cb847eae532656aa81a7c08c76d939fe426e2e85329d56d0d279bf546773319599dd0bdf75b484d25083c8a2ac7ccb694a30e86"^^xsd:string .
 
-niiri:2623a47371135f56c2aecb37063cac44 prov:wasDerivedFrom niiri:51246b06ba783f764ebdcafdef38e2e3 .
+niiri:f2d25df0f1d380a37ffc86ec505d0987 prov:wasDerivedFrom niiri:1d80b51894720953bd75f667c1e8d960 .
 
-niiri:2623a47371135f56c2aecb37063cac44 prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+niiri:f2d25df0f1d380a37ffc86ec505d0987 prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
 
-niiri:9a291bb486326720055fc2883364893a
+niiri:f89edafcbb5a3cc6c1e71d9a08caf49e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 .
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 .
 
-niiri:0575f791e06f7944f37a4249570f2201
+niiri:e06126279c6b3cc3de4edddb8525281c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "f54847aa8325ebc7e962e70e87b4ecc5cfc95e840fa0229889bfab2345836d6b6032c0d29f89f2bc95abc2581dfd7ad2af5833031d4c2974513717c3f0ec29f8"^^xsd:string .
 
-niiri:9a291bb486326720055fc2883364893a prov:wasDerivedFrom niiri:0575f791e06f7944f37a4249570f2201 .
+niiri:f89edafcbb5a3cc6c1e71d9a08caf49e prov:wasDerivedFrom niiri:e06126279c6b3cc3de4edddb8525281c .
 
-niiri:9a291bb486326720055fc2883364893a prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+niiri:f89edafcbb5a3cc6c1e71d9a08caf49e prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
 
-niiri:b9cbdd666979ec7a12ae681547b560f7
+niiri:0dcb05747e20cb33a44bc7d7ca0576cb
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     crypto:sha512 "693dd1daf261efafb742c7da149cccc8b7383b49e672358dd29c6bcd31a6ee983270e23c3f118d86b0758d86162d77033926cb1ae0f653efb0b7102c922ca40b"^^xsd:string .
 
-niiri:51db014e8a30d126f73e7f235977299f
+niiri:b6f9383af3eb3dc8144e7261991f9fb1
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "afca09bea5ebf5bceda101c9cb4d803de2cc2307b72a539454ce04e72ad6f655304b653779a287d3f38fca841819bf8126c51cb0a095e8710882e87d5eb7c565"^^xsd:string .
 
-niiri:b9cbdd666979ec7a12ae681547b560f7 prov:wasDerivedFrom niiri:51db014e8a30d126f73e7f235977299f .
+niiri:0dcb05747e20cb33a44bc7d7ca0576cb prov:wasDerivedFrom niiri:b6f9383af3eb3dc8144e7261991f9fb1 .
 
-niiri:b9cbdd666979ec7a12ae681547b560f7 prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+niiri:0dcb05747e20cb33a44bc7d7ca0576cb prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
 
-niiri:4b89f205af8d9f723bc3dd1382c941ba
+niiri:dcbee28f8fa480eb84e376111f7b6875
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     crypto:sha512 "58dcbf304825e142d28af1f78351fa5fa758ea20a597f7c117967af6a2d051d80f69686dc6858c0d6b1b677ff279e00d600772ce8175eae7a54dbedd0848bfd5"^^xsd:string .
 
-niiri:d5024dc0bc94c982918144fd5349aa97
+niiri:4cb25d713c24e1d3d5fa873ee3dbfceb
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "42b06ae2316603cd1635234bdc474edf4cfac04b7ffe7acfe80221ee4cb3ecc0e6b514f5ebf1391df5ced6eb2fd5a91cd62a58ce1c4318ed4514eb8e1b41729b"^^xsd:string .
 
-niiri:4b89f205af8d9f723bc3dd1382c941ba prov:wasDerivedFrom niiri:d5024dc0bc94c982918144fd5349aa97 .
+niiri:dcbee28f8fa480eb84e376111f7b6875 prov:wasDerivedFrom niiri:4cb25d713c24e1d3d5fa873ee3dbfceb .
 
-niiri:4b89f205af8d9f723bc3dd1382c941ba prov:wasGeneratedBy niiri:fc1b05994ad6f530ee7e2818c82ace02 .
+niiri:dcbee28f8fa480eb84e376111f7b6875 prov:wasGeneratedBy niiri:169c4819223a8702ebf9447665c6a242 .
 
-niiri:43cb4a137447d784b18f0327f0c441f9
+niiri:1d97aaaad1a6968e4783cd6214ee5179
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     rdfs:label "Contrast: mr vs plain" ;
     prov:value "[1, 0]"^^xsd:string .
 
-niiri:8106d8f378522cc994936b6c1d2b0f47
+niiri:54a8d8c7177e25879aa8c042805dfebe
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:8106d8f378522cc994936b6c1d2b0f47 prov:wasAssociatedWith niiri:d515e4539ba77e4aaafcb479a1267ad1 .
+niiri:54a8d8c7177e25879aa8c042805dfebe prov:wasAssociatedWith niiri:7cd23874d74598fb93575d0ca339d267 .
 
-niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:a0e2e4659c44ec8283f603e4d63d4cb7 .
+niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:43e01138ea166419cf89ae0c1b960c02 .
 
-niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:b9cbdd666979ec7a12ae681547b560f7 .
+niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:0dcb05747e20cb33a44bc7d7ca0576cb .
 
-niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:f49fb0ce586d5bba164b397ad004843d .
+niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:8cc550f78b4df2ff508e85441d0a1fd0 .
 
-niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:43cb4a137447d784b18f0327f0c441f9 .
+niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:1d97aaaad1a6968e4783cd6214ee5179 .
 
-niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:2623a47371135f56c2aecb37063cac44 .
+niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:f2d25df0f1d380a37ffc86ec505d0987 .
 
-niiri:8106d8f378522cc994936b6c1d2b0f47 prov:used niiri:9a291bb486326720055fc2883364893a .
+niiri:54a8d8c7177e25879aa8c042805dfebe prov:used niiri:f89edafcbb5a3cc6c1e71d9a08caf49e .
 
-niiri:7180fa05eac2a8815661ff232ad535d2
+niiri:78c3a55d6161c2415d14067b8c63d784
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -317,124 +317,124 @@ niiri:7180fa05eac2a8815661ff232ad535d2
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "11"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     crypto:sha512 "370387f786b51f404f6ca9acd10c4e35fbac46e4f5ec42750cf05c4236bda63dc8c003dea0989fd6c397d05d2e46bf0e0685ef08fa143418c0f1fdc3e7fe0d8b"^^xsd:string .
 
-niiri:a909b2437ec845db0a946d87fcdbf110
+niiri:40a16c560c78731e96db83110db91267
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "489d1d288d622546f52d846311adfd3c6b7a5a604e0356335c997c6c7c2cfdf648e312383d151343007194e94ae8e681af5c7c1c0f69754126dd9561cbcf622b"^^xsd:string .
 
-niiri:7180fa05eac2a8815661ff232ad535d2 prov:wasDerivedFrom niiri:a909b2437ec845db0a946d87fcdbf110 .
+niiri:78c3a55d6161c2415d14067b8c63d784 prov:wasDerivedFrom niiri:40a16c560c78731e96db83110db91267 .
 
-niiri:7180fa05eac2a8815661ff232ad535d2 prov:wasGeneratedBy niiri:8106d8f378522cc994936b6c1d2b0f47 .
+niiri:78c3a55d6161c2415d14067b8c63d784 prov:wasGeneratedBy niiri:54a8d8c7177e25879aa8c042805dfebe .
 
-niiri:f88a91a1a09378bbfdb3dd220962cbd0
+niiri:3becd9191b28badb59abfebfeab96ef5
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: mr vs plain" ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     crypto:sha512 "ab6e3d990747f48517f1cf7eb1dd7dd0e973d4f5b7f468963c982c906f3dfcafa7c056c8f34d9f54c10330a67ab92b7f7ab3d95781a568b7fbaddf9f17746216"^^xsd:string .
 
-niiri:1282ac0f2eeb5bc9dde3259940a5b967
+niiri:78c411926e48aaf00a21986fb6b38f41
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "9dc48e80c35ac0d74eb3131bab4e8cac2db2df834fef3c5cb6ddb5d91082d573d885a8e703a03652b5745f3f52b0e3397feb130f3ebccae549142ce88c29cb59"^^xsd:string .
 
-niiri:f88a91a1a09378bbfdb3dd220962cbd0 prov:wasDerivedFrom niiri:1282ac0f2eeb5bc9dde3259940a5b967 .
+niiri:3becd9191b28badb59abfebfeab96ef5 prov:wasDerivedFrom niiri:78c411926e48aaf00a21986fb6b38f41 .
 
-niiri:f88a91a1a09378bbfdb3dd220962cbd0 prov:wasGeneratedBy niiri:8106d8f378522cc994936b6c1d2b0f47 .
+niiri:3becd9191b28badb59abfebfeab96ef5 prov:wasGeneratedBy niiri:54a8d8c7177e25879aa8c042805dfebe .
 
-niiri:c68b99924630158595413c4285a41ec7
+niiri:e74be4649036d7e5c6372c0258817b2b
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     crypto:sha512 "a36854cf6dd56807c2a335d31d64f3f265785b7b573115e7cfaec97da31078aad22aa084ac09c3a550605f550228a781457821df43845b7a92c8b375bc9ac9dc"^^xsd:string .
 
-niiri:c68b99924630158595413c4285a41ec7 prov:wasGeneratedBy niiri:8106d8f378522cc994936b6c1d2b0f47 .
+niiri:e74be4649036d7e5c6372c0258817b2b prov:wasGeneratedBy niiri:54a8d8c7177e25879aa8c042805dfebe .
 
-niiri:98a24053ecc198c682c361b35db9d066
+niiri:5fc89d76faab61ee021d9cc78f0fd0b5
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500148243682"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:7d4015daee5ad33cd195777edd7b45e7 ;
-    nidm_equivalentThreshold: niiri:2e33ccc4e77256ac0c3122164affbf0f .
+    nidm_equivalentThreshold: niiri:550ff496a1f20b888585d452cf21e219 ;
+    nidm_equivalentThreshold: niiri:268cc3d07350375a06d59e1c72255036 .
 
-niiri:7d4015daee5ad33cd195777edd7b45e7
+niiri:550ff496a1f20b888585d452cf21e219
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.02470104841152"^^xsd:float .
 
-niiri:2e33ccc4e77256ac0c3122164affbf0f
+niiri:268cc3d07350375a06d59e1c72255036
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999999987"^^xsd:float .
 
-niiri:97c3deab28ad09270d41f36ac051abf0
+niiri:fb431b6d009d90dc5f369aadeb468547
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:dc2315d702ea7d63764b08840958382b ;
-    nidm_equivalentThreshold: niiri:3a2b050a6e9b6bf8427850e20e551ae4 .
+    nidm_equivalentThreshold: niiri:bbb30eb0dc56085d0bb3b8f32e1aa7d8 ;
+    nidm_equivalentThreshold: niiri:6af35793d4c30300501f6e4843ea64f9 .
 
-niiri:dc2315d702ea7d63764b08840958382b
+niiri:bbb30eb0dc56085d0bb3b8f32e1aa7d8
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:3a2b050a6e9b6bf8427850e20e551ae4
+niiri:6af35793d4c30300501f6e4843ea64f9
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:b96cd6ef89bc01300f460e26e2535619
+niiri:e3fc10780da51f8073baec6993b81559
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:a6afd19740d69851bcebb4de3abcb4e7
+niiri:a7fcffe68706a024505ad48123a3a597
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548
+niiri:f74ee55215d923c382e467dc5985637f
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:wasAssociatedWith niiri:d515e4539ba77e4aaafcb479a1267ad1 .
+niiri:f74ee55215d923c382e467dc5985637f prov:wasAssociatedWith niiri:7cd23874d74598fb93575d0ca339d267 .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:98a24053ecc198c682c361b35db9d066 .
+niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:5fc89d76faab61ee021d9cc78f0fd0b5 .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:97c3deab28ad09270d41f36ac051abf0 .
+niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:fb431b6d009d90dc5f369aadeb468547 .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:7180fa05eac2a8815661ff232ad535d2 .
+niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:78c3a55d6161c2415d14067b8c63d784 .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:4b89f205af8d9f723bc3dd1382c941ba .
+niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:dcbee28f8fa480eb84e376111f7b6875 .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:a0e2e4659c44ec8283f603e4d63d4cb7 .
+niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:43e01138ea166419cf89ae0c1b960c02 .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:b96cd6ef89bc01300f460e26e2535619 .
+niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:e3fc10780da51f8073baec6993b81559 .
 
-niiri:58ea1c58f6fd442a5f0b30714b02f548 prov:used niiri:a6afd19740d69851bcebb4de3abcb4e7 .
+niiri:f74ee55215d923c382e467dc5985637f prov:used niiri:a7fcffe68706a024505ad48123a3a597 .
 
-niiri:af00c4dc59502bf1fe7721773eb5a850
+niiri:4210503ffa69b7e56d701bcba7b1b2df
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     nidm_searchVolumeInVoxels: "162104"^^xsd:int ;
     nidm_searchVolumeInUnits: "1296832"^^xsd:float ;
     nidm_reselSizeInVoxels: "95.2875561406722"^^xsd:float ;
@@ -451,9 +451,9 @@ niiri:af00c4dc59502bf1fe7721773eb5a850
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "9e4f4f0e7228f634857528b947021f1e8ae0906c27541ec43c5e7119bf29a0dec551a92bb76443f3dd9376e83ce3012ad96c8bbe81a353cfe99a7059dff0bf8f"^^xsd:string .
 
-niiri:af00c4dc59502bf1fe7721773eb5a850 prov:wasGeneratedBy niiri:58ea1c58f6fd442a5f0b30714b02f548 .
+niiri:4210503ffa69b7e56d701bcba7b1b2df prov:wasGeneratedBy niiri:f74ee55215d923c382e467dc5985637f .
 
-niiri:d60a0c55d948a11dac535e382316f31f
+niiri:ff2b188fd5ef195057b9076462d97f0c
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -461,26 +461,26 @@ niiri:d60a0c55d948a11dac535e382316f31f
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "29"^^xsd:int ;
     nidm_pValue: "0.722893095431427"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:aae74d51171ea0af243cd165c716a211 ;
-    nidm_hasMaximumIntensityProjection: niiri:93a498407930e7c2f57870d6e06e32d4 ;
-    nidm_inCoordinateSpace: niiri:29ca7f31a8b4fa610180435e7362a7d0 ;
+    nidm_hasClusterLabelsMap: niiri:3fe999af53b6ff1062dd11597b4540ec ;
+    nidm_hasMaximumIntensityProjection: niiri:ec2532bdcd7e520faba8a90cf9625856 ;
+    nidm_inCoordinateSpace: niiri:e7538b8eeead984e7d4168b9eb1e2185 ;
     crypto:sha512 "2bbcc39452bb1127d7205b05c820b5d31d5e2daa43e4ba6ccaf43c229aa7d708af405aff650daa9a08b3582c5aa013e32a6535188542c9c1fc3fa24fcc03c59c"^^xsd:string .
 
-niiri:aae74d51171ea0af243cd165c716a211
+niiri:3fe999af53b6ff1062dd11597b4540ec
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:93a498407930e7c2f57870d6e06e32d4
+niiri:ec2532bdcd7e520faba8a90cf9625856
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:d60a0c55d948a11dac535e382316f31f prov:wasGeneratedBy niiri:58ea1c58f6fd442a5f0b30714b02f548 .
+niiri:ff2b188fd5ef195057b9076462d97f0c prov:wasGeneratedBy niiri:f74ee55215d923c382e467dc5985637f .
 
-niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b
+niiri:be91aa057bdd9d8651b94a428f9d7e04
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -490,9 +490,9 @@ niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:be91aa057bdd9d8651b94a428f9d7e04 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:02bd1b0dd4f143323060712eeb0b3401
+niiri:8c1f835fe33bb35a741db5d71610f74d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -502,9 +502,9 @@ niiri:02bd1b0dd4f143323060712eeb0b3401
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:02bd1b0dd4f143323060712eeb0b3401 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:8c1f835fe33bb35a741db5d71610f74d prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:4feafd8d4a6ff76500cde244ec4a9ac0
+niiri:427a5e18f5920cd494cd57b5222b9804
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -514,9 +514,9 @@ niiri:4feafd8d4a6ff76500cde244ec4a9ac0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:4feafd8d4a6ff76500cde244ec4a9ac0 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:427a5e18f5920cd494cd57b5222b9804 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:6267cdb89b255ce524220439e2d056f1
+niiri:8cd69d4c2bcb674537c0f59674d850f8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -526,9 +526,9 @@ niiri:6267cdb89b255ce524220439e2d056f1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:6267cdb89b255ce524220439e2d056f1 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:8cd69d4c2bcb674537c0f59674d850f8 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:dccae6a3d4de3910d04419b8bb7c8d62
+niiri:1c094c13c4622d206afcab0831c06c8e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -538,9 +538,9 @@ niiri:dccae6a3d4de3910d04419b8bb7c8d62
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:dccae6a3d4de3910d04419b8bb7c8d62 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:1c094c13c4622d206afcab0831c06c8e prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:8a59a0d3509f23181ea020ba988244a4
+niiri:d03fb3a214226f8e359063dd56622b80
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -550,9 +550,9 @@ niiri:8a59a0d3509f23181ea020ba988244a4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:8a59a0d3509f23181ea020ba988244a4 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:d03fb3a214226f8e359063dd56622b80 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:26f9f618c22ef5edf5685712623da454
+niiri:08acd9d5e3c86a5597634b63f9ca5b76
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -562,9 +562,9 @@ niiri:26f9f618c22ef5edf5685712623da454
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:26f9f618c22ef5edf5685712623da454 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:08acd9d5e3c86a5597634b63f9ca5b76 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:d2f346a025c15c9fc9c31510f24b5886
+niiri:33fdb3dcbde308077cb41f61bbb538d4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -574,9 +574,9 @@ niiri:d2f346a025c15c9fc9c31510f24b5886
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:d2f346a025c15c9fc9c31510f24b5886 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:33fdb3dcbde308077cb41f61bbb538d4 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:d2e202f26f07d353e876c8513aaac055
+niiri:a1dfe524338b100e2c0b4aac79347135
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -586,9 +586,9 @@ niiri:d2e202f26f07d353e876c8513aaac055
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:d2e202f26f07d353e876c8513aaac055 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:a1dfe524338b100e2c0b4aac79347135 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:d0abf7f944018518c8b2f88645568e05
+niiri:398e18e13e41fd86f9c91a0c37179f94
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -598,9 +598,9 @@ niiri:d0abf7f944018518c8b2f88645568e05
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:d0abf7f944018518c8b2f88645568e05 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:398e18e13e41fd86f9c91a0c37179f94 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:71dd070abfb1b28ce2b0e47fb4f49daf
+niiri:fc5a20643a49d6b48c632806b9fb3669
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -610,9 +610,9 @@ niiri:71dd070abfb1b28ce2b0e47fb4f49daf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:71dd070abfb1b28ce2b0e47fb4f49daf prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:fc5a20643a49d6b48c632806b9fb3669 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:354b333049efc8a35bffb5e871d5df51
+niiri:7977d3c2d53495076863f90a7414369f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -622,9 +622,9 @@ niiri:354b333049efc8a35bffb5e871d5df51
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:354b333049efc8a35bffb5e871d5df51 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:7977d3c2d53495076863f90a7414369f prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:dfcda071a872154b10c43f862bf52d69
+niiri:e6d67f5c8f427474527d0d727f3dce58
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -634,9 +634,9 @@ niiri:dfcda071a872154b10c43f862bf52d69
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:dfcda071a872154b10c43f862bf52d69 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:e6d67f5c8f427474527d0d727f3dce58 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:9f93d2b40c1f794cb34e0ae17e04bd0c
+niiri:9ba6b697c18c9fa2a070f1ac777899c3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -646,9 +646,9 @@ niiri:9f93d2b40c1f794cb34e0ae17e04bd0c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:9f93d2b40c1f794cb34e0ae17e04bd0c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:9ba6b697c18c9fa2a070f1ac777899c3 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:899db6b982fa96374440fc31d77225c7
+niiri:17cf04133d00b334b009343c68cc794f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -658,9 +658,9 @@ niiri:899db6b982fa96374440fc31d77225c7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:899db6b982fa96374440fc31d77225c7 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:17cf04133d00b334b009343c68cc794f prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:d19f972dfab2b23346202c34e5574f29
+niiri:715dbdcf861d88449d6bf9fd80be68c2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -670,9 +670,9 @@ niiri:d19f972dfab2b23346202c34e5574f29
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:d19f972dfab2b23346202c34e5574f29 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:715dbdcf861d88449d6bf9fd80be68c2 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:c8e45b2b37dac3869716ea38f6f82aa2
+niiri:a722ba5c3f48104c4bffaa9f1bc96e93
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -682,9 +682,9 @@ niiri:c8e45b2b37dac3869716ea38f6f82aa2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:c8e45b2b37dac3869716ea38f6f82aa2 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:a722ba5c3f48104c4bffaa9f1bc96e93 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:f4fe3e2f741c280bd998a6eaf285b07c
+niiri:0aa4b1a84fee2649d333d5561003c8bf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -694,9 +694,9 @@ niiri:f4fe3e2f741c280bd998a6eaf285b07c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:f4fe3e2f741c280bd998a6eaf285b07c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:0aa4b1a84fee2649d333d5561003c8bf prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:f18795394da513a451940bf5032734eb
+niiri:5b1d37cc88f4111dc6ae2a4f48520a59
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -706,9 +706,9 @@ niiri:f18795394da513a451940bf5032734eb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:f18795394da513a451940bf5032734eb prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:5b1d37cc88f4111dc6ae2a4f48520a59 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:350e81fc1b83d10ae96dfefb3bab3615
+niiri:7a1feca53667470e0f2534f053958e05
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -718,9 +718,9 @@ niiri:350e81fc1b83d10ae96dfefb3bab3615
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:350e81fc1b83d10ae96dfefb3bab3615 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:7a1feca53667470e0f2534f053958e05 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b
+niiri:bda46dfc41022916ad6faceac091ba3d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -730,9 +730,9 @@ niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:bda46dfc41022916ad6faceac091ba3d prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:3e2d682ff8be1f7b5e4954125d52dc9c
+niiri:0c786e61d78880c4e546692954781ced
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -742,9 +742,9 @@ niiri:3e2d682ff8be1f7b5e4954125d52dc9c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:3e2d682ff8be1f7b5e4954125d52dc9c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:0c786e61d78880c4e546692954781ced prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:9a3e77b28376a93d769c670fd53a30cb
+niiri:b9a4c4c2b5a9793a35534927d9578f48
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -754,9 +754,9 @@ niiri:9a3e77b28376a93d769c670fd53a30cb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:9a3e77b28376a93d769c670fd53a30cb prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:b9a4c4c2b5a9793a35534927d9578f48 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:0cff727da02fc982bbc0f11d56d44db2
+niiri:f4849377c56edcbca1dc5384795946ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -766,9 +766,9 @@ niiri:0cff727da02fc982bbc0f11d56d44db2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:0cff727da02fc982bbc0f11d56d44db2 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:f4849377c56edcbca1dc5384795946ce prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:8fb299584020cc344c3c2c82de2f748c
+niiri:6ad64a79d36f37c1cd1b1433a1aef9ca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -778,9 +778,9 @@ niiri:8fb299584020cc344c3c2c82de2f748c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:8fb299584020cc344c3c2c82de2f748c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:6ad64a79d36f37c1cd1b1433a1aef9ca prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:6e2110d791417b070202a6783afba19c
+niiri:50d65ffbbedadcbcef20b8bacaa5bf32
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -790,9 +790,9 @@ niiri:6e2110d791417b070202a6783afba19c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:6e2110d791417b070202a6783afba19c prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:50d65ffbbedadcbcef20b8bacaa5bf32 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:b0fbdf26b837fa676d008fcff5a30ee9
+niiri:57ec9ce901bb55b112e2f594ad471e7a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -802,9 +802,9 @@ niiri:b0fbdf26b837fa676d008fcff5a30ee9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:b0fbdf26b837fa676d008fcff5a30ee9 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:57ec9ce901bb55b112e2f594ad471e7a prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:5167e145ebaf9f5693dffbc09df2f2f8
+niiri:1318d2cd1289a2678d066b7cca2986f1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -814,9 +814,9 @@ niiri:5167e145ebaf9f5693dffbc09df2f2f8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:5167e145ebaf9f5693dffbc09df2f2f8 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:1318d2cd1289a2678d066b7cca2986f1 prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:17c3abf712c940e8e07c2fa7b3493dc1
+niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -826,498 +826,498 @@ niiri:17c3abf712c940e8e07c2fa7b3493dc1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:17c3abf712c940e8e07c2fa7b3493dc1 prov:wasDerivedFrom niiri:d60a0c55d948a11dac535e382316f31f .
+niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea prov:wasDerivedFrom niiri:ff2b188fd5ef195057b9076462d97f0c .
 
-niiri:70a79fb5d0fafa6b4641330f8f8b12aa
+niiri:da098c4cc640a214fd988ad023eb1a86
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:654d6238fa35ad568af3286425629272 ;
+    prov:atLocation niiri:ba3f25e2c5e1f415cd2525e4abcdb621 ;
     prov:value "6.37317276000977"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04320073372639"^^xsd:float ;
     nidm_pValueUncorrected: "2.63632212645915e-05"^^xsd:float ;
     nidm_pValueFWER: "0.958902832016109"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:654d6238fa35ad568af3286425629272
+niiri:ba3f25e2c5e1f415cd2525e4abcdb621
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[28,-36,38]"^^xsd:string .
 
-niiri:70a79fb5d0fafa6b4641330f8f8b12aa prov:wasDerivedFrom niiri:fda13dcdf66d7ff9d5cf2436f5ab3b3b .
+niiri:da098c4cc640a214fd988ad023eb1a86 prov:wasDerivedFrom niiri:be91aa057bdd9d8651b94a428f9d7e04 .
 
-niiri:81a8683173d0ed24bd3d2f6be8ec0f77
+niiri:3f041463e58131d17c3adb62ae04b812
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:eacbf2fc9ec48207e00dc693c683bf1f ;
+    prov:atLocation niiri:96c5c034a22620ddcd2779d651b4b97e ;
     prov:value "5.69066715240479"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8079805415517"^^xsd:float ;
     nidm_pValueUncorrected: "7.00531473561972e-05"^^xsd:float ;
     nidm_pValueFWER: "0.997756103851125"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:eacbf2fc9ec48207e00dc693c683bf1f
+niiri:96c5c034a22620ddcd2779d651b4b97e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[10,-48,16]"^^xsd:string .
 
-niiri:81a8683173d0ed24bd3d2f6be8ec0f77 prov:wasDerivedFrom niiri:02bd1b0dd4f143323060712eeb0b3401 .
+niiri:3f041463e58131d17c3adb62ae04b812 prov:wasDerivedFrom niiri:8c1f835fe33bb35a741db5d71610f74d .
 
-niiri:b6d7f661e892640001af0eea6f38dc9e
+niiri:7b61b8562a0fa2a8fc1be01625db2383
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:79a643a3d5d92c1658b5fb52ce02a6d1 ;
+    prov:atLocation niiri:709ff8ac6d109875a6c00824a37dec97 ;
     prov:value "5.404944896698"^^xsd:float ;
     nidm_equivalentZStatistic: "3.70067578615084"^^xsd:float ;
     nidm_pValueUncorrected: "0.000107513031460726"^^xsd:float ;
     nidm_pValueFWER: "0.999684183052173"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:79a643a3d5d92c1658b5fb52ce02a6d1
+niiri:709ff8ac6d109875a6c00824a37dec97
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-34,-6,-32]"^^xsd:string .
 
-niiri:b6d7f661e892640001af0eea6f38dc9e prov:wasDerivedFrom niiri:4feafd8d4a6ff76500cde244ec4a9ac0 .
+niiri:7b61b8562a0fa2a8fc1be01625db2383 prov:wasDerivedFrom niiri:427a5e18f5920cd494cd57b5222b9804 .
 
-niiri:640d2f1d4cb2fff0fb98dd63f4292b5e
+niiri:1e33617f26a669bbc5d4a8e1a84861df
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:26366fb427147de255e4516551b308e9 ;
+    prov:atLocation niiri:ef91d2750f81ce9286534c4378095103 ;
     prov:value "5.20687818527222"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62288194485815"^^xsd:float ;
     nidm_pValueUncorrected: "0.000145669405598126"^^xsd:float ;
     nidm_pValueFWER: "0.999944545222406"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:26366fb427147de255e4516551b308e9
+niiri:ef91d2750f81ce9286534c4378095103
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-28,-80,24]"^^xsd:string .
 
-niiri:640d2f1d4cb2fff0fb98dd63f4292b5e prov:wasDerivedFrom niiri:6267cdb89b255ce524220439e2d056f1 .
+niiri:1e33617f26a669bbc5d4a8e1a84861df prov:wasDerivedFrom niiri:8cd69d4c2bcb674537c0f59674d850f8 .
 
-niiri:aaba7d880bfd3cc9e40f6e040f3df3ca
+niiri:f9aa7f4153c94329f57f5a213c31ad9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:ceafb447ebc334cf0885953cb12180dc ;
+    prov:atLocation niiri:a01b0efba27795b5259e72e8b06cc19e ;
     prov:value "4.90865421295166"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50007991972101"^^xsd:float ;
     nidm_pValueUncorrected: "0.000232559344231609"^^xsd:float ;
     nidm_pValueFWER: "0.999998126675029"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:ceafb447ebc334cf0885953cb12180dc
+niiri:a01b0efba27795b5259e72e8b06cc19e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[-12,-32,28]"^^xsd:string .
 
-niiri:aaba7d880bfd3cc9e40f6e040f3df3ca prov:wasDerivedFrom niiri:dccae6a3d4de3910d04419b8bb7c8d62 .
+niiri:f9aa7f4153c94329f57f5a213c31ad9d prov:wasDerivedFrom niiri:1c094c13c4622d206afcab0831c06c8e .
 
-niiri:c9d9194d3fc86fceb8cbb0ad72e5e116
+niiri:afa5a345b8d55093f5d0ff485e694dbf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:39876766efea7749fdb1e3ec89516c50 ;
+    prov:atLocation niiri:2f8f1cfad3185761941c0d73d52f473c ;
     prov:value "4.84440040588379"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47268080874189"^^xsd:float ;
     nidm_pValueUncorrected: "0.000257643895570592"^^xsd:float ;
     nidm_pValueFWER: "0.999999219649123"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:39876766efea7749fdb1e3ec89516c50
+niiri:2f8f1cfad3185761941c0d73d52f473c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[-18,-76,-12]"^^xsd:string .
 
-niiri:c9d9194d3fc86fceb8cbb0ad72e5e116 prov:wasDerivedFrom niiri:8a59a0d3509f23181ea020ba988244a4 .
+niiri:afa5a345b8d55093f5d0ff485e694dbf prov:wasDerivedFrom niiri:d03fb3a214226f8e359063dd56622b80 .
 
-niiri:7361b36fbc686ac319529770f44965bb
+niiri:60a2332e10d9170f38d2463aeabd0113
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:d6b455e1b17b09ffb45f2319ae5feaa7 ;
+    prov:atLocation niiri:8c54f00fb0e08af1fb95533f64c42abe ;
     prov:value "4.84136772155762"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47137907963827"^^xsd:float ;
     nidm_pValueUncorrected: "0.000258896237096851"^^xsd:float ;
     nidm_pValueFWER: "0.999999252321799"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:d6b455e1b17b09ffb45f2319ae5feaa7
+niiri:8c54f00fb0e08af1fb95533f64c42abe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[32,16,40]"^^xsd:string .
 
-niiri:7361b36fbc686ac319529770f44965bb prov:wasDerivedFrom niiri:26f9f618c22ef5edf5685712623da454 .
+niiri:60a2332e10d9170f38d2463aeabd0113 prov:wasDerivedFrom niiri:08acd9d5e3c86a5597634b63f9ca5b76 .
 
-niiri:71afea378b2be0836e3b1e53b4c621c4
+niiri:79e0ce1a82f0e80e09c1b5064a2d60b2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:a1d44e4d1e3f9e624a75e1de128e43a4 ;
+    prov:atLocation niiri:80f6cd9cf5fcdd939d578cbb14fba341 ;
     prov:value "4.78605508804321"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4475005479143"^^xsd:float ;
     nidm_pValueUncorrected: "0.000282899629741595"^^xsd:float ;
     nidm_pValueFWER: "0.999999665309186"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:a1d44e4d1e3f9e624a75e1de128e43a4
+niiri:80f6cd9cf5fcdd939d578cbb14fba341
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-26,-78,46]"^^xsd:string .
 
-niiri:71afea378b2be0836e3b1e53b4c621c4 prov:wasDerivedFrom niiri:d2f346a025c15c9fc9c31510f24b5886 .
+niiri:79e0ce1a82f0e80e09c1b5064a2d60b2 prov:wasDerivedFrom niiri:33fdb3dcbde308077cb41f61bbb538d4 .
 
-niiri:8d7d3064a7e3b5bf7e85fffe64b06bc6
+niiri:33896a562b3020901f0a9129b329ca9f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:6d9c75885354734cf3570762871d32aa ;
+    prov:atLocation niiri:46882cfa883eb6417029f9e14cfcd78d ;
     prov:value "4.75920820236206"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43581665930553"^^xsd:float ;
     nidm_pValueUncorrected: "0.000295385308778928"^^xsd:float ;
     nidm_pValueFWER: "0.999999777160537"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:6d9c75885354734cf3570762871d32aa
+niiri:46882cfa883eb6417029f9e14cfcd78d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-50,-2,42]"^^xsd:string .
 
-niiri:8d7d3064a7e3b5bf7e85fffe64b06bc6 prov:wasDerivedFrom niiri:d2e202f26f07d353e876c8513aaac055 .
+niiri:33896a562b3020901f0a9129b329ca9f prov:wasDerivedFrom niiri:a1dfe524338b100e2c0b4aac79347135 .
 
-niiri:00f11aa6a9bf3c67963ec8004894a193
+niiri:0a36f87ab7a0b75562073c6947d4f7b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:cfe98ef5194606348538a89c7dce71b0 ;
+    prov:atLocation niiri:7573b7d12c8d035c9d5d8631ccb22a9f ;
     prov:value "4.70320177078247"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41124192966355"^^xsd:float ;
     nidm_pValueUncorrected: "0.000323338426391984"^^xsd:float ;
     nidm_pValueFWER: "0.999999908044234"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:cfe98ef5194606348538a89c7dce71b0
+niiri:7573b7d12c8d035c9d5d8631ccb22a9f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[22,-34,34]"^^xsd:string .
 
-niiri:00f11aa6a9bf3c67963ec8004894a193 prov:wasDerivedFrom niiri:d0abf7f944018518c8b2f88645568e05 .
+niiri:0a36f87ab7a0b75562073c6947d4f7b1 prov:wasDerivedFrom niiri:398e18e13e41fd86f9c91a0c37179f94 .
 
-niiri:057cb92551aa371b6f6dc683d506bf96
+niiri:6eab38ddecebcaaa0bf86b72dc12049c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:a7a44c477f5330dc6c8b7bbe1aa3f387 ;
+    prov:atLocation niiri:7f68e73a36ee3f3687de8c6c9b97a7fe ;
     prov:value "4.65910387039185"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39169946109688"^^xsd:float ;
     nidm_pValueUncorrected: "0.000347302923845438"^^xsd:float ;
     nidm_pValueFWER: "0.999999955827132"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:a7a44c477f5330dc6c8b7bbe1aa3f387
+niiri:7f68e73a36ee3f3687de8c6c9b97a7fe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-20,-44,-36]"^^xsd:string .
 
-niiri:057cb92551aa371b6f6dc683d506bf96 prov:wasDerivedFrom niiri:71dd070abfb1b28ce2b0e47fb4f49daf .
+niiri:6eab38ddecebcaaa0bf86b72dc12049c prov:wasDerivedFrom niiri:fc5a20643a49d6b48c632806b9fb3669 .
 
-niiri:32caa29266a76db202d1c2c5c68c7445
+niiri:8dff42675f00ab4b9ddd2b53dc34917f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:5e965e5ef7f2d1914d1b1f52d8cbddea ;
+    prov:atLocation niiri:7eab74d15593b8c8ffc29b17ea34173f ;
     prov:value "4.63754796981812"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38208413500926"^^xsd:float ;
     nidm_pValueUncorrected: "0.00035969054090712"^^xsd:float ;
     nidm_pValueFWER: "0.999999969503"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:5e965e5ef7f2d1914d1b1f52d8cbddea
+niiri:7eab74d15593b8c8ffc29b17ea34173f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[34,-22,26]"^^xsd:string .
 
-niiri:32caa29266a76db202d1c2c5c68c7445 prov:wasDerivedFrom niiri:354b333049efc8a35bffb5e871d5df51 .
+niiri:8dff42675f00ab4b9ddd2b53dc34917f prov:wasDerivedFrom niiri:7977d3c2d53495076863f90a7414369f .
 
-niiri:4c62c0e8cf4e83463b2cd8ef62f9c602
+niiri:69505c505831c5f7ad6ff3002082e4c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:b3021dc8859525200429834fc6310f99 ;
+    prov:atLocation niiri:dc677f45978a7877a700f4d03cf0e7ce ;
     prov:value "4.61526584625244"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37210130568973"^^xsd:float ;
     nidm_pValueUncorrected: "0.000372985020458683"^^xsd:float ;
     nidm_pValueFWER: "0.999999979383511"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:b3021dc8859525200429834fc6310f99
+niiri:dc677f45978a7877a700f4d03cf0e7ce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-8,-24,-20]"^^xsd:string .
 
-niiri:4c62c0e8cf4e83463b2cd8ef62f9c602 prov:wasDerivedFrom niiri:dfcda071a872154b10c43f862bf52d69 .
+niiri:69505c505831c5f7ad6ff3002082e4c0 prov:wasDerivedFrom niiri:e6d67f5c8f427474527d0d727f3dce58 .
 
-niiri:8a73d008087b3fa9d94106936d72a9cf
+niiri:07fc7144bacb9a33351978163ec7665f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:f56aea2994cdd430b079943b1299d6ba ;
+    prov:atLocation niiri:2aa908545a5498195b685e803d760c2a ;
     prov:value "4.51868915557861"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32831433156359"^^xsd:float ;
     nidm_pValueUncorrected: "0.000436866114896683"^^xsd:float ;
     nidm_pValueFWER: "0.999999996599993"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:f56aea2994cdd430b079943b1299d6ba
+niiri:2aa908545a5498195b685e803d760c2a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[10,-12,-8]"^^xsd:string .
 
-niiri:8a73d008087b3fa9d94106936d72a9cf prov:wasDerivedFrom niiri:9f93d2b40c1f794cb34e0ae17e04bd0c .
+niiri:07fc7144bacb9a33351978163ec7665f prov:wasDerivedFrom niiri:9ba6b697c18c9fa2a070f1ac777899c3 .
 
-niiri:a96fc8bfcb9cf24f47dbdf7bfe7afd17
+niiri:2a7de24428d3d14a74344f3a2ed53ab9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:ac7a10e1bead2a7d7fd42038f3949443 ;
+    prov:atLocation niiri:402ce4265cfb6d8f4eccfcd7202c27c6 ;
     prov:value "4.45568466186523"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2992865242182"^^xsd:float ;
     nidm_pValueUncorrected: "0.000484654601471068"^^xsd:float ;
     nidm_pValueFWER: "0.999999999048352"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:ac7a10e1bead2a7d7fd42038f3949443
+niiri:402ce4265cfb6d8f4eccfcd7202c27c6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[16,-48,-46]"^^xsd:string .
 
-niiri:a96fc8bfcb9cf24f47dbdf7bfe7afd17 prov:wasDerivedFrom niiri:899db6b982fa96374440fc31d77225c7 .
+niiri:2a7de24428d3d14a74344f3a2ed53ab9 prov:wasDerivedFrom niiri:17cf04133d00b334b009343c68cc794f .
 
-niiri:3d6d68b50c110bd970cae436330e36d9
+niiri:71a4d25f7fb9dd5f2ff89ce4a6426ed6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:daf43d66330a2ead30991863c01caec5 ;
+    prov:atLocation niiri:170bf99fa55adf19b4bcf6bac2226035 ;
     prov:value "4.42093467712402"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28311730425125"^^xsd:float ;
     nidm_pValueUncorrected: "0.000513329675929763"^^xsd:float ;
     nidm_pValueFWER: "0.999999999544708"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:daf43d66330a2ead30991863c01caec5
+niiri:170bf99fa55adf19b4bcf6bac2226035
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-20,52,16]"^^xsd:string .
 
-niiri:3d6d68b50c110bd970cae436330e36d9 prov:wasDerivedFrom niiri:d19f972dfab2b23346202c34e5574f29 .
+niiri:71a4d25f7fb9dd5f2ff89ce4a6426ed6 prov:wasDerivedFrom niiri:715dbdcf861d88449d6bf9fd80be68c2 .
 
-niiri:00d1711e3ed46fde327d5581de9dd791
+niiri:3fe2b2a2a97891aa0347dc4a8041143b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:ae59229032d7c40d79b030470e5f23b9 ;
+    prov:atLocation niiri:a810311fe07f257dbdaf36cba74972bf ;
     prov:value "4.41627073287964"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28093847762164"^^xsd:float ;
     nidm_pValueUncorrected: "0.00051731154621093"^^xsd:float ;
     nidm_pValueFWER: "0.999999999588405"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:ae59229032d7c40d79b030470e5f23b9
+niiri:a810311fe07f257dbdaf36cba74972bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[10,62,20]"^^xsd:string .
 
-niiri:00d1711e3ed46fde327d5581de9dd791 prov:wasDerivedFrom niiri:c8e45b2b37dac3869716ea38f6f82aa2 .
+niiri:3fe2b2a2a97891aa0347dc4a8041143b prov:wasDerivedFrom niiri:a722ba5c3f48104c4bffaa9f1bc96e93 .
 
-niiri:7e851910d726d6995c852ed218ac5570
+niiri:771d0950142ef5727aa4539533181ebe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:a01d789cee79784cca55a545db21ce87 ;
+    prov:atLocation niiri:01971ac462b6f6a68ddf7a4bcb329cd1 ;
     prov:value "4.39752912521362"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27216223374679"^^xsd:float ;
     nidm_pValueUncorrected: "0.000533641570346299"^^xsd:float ;
     nidm_pValueFWER: "0.999999999726897"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:a01d789cee79784cca55a545db21ce87
+niiri:01971ac462b6f6a68ddf7a4bcb329cd1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[50,-66,38]"^^xsd:string .
 
-niiri:7e851910d726d6995c852ed218ac5570 prov:wasDerivedFrom niiri:f4fe3e2f741c280bd998a6eaf285b07c .
+niiri:771d0950142ef5727aa4539533181ebe prov:wasDerivedFrom niiri:0aa4b1a84fee2649d333d5561003c8bf .
 
-niiri:9fe2a624ae89ae7fa855b69eec31ebbd
+niiri:8fa040e1a3007565edd3ecf0c6827522
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:88780e43a9ab7fafa2461b5df7d58e73 ;
+    prov:atLocation niiri:386b7d31755630d505a2b693dea28f77 ;
     prov:value "4.30746841430664"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22951851195682"^^xsd:float ;
     nidm_pValueUncorrected: "0.000619994267038626"^^xsd:float ;
     nidm_pValueFWER: "0.999999999965896"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:88780e43a9ab7fafa2461b5df7d58e73
+niiri:386b7d31755630d505a2b693dea28f77
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-4,-4,-8]"^^xsd:string .
 
-niiri:9fe2a624ae89ae7fa855b69eec31ebbd prov:wasDerivedFrom niiri:f18795394da513a451940bf5032734eb .
+niiri:8fa040e1a3007565edd3ecf0c6827522 prov:wasDerivedFrom niiri:5b1d37cc88f4111dc6ae2a4f48520a59 .
 
-niiri:a74e55a109a945b087544cc3e5a316c8
+niiri:2c9566f77e7f82b34e22874819f8c710
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:f763f5cde1a933a22512bd1463316cc3 ;
+    prov:atLocation niiri:170fb7ed6d4143e9075bf54c54eb7793 ;
     prov:value "4.29710006713867"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2245585560768"^^xsd:float ;
     nidm_pValueUncorrected: "0.000630835257803941"^^xsd:float ;
     nidm_pValueFWER: "0.999999999973481"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:f763f5cde1a933a22512bd1463316cc3
+niiri:170fb7ed6d4143e9075bf54c54eb7793
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-20,-56,14]"^^xsd:string .
 
-niiri:a74e55a109a945b087544cc3e5a316c8 prov:wasDerivedFrom niiri:350e81fc1b83d10ae96dfefb3bab3615 .
+niiri:2c9566f77e7f82b34e22874819f8c710 prov:wasDerivedFrom niiri:7a1feca53667470e0f2534f053958e05 .
 
-niiri:f450448fe12d0362b602a56046e2eca2
+niiri:b0fa3c1d2ceac260635bee3e4a36167b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:c65359940d6cccd84bad6f3231507649 ;
+    prov:atLocation niiri:a83c51a65ddebc4a61818ab017d3f959 ;
     prov:value "4.28621673583984"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21934090215671"^^xsd:float ;
     nidm_pValueUncorrected: "0.000642428185358868"^^xsd:float ;
     nidm_pValueFWER: "0.999999999979691"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:c65359940d6cccd84bad6f3231507649
+niiri:a83c51a65ddebc4a61818ab017d3f959
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[32,24,30]"^^xsd:string .
 
-niiri:f450448fe12d0362b602a56046e2eca2 prov:wasDerivedFrom niiri:d26601e6f8fbfb6728ae5b19b5b4ce3b .
+niiri:b0fa3c1d2ceac260635bee3e4a36167b prov:wasDerivedFrom niiri:bda46dfc41022916ad6faceac091ba3d .
 
-niiri:eb48ceb96e89cae6a5b3a0ba68de877a
+niiri:69ba9d52a63ad25b2c1f23f677985988
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:135e25c43b8fa91ac5f365849500911d ;
+    prov:atLocation niiri:2a05164883101591007a84904b255170 ;
     prov:value "4.28483486175537"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21867757532573"^^xsd:float ;
     nidm_pValueUncorrected: "0.000643916016166424"^^xsd:float ;
     nidm_pValueFWER: "0.999999999980371"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:135e25c43b8fa91ac5f365849500911d
+niiri:2a05164883101591007a84904b255170
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-18,-48,12]"^^xsd:string .
 
-niiri:eb48ceb96e89cae6a5b3a0ba68de877a prov:wasDerivedFrom niiri:3e2d682ff8be1f7b5e4954125d52dc9c .
+niiri:69ba9d52a63ad25b2c1f23f677985988 prov:wasDerivedFrom niiri:0c786e61d78880c4e546692954781ced .
 
-niiri:a02879441932ceb79462d5b20fa110d6
+niiri:8af718e4eb7ee27c7d2b1f62ae1f4fc8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:006c681558a6a4b518e9cfbba9778dc6 ;
+    prov:atLocation niiri:9327092d5f9ad138d37b770b39d5e356 ;
     prov:value "4.27967262268066"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21619793589097"^^xsd:float ;
     nidm_pValueUncorrected: "0.000649506017056822"^^xsd:float ;
     nidm_pValueFWER: "0.999999999982724"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:006c681558a6a4b518e9cfbba9778dc6
+niiri:9327092d5f9ad138d37b770b39d5e356
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-26,-80,16]"^^xsd:string .
 
-niiri:a02879441932ceb79462d5b20fa110d6 prov:wasDerivedFrom niiri:9a3e77b28376a93d769c670fd53a30cb .
+niiri:8af718e4eb7ee27c7d2b1f62ae1f4fc8 prov:wasDerivedFrom niiri:b9a4c4c2b5a9793a35534927d9578f48 .
 
-niiri:2dfef592e2c3fe76668cd44d20d63b01
+niiri:49c4aad3b156440f8fd3346227c812bb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:6219f06a8442157e1456fc904d88c25a ;
+    prov:atLocation niiri:219d1a9528adbd1b3e9fad127c12ba45 ;
     prov:value "4.27626991271973"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21456203610231"^^xsd:float ;
     nidm_pValueUncorrected: "0.000653218409537804"^^xsd:float ;
     nidm_pValueFWER: "0.999999999984125"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:6219f06a8442157e1456fc904d88c25a
+niiri:219d1a9528adbd1b3e9fad127c12ba45
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[22,-42,-44]"^^xsd:string .
 
-niiri:2dfef592e2c3fe76668cd44d20d63b01 prov:wasDerivedFrom niiri:0cff727da02fc982bbc0f11d56d44db2 .
+niiri:49c4aad3b156440f8fd3346227c812bb prov:wasDerivedFrom niiri:f4849377c56edcbca1dc5384795946ce .
 
-niiri:0fa6e1dc1111a03b5e4039ea1ac7bb00
+niiri:86047a3e6b7ffa4a1d1b9a29cb05f3c8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:512c7eaa981cfb72974cfb868f502dd3 ;
+    prov:atLocation niiri:29a67515a2b3cfc85dfdfd1fc059f75c ;
     prov:value "4.25063323974609"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20220005940261"^^xsd:float ;
     nidm_pValueUncorrected: "0.000681911226584231"^^xsd:float ;
     nidm_pValueFWER: "0.999999999991679"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:512c7eaa981cfb72974cfb868f502dd3
+niiri:29a67515a2b3cfc85dfdfd1fc059f75c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[20,28,6]"^^xsd:string .
 
-niiri:0fa6e1dc1111a03b5e4039ea1ac7bb00 prov:wasDerivedFrom niiri:8fb299584020cc344c3c2c82de2f748c .
+niiri:86047a3e6b7ffa4a1d1b9a29cb05f3c8 prov:wasDerivedFrom niiri:6ad64a79d36f37c1cd1b1433a1aef9ca .
 
-niiri:ced62c2013b6703081946558916b11da
+niiri:2d96bb4e97bbf9cdca301464aea060d7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:a829e3773a01f331491ad7d37354892f ;
+    prov:atLocation niiri:17e914d0522a7782b8946f4570a112a0 ;
     prov:value "4.22958660125732"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19200261281843"^^xsd:float ;
     nidm_pValueUncorrected: "0.000706450272937809"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995163"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:a829e3773a01f331491ad7d37354892f
+niiri:17e914d0522a7782b8946f4570a112a0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[44,26,40]"^^xsd:string .
 
-niiri:ced62c2013b6703081946558916b11da prov:wasDerivedFrom niiri:6e2110d791417b070202a6783afba19c .
+niiri:2d96bb4e97bbf9cdca301464aea060d7 prov:wasDerivedFrom niiri:50d65ffbbedadcbcef20b8bacaa5bf32 .
 
-niiri:e47ab6c45400adc2077bdd0ae11df79c
+niiri:b544c89d1296f2203fb8e262999b2903
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:aa889a8c10c7df77f4c657a1ba5d6cc2 ;
+    prov:atLocation niiri:7ab866ab624608ae371a87356ccbb246 ;
     prov:value "4.13231182098389"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14429239999158"^^xsd:float ;
     nidm_pValueUncorrected: "0.000832444966141432"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999966"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:aa889a8c10c7df77f4c657a1ba5d6cc2
+niiri:7ab866ab624608ae371a87356ccbb246
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-32,-78,44]"^^xsd:string .
 
-niiri:e47ab6c45400adc2077bdd0ae11df79c prov:wasDerivedFrom niiri:b0fbdf26b837fa676d008fcff5a30ee9 .
+niiri:b544c89d1296f2203fb8e262999b2903 prov:wasDerivedFrom niiri:57ec9ce901bb55b112e2f594ad471e7a .
 
-niiri:2b415d5e579030f0e97fe16ff764d1af
+niiri:e8fc125bac22d26604b604112b05554d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:1a87f060e179e8d5d5fad75dee9e561e ;
+    prov:atLocation niiri:0e198fd93d34f6f23b1574200bd77922 ;
     prov:value "4.0775408744812"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11700347232274"^^xsd:float ;
     nidm_pValueUncorrected: "0.000913497101264649"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999932"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:1a87f060e179e8d5d5fad75dee9e561e
+niiri:0e198fd93d34f6f23b1574200bd77922
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[4,-54,-42]"^^xsd:string .
 
-niiri:2b415d5e579030f0e97fe16ff764d1af prov:wasDerivedFrom niiri:5167e145ebaf9f5693dffbc09df2f2f8 .
+niiri:e8fc125bac22d26604b604112b05554d prov:wasDerivedFrom niiri:1318d2cd1289a2678d066b7cca2986f1 .
 
-niiri:a4068ca93949e6e3223a16b3e3bfeb42
+niiri:93ad18b2412733cb3a43ab2edf151f7d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:e82cbbcc7b634200287898ef5f614f70 ;
+    prov:atLocation niiri:65f92900970c3f35426b598b6b9b186c ;
     prov:value "4.07394027709961"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11519863095218"^^xsd:float ;
     nidm_pValueUncorrected: "0.000919105401866016"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999939"^^xsd:float ;
     nidm_qValueFDR: "0.882167584555376"^^xsd:float .
 
-niiri:e82cbbcc7b634200287898ef5f614f70
+niiri:65f92900970c3f35426b598b6b9b186c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[34,14,56]"^^xsd:string .
 
-niiri:a4068ca93949e6e3223a16b3e3bfeb42 prov:wasDerivedFrom niiri:17c3abf712c940e8e07c2fa7b3493dc1 .
+niiri:93ad18b2412733cb3a43ab2edf151f7d prov:wasDerivedFrom niiri:d3124b3f5d244eeb2fba0e7fb6bf71ea .
 

--- a/spmexport/ex_spm_f_test/config.json
+++ b/spmexport/ex_spm_f_test/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["f_test/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_f_test/nidm.provn
+++ b/spmexport/ex_spm_f_test/nidm.provn
@@ -1,0 +1,2892 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:21b3c4311946920c7bb866cb7241f06a,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:26e4ed7e4ca9f8d6f69ba2608dc2bb2b,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:cfc5d5cf6de0f5ccfe313e6d43587323,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:cfc5d5cf6de0f5ccfe313e6d43587323, niiri:26e4ed7e4ca9f8d6f69ba2608dc2bb2b, -)
+  wasGeneratedBy(niiri:21b3c4311946920c7bb866cb7241f06a, niiri:cfc5d5cf6de0f5ccfe313e6d43587323, 2016-01-11T10:11:24)
+  bundle niiri:21b3c4311946920c7bb866cb7241f06a
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_FStatistic <http://purl.obolibrary.org/obo/STATO_0000282>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastExplainedMeanSquareMap <http://purl.org/nidash/nidm#NIDM_0000163>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+    prefix nidm_SupraThresholdCluster <http://purl.org/nidash/nidm#NIDM_0000070>
+    prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
+    prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+    prefix nidm_qValueFDR <http://purl.org/nidash/nidm#NIDM_0000119>
+    prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
+    prefix nidm_Peak <http://purl.org/nidash/nidm#NIDM_0000062>
+    prefix nidm_equivalentZStatistic <http://purl.org/nidash/nidm#NIDM_0000092>
+    prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
+    prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
+
+    agent(niiri:43a3ee53f98ee35a82fd6af9eebbd163,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:6cbc3e147cf7f32be569d44f46d94c1f,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:e3676e8eec4990ea33ab365f41819e4c,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:a4aacd65a7c45519a9f2f3175def869f,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:3769ef4c5efe49a97295e3959f9dc7ad,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:e95fdfe90dea233f4527fc2ab0df8f98',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:a4aacd65a7c45519a9f2f3175def869f',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:e95fdfe90dea233f4527fc2ab0df8f98,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:b2fe7439c407fcd2dde1efc329a7b0f3,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:403063ca7469ea436c4ddd80ac3e76cd,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:403063ca7469ea436c4ddd80ac3e76cd, niiri:43a3ee53f98ee35a82fd6af9eebbd163, -)
+    used(niiri:403063ca7469ea436c4ddd80ac3e76cd, niiri:3769ef4c5efe49a97295e3959f9dc7ad, -)
+    used(niiri:403063ca7469ea436c4ddd80ac3e76cd, niiri:e3676e8eec4990ea33ab365f41819e4c, -)
+    used(niiri:403063ca7469ea436c4ddd80ac3e76cd, niiri:b2fe7439c407fcd2dde1efc329a7b0f3, -)
+    entity(niiri:2dfea426e8928d3252adb676004ffb9d,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
+    entity(niiri:9791d34c6aacce2cfbb27ce2f9075562,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
+    wasDerivedFrom(niiri:2dfea426e8928d3252adb676004ffb9d, niiri:9791d34c6aacce2cfbb27ce2f9075562, -, -, -)
+    wasGeneratedBy(niiri:2dfea426e8928d3252adb676004ffb9d, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:fe1de7f78c02a415bd4ad2098cae4f59,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "108.038318634033" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
+    wasGeneratedBy(niiri:fe1de7f78c02a415bd4ad2098cae4f59, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
+    entity(niiri:335e2de27a1a351eae295b2d6aba0ccc,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "11c208792e1874b4837ea90ec03320c8eeb702ad3966ee5912aa2e33b5bdb17b0e88caa31ed546f7f601160ced8eceebdf5db6449df6ec3ffbd17e27917ec328" %% xsd:string])
+    wasDerivedFrom(niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7, niiri:335e2de27a1a351eae295b2d6aba0ccc, -, -, -)
+    wasGeneratedBy(niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:40508269ce9f0c03d9af35c886882e23,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
+    entity(niiri:493248b59478ddca0df41a77bc6f1482,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
+    wasDerivedFrom(niiri:40508269ce9f0c03d9af35c886882e23, niiri:493248b59478ddca0df41a77bc6f1482, -, -, -)
+    wasGeneratedBy(niiri:40508269ce9f0c03d9af35c886882e23, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:336fa6f65e23fda5fa34e118d1c9a0e1,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
+    entity(niiri:7fd42856ebc39326ecf3d9c7336203ad,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "833a477bd4e758bdde7fcc9e6682186e9e38c1eeaa2a66de7d67e5f3c57cbaed7bddd45a7f7c86db713a8aa708790eaa31e0d8f0d0af9db9e87b545990b9e91e" %% xsd:string])
+    wasDerivedFrom(niiri:336fa6f65e23fda5fa34e118d1c9a0e1, niiri:7fd42856ebc39326ecf3d9c7336203ad, -, -, -)
+    wasGeneratedBy(niiri:336fa6f65e23fda5fa34e118d1c9a0e1, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:16e0178c267997ead20f777bffe45894,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 4" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
+    entity(niiri:ffb56ac43e312f7d862bd04227ca2771,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0004.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "8044c2e517efad185114b1d5478983a5073547d99f6b5778bcefe9caa7d243b89824b69841e3e5aa05e1da5393c9d1a34fec9a050b6a1e8a87da31cad99bfe69" %% xsd:string])
+    wasDerivedFrom(niiri:16e0178c267997ead20f777bffe45894, niiri:ffb56ac43e312f7d862bd04227ca2771, -, -, -)
+    wasGeneratedBy(niiri:16e0178c267997ead20f777bffe45894, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:717d24f6fc8fcd6daeec2603e49ed740,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 5" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
+    entity(niiri:67d86f251b1b458908a8aee56a029301,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0005.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "15551a7f3970720338fd0643bd017ba2f7f5db09c16b38909560b0479aa69eb74cd746fa98b2adc796153af88fba9b2ddd4eb5713b6f6011e62b7efb6531426d" %% xsd:string])
+    wasDerivedFrom(niiri:717d24f6fc8fcd6daeec2603e49ed740, niiri:67d86f251b1b458908a8aee56a029301, -, -, -)
+    wasGeneratedBy(niiri:717d24f6fc8fcd6daeec2603e49ed740, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:b8e1b2bd6e02f1d74415b3190da5e6ce,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 6" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
+    entity(niiri:0f227926cc2656b6333cd6e70b59bef0,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0006.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
+    wasDerivedFrom(niiri:b8e1b2bd6e02f1d74415b3190da5e6ce, niiri:0f227926cc2656b6333cd6e70b59bef0, -, -, -)
+    wasGeneratedBy(niiri:b8e1b2bd6e02f1d74415b3190da5e6ce, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:f446aad676c7f507c6dfdb3e65bd6cb3,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        crypto:sha512 = "9f1acf4f335317f388cc8adcc04086aa4e6bc6d19d5633a6a8d8dd85716386748c7ed700ef8031c7a3733228557d5ecf96eb6a889e2d36ad065e7bc852ae0b8c" %% xsd:string])
+    entity(niiri:7dc7be1e08841016c50f481df400db45,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "641184631587ff0ed74f92302d94dd40f2802efab358753eade14667fb6ee74fe64f3090b02fdf20e4a99d444610a61a1ae8a684628c9b2037535fbed9d53a12" %% xsd:string])
+    wasDerivedFrom(niiri:f446aad676c7f507c6dfdb3e65bd6cb3, niiri:7dc7be1e08841016c50f481df400db45, -, -, -)
+    wasGeneratedBy(niiri:f446aad676c7f507c6dfdb3e65bd6cb3, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:952c39e2aa9fff43b62bbe9b77405227,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        crypto:sha512 = "a093dd7a9dd81e95f3696221e49cbb3ad8080b1f316ece53c9aafcb5cc9b767e55c594b7131d933e31231744c65db07483e64245480afd95075b76ccd2432789" %% xsd:string])
+    entity(niiri:48a4ebca3d7eaf837f3c511ad76b8b82,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "6ccf9e1895f8a26549f392b1d1a3676888cd729a207c6a93bcda6d549de2d4f133c0b2847bd2e839a462f3ba74cb9d9525eddb9f8499b99fb452b93cd713a158" %% xsd:string])
+    wasDerivedFrom(niiri:952c39e2aa9fff43b62bbe9b77405227, niiri:48a4ebca3d7eaf837f3c511ad76b8b82, -, -, -)
+    wasGeneratedBy(niiri:952c39e2aa9fff43b62bbe9b77405227, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
+    entity(niiri:eaf42d3560a64658c65dfc990556d651,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_FStatistic:',
+        nidm_contrastName: = "F Contrast Test" %% xsd:string,
+        prov:label = "Contrast: F Contrast Test" %% xsd:string,
+        prov:value = "[[1, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0],[0, 0, 0, 1, 0, 0]]" %% xsd:string])
+    activity(niiri:b6fffa4c3247dbca41c70d6abf376201,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:43a3ee53f98ee35a82fd6af9eebbd163, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:2dfea426e8928d3252adb676004ffb9d, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:f446aad676c7f507c6dfdb3e65bd6cb3, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:3769ef4c5efe49a97295e3959f9dc7ad, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:eaf42d3560a64658c65dfc990556d651, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:40508269ce9f0c03d9af35c886882e23, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:336fa6f65e23fda5fa34e118d1c9a0e1, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:16e0178c267997ead20f777bffe45894, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:717d24f6fc8fcd6daeec2603e49ed740, -)
+    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:b8e1b2bd6e02f1d74415b3190da5e6ce, -)
+    entity(niiri:b61012119e0a476f635df26d721e8c30,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "FStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "FStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: F Contrast Test" %% xsd:string,
+        nidm_statisticType: = 'stato_FStatistic:',
+        nidm_contrastName: = "F Contrast Test" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "192.999999999651" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "3.99999999999962" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        crypto:sha512 = "ca31a667d26797ee68a3709a8fa04f799ad113f17e6eff75ad6e88f53c44aa9e158a0d007354d454ad01df82d6b0f25f07b324cc3baa32f7623096a92ee6f304" %% xsd:string])
+    entity(niiri:7a977781f43baadb29a7109b66db5c80,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmF_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "db6d4200b2e060c1fbd3e5c71011ac95ce60024087239685545954651a68733ec2d949c56520d2637add9e91c8e7883742c7d307667ad83c4ebe2a8531a1cc53" %% xsd:string])
+    wasDerivedFrom(niiri:b61012119e0a476f635df26d721e8c30, niiri:7a977781f43baadb29a7109b66db5c80, -, -, -)
+    wasGeneratedBy(niiri:b61012119e0a476f635df26d721e8c30, niiri:b6fffa4c3247dbca41c70d6abf376201, -)
+    entity(niiri:5da9115bb9224fc27deb59c4db51293d,
+        [prov:type = 'nidm_ContrastExplainedMeanSquareMap:',
+        prov:location = "ContrastExplainedMeanSquare.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastExplainedMeanSquare.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Explained Mean Square Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        crypto:sha512 = "a4b2ff6f792524a027a625aba962b798c3ea321cdd6636193ab521acf5dafa8ceb7fd4cb99a450ab7872359d0e6dac97f82b7523d609747780623b5077e02588" %% xsd:string])
+    wasGeneratedBy(niiri:5da9115bb9224fc27deb59c4db51293d, niiri:b6fffa4c3247dbca41c70d6abf376201, -)
+    entity(niiri:790a0bb2d27b9d88e6869e877e73216b,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
+        prov:value = "0.000999500086842908" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:cdc27d5485a25b98dc806d64eab06294',
+        nidm_equivalentThreshold: = 'niiri:3a45a7e93b85e390a50cf7b33998e058'])
+    entity(niiri:cdc27d5485a25b98dc806d64eab06294,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "4.81888651656205" %% xsd:float])
+    entity(niiri:3a45a7e93b85e390a50cf7b33998e058,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:311c74b903cbe301d2ea1ed406ef3819,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:d03c098b559b5d8b940ae0e6f4e45ac2',
+        nidm_equivalentThreshold: = 'niiri:1256253b1ec8513cc907a598b85b5d25'])
+    entity(niiri:d03c098b559b5d8b940ae0e6f4e45ac2,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:1256253b1ec8513cc907a598b85b5d25,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:0499a436458abc172a88ee306d18a605,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:83fc9ee7c0ea36a7bd88d4420b89b29c,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:43a3ee53f98ee35a82fd6af9eebbd163, -)
+    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:790a0bb2d27b9d88e6869e877e73216b, -)
+    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:311c74b903cbe301d2ea1ed406ef3819, -)
+    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:b61012119e0a476f635df26d721e8c30, -)
+    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:952c39e2aa9fff43b62bbe9b77405227, -)
+    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:2dfea426e8928d3252adb676004ffb9d, -)
+    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:0499a436458abc172a88ee306d18a605, -)
+    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:83fc9ee7c0ea36a7bd88d4420b89b29c, -)
+    entity(niiri:0bd153c871e44425ad2d0d70154ff868,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
+        nidm_reselSizeInVoxels: = "68.4409986586639" %% xsd:float,
+        nidm_searchVolumeInResels: = "2811.45809925498" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[5, 96.6116867805811, 900.100332657459, 2811.45809925498]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.16320607513029, 4.05765428344923, 4.05147708968716]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.32641215026059, 8.11530856689846, 8.10295417937431]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "4.8177623848126" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "45.9650640219086" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "9.80643263054093" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "8.38272571563721" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "68" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "51" %% xsd:int,
+        crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
+    wasGeneratedBy(niiri:0bd153c871e44425ad2d0d70154ff868, niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, -)
+    entity(niiri:1f1a3d63428e4d2bf1696942c7dcd71e,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "89" %% xsd:int,
+        nidm_pValue: = "1.20671430625663e-08" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:ea2c3c814c10994917dd56bc9fe21873',
+        nidm_hasMaximumIntensityProjection: = 'niiri:dd34657f27860de0933d54ae20a5bde9',
+        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        crypto:sha512 = "7655b200bdcbba72ab5ab79029728a420df3f3368bcb553410540390e1372e99531cb91885edbdd03945d7e2391516a3d8dc537da81527730e866035d4af7894" %% xsd:string])
+    entity(niiri:ea2c3c814c10994917dd56bc9fe21873,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:dd34657f27860de0933d54ae20a5bde9,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:1f1a3d63428e4d2bf1696942c7dcd71e, niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, -)
+    entity(niiri:0af3c1dadf9b022bafb92d73c4057be6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1078" %% xsd:int,
+        nidm_clusterSizeInResels: = "15.7507929622172" %% xsd:float,
+        nidm_pValueUncorrected: = "4.44714364460473e-20" %% xsd:float,
+        nidm_pValueFWER: = "0" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "1" %% xsd:int])
+    wasDerivedFrom(niiri:0af3c1dadf9b022bafb92d73c4057be6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:1f6332db35b31af3ee6ca935dfaeba0c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "930" %% xsd:int,
+        nidm_clusterSizeInResels: = "13.5883464330816" %% xsd:float,
+        nidm_pValueUncorrected: = "2.90091267643839e-18" %% xsd:float,
+        nidm_pValueFWER: = "1.11022302462516e-16" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "2" %% xsd:int])
+    wasDerivedFrom(niiri:1f6332db35b31af3ee6ca935dfaeba0c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:0d4bf8c640cd15c305d2e49ef14b9ac6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "61" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.891278637008579" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00140501536931943" %% xsd:float,
+        nidm_pValueFWER: = "0.0625404056276491" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "3" %% xsd:int])
+    wasDerivedFrom(niiri:0d4bf8c640cd15c305d2e49ef14b9ac6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:32439b88059be589d0e2a8586ea799ec,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "51" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.74516738503996" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00294180828906497" %% xsd:float,
+        nidm_pValueFWER: = "0.126476639623878" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "4" %% xsd:int])
+    wasDerivedFrom(niiri:32439b88059be589d0e2a8586ea799ec, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:d8b9846e25000609adbc385c634a1be0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "102" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.49033477007992" %% xsd:float,
+        nidm_pValueUncorrected: = "9.58684672197711e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.00439690541625271" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "5" %% xsd:int])
+    wasDerivedFrom(niiri:d8b9846e25000609adbc385c634a1be0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:f8e22d4c567142a3ab813140dd91551e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "69" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.00816763858347" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000800670143082103" %% xsd:float,
+        nidm_pValueFWER: = "0.0361338614001637" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "6" %% xsd:int])
+    wasDerivedFrom(niiri:f8e22d4c567142a3ab813140dd91551e, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:96a2e290f72fc28530510650c52e2805,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "81" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.18350114094582" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000358186300522155" %% xsd:float,
+        nidm_pValueFWER: = "0.0163292644152585" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "7" %% xsd:int])
+    wasDerivedFrom(niiri:96a2e290f72fc28530510650c52e2805, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:1062efea331d3022773f16c049f8543d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "62" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.905889762205441" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00130795483514697" %% xsd:float,
+        nidm_pValueFWER: = "0.0583486858266125" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "8" %% xsd:int])
+    wasDerivedFrom(niiri:1062efea331d3022773f16c049f8543d, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:5577dc13c7013d8bb90b8dd111792d46,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "27" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.394500380315273" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0220489738091681" %% xsd:float,
+        nidm_pValueFWER: = "0.637047204368496" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "9" %% xsd:int])
+    wasDerivedFrom(niiri:5577dc13c7013d8bb90b8dd111792d46, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:64ae5737521bbc7fe14f0c862379e927,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "69" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.00816763858347" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000800670143082103" %% xsd:float,
+        nidm_pValueFWER: = "0.0361338614001637" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "10" %% xsd:int])
+    wasDerivedFrom(niiri:64ae5737521bbc7fe14f0c862379e927, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:900846b4c16bba4a9b8a34762cba2da0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "34" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.496778256693306" %% xsd:float,
+        nidm_pValueUncorrected: = "0.011700144046285" %% xsd:float,
+        nidm_pValueFWER: = "0.41596704628578" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "11" %% xsd:int])
+    wasDerivedFrom(niiri:900846b4c16bba4a9b8a34762cba2da0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:7ede1db6987922a4806abc265aecda62,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "16" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.233778003149791" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0678018153345425" %% xsd:float,
+        nidm_pValueFWER: = "0.955688665756324" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "12" %% xsd:int])
+    wasDerivedFrom(niiri:7ede1db6987922a4806abc265aecda62, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:9287b2a8106c3ffe3abf93837cfbd61c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "33" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.482167131496445" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0127719721079915" %% xsd:float,
+        nidm_pValueFWER: = "0.444043105508432" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "13" %% xsd:int])
+    wasDerivedFrom(niiri:9287b2a8106c3ffe3abf93837cfbd61c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:c515278968596a92906ae29ffad63511,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "29" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.423722630708997" %% xsd:float,
+        nidm_pValueUncorrected: = "0.01830452631499" %% xsd:float,
+        nidm_pValueFWER: = "0.568879964907834" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "14" %% xsd:int])
+    wasDerivedFrom(niiri:c515278968596a92906ae29ffad63511, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:0493a379c4735cda662e56229168b8a9,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "52" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.759778510236822" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00272666362579781" %% xsd:float,
+        nidm_pValueFWER: = "0.117795392093901" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "15" %% xsd:int])
+    wasDerivedFrom(niiri:0493a379c4735cda662e56229168b8a9, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:6f915c93d573d9f832d05fb003dcbfb0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "19" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.277611378740377" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0489067183857246" %% xsd:float,
+        nidm_pValueFWER: = "0.894389812698126" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "16" %% xsd:int])
+    wasDerivedFrom(niiri:6f915c93d573d9f832d05fb003dcbfb0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:2344710a34a75f050910ebd48e1159af,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "15" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.219166877952929" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0759384102313504" %% xsd:float,
+        nidm_pValueFWER: = "0.969514797834504" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "17" %% xsd:int])
+    wasDerivedFrom(niiri:2344710a34a75f050910ebd48e1159af, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:a904380f9b13e67a2253c5f952a57f9f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346653" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0606787631410972" %% xsd:float,
+        nidm_pValueFWER: = "0.938523680835064" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "18" %% xsd:int])
+    wasDerivedFrom(niiri:a904380f9b13e67a2253c5f952a57f9f, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:8348fc8e7248e46840dad7df7f8763bf,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "37" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.540611632283892" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00903991120867935" %% xsd:float,
+        nidm_pValueFWER: = "0.340003071301302" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "19" %% xsd:int])
+    wasDerivedFrom(niiri:8348fc8e7248e46840dad7df7f8763bf, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:db6eb647802a5fc531c369aa668af574,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "9" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.131500126771758" %% xsd:float,
+        nidm_pValueUncorrected: = "0.15980273271822" %% xsd:float,
+        nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "20" %% xsd:int])
+    wasDerivedFrom(niiri:db6eb647802a5fc531c369aa668af574, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:efddc25357ec7a4b9a063a62f5a2c864,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "27" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.394500380315273" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0220489738091681" %% xsd:float,
+        nidm_pValueFWER: = "0.637047204368496" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "21" %% xsd:int])
+    wasDerivedFrom(niiri:efddc25357ec7a4b9a063a62f5a2c864, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:92832eb3b91834fca357233c33e92d47,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "24" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.350667004724687" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0294098545193599" %% xsd:float,
+        nidm_pValueFWER: = "0.741232640256625" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "22" %% xsd:int])
+    wasDerivedFrom(niiri:92832eb3b91834fca357233c33e92d47, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:27a928cca18b5d563bf58797f306d0e0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "30" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.438333755905859" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0167048818724221" %% xsd:float,
+        nidm_pValueFWER: = "0.535986190221124" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "23" %% xsd:int])
+    wasDerivedFrom(niiri:27a928cca18b5d563bf58797f306d0e0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:9197197694f96c553e0e78334284b0c7,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "19" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.277611378740377" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0489067183857246" %% xsd:float,
+        nidm_pValueFWER: = "0.894389812698126" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "24" %% xsd:int])
+    wasDerivedFrom(niiri:9197197694f96c553e0e78334284b0c7, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:4babeddab7c30570f5f7bca47ad8e349,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "68" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.993556513386613" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000857915851634946" %% xsd:float,
+        nidm_pValueFWER: = "0.0386667510721175" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "25" %% xsd:int])
+    wasDerivedFrom(niiri:4babeddab7c30570f5f7bca47ad8e349, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:abcdfa125cb9a6705001908f8633bf90,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160722377165481" %% xsd:float,
+        nidm_pValueUncorrected: = "0.122909028578024" %% xsd:float,
+        nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "26" %% xsd:int])
+    wasDerivedFrom(niiri:abcdfa125cb9a6705001908f8633bf90, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:2583f6b74e4ca256d5338bb9b9f07a29,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.14611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.139840260197002" %% xsd:float,
+        nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "27" %% xsd:int])
+    wasDerivedFrom(niiri:2583f6b74e4ca256d5338bb9b9f07a29, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:9656cbf27ba556542b025f2f8e45acfd,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "15" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.219166877952929" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0759384102313504" %% xsd:float,
+        nidm_pValueFWER: = "0.969514797834504" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "28" %% xsd:int])
+    wasDerivedFrom(niiri:9656cbf27ba556542b025f2f8e45acfd, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:52cafab6790abfb27ec51f00e747fe9a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346653" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0606787631410972" %% xsd:float,
+        nidm_pValueFWER: = "0.938523680835064" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "29" %% xsd:int])
+    wasDerivedFrom(niiri:52cafab6790abfb27ec51f00e747fe9a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:4c64b57b636863b3e947522d1311c0f1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.175333502362343" %% xsd:float,
+        nidm_pValueUncorrected: = "0.108445358385968" %% xsd:float,
+        nidm_pValueFWER: = "0.993158154960398" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "30" %% xsd:int])
+    wasDerivedFrom(niiri:4c64b57b636863b3e947522d1311c0f1, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:a8236e3bfdb590d4516edd326dbac95d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.343698638066254" %% xsd:float,
+        nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "31" %% xsd:int])
+    wasDerivedFrom(niiri:a8236e3bfdb590d4516edd326dbac95d, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:90dce13e46266944c40d12f4f1a86219,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160722377165481" %% xsd:float,
+        nidm_pValueUncorrected: = "0.122909028578024" %% xsd:float,
+        nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "32" %% xsd:int])
+    wasDerivedFrom(niiri:90dce13e46266944c40d12f4f1a86219, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:4b569159d1ddc968752a57917503c6f4,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.14611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.139840260197002" %% xsd:float,
+        nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "33" %% xsd:int])
+    wasDerivedFrom(niiri:4b569159d1ddc968752a57917503c6f4, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:674c9062dc421a541e91be283cce8f16,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "9" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.131500126771758" %% xsd:float,
+        nidm_pValueUncorrected: = "0.15980273271822" %% xsd:float,
+        nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "34" %% xsd:int])
+    wasDerivedFrom(niiri:674c9062dc421a541e91be283cce8f16, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:d3a1762138c1b259db52c75933757662,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.116889001574896" %% xsd:float,
+        nidm_pValueUncorrected: = "0.183538919045686" %% xsd:float,
+        nidm_pValueFWER: = "0.999783165932851" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "35" %% xsd:int])
+    wasDerivedFrom(niiri:d3a1762138c1b259db52c75933757662, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:9dc472e5df63cfbf55f8afa2ad7233f1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.343698638066254" %% xsd:float,
+        nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "36" %% xsd:int])
+    wasDerivedFrom(niiri:9dc472e5df63cfbf55f8afa2ad7233f1, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:3fd667ca8587427124fe4b4ff80af21a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.175333502362343" %% xsd:float,
+        nidm_pValueUncorrected: = "0.108445358385968" %% xsd:float,
+        nidm_pValueFWER: = "0.993158154960398" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "37" %% xsd:int])
+    wasDerivedFrom(niiri:3fd667ca8587427124fe4b4ff80af21a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:c60cf8d223f50376ab05520bb51598af,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "13" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.189944627559205" %% xsd:float,
+        nidm_pValueUncorrected: = "0.096012927539169" %% xsd:float,
+        nidm_pValueFWER: = "0.987884145093703" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "38" %% xsd:int])
+    wasDerivedFrom(niiri:c60cf8d223f50376ab05520bb51598af, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:f551110d12542058bdc59cae03013010,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811717" %% xsd:float,
+        nidm_pValueUncorrected: = "0.246729452566726" %% xsd:float,
+        nidm_pValueFWER: = "0.999988123335902" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "39" %% xsd:int])
+    wasDerivedFrom(niiri:f551110d12542058bdc59cae03013010, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:fb9120500eef24a89fb5e84238991362,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.343698638066254" %% xsd:float,
+        nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "40" %% xsd:int])
+    wasDerivedFrom(niiri:fb9120500eef24a89fb5e84238991362, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:dde8bc734b1e70c777683f3419f9b22a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811717" %% xsd:float,
+        nidm_pValueUncorrected: = "0.246729452566726" %% xsd:float,
+        nidm_pValueFWER: = "0.999988123335902" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "41" %% xsd:int])
+    wasDerivedFrom(niiri:dde8bc734b1e70c777683f3419f9b22a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:89223f01a7e676c300c22c8da4a82ef8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160722377165481" %% xsd:float,
+        nidm_pValueUncorrected: = "0.122909028578024" %% xsd:float,
+        nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "42" %% xsd:int])
+    wasDerivedFrom(niiri:89223f01a7e676c300c22c8da4a82ef8, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:7ac6ced5ac5b95c88fbe93f4ad51726c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "14" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.204555752756067" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0852685099572997" %% xsd:float,
+        nidm_pValueFWER: = "0.980146451443566" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "43" %% xsd:int])
+    wasDerivedFrom(niiri:7ac6ced5ac5b95c88fbe93f4ad51726c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:5d05848ec2715382392265640fc9d57e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.14611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.139840260197002" %% xsd:float,
+        nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "44" %% xsd:int])
+    wasDerivedFrom(niiri:5d05848ec2715382392265640fc9d57e, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:ca24bdc833f185dc48a439c9bd8cfea6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102277876378034" %% xsd:float,
+        nidm_pValueUncorrected: = "0.212050388130978" %% xsd:float,
+        nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "45" %% xsd:int])
+    wasDerivedFrom(niiri:ca24bdc833f185dc48a439c9bd8cfea6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:302ad243c21e156bc35f157e2595460d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "46" %% xsd:int])
+    wasDerivedFrom(niiri:302ad243c21e156bc35f157e2595460d, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:b0e84ab2cd541b237634e56ebf391609,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.116889001574896" %% xsd:float,
+        nidm_pValueUncorrected: = "0.183538919045686" %% xsd:float,
+        nidm_pValueFWER: = "0.999783165932851" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "47" %% xsd:int])
+    wasDerivedFrom(niiri:b0e84ab2cd541b237634e56ebf391609, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:27969eb0dc2d34026b32c881a0f07667,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "48" %% xsd:int])
+    wasDerivedFrom(niiri:27969eb0dc2d34026b32c881a0f07667, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:488053a695a16e1621e578a90cd45d96,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "9" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.131500126771758" %% xsd:float,
+        nidm_pValueUncorrected: = "0.15980273271822" %% xsd:float,
+        nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "49" %% xsd:int])
+    wasDerivedFrom(niiri:488053a695a16e1621e578a90cd45d96, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:ed908db943ba3e97ea5826f9b78e251e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.343698638066254" %% xsd:float,
+        nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "50" %% xsd:int])
+    wasDerivedFrom(niiri:ed908db943ba3e97ea5826f9b78e251e, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:f5e02329544635d1b1ebf65b366251dc,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102277876378034" %% xsd:float,
+        nidm_pValueUncorrected: = "0.212050388130978" %% xsd:float,
+        nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "51" %% xsd:int])
+    wasDerivedFrom(niiri:f5e02329544635d1b1ebf65b366251dc, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:48785ebe53244b67446462ca165511f6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0730556259843098" %% xsd:float,
+        nidm_pValueUncorrected: = "0.289588977139942" %% xsd:float,
+        nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "52" %% xsd:int])
+    wasDerivedFrom(niiri:48785ebe53244b67446462ca165511f6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:dd83d9e917f614f418e9401cdb99e43c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.343698638066254" %% xsd:float,
+        nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "53" %% xsd:int])
+    wasDerivedFrom(niiri:dd83d9e917f614f418e9401cdb99e43c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:f9dfccb5b804ef9741131141e3190a4b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102277876378034" %% xsd:float,
+        nidm_pValueUncorrected: = "0.212050388130978" %% xsd:float,
+        nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "54" %% xsd:int])
+    wasDerivedFrom(niiri:f9dfccb5b804ef9741131141e3190a4b, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160722377165481" %% xsd:float,
+        nidm_pValueUncorrected: = "0.122909028578024" %% xsd:float,
+        nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "55" %% xsd:int])
+    wasDerivedFrom(niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:024c443604af80b2271c971bd66fc9a0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "56" %% xsd:int])
+    wasDerivedFrom(niiri:024c443604af80b2271c971bd66fc9a0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:bd7d210916ff0d725f61db0ca48f5d05,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "57" %% xsd:int])
+    wasDerivedFrom(niiri:bd7d210916ff0d725f61db0ca48f5d05, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:7925cec36e37f32d88f7027ba176a2e1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "58" %% xsd:int])
+    wasDerivedFrom(niiri:7925cec36e37f32d88f7027ba176a2e1, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:11d4226a2f26d5d215e759b0b4e1b65c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102277876378034" %% xsd:float,
+        nidm_pValueUncorrected: = "0.212050388130978" %% xsd:float,
+        nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "59" %% xsd:int])
+    wasDerivedFrom(niiri:11d4226a2f26d5d215e759b0b4e1b65c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:cd265e81b525edcdebe748129d48fb9f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.343698638066254" %% xsd:float,
+        nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "60" %% xsd:int])
+    wasDerivedFrom(niiri:cd265e81b525edcdebe748129d48fb9f, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:aa2c86e9352626823ca6bb3bbda5947a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "61" %% xsd:int])
+    wasDerivedFrom(niiri:aa2c86e9352626823ca6bb3bbda5947a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:8d3a03589611da3ed8127a06d493acd6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905859" %% xsd:float,
+        nidm_pValueUncorrected: = "0.41411715244508" %% xsd:float,
+        nidm_pValueFWER: = "0.999999994589484" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "62" %% xsd:int])
+    wasDerivedFrom(niiri:8d3a03589611da3ed8127a06d493acd6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:3f311421a632e712f70cc6839f7e9489,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "63" %% xsd:int])
+    wasDerivedFrom(niiri:3f311421a632e712f70cc6839f7e9489, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:bcc132262f6d7297d1d28a6f0a171093,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.343698638066254" %% xsd:float,
+        nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "64" %% xsd:int])
+    wasDerivedFrom(niiri:bcc132262f6d7297d1d28a6f0a171093, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:3bdec6eb0b5535174fa631dd70795a7e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "65" %% xsd:int])
+    wasDerivedFrom(niiri:3bdec6eb0b5535174fa631dd70795a7e, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:f1946d8aa4c75dc6c7b6e735e96e1847,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "66" %% xsd:int])
+    wasDerivedFrom(niiri:f1946d8aa4c75dc6c7b6e735e96e1847, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:3592a75cac312314b4a818b743916efd,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "67" %% xsd:int])
+    wasDerivedFrom(niiri:3592a75cac312314b4a818b743916efd, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:a457cd8f3b3381f0a12661e0907b556a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.343698638066254" %% xsd:float,
+        nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "68" %% xsd:int])
+    wasDerivedFrom(niiri:a457cd8f3b3381f0a12661e0907b556a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:698306b72f010c2b2851ac92120e72d6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0730556259843098" %% xsd:float,
+        nidm_pValueUncorrected: = "0.289588977139942" %% xsd:float,
+        nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "69" %% xsd:int])
+    wasDerivedFrom(niiri:698306b72f010c2b2851ac92120e72d6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:5d9c59bbe6ff835dfd7a715340e2d8b7,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "70" %% xsd:int])
+    wasDerivedFrom(niiri:5d9c59bbe6ff835dfd7a715340e2d8b7, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:8cb05ce5ff1f36539390753e60f586ff,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905859" %% xsd:float,
+        nidm_pValueUncorrected: = "0.41411715244508" %% xsd:float,
+        nidm_pValueFWER: = "0.999999994589484" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "71" %% xsd:int])
+    wasDerivedFrom(niiri:8cb05ce5ff1f36539390753e60f586ff, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0072" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "72" %% xsd:int])
+    wasDerivedFrom(niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:08144c2f2914ca0e8f2d5090a382dd9c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0073" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "73" %% xsd:int])
+    wasDerivedFrom(niiri:08144c2f2914ca0e8f2d5090a382dd9c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:20fdb21c4b6e1b56aba03dc17e6e0cad,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0074" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "74" %% xsd:int])
+    wasDerivedFrom(niiri:20fdb21c4b6e1b56aba03dc17e6e0cad, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:b16302312e147e9c8ce1bdd421f19045,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0075" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "75" %% xsd:int])
+    wasDerivedFrom(niiri:b16302312e147e9c8ce1bdd421f19045, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:9e57216b41802f20cbaf2104bd85f6ec,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0076" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "76" %% xsd:int])
+    wasDerivedFrom(niiri:9e57216b41802f20cbaf2104bd85f6ec, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:002e00007a510fe7b30fd39adc263872,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0077" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "77" %% xsd:int])
+    wasDerivedFrom(niiri:002e00007a510fe7b30fd39adc263872, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:2b00f1f0bcfadf17e4e74a633d9cbe02,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0078" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "78" %% xsd:int])
+    wasDerivedFrom(niiri:2b00f1f0bcfadf17e4e74a633d9cbe02, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:0a99da6db6ffdb6abd70dfec062dacc6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0079" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0730556259843098" %% xsd:float,
+        nidm_pValueUncorrected: = "0.289588977139942" %% xsd:float,
+        nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "79" %% xsd:int])
+    wasDerivedFrom(niiri:0a99da6db6ffdb6abd70dfec062dacc6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:ee9edf2a051832c657f8417f27f95a8f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0080" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "80" %% xsd:int])
+    wasDerivedFrom(niiri:ee9edf2a051832c657f8417f27f95a8f, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:db1e7cd2ec53abce67f4898eb3c88730,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0081" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "81" %% xsd:int])
+    wasDerivedFrom(niiri:db1e7cd2ec53abce67f4898eb3c88730, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:1066c8d3aa41693bfd354d1824cc7afe,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0082" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.510282095685957" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "82" %% xsd:int])
+    wasDerivedFrom(niiri:1066c8d3aa41693bfd354d1824cc7afe, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:176e7ef375f6f1d2e26f1a064f8f6d39,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0083" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "83" %% xsd:int])
+    wasDerivedFrom(niiri:176e7ef375f6f1d2e26f1a064f8f6d39, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:08a3f7b7f6c942ab91160dfccbb968f2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0084" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "84" %% xsd:int])
+    wasDerivedFrom(niiri:08a3f7b7f6c942ab91160dfccbb968f2, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:bddc2499a043f720b9c5a3c2a309f42c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0085" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "85" %% xsd:int])
+    wasDerivedFrom(niiri:bddc2499a043f720b9c5a3c2a309f42c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:189d9d696ac51ec44003eb5f973b6c64,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0086" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "86" %% xsd:int])
+    wasDerivedFrom(niiri:189d9d696ac51ec44003eb5f973b6c64, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:5d37a307684854af5c2a17ddbdb8f17f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0087" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "87" %% xsd:int])
+    wasDerivedFrom(niiri:5d37a307684854af5c2a17ddbdb8f17f, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:df310d7fb2c5397364d68a8d3fa65bc0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0088" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "88" %% xsd:int])
+    wasDerivedFrom(niiri:df310d7fb2c5397364d68a8d3fa65bc0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:d0abba065cadfdf673c1ba317a4155ef,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0089" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.014611125196862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654533745817325" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "89" %% xsd:int])
+    wasDerivedFrom(niiri:d0abba065cadfdf673c1ba317a4155ef, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
+    entity(niiri:cd9309db3e1c88a98ba96314ae5579f0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0001" %% xsd:string,
+        prov:location = 'niiri:4bc98dbacc7bcd13b355272508d662cd',
+        prov:value = "16.0820484161377" %% xsd:float,
+        nidm_equivalentZStatistic: = "6.58928757769047" %% xsd:float,
+        nidm_pValueUncorrected: = "2.20971019260219e-11" %% xsd:float,
+        nidm_pValueFWER: = "4.59341100222943e-06" %% xsd:float,
+        nidm_qValueFDR: = "2.11792501803032e-06" %% xsd:float])
+    entity(niiri:4bc98dbacc7bcd13b355272508d662cd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0001" %% xsd:string,
+        nidm_coordinateVector: = "[-14,-84,-14]" %% xsd:string])
+    wasDerivedFrom(niiri:cd9309db3e1c88a98ba96314ae5579f0, niiri:0af3c1dadf9b022bafb92d73c4057be6, -, -, -)
+    entity(niiri:89156d76de8aafb9c0d7504b45de19a1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0002" %% xsd:string,
+        prov:location = 'niiri:0692b895967968b5ad50805b77073b6f',
+        prov:value = "13.9779033660889" %% xsd:float,
+        nidm_equivalentZStatistic: = "6.11142244434854" %% xsd:float,
+        nidm_pValueUncorrected: = "4.93734941819923e-10" %% xsd:float,
+        nidm_pValueFWER: = "0.000102635598608014" %% xsd:float,
+        nidm_qValueFDR: = "5.60210458059015e-06" %% xsd:float])
+    entity(niiri:0692b895967968b5ad50805b77073b6f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0002" %% xsd:string,
+        nidm_coordinateVector: = "[-42,-76,-12]" %% xsd:string])
+    wasDerivedFrom(niiri:89156d76de8aafb9c0d7504b45de19a1, niiri:0af3c1dadf9b022bafb92d73c4057be6, -, -, -)
+    entity(niiri:3cc1aa7c32068139da6b5f92edd82cb6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0003" %% xsd:string,
+        prov:location = 'niiri:5dfe29da2cb5f0c3c504895aeba5f33f',
+        prov:value = "10.3123865127563" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.1402197604635" %% xsd:float,
+        nidm_pValueUncorrected: = "1.3720866187672e-07" %% xsd:float,
+        nidm_pValueFWER: = "0.0248386091747108" %% xsd:float,
+        nidm_qValueFDR: = "0.000165827847161811" %% xsd:float])
+    entity(niiri:5dfe29da2cb5f0c3c504895aeba5f33f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0003" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-90,8]" %% xsd:string])
+    wasDerivedFrom(niiri:3cc1aa7c32068139da6b5f92edd82cb6, niiri:0af3c1dadf9b022bafb92d73c4057be6, -, -, -)
+    entity(niiri:92bb19c86792f383f51524cf04efcf6f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0004" %% xsd:string,
+        prov:location = 'niiri:9872f9d3dc8e27014ef5a3559e09b981',
+        prov:value = "13.7427864074707" %% xsd:float,
+        nidm_equivalentZStatistic: = "6.05489626279796" %% xsd:float,
+        nidm_pValueUncorrected: = "7.02540914332417e-10" %% xsd:float,
+        nidm_pValueFWER: = "0.000146041348950021" %% xsd:float,
+        nidm_qValueFDR: = "5.84165395800085e-06" %% xsd:float])
+    entity(niiri:9872f9d3dc8e27014ef5a3559e09b981,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0004" %% xsd:string,
+        nidm_coordinateVector: = "[22,-98,10]" %% xsd:string])
+    wasDerivedFrom(niiri:92bb19c86792f383f51524cf04efcf6f, niiri:1f6332db35b31af3ee6ca935dfaeba0c, -, -, -)
+    entity(niiri:20e1e7c992a4871fb508554d0585da06,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0005" %% xsd:string,
+        prov:location = 'niiri:db23149ad95a1fe9c4c1cd4d7de870aa',
+        prov:value = "12.7449989318848" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.80709618365418" %% xsd:float,
+        nidm_pValueUncorrected: = "3.17828119378305e-09" %% xsd:float,
+        nidm_pValueFWER: = "0.000660688335281101" %% xsd:float,
+        nidm_qValueFDR: = "1.54333527599919e-05" %% xsd:float])
+    entity(niiri:db23149ad95a1fe9c4c1cd4d7de870aa,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0005" %% xsd:string,
+        nidm_coordinateVector: = "[40,-76,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:20e1e7c992a4871fb508554d0585da06, niiri:1f6332db35b31af3ee6ca935dfaeba0c, -, -, -)
+    entity(niiri:9b0669d94cf1e0b09df66fa7a674c7e3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0006" %% xsd:string,
+        prov:location = 'niiri:241eddcd45421fb2df8644ec543399de',
+        prov:value = "11.9460592269897" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.59865646408728" %% xsd:float,
+        nidm_pValueUncorrected: = "1.08009692301181e-08" %% xsd:float,
+        nidm_pValueFWER: = "0.00224526225660115" %% xsd:float,
+        nidm_qValueFDR: = "3.11841980083494e-05" %% xsd:float])
+    entity(niiri:241eddcd45421fb2df8644ec543399de,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0006" %% xsd:string,
+        nidm_coordinateVector: = "[36,-86,8]" %% xsd:string])
+    wasDerivedFrom(niiri:9b0669d94cf1e0b09df66fa7a674c7e3, niiri:1f6332db35b31af3ee6ca935dfaeba0c, -, -, -)
+    entity(niiri:fd3df422ba6b5a2312c81b7470fa4ce8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0007" %% xsd:string,
+        prov:location = 'niiri:785ed6e870cebde278aee39c7b6befdd',
+        prov:value = "10.8997001647949" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.31044487629651" %% xsd:float,
+        nidm_pValueUncorrected: = "5.46789791222579e-08" %% xsd:float,
+        nidm_pValueFWER: = "0.0109446324802115" %% xsd:float,
+        nidm_qValueFDR: = "8.7562484520721e-05" %% xsd:float])
+    entity(niiri:785ed6e870cebde278aee39c7b6befdd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0007" %% xsd:string,
+        nidm_coordinateVector: = "[32,-66,32]" %% xsd:string])
+    wasDerivedFrom(niiri:fd3df422ba6b5a2312c81b7470fa4ce8, niiri:0d4bf8c640cd15c305d2e49ef14b9ac6, -, -, -)
+    entity(niiri:53ee6d1cb132259d2b6100b015ee9dce,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0008" %% xsd:string,
+        prov:location = 'niiri:72b3ecc6501f7b746bb979c1808000d5',
+        prov:value = "5.45807838439941" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.39070148271528" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000348569950826771" %% xsd:float,
+        nidm_pValueFWER: = "0.999999998685327" %% xsd:float,
+        nidm_qValueFDR: = "0.0335543570769498" %% xsd:float])
+    entity(niiri:72b3ecc6501f7b746bb979c1808000d5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0008" %% xsd:string,
+        nidm_coordinateVector: = "[32,-74,38]" %% xsd:string])
+    wasDerivedFrom(niiri:53ee6d1cb132259d2b6100b015ee9dce, niiri:0d4bf8c640cd15c305d2e49ef14b9ac6, -, -, -)
+    entity(niiri:c8c92c4cb3dd742ebdf460a03d8ef227,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0009" %% xsd:string,
+        prov:location = 'niiri:b66031c85008481c6c52a889639df78f',
+        prov:value = "10.0041055679321" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.04819646859005" %% xsd:float,
+        nidm_pValueUncorrected: = "2.23000182986155e-07" %% xsd:float,
+        nidm_pValueFWER: = "0.0380835451252286" %% xsd:float,
+        nidm_qValueFDR: = "0.000232018725953295" %% xsd:float])
+    entity(niiri:b66031c85008481c6c52a889639df78f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0009" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-74,26]" %% xsd:string])
+    wasDerivedFrom(niiri:c8c92c4cb3dd742ebdf460a03d8ef227, niiri:32439b88059be589d0e2a8586ea799ec, -, -, -)
+    entity(niiri:915c8684b1426b41a850e906a6cb7e51,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0010" %% xsd:string,
+        prov:location = 'niiri:fc9bb7ec98d0292b3cf09ece5735cbf7',
+        prov:value = "9.62718677520752" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.933015925023" %% xsd:float,
+        nidm_pValueUncorrected: = "4.04847753543436e-07" %% xsd:float,
+        nidm_pValueFWER: = "0.063890884133409" %% xsd:float,
+        nidm_qValueFDR: = "0.000364320989617512" %% xsd:float])
+    entity(niiri:fc9bb7ec98d0292b3cf09ece5735cbf7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0010" %% xsd:string,
+        nidm_coordinateVector: = "[-42,24,20]" %% xsd:string])
+    wasDerivedFrom(niiri:915c8684b1426b41a850e906a6cb7e51, niiri:d8b9846e25000609adbc385c634a1be0, -, -, -)
+    entity(niiri:50922e240192f8efd5ba7edc5395921e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0011" %% xsd:string,
+        prov:location = 'niiri:0090ece1129de1a64a6093a76eead257',
+        prov:value = "8.07208061218262" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.42255808855286" %% xsd:float,
+        nidm_pValueUncorrected: = "4.87695566220303e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.443484796305441" %% xsd:float,
+        nidm_qValueFDR: = "0.00197238230997959" %% xsd:float])
+    entity(niiri:0090ece1129de1a64a6093a76eead257,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0011" %% xsd:string,
+        nidm_coordinateVector: = "[-50,28,22]" %% xsd:string])
+    wasDerivedFrom(niiri:50922e240192f8efd5ba7edc5395921e, niiri:d8b9846e25000609adbc385c634a1be0, -, -, -)
+    entity(niiri:7d5e6a7fd65e7845a2f6021bbbfe1474,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0012" %% xsd:string,
+        prov:location = 'niiri:a94285933cf50e277523e5b72912eebe',
+        prov:value = "9.20645141601562" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.80076510146651" %% xsd:float,
+        nidm_pValueUncorrected: = "7.90302914999153e-07" %% xsd:float,
+        nidm_pValueFWER: = "0.112525268059434" %% xsd:float,
+        nidm_qValueFDR: = "0.000576835659463966" %% xsd:float])
+    entity(niiri:a94285933cf50e277523e5b72912eebe,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0012" %% xsd:string,
+        nidm_coordinateVector: = "[-50,8,42]" %% xsd:string])
+    wasDerivedFrom(niiri:7d5e6a7fd65e7845a2f6021bbbfe1474, niiri:f8e22d4c567142a3ab813140dd91551e, -, -, -)
+    entity(niiri:48d52b482ad32267090b771eef9d8a13,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0013" %% xsd:string,
+        prov:location = 'niiri:3f8983479e0d587591c1816f757bfb40',
+        prov:value = "7.18871355056763" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.10255932739581" %% xsd:float,
+        nidm_pValueUncorrected: = "2.04302517635702e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.864381142749573" %% xsd:float,
+        nidm_qValueFDR: = "0.00518559511521378" %% xsd:float])
+    entity(niiri:3f8983479e0d587591c1816f757bfb40,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0013" %% xsd:string,
+        nidm_coordinateVector: = "[-52,2,48]" %% xsd:string])
+    wasDerivedFrom(niiri:48d52b482ad32267090b771eef9d8a13, niiri:f8e22d4c567142a3ab813140dd91551e, -, -, -)
+    entity(niiri:6bc27ded8e7208b5260f9cfa18a8c8c7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0014" %% xsd:string,
+        prov:location = 'niiri:a58791ee2a73dbe92a31d79f5a887db7',
+        prov:value = "8.94470500946045" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.71641138081763" %% xsd:float,
+        nidm_pValueUncorrected: = "1.20020424165812e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.158435738485403" %% xsd:float,
+        nidm_qValueFDR: = "0.000760651849406736" %% xsd:float])
+    entity(niiri:a58791ee2a73dbe92a31d79f5a887db7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0014" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-64,66]" %% xsd:string])
+    wasDerivedFrom(niiri:6bc27ded8e7208b5260f9cfa18a8c8c7, niiri:96a2e290f72fc28530510650c52e2805, -, -, -)
+    entity(niiri:3f894ae7abee049abdc170030b86694a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0015" %% xsd:string,
+        prov:location = 'niiri:5ee690d78930edfd59a3872c7c5bbdaf',
+        prov:value = "7.5668888092041" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.24258939908316" %% xsd:float,
+        nidm_pValueUncorrected: = "1.10477738578529e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.693995702855766" %% xsd:float,
+        nidm_qValueFDR: = "0.0033973072847523" %% xsd:float])
+    entity(niiri:5ee690d78930edfd59a3872c7c5bbdaf,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0015" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-56,62]" %% xsd:string])
+    wasDerivedFrom(niiri:3f894ae7abee049abdc170030b86694a, niiri:96a2e290f72fc28530510650c52e2805, -, -, -)
+    entity(niiri:8aed68850a4238bd9003356dee5c1046,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0016" %% xsd:string,
+        prov:location = 'niiri:fa9d9d6751bc279dd4c31bcc4b3c5b6f',
+        prov:value = "8.42212200164795" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.54288070436711" %% xsd:float,
+        nidm_pValueUncorrected: = "2.77453287811369e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.301737952159247" %% xsd:float,
+        nidm_qValueFDR: = "0.00135672565933354" %% xsd:float])
+    entity(niiri:fa9d9d6751bc279dd4c31bcc4b3c5b6f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0016" %% xsd:string,
+        nidm_coordinateVector: = "[22,-52,4]" %% xsd:string])
+    wasDerivedFrom(niiri:8aed68850a4238bd9003356dee5c1046, niiri:1062efea331d3022773f16c049f8543d, -, -, -)
+    entity(niiri:17a00ab62ce14cefa4ccb65ef36cb0a3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0017" %% xsd:string,
+        prov:location = 'niiri:2e878a68f59b4166e7af126a1d092dd7',
+        prov:value = "8.14441299438477" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.44770400954001" %% xsd:float,
+        nidm_pValueUncorrected: = "4.33965069324138e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.411238149698711" %% xsd:float,
+        nidm_qValueFDR: = "0.00180683059312593" %% xsd:float])
+    entity(niiri:2e878a68f59b4166e7af126a1d092dd7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0017" %% xsd:string,
+        nidm_coordinateVector: = "[-36,-54,-22]" %% xsd:string])
+    wasDerivedFrom(niiri:17a00ab62ce14cefa4ccb65ef36cb0a3, niiri:5577dc13c7013d8bb90b8dd111792d46, -, -, -)
+    entity(niiri:df246b9f6ad9be0fa1598d6017c22c17,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0018" %% xsd:string,
+        prov:location = 'niiri:dbfef4bdf74855624e49b48413b48527',
+        prov:value = "7.75212860107422" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.30948435197428" %% xsd:float,
+        nidm_pValueUncorrected: = "8.18178178840778e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.599664226758408" %% xsd:float,
+        nidm_qValueFDR: = "0.00278317762946249" %% xsd:float])
+    entity(niiri:dbfef4bdf74855624e49b48413b48527,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0018" %% xsd:string,
+        nidm_coordinateVector: = "[10,-66,-50]" %% xsd:string])
+    wasDerivedFrom(niiri:df246b9f6ad9be0fa1598d6017c22c17, niiri:64ae5737521bbc7fe14f0c862379e927, -, -, -)
+    entity(niiri:0f733836ed39e3d5c7c881ba1d4b0f3c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0019" %% xsd:string,
+        prov:location = 'niiri:2d648076c6516fc9f5b180d7e46bd38d',
+        prov:value = "6.59869337081909" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.87398612970452" %% xsd:float,
+        nidm_pValueUncorrected: = "5.35347545974618e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.988687386127249" %% xsd:float,
+        nidm_qValueFDR: = "0.0099990013840748" %% xsd:float])
+    entity(niiri:2d648076c6516fc9f5b180d7e46bd38d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0019" %% xsd:string,
+        nidm_coordinateVector: = "[26,-72,-50]" %% xsd:string])
+    wasDerivedFrom(niiri:0f733836ed39e3d5c7c881ba1d4b0f3c, niiri:64ae5737521bbc7fe14f0c862379e927, -, -, -)
+    entity(niiri:fccb01f20ca9740796a77be1dc284607,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0020" %% xsd:string,
+        prov:location = 'niiri:de5ae9445107927a2f321f5cb43d375a',
+        prov:value = "6.09796094894409" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.6691747416434" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000121667358184974" %% xsd:float,
+        nidm_pValueFWER: = "0.999849800966092" %% xsd:float,
+        nidm_qValueFDR: = "0.0170443244379802" %% xsd:float])
+    entity(niiri:de5ae9445107927a2f321f5cb43d375a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0020" %% xsd:string,
+        nidm_coordinateVector: = "[16,-72,-50]" %% xsd:string])
+    wasDerivedFrom(niiri:fccb01f20ca9740796a77be1dc284607, niiri:64ae5737521bbc7fe14f0c862379e927, -, -, -)
+    entity(niiri:73c78b95c93f862d2d03440138b1b31d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0021" %% xsd:string,
+        prov:location = 'niiri:f70e1a4652c056f2ce720d0c047e4050',
+        prov:value = "7.67598438262939" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.28211703257948" %% xsd:float,
+        nidm_pValueUncorrected: = "9.25617831770698e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.638571937641115" %% xsd:float,
+        nidm_qValueFDR: = "0.00302106969058158" %% xsd:float])
+    entity(niiri:f70e1a4652c056f2ce720d0c047e4050,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0021" %% xsd:string,
+        nidm_coordinateVector: = "[42,-22,66]" %% xsd:string])
+    wasDerivedFrom(niiri:73c78b95c93f862d2d03440138b1b31d, niiri:900846b4c16bba4a9b8a34762cba2da0, -, -, -)
+    entity(niiri:b6efabc36e950249575e4d4ac70621f0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0022" %% xsd:string,
+        prov:location = 'niiri:4dbfbaac273513d9f226876fdf8b306f',
+        prov:value = "6.16005897521973" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.6951610937944" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000109873708078023" %% xsd:float,
+        nidm_pValueFWER: = "0.999696971784475" %% xsd:float,
+        nidm_qValueFDR: = "0.0160177852706299" %% xsd:float])
+    entity(niiri:4dbfbaac273513d9f226876fdf8b306f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0022" %% xsd:string,
+        nidm_coordinateVector: = "[48,-18,62]" %% xsd:string])
+    wasDerivedFrom(niiri:b6efabc36e950249575e4d4ac70621f0, niiri:900846b4c16bba4a9b8a34762cba2da0, -, -, -)
+    entity(niiri:ce78c1d328ebf373304efd0ad0d63b55,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0023" %% xsd:string,
+        prov:location = 'niiri:b48d465b5d910dd4c05a26a988a8418b',
+        prov:value = "7.57218790054321" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.24451811148991" %% xsd:float,
+        nidm_pValueUncorrected: = "1.09531837353405e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.691329596120285" %% xsd:float,
+        nidm_qValueFDR: = "0.00338801480937036" %% xsd:float])
+    entity(niiri:b48d465b5d910dd4c05a26a988a8418b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0023" %% xsd:string,
+        nidm_coordinateVector: = "[30,-36,-22]" %% xsd:string])
+    wasDerivedFrom(niiri:ce78c1d328ebf373304efd0ad0d63b55, niiri:7ede1db6987922a4806abc265aecda62, -, -, -)
+    entity(niiri:1cd13c2942d906be09937adb3135674a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0024" %% xsd:string,
+        prov:location = 'niiri:4c8fbc4e92f73c6bb61d3f66d9c3c99e',
+        prov:value = "7.4740514755249" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.20865253327564" %% xsd:float,
+        nidm_pValueUncorrected: = "1.28449040975864e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.739935004547452" %% xsd:float,
+        nidm_qValueFDR: = "0.00374497115452541" %% xsd:float])
+    entity(niiri:4c8fbc4e92f73c6bb61d3f66d9c3c99e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0024" %% xsd:string,
+        nidm_coordinateVector: = "[22,-70,60]" %% xsd:string])
+    wasDerivedFrom(niiri:1cd13c2942d906be09937adb3135674a, niiri:9287b2a8106c3ffe3abf93837cfbd61c, -, -, -)
+    entity(niiri:3121dd1ff9adac7ae75e440df583fb9d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0025" %% xsd:string,
+        prov:location = 'niiri:939c1c6e7eee0ff04a1bae0f1e2b3a44',
+        prov:value = "7.42476272583008" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.19052086074216" %% xsd:float,
+        nidm_pValueUncorrected: = "1.39157412012425e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.76353829505901" %% xsd:float,
+        nidm_qValueFDR: = "0.00397904916843096" %% xsd:float])
+    entity(niiri:939c1c6e7eee0ff04a1bae0f1e2b3a44,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0025" %% xsd:string,
+        nidm_coordinateVector: = "[14,-44,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:3121dd1ff9adac7ae75e440df583fb9d, niiri:c515278968596a92906ae29ffad63511, -, -, -)
+    entity(niiri:2cde520c847515e95346b9608b4b29b1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0026" %% xsd:string,
+        prov:location = 'niiri:fec739a9148832b2f9f9f6df4c90ef60',
+        prov:value = "7.41156482696533" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.1856522195161" %% xsd:float,
+        nidm_pValueUncorrected: = "1.42174217934166e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.76974170216107" %% xsd:float,
+        nidm_qValueFDR: = "0.00404779744790916" %% xsd:float])
+    entity(niiri:fec739a9148832b2f9f9f6df4c90ef60,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0026" %% xsd:string,
+        nidm_coordinateVector: = "[0,-22,66]" %% xsd:string])
+    wasDerivedFrom(niiri:2cde520c847515e95346b9608b4b29b1, niiri:0493a379c4735cda662e56229168b8a9, -, -, -)
+    entity(niiri:435b54b1b98826b7c51b454f604d72e2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0027" %% xsd:string,
+        prov:location = 'niiri:f5083c9588b5eb1d38e2b68f14c48ec5',
+        prov:value = "7.3316125869751" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.15603434431885" %% xsd:float,
+        nidm_pValueUncorrected: = "1.61909583913378e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.806071531912271" %% xsd:float,
+        nidm_qValueFDR: = "0.00442558415624652" %% xsd:float])
+    entity(niiri:f5083c9588b5eb1d38e2b68f14c48ec5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0027" %% xsd:string,
+        nidm_coordinateVector: = "[-40,-26,-22]" %% xsd:string])
+    wasDerivedFrom(niiri:435b54b1b98826b7c51b454f604d72e2, niiri:6f915c93d573d9f832d05fb003dcbfb0, -, -, -)
+    entity(niiri:ff2cc94456764baf2e5e407f30f996e8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0028" %% xsd:string,
+        prov:location = 'niiri:bfdee7cfc8fffe98250a78af5abdc715',
+        prov:value = "7.15871143341064" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.09124266610495" %% xsd:float,
+        nidm_pValueUncorrected: = "2.14533936502281e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.875348981068006" %% xsd:float,
+        nidm_qValueFDR: = "0.00534735431216318" %% xsd:float])
+    entity(niiri:bfdee7cfc8fffe98250a78af5abdc715,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0028" %% xsd:string,
+        nidm_coordinateVector: = "[-48,-42,58]" %% xsd:string])
+    wasDerivedFrom(niiri:ff2cc94456764baf2e5e407f30f996e8, niiri:2344710a34a75f050910ebd48e1159af, -, -, -)
+    entity(niiri:1d8688390cefe3ad6af53ca62e203d1f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0029" %% xsd:string,
+        prov:location = 'niiri:05d5987ec004e7f8a055c0e0f8991383',
+        prov:value = "7.11809158325195" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.075870818357" %% xsd:float,
+        nidm_pValueUncorrected: = "2.29212322924166e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.889420975253515" %% xsd:float,
+        nidm_qValueFDR: = "0.00557942469794563" %% xsd:float])
+    entity(niiri:05d5987ec004e7f8a055c0e0f8991383,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0029" %% xsd:string,
+        nidm_coordinateVector: = "[-40,-34,66]" %% xsd:string])
+    wasDerivedFrom(niiri:1d8688390cefe3ad6af53ca62e203d1f, niiri:a904380f9b13e67a2253c5f952a57f9f, -, -, -)
+    entity(niiri:458ec12f9ad36a91b5eaa2f1aae4c164,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0030" %% xsd:string,
+        prov:location = 'niiri:7021fdf0169b26db50952433ad70adc0',
+        prov:value = "7.07621002197266" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.05996049269805" %% xsd:float,
+        nidm_pValueUncorrected: = "2.45405099345009e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.902960652497904" %% xsd:float,
+        nidm_qValueFDR: = "0.00587047829619361" %% xsd:float])
+    entity(niiri:7021fdf0169b26db50952433ad70adc0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0030" %% xsd:string,
+        nidm_coordinateVector: = "[-28,-64,36]" %% xsd:string])
+    wasDerivedFrom(niiri:458ec12f9ad36a91b5eaa2f1aae4c164, niiri:8348fc8e7248e46840dad7df7f8763bf, -, -, -)
+    entity(niiri:d4cd299a7933f93390ebcea529b036b0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0031" %% xsd:string,
+        prov:location = 'niiri:000b610104b25fcabfd24c7ac9c414e9',
+        prov:value = "6.77566051483154" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.94391444392688" %% xsd:float,
+        nidm_pValueUncorrected: = "4.0081133562353e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.970449378854534" %% xsd:float,
+        nidm_qValueFDR: = "0.0083237489519884" %% xsd:float])
+    entity(niiri:000b610104b25fcabfd24c7ac9c414e9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0031" %% xsd:string,
+        nidm_coordinateVector: = "[56,-14,52]" %% xsd:string])
+    wasDerivedFrom(niiri:d4cd299a7933f93390ebcea529b036b0, niiri:db6eb647802a5fc531c369aa668af574, -, -, -)
+    entity(niiri:c18aee0f08a51ffb9a71f22087ef50c5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0032" %% xsd:string,
+        prov:location = 'niiri:58fc0101181c3b004a7dd3b51e2ceb83',
+        prov:value = "6.75197219848633" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.9346244929229" %% xsd:float,
+        nidm_pValueUncorrected: = "4.16634347842892e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.973679338420771" %% xsd:float,
+        nidm_qValueFDR: = "0.00848286835858746" %% xsd:float])
+    entity(niiri:58fc0101181c3b004a7dd3b51e2ceb83,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0032" %% xsd:string,
+        nidm_coordinateVector: = "[-40,56,6]" %% xsd:string])
+    wasDerivedFrom(niiri:c18aee0f08a51ffb9a71f22087ef50c5, niiri:efddc25357ec7a4b9a063a62f5a2c864, -, -, -)
+    entity(niiri:94d6c08508093e713ac4415d0a932884,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0033" %% xsd:string,
+        prov:location = 'niiri:bf7aac775c73f4c943e7eaf5e718d980',
+        prov:value = "5.62889766693115" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.4670438729023" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000263107996845591" %% xsd:float,
+        nidm_pValueFWER: = "0.999999922471127" %% xsd:float,
+        nidm_qValueFDR: = "0.0280636167791234" %% xsd:float])
+    entity(niiri:bf7aac775c73f4c943e7eaf5e718d980,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0033" %% xsd:string,
+        nidm_coordinateVector: = "[-34,62,8]" %% xsd:string])
+    wasDerivedFrom(niiri:94d6c08508093e713ac4415d0a932884, niiri:efddc25357ec7a4b9a063a62f5a2c864, -, -, -)
+    entity(niiri:68ee8476808402fcd35123f92e1fe86d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0034" %% xsd:string,
+        prov:location = 'niiri:97631cb919ed750fce6fd5369d603724',
+        prov:value = "6.72361373901367" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.92347467532863" %% xsd:float,
+        nidm_pValueUncorrected: = "4.3640471964479e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.977197537328254" %% xsd:float,
+        nidm_qValueFDR: = "0.00877369894078824" %% xsd:float])
+    entity(niiri:97631cb919ed750fce6fd5369d603724,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0034" %% xsd:string,
+        nidm_coordinateVector: = "[-4,-52,6]" %% xsd:string])
+    wasDerivedFrom(niiri:68ee8476808402fcd35123f92e1fe86d, niiri:92832eb3b91834fca357233c33e92d47, -, -, -)
+    entity(niiri:97c0b234b24d4cfa8426c9b127f1426a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0035" %% xsd:string,
+        prov:location = 'niiri:07a69af261f8c7ce9c1e9223b91c2b3f',
+        prov:value = "5.89449167251587" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.58279190167641" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000169970706923372" %% xsd:float,
+        nidm_pValueFWER: = "0.999990278549049" %% xsd:float,
+        nidm_qValueFDR: = "0.0210834330463974" %% xsd:float])
+    entity(niiri:07a69af261f8c7ce9c1e9223b91c2b3f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0035" %% xsd:string,
+        nidm_coordinateVector: = "[-8,-56,0]" %% xsd:string])
+    wasDerivedFrom(niiri:97c0b234b24d4cfa8426c9b127f1426a, niiri:92832eb3b91834fca357233c33e92d47, -, -, -)
+    entity(niiri:208bd0fa9e65bd7ecda2f9025fbf5026,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0036" %% xsd:string,
+        prov:location = 'niiri:8a98506f0a361325cf3279d2ee5df080',
+        prov:value = "6.7043924331665" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.91589968256295" %% xsd:float,
+        nidm_pValueUncorrected: = "4.5033848123488e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.979375630051391" %% xsd:float,
+        nidm_qValueFDR: = "0.00887748685076858" %% xsd:float])
+    entity(niiri:8a98506f0a361325cf3279d2ee5df080,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0036" %% xsd:string,
+        nidm_coordinateVector: = "[50,-64,-6]" %% xsd:string])
+    wasDerivedFrom(niiri:208bd0fa9e65bd7ecda2f9025fbf5026, niiri:27a928cca18b5d563bf58797f306d0e0, -, -, -)
+    entity(niiri:b0078cef21c117e25080fc7b68a2e9f6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0037" %% xsd:string,
+        prov:location = 'niiri:4b3286c3a11f909de28869ea7523656c',
+        prov:value = "6.67913484573364" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.90592399967592" %% xsd:float,
+        nidm_pValueUncorrected: = "4.6933006303207e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.981996459937482" %% xsd:float,
+        nidm_qValueFDR: = "0.00914383746051283" %% xsd:float])
+    entity(niiri:4b3286c3a11f909de28869ea7523656c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0037" %% xsd:string,
+        nidm_coordinateVector: = "[-34,-40,36]" %% xsd:string])
+    wasDerivedFrom(niiri:b0078cef21c117e25080fc7b68a2e9f6, niiri:9197197694f96c553e0e78334284b0c7, -, -, -)
+    entity(niiri:51561d272cfbd20b578e0d0cb999769c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0038" %% xsd:string,
+        prov:location = 'niiri:7391c47b3ce0a5295cfbe1d0b7dfa35c',
+        prov:value = "6.64170026779175" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.89109301638303" %% xsd:float,
+        nidm_pValueUncorrected: = "4.98968323957572e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.985407255166263" %% xsd:float,
+        nidm_qValueFDR: = "0.00949872959107623" %% xsd:float])
+    entity(niiri:7391c47b3ce0a5295cfbe1d0b7dfa35c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0038" %% xsd:string,
+        nidm_coordinateVector: = "[22,10,-12]" %% xsd:string])
+    wasDerivedFrom(niiri:51561d272cfbd20b578e0d0cb999769c, niiri:4babeddab7c30570f5f7bca47ad8e349, -, -, -)
+    entity(niiri:462393ac68491f3db8a262b5078fc9a9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0039" %% xsd:string,
+        prov:location = 'niiri:86657e11e856b1fdbc9692e7270e9f36',
+        prov:value = "5.66292333602905" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.48206928174656" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000248777471726358" %% xsd:float,
+        nidm_pValueFWER: = "0.999999841793879" %% xsd:float,
+        nidm_qValueFDR: = "0.0270792144117247" %% xsd:float])
+    entity(niiri:86657e11e856b1fdbc9692e7270e9f36,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0039" %% xsd:string,
+        nidm_coordinateVector: = "[22,10,2]" %% xsd:string])
+    wasDerivedFrom(niiri:462393ac68491f3db8a262b5078fc9a9, niiri:4babeddab7c30570f5f7bca47ad8e349, -, -, -)
+    entity(niiri:662a754e5ebb07a4f3658f0ab369277c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0040" %% xsd:string,
+        prov:location = 'niiri:dce98efb340c18452b3198b7a9d43ec6',
+        prov:value = "6.58932304382324" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.87024913662237" %% xsd:float,
+        nidm_pValueUncorrected: = "5.43620931486855e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.9893188063809" %% xsd:float,
+        nidm_qValueFDR: = "0.0101197978315716" %% xsd:float])
+    entity(niiri:dce98efb340c18452b3198b7a9d43ec6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0040" %% xsd:string,
+        nidm_coordinateVector: = "[16,-8,20]" %% xsd:string])
+    wasDerivedFrom(niiri:662a754e5ebb07a4f3658f0ab369277c, niiri:abcdfa125cb9a6705001908f8633bf90, -, -, -)
+    entity(niiri:21f4ad1561991121f81c93c4a406ef8b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0041" %% xsd:string,
+        prov:location = 'niiri:ea0358caee1ca0292b7b7a8d309dd06c',
+        prov:value = "6.53873300552368" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.8500124840786" %% xsd:float,
+        nidm_pValueUncorrected: = "5.90559022480841e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.992265133018752" %% xsd:float,
+        nidm_qValueFDR: = "0.0107045232421608" %% xsd:float])
+    entity(niiri:ea0358caee1ca0292b7b7a8d309dd06c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0041" %% xsd:string,
+        nidm_coordinateVector: = "[28,-48,72]" %% xsd:string])
+    wasDerivedFrom(niiri:21f4ad1561991121f81c93c4a406ef8b, niiri:2583f6b74e4ca256d5338bb9b9f07a29, -, -, -)
+    entity(niiri:1babf001e3351aeb7fac6dc5454363cc,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0042" %% xsd:string,
+        prov:location = 'niiri:a42f9f1e579000b2dc77292a8cf2acb7',
+        prov:value = "6.41633129119873" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.80061969992356" %% xsd:float,
+        nidm_pValueUncorrected: = "7.2167337301976e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.996780557608903" %% xsd:float,
+        nidm_qValueFDR: = "0.0122368668491247" %% xsd:float])
+    entity(niiri:a42f9f1e579000b2dc77292a8cf2acb7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0042" %% xsd:string,
+        nidm_coordinateVector: = "[30,-48,-18]" %% xsd:string])
+    wasDerivedFrom(niiri:1babf001e3351aeb7fac6dc5454363cc, niiri:9656cbf27ba556542b025f2f8e45acfd, -, -, -)
+    entity(niiri:b338a4dd4022769457498158e6091888,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0043" %% xsd:string,
+        prov:location = 'niiri:3e89e3f7a8baa5ac4d836dcdac1c0bda',
+        prov:value = "6.32824850082397" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.764690456476" %% xsd:float,
+        nidm_pValueUncorrected: = "8.33777634952071e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.998439799137585" %% xsd:float,
+        nidm_qValueFDR: = "0.0133433091347082" %% xsd:float])
+    entity(niiri:3e89e3f7a8baa5ac4d836dcdac1c0bda,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0043" %% xsd:string,
+        nidm_coordinateVector: = "[34,64,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:b338a4dd4022769457498158e6091888, niiri:52cafab6790abfb27ec51f00e747fe9a, -, -, -)
+    entity(niiri:e6169278f433610ff37f3974658c92df,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0044" %% xsd:string,
+        prov:location = 'niiri:c70c80c37a08562550518b4cd4541c41',
+        prov:value = "6.23233604431152" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.72519134385979" %% xsd:float,
+        nidm_pValueUncorrected: = "9.75835625125487e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.999359408722565" %% xsd:float,
+        nidm_qValueFDR: = "0.0147821614629234" %% xsd:float])
+    entity(niiri:c70c80c37a08562550518b4cd4541c41,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0044" %% xsd:string,
+        nidm_coordinateVector: = "[-42,44,26]" %% xsd:string])
+    wasDerivedFrom(niiri:e6169278f433610ff37f3974658c92df, niiri:4c64b57b636863b3e947522d1311c0f1, -, -, -)
+    entity(niiri:07af75e3341c3d93da4de231688d5549,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0045" %% xsd:string,
+        prov:location = 'niiri:b7f3f00892f46b6b0ce77c4037087b40',
+        prov:value = "6.06225728988647" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.6541549978965" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000129015181687619" %% xsd:float,
+        nidm_pValueFWER: = "0.999902284410057" %% xsd:float,
+        nidm_qValueFDR: = "0.0177419633224147" %% xsd:float])
+    entity(niiri:b7f3f00892f46b6b0ce77c4037087b40,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0045" %% xsd:string,
+        nidm_coordinateVector: = "[0,-10,76]" %% xsd:string])
+    wasDerivedFrom(niiri:07af75e3341c3d93da4de231688d5549, niiri:a8236e3bfdb590d4516edd326dbac95d, -, -, -)
+    entity(niiri:41260b633b6a2691ee72574f2598723a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0046" %% xsd:string,
+        prov:location = 'niiri:e5d27e5d68b5b3c32ee4902f86477d7a',
+        prov:value = "6.03189373016357" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.64133598155782" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000135613449379846" %% xsd:float,
+        nidm_pValueFWER: = "0.999933280387137" %% xsd:float,
+        nidm_qValueFDR: = "0.0183426760576609" %% xsd:float])
+    entity(niiri:e5d27e5d68b5b3c32ee4902f86477d7a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0046" %% xsd:string,
+        nidm_coordinateVector: = "[34,-16,-12]" %% xsd:string])
+    wasDerivedFrom(niiri:41260b633b6a2691ee72574f2598723a, niiri:90dce13e46266944c40d12f4f1a86219, -, -, -)
+    entity(niiri:2ec9227f9219716d869254e96c9d0037,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0047" %% xsd:string,
+        prov:location = 'niiri:b099faca4ffbe79b539a9a37c0fecc5b',
+        prov:value = "6.02538537979126" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.63858275251093" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000137071270502886" %% xsd:float,
+        nidm_pValueFWER: = "0.999938640797957" %% xsd:float,
+        nidm_qValueFDR: = "0.0183962430264957" %% xsd:float])
+    entity(niiri:b099faca4ffbe79b539a9a37c0fecc5b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0047" %% xsd:string,
+        nidm_coordinateVector: = "[6,-80,-22]" %% xsd:string])
+    wasDerivedFrom(niiri:2ec9227f9219716d869254e96c9d0037, niiri:4b569159d1ddc968752a57917503c6f4, -, -, -)
+    entity(niiri:0c5f2ba8ccadcaf3990cf555adbad737,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0048" %% xsd:string,
+        prov:location = 'niiri:aa874dbac7a9c1e02e0a4e28bd39dfb7',
+        prov:value = "5.95283126831055" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.60775727167743" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000154427613028529" %% xsd:float,
+        nidm_pValueFWER: = "0.999977036852347" %% xsd:float,
+        nidm_qValueFDR: = "0.0199653441808624" %% xsd:float])
+    entity(niiri:aa874dbac7a9c1e02e0a4e28bd39dfb7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0048" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-38,-52]" %% xsd:string])
+    wasDerivedFrom(niiri:0c5f2ba8ccadcaf3990cf555adbad737, niiri:674c9062dc421a541e91be283cce8f16, -, -, -)
+    entity(niiri:3d268b9ac3f787ed4e0702d7f1ec3eb8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0049" %% xsd:string,
+        prov:location = 'niiri:d0604d3ccc8739eebfb0264b562dd48c',
+        prov:value = "5.9493842124939" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.60628663469786" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000155305014835405" %% xsd:float,
+        nidm_pValueFWER: = "0.999978135328144" %% xsd:float,
+        nidm_qValueFDR: = "0.0200343508975978" %% xsd:float])
+    entity(niiri:d0604d3ccc8739eebfb0264b562dd48c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0049" %% xsd:string,
+        nidm_coordinateVector: = "[32,-52,46]" %% xsd:string])
+    wasDerivedFrom(niiri:3d268b9ac3f787ed4e0702d7f1ec3eb8, niiri:d3a1762138c1b259db52c75933757662, -, -, -)
+    entity(niiri:110d36e0f43c3b73543fd2a54c15fcef,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0050" %% xsd:string,
+        prov:location = 'niiri:6f51bb746dc99583cc8e3bccd8b52a17',
+        prov:value = "5.90739822387695" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.58832892416593" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00016640212943575" %% xsd:float,
+        nidm_pValueFWER: = "0.999988176695278" %% xsd:float,
+        nidm_qValueFDR: = "0.0208396911967648" %% xsd:float])
+    entity(niiri:6f51bb746dc99583cc8e3bccd8b52a17,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0050" %% xsd:string,
+        nidm_coordinateVector: = "[20,58,6]" %% xsd:string])
+    wasDerivedFrom(niiri:110d36e0f43c3b73543fd2a54c15fcef, niiri:9dc472e5df63cfbf55f8afa2ad7233f1, -, -, -)
+    entity(niiri:5c65ee8dd873a043b1b0ce011fed4f35,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0051" %% xsd:string,
+        prov:location = 'niiri:89b9ae5151cd9b1561aaf8ff96b4b6ec',
+        prov:value = "5.88568687438965" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.57901000852841" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000172449130450447" %% xsd:float,
+        nidm_pValueFWER: = "0.999991509605729" %% xsd:float,
+        nidm_qValueFDR: = "0.0213019172775607" %% xsd:float])
+    entity(niiri:89b9ae5151cd9b1561aaf8ff96b4b6ec,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0051" %% xsd:string,
+        nidm_coordinateVector: = "[-28,-70,-52]" %% xsd:string])
+    wasDerivedFrom(niiri:5c65ee8dd873a043b1b0ce011fed4f35, niiri:3fd667ca8587427124fe4b4ff80af21a, -, -, -)
+    entity(niiri:57c990b6ba31385d10715d6c40e7aa55,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0052" %% xsd:string,
+        prov:location = 'niiri:9ebb93a3d4e207e403dbaa5999a1be35',
+        prov:value = "5.88288545608521" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.57780594841694" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000173245266573252" %% xsd:float,
+        nidm_pValueFWER: = "0.999991870214044" %% xsd:float,
+        nidm_qValueFDR: = "0.0213621903805226" %% xsd:float])
+    entity(niiri:9ebb93a3d4e207e403dbaa5999a1be35,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0052" %% xsd:string,
+        nidm_coordinateVector: = "[-16,-58,-38]" %% xsd:string])
+    wasDerivedFrom(niiri:57c990b6ba31385d10715d6c40e7aa55, niiri:c60cf8d223f50376ab05520bb51598af, -, -, -)
+    entity(niiri:2098d30ab385854e90d3cb8115b3a9b2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0053" %% xsd:string,
+        prov:location = 'niiri:c3eb4272d1ec05c8e84a0681eea459bd',
+        prov:value = "5.87665224075317" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.57512554105657" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000175029940004845" %% xsd:float,
+        nidm_pValueFWER: = "0.999992622705061" %% xsd:float,
+        nidm_qValueFDR: = "0.0214921236782135" %% xsd:float])
+    entity(niiri:c3eb4272d1ec05c8e84a0681eea459bd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0053" %% xsd:string,
+        nidm_coordinateVector: = "[-10,-82,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:2098d30ab385854e90d3cb8115b3a9b2, niiri:f551110d12542058bdc59cae03013010, -, -, -)
+    entity(niiri:3e504483f4e511a366bffb06b50ca097,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0054" %% xsd:string,
+        prov:location = 'niiri:7c66d78243fad1b742ee22ad32e56f1b',
+        prov:value = "5.86712741851807" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.57102607807387" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000177792742607208" %% xsd:float,
+        nidm_pValueFWER: = "0.999993649803941" %% xsd:float,
+        nidm_qValueFDR: = "0.0216816267105749" %% xsd:float])
+    entity(niiri:7c66d78243fad1b742ee22ad32e56f1b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0054" %% xsd:string,
+        nidm_coordinateVector: = "[50,50,8]" %% xsd:string])
+    wasDerivedFrom(niiri:3e504483f4e511a366bffb06b50ca097, niiri:fb9120500eef24a89fb5e84238991362, -, -, -)
+    entity(niiri:38cfaeebf97d0d2b0b71a5f0ba640e98,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0055" %% xsd:string,
+        prov:location = 'niiri:83fb05512223e38d67cb83a805cd00b3',
+        prov:value = "5.85824680328369" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.56719995255891" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000180408078987448" %% xsd:float,
+        nidm_pValueFWER: = "0.999994487319543" %% xsd:float,
+        nidm_qValueFDR: = "0.0217930814133279" %% xsd:float])
+    entity(niiri:83fb05512223e38d67cb83a805cd00b3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0055" %% xsd:string,
+        nidm_coordinateVector: = "[-6,-78,56]" %% xsd:string])
+    wasDerivedFrom(niiri:38cfaeebf97d0d2b0b71a5f0ba640e98, niiri:dde8bc734b1e70c777683f3419f9b22a, -, -, -)
+    entity(niiri:6bed9eb8c16b5bfc1b7f13853ba3719d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0056" %% xsd:string,
+        prov:location = 'niiri:07d1fc16b4011bf11b157bc94038717f',
+        prov:value = "5.81644201278687" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.54913757298709" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000193247549691744" %% xsd:float,
+        nidm_pValueFWER: = "0.99999722874557" %% xsd:float,
+        nidm_qValueFDR: = "0.022905022613713" %% xsd:float])
+    entity(niiri:07d1fc16b4011bf11b157bc94038717f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0056" %% xsd:string,
+        nidm_coordinateVector: = "[44,50,20]" %% xsd:string])
+    wasDerivedFrom(niiri:6bed9eb8c16b5bfc1b7f13853ba3719d, niiri:89223f01a7e676c300c22c8da4a82ef8, -, -, -)
+    entity(niiri:13789ff64ea178d4dd930d5649ad0efa,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0057" %% xsd:string,
+        prov:location = 'niiri:09872dc9def2ebbedbd2d8b56d8ccec8',
+        prov:value = "5.75350570678711" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.52178406559812" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000214326572548162" %% xsd:float,
+        nidm_pValueFWER: = "0.999999083879168" %% xsd:float,
+        nidm_qValueFDR: = "0.0245474913207941" %% xsd:float])
+    entity(niiri:09872dc9def2ebbedbd2d8b56d8ccec8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0057" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-58,-52]" %% xsd:string])
+    wasDerivedFrom(niiri:13789ff64ea178d4dd930d5649ad0efa, niiri:7ac6ced5ac5b95c88fbe93f4ad51726c, -, -, -)
+    entity(niiri:9d748709970f09ad37966b4ebd88970d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0058" %% xsd:string,
+        prov:location = 'niiri:a8566c5632b9f7d195407d5bbeb8d694',
+        prov:value = "5.74829816818237" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.51951200270118" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000216170736607735" %% xsd:float,
+        nidm_pValueFWER: = "0.999999167412893" %% xsd:float,
+        nidm_qValueFDR: = "0.0246525319493899" %% xsd:float])
+    entity(niiri:a8566c5632b9f7d195407d5bbeb8d694,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0058" %% xsd:string,
+        nidm_coordinateVector: = "[-38,36,-14]" %% xsd:string])
+    wasDerivedFrom(niiri:9d748709970f09ad37966b4ebd88970d, niiri:5d05848ec2715382392265640fc9d57e, -, -, -)
+    entity(niiri:8f1086c487206beee6166192435ccbb7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0059" %% xsd:string,
+        prov:location = 'niiri:7bd2497735bee9acdd922777fd6b5af3',
+        prov:value = "5.7312970161438" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.51208496979963" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000222302913436612" %% xsd:float,
+        nidm_pValueFWER: = "0.99999939333845" %% xsd:float,
+        nidm_qValueFDR: = "0.0250806761204491" %% xsd:float])
+    entity(niiri:7bd2497735bee9acdd922777fd6b5af3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0059" %% xsd:string,
+        nidm_coordinateVector: = "[-50,12,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:8f1086c487206beee6166192435ccbb7, niiri:ca24bdc833f185dc48a439c9bd8cfea6, -, -, -)
+    entity(niiri:9622cbdc321584d153d90164a7e3a512,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0060" %% xsd:string,
+        prov:location = 'niiri:ab618775ab67eaf9567d2f85e813dc0d',
+        prov:value = "5.61407613754272" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.46048027314539" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000269606369816766" %% xsd:float,
+        nidm_pValueFWER: = "0.999999943721802" %% xsd:float,
+        nidm_qValueFDR: = "0.0285650985701987" %% xsd:float])
+    entity(niiri:ab618775ab67eaf9567d2f85e813dc0d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0060" %% xsd:string,
+        nidm_coordinateVector: = "[-52,38,14]" %% xsd:string])
+    wasDerivedFrom(niiri:9622cbdc321584d153d90164a7e3a512, niiri:302ad243c21e156bc35f157e2595460d, -, -, -)
+    entity(niiri:dafa541111dbf27389241fc1622583e6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0061" %% xsd:string,
+        prov:location = 'niiri:8a2dcced4bbeb2d604abdc206edbd812',
+        prov:value = "5.53163862228394" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.42376539987989" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000308799561745898" %% xsd:float,
+        nidm_pValueFWER: = "0.999999991534363" %% xsd:float,
+        nidm_qValueFDR: = "0.0312013208214028" %% xsd:float])
+    entity(niiri:8a2dcced4bbeb2d604abdc206edbd812,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0061" %% xsd:string,
+        nidm_coordinateVector: = "[-14,-80,10]" %% xsd:string])
+    wasDerivedFrom(niiri:dafa541111dbf27389241fc1622583e6, niiri:b0e84ab2cd541b237634e56ebf391609, -, -, -)
+    entity(niiri:a1b7280bae7cb27c5d032057b5e5ee6a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0062" %% xsd:string,
+        prov:location = 'niiri:c15f83bf0af7227fccfcc19a8ff53a78',
+        prov:value = "5.52454996109009" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.42059171809414" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000312425309546338" %% xsd:float,
+        nidm_pValueFWER: = "0.999999992873262" %% xsd:float,
+        nidm_qValueFDR: = "0.0313644959462665" %% xsd:float])
+    entity(niiri:c15f83bf0af7227fccfcc19a8ff53a78,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0062" %% xsd:string,
+        nidm_coordinateVector: = "[-66,-40,18]" %% xsd:string])
+    wasDerivedFrom(niiri:a1b7280bae7cb27c5d032057b5e5ee6a, niiri:27969eb0dc2d34026b32c881a0f07667, -, -, -)
+    entity(niiri:3240ad2c7b4c375b2ffb7def8241fc33,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0063" %% xsd:string,
+        prov:location = 'niiri:8977a52fd8fb3c0c00a547480b793cb2',
+        prov:value = "5.51989889144897" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.41850793238069" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000314827412227103" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999363976" %% xsd:float,
+        nidm_qValueFDR: = "0.0315295603356192" %% xsd:float])
+    entity(niiri:8977a52fd8fb3c0c00a547480b793cb2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0063" %% xsd:string,
+        nidm_coordinateVector: = "[-2,-90,16]" %% xsd:string])
+    wasDerivedFrom(niiri:3240ad2c7b4c375b2ffb7def8241fc33, niiri:488053a695a16e1621e578a90cd45d96, -, -, -)
+    entity(niiri:e98e410c62ad05bb4759e8520048a9be,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0064" %% xsd:string,
+        prov:location = 'niiri:c244d6cda3ac6e6dc81d3a691f072524',
+        prov:value = "5.50013113021851" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.40963871850162" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000325244937404157" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999610751" %% xsd:float,
+        nidm_qValueFDR: = "0.0320937892728011" %% xsd:float])
+    entity(niiri:c244d6cda3ac6e6dc81d3a691f072524,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0064" %% xsd:string,
+        nidm_coordinateVector: = "[48,-68,24]" %% xsd:string])
+    wasDerivedFrom(niiri:e98e410c62ad05bb4759e8520048a9be, niiri:ed908db943ba3e97ea5826f9b78e251e, -, -, -)
+    entity(niiri:028200a0f3330e69e713e62343e4c118,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0065" %% xsd:string,
+        prov:location = 'niiri:6672ab9c3b56f3def7af8a2d31e7bf6b',
+        prov:value = "5.47258329391479" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.39724406479958" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000340341137511579" %% xsd:float,
+        nidm_pValueFWER: = "0.999999998076035" %% xsd:float,
+        nidm_qValueFDR: = "0.0330219418190176" %% xsd:float])
+    entity(niiri:6672ab9c3b56f3def7af8a2d31e7bf6b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0065" %% xsd:string,
+        nidm_coordinateVector: = "[-66,-52,14]" %% xsd:string])
+    wasDerivedFrom(niiri:028200a0f3330e69e713e62343e4c118, niiri:f5e02329544635d1b1ebf65b366251dc, -, -, -)
+    entity(niiri:83b5e42ee4a22a019efa3ad1b7c43432,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0066" %% xsd:string,
+        prov:location = 'niiri:1365efa4ae8395b0cf5121fab0888e16',
+        prov:value = "5.47253847122192" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.39722386451209" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000340366263790748" %% xsd:float,
+        nidm_pValueFWER: = "0.999999998078278" %% xsd:float,
+        nidm_qValueFDR: = "0.0330219418190176" %% xsd:float])
+    entity(niiri:1365efa4ae8395b0cf5121fab0888e16,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0066" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-70,-40]" %% xsd:string])
+    wasDerivedFrom(niiri:83b5e42ee4a22a019efa3ad1b7c43432, niiri:48785ebe53244b67446462ca165511f6, -, -, -)
+    entity(niiri:4d855c9b2c870365cbdf9a1cf976b2f7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0067" %% xsd:string,
+        prov:location = 'niiri:bc66a863068c99d04a911bb1348a178e',
+        prov:value = "5.40879058837891" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.36838466104027" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00037805012668235" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999657857" %% xsd:float,
+        nidm_qValueFDR: = "0.0351846046980527" %% xsd:float])
+    entity(niiri:bc66a863068c99d04a911bb1348a178e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0067" %% xsd:string,
+        nidm_coordinateVector: = "[-52,28,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:4d855c9b2c870365cbdf9a1cf976b2f7, niiri:dd83d9e917f614f418e9401cdb99e43c, -, -, -)
+    entity(niiri:086b014ac09ab4e4ea973ffddfa71a22,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0068" %% xsd:string,
+        prov:location = 'niiri:06cfc8651ab4c54efee830c631e39857',
+        prov:value = "5.40180397033691" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.36521050637541" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000382426408436776" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999719179" %% xsd:float,
+        nidm_qValueFDR: = "0.0353860600288775" %% xsd:float])
+    entity(niiri:06cfc8651ab4c54efee830c631e39857,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0068" %% xsd:string,
+        nidm_coordinateVector: = "[46,40,-20]" %% xsd:string])
+    wasDerivedFrom(niiri:086b014ac09ab4e4ea973ffddfa71a22, niiri:f9dfccb5b804ef9741131141e3190a4b, -, -, -)
+    entity(niiri:53c569adbfc5ab366e0314685b165853,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0069" %% xsd:string,
+        prov:location = 'niiri:13c44e2155af4ee2e20a16ec29b76a47',
+        prov:value = "5.37467432022095" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.35285956111335" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000399906393667493" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999871685" %% xsd:float,
+        nidm_qValueFDR: = "0.0362799194266732" %% xsd:float])
+    entity(niiri:13c44e2155af4ee2e20a16ec29b76a47,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0069" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-64,-26]" %% xsd:string])
+    wasDerivedFrom(niiri:53c569adbfc5ab366e0314685b165853, niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5, -, -, -)
+    entity(niiri:be4788197353dff3599d99682ec3031b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0070" %% xsd:string,
+        prov:location = 'niiri:917e6352e6ae3e3613ae739c3f135a19',
+        prov:value = "5.37411737442017" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.35260558298398" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00040027350203431" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999873767" %% xsd:float,
+        nidm_qValueFDR: = "0.0362799194266732" %% xsd:float])
+    entity(niiri:917e6352e6ae3e3613ae739c3f135a19,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0070" %% xsd:string,
+        nidm_coordinateVector: = "[6,-78,4]" %% xsd:string])
+    wasDerivedFrom(niiri:be4788197353dff3599d99682ec3031b, niiri:024c443604af80b2271c971bd66fc9a0, -, -, -)
+    entity(niiri:3f93410e4f041c83e4b8d8a0e0adbfff,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0071" %% xsd:string,
+        prov:location = 'niiri:0b950426b4901232779f3393314e29d9',
+        prov:value = "5.30396842956543" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.32047825714677" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000449316793136201" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999985317" %% xsd:float,
+        nidm_qValueFDR: = "0.038893908226916" %% xsd:float])
+    entity(niiri:0b950426b4901232779f3393314e29d9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0071" %% xsd:string,
+        nidm_coordinateVector: = "[-18,6,-16]" %% xsd:string])
+    wasDerivedFrom(niiri:3f93410e4f041c83e4b8d8a0e0adbfff, niiri:bd7d210916ff0d725f61db0ca48f5d05, -, -, -)
+    entity(niiri:5f9a78d502e9bb9f0b83b39b814fcb68,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0072" %% xsd:string,
+        prov:location = 'niiri:b466f652f73aa477a6d1a60f80c8435c',
+        prov:value = "5.3003044128418" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.31879260124815" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000452037748311596" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999986945" %% xsd:float,
+        nidm_qValueFDR: = "0.0390806835204476" %% xsd:float])
+    entity(niiri:b466f652f73aa477a6d1a60f80c8435c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0072" %% xsd:string,
+        nidm_coordinateVector: = "[44,34,22]" %% xsd:string])
+    wasDerivedFrom(niiri:5f9a78d502e9bb9f0b83b39b814fcb68, niiri:7925cec36e37f32d88f7027ba176a2e1, -, -, -)
+    entity(niiri:d0e4dbe4e90bfbe444d4822b9a651afc,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0073" %% xsd:string,
+        prov:location = 'niiri:be4116def5b2ec22ad63aa256b25428e',
+        prov:value = "5.2790060043335" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.30897907487843" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000468184175549835" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999993475" %% xsd:float,
+        nidm_qValueFDR: = "0.0399946769218688" %% xsd:float])
+    entity(niiri:be4116def5b2ec22ad63aa256b25428e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0073" %% xsd:string,
+        nidm_coordinateVector: = "[-16,-70,62]" %% xsd:string])
+    wasDerivedFrom(niiri:d0e4dbe4e90bfbe444d4822b9a651afc, niiri:11d4226a2f26d5d215e759b0b4e1b65c, -, -, -)
+    entity(niiri:7ab232ff50649870750ccc2d7f5c4da3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0074" %% xsd:string,
+        prov:location = 'niiri:6f88478d05d4710af9b94706fcfdcacb',
+        prov:value = "5.22220420837402" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.28268028866984" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000514126053509312" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999062" %% xsd:float,
+        nidm_qValueFDR: = "0.0424551034128408" %% xsd:float])
+    entity(niiri:6f88478d05d4710af9b94706fcfdcacb,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0074" %% xsd:string,
+        nidm_coordinateVector: = "[-18,-90,34]" %% xsd:string])
+    wasDerivedFrom(niiri:7ab232ff50649870750ccc2d7f5c4da3, niiri:cd265e81b525edcdebe748129d48fb9f, -, -, -)
+    entity(niiri:dbaf7dcfae21971052a8c4d8630590a6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0075" %% xsd:string,
+        prov:location = 'niiri:803c967b5027caa5ecf5d2a6fc5e8db2',
+        prov:value = "5.1730318069458" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.25976321879304" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000557526302441769" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999843" %% xsd:float,
+        nidm_qValueFDR: = "0.0447389446131481" %% xsd:float])
+    entity(niiri:803c967b5027caa5ecf5d2a6fc5e8db2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0075" %% xsd:string,
+        nidm_coordinateVector: = "[36,62,8]" %% xsd:string])
+    wasDerivedFrom(niiri:dbaf7dcfae21971052a8c4d8630590a6, niiri:aa2c86e9352626823ca6bb3bbda5947a, -, -, -)
+    entity(niiri:4cc71160f45e34b952ca323ad055c180,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0076" %% xsd:string,
+        prov:location = 'niiri:c7f8ed36a2e92d11b23926f9debb338a',
+        prov:value = "5.17224788665771" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.25939672404754" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000558247108556009" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999848" %% xsd:float,
+        nidm_qValueFDR: = "0.0447389446131481" %% xsd:float])
+    entity(niiri:c7f8ed36a2e92d11b23926f9debb338a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0076" %% xsd:string,
+        nidm_coordinateVector: = "[44,46,-18]" %% xsd:string])
+    wasDerivedFrom(niiri:4cc71160f45e34b952ca323ad055c180, niiri:8d3a03589611da3ed8127a06d493acd6, -, -, -)
+    entity(niiri:fbddf0f56adf238723f50586d9383121,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0077" %% xsd:string,
+        prov:location = 'niiri:827b144eb0409183e6f5e65935ea8fac',
+        prov:value = "5.13746070861816" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.24309671226403" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000591190343014691" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999999996" %% xsd:float,
+        nidm_qValueFDR: = "0.0465822754926653" %% xsd:float])
+    entity(niiri:827b144eb0409183e6f5e65935ea8fac,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0077" %% xsd:string,
+        nidm_coordinateVector: = "[22,-18,-10]" %% xsd:string])
+    wasDerivedFrom(niiri:fbddf0f56adf238723f50586d9383121, niiri:3f311421a632e712f70cc6839f7e9489, -, -, -)
+    entity(niiri:f7fbd57305037f549d9fa2567e5b8559,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0078" %% xsd:string,
+        prov:location = 'niiri:82ccce4a7354b15f17bc0943ef2b529c',
+        prov:value = "5.11799764633179" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.23394572778211" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000610463272072148" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999981" %% xsd:float,
+        nidm_qValueFDR: = "0.0474717326152994" %% xsd:float])
+    entity(niiri:82ccce4a7354b15f17bc0943ef2b529c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0078" %% xsd:string,
+        nidm_coordinateVector: = "[-54,34,4]" %% xsd:string])
+    wasDerivedFrom(niiri:f7fbd57305037f549d9fa2567e5b8559, niiri:bcc132262f6d7297d1d28a6f0a171093, -, -, -)
+    entity(niiri:dbb595cffa04de52d8f33921efbecc84,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0079" %% xsd:string,
+        prov:location = 'niiri:27b2020b2732af62cc07a03a8002f7be',
+        prov:value = "5.10930299758911" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.22985044435181" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000619274939217984" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999987" %% xsd:float,
+        nidm_qValueFDR: = "0.047852944668371" %% xsd:float])
+    entity(niiri:27b2020b2732af62cc07a03a8002f7be,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0079" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-64,-52]" %% xsd:string])
+    wasDerivedFrom(niiri:dbb595cffa04de52d8f33921efbecc84, niiri:3bdec6eb0b5535174fa631dd70795a7e, -, -, -)
+    entity(niiri:49c1e9ef96178d1e9db83a47b1907de9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0080" %% xsd:string,
+        prov:location = 'niiri:dc95edb06b3ad737ba9ce90d974a8f91',
+        prov:value = "5.10401487350464" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.22735746106492" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000624696357977461" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999989" %% xsd:float,
+        nidm_qValueFDR: = "0.0480043833565767" %% xsd:float])
+    entity(niiri:dc95edb06b3ad737ba9ce90d974a8f91,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0080" %% xsd:string,
+        nidm_coordinateVector: = "[-48,-78,18]" %% xsd:string])
+    wasDerivedFrom(niiri:49c1e9ef96178d1e9db83a47b1907de9, niiri:f1946d8aa4c75dc6c7b6e735e96e1847, -, -, -)
+    entity(niiri:c4b0c9d7d5bf10ed940aa36f9a2898fc,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0081" %% xsd:string,
+        prov:location = 'niiri:690f349d00c402f64f9afef69a04d47d',
+        prov:value = "5.09518003463745" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.22318870378714" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000633860042171808" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999993" %% xsd:float,
+        nidm_qValueFDR: = "0.0483657513246105" %% xsd:float])
+    entity(niiri:690f349d00c402f64f9afef69a04d47d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0081" %% xsd:string,
+        nidm_coordinateVector: = "[4,-86,38]" %% xsd:string])
+    wasDerivedFrom(niiri:c4b0c9d7d5bf10ed940aa36f9a2898fc, niiri:3592a75cac312314b4a818b743916efd, -, -, -)
+    entity(niiri:6f1dcaa9702ce8b1e56004f2e154bcc7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0082" %% xsd:string,
+        prov:location = 'niiri:6579bb9b7980bc6caf30f72d161dccb3',
+        prov:value = "5.08291101455688" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.21739172198432" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000646809225746448" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999996" %% xsd:float,
+        nidm_qValueFDR: = "0.0489980390158314" %% xsd:float])
+    entity(niiri:6579bb9b7980bc6caf30f72d161dccb3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0082" %% xsd:string,
+        nidm_coordinateVector: = "[-14,-50,-36]" %% xsd:string])
+    wasDerivedFrom(niiri:6f1dcaa9702ce8b1e56004f2e154bcc7, niiri:a457cd8f3b3381f0a12661e0907b556a, -, -, -)
+    entity(niiri:bb4e0dcfa0ad034c05e92f6d076501cb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0083" %% xsd:string,
+        prov:location = 'niiri:1a121ade9e841ce8da6580e606ec3b7b',
+        prov:value = "5.0689902305603" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.21080328886987" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000661822545445001" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
+        nidm_qValueFDR: = "0.0496832380294054" %% xsd:float])
+    entity(niiri:1a121ade9e841ce8da6580e606ec3b7b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0083" %% xsd:string,
+        nidm_coordinateVector: = "[30,68,10]" %% xsd:string])
+    wasDerivedFrom(niiri:bb4e0dcfa0ad034c05e92f6d076501cb, niiri:698306b72f010c2b2851ac92120e72d6, -, -, -)
+    entity(niiri:77969ad2ea1b902a3de4c5dfa8bce613,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0084" %% xsd:string,
+        prov:location = 'niiri:ee032b83f3abbbdb30b2a62197d9e399',
+        prov:value = "5.05907249450684" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.20610225272296" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000672730842027125" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
+        nidm_qValueFDR: = "0.0501943510982274" %% xsd:float])
+    entity(niiri:ee032b83f3abbbdb30b2a62197d9e399,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0084" %% xsd:string,
+        nidm_coordinateVector: = "[10,-30,80]" %% xsd:string])
+    wasDerivedFrom(niiri:77969ad2ea1b902a3de4c5dfa8bce613, niiri:5d9c59bbe6ff835dfd7a715340e2d8b7, -, -, -)
+    entity(niiri:0bc108a04fa102d651c09d417f06163e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0085" %% xsd:string,
+        prov:location = 'niiri:85320af157905fd663b941a235d3c218',
+        prov:value = "5.05790328979492" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.20554765226523" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000674028618936839" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
+        nidm_qValueFDR: = "0.0502551505802037" %% xsd:float])
+    entity(niiri:85320af157905fd663b941a235d3c218,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0085" %% xsd:string,
+        nidm_coordinateVector: = "[44,-76,8]" %% xsd:string])
+    wasDerivedFrom(niiri:0bc108a04fa102d651c09d417f06163e, niiri:8cb05ce5ff1f36539390753e60f586ff, -, -, -)
+    entity(niiri:9ad0a5fb1e4870a3f1763d5f1630bf32,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0086" %% xsd:string,
+        prov:location = 'niiri:3906fb2e94c751bdf7ed2d37f73381e1',
+        prov:value = "5.04969549179077" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.20165202224461" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000683209765197312" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999999" %% xsd:float,
+        nidm_qValueFDR: = "0.050613270744433" %% xsd:float])
+    entity(niiri:3906fb2e94c751bdf7ed2d37f73381e1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0086" %% xsd:string,
+        nidm_coordinateVector: = "[-52,-36,44]" %% xsd:string])
+    wasDerivedFrom(niiri:9ad0a5fb1e4870a3f1763d5f1630bf32, niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5, -, -, -)
+    entity(niiri:f5ef66098a9f9c1e70f89f697490eeaf,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0087" %% xsd:string,
+        prov:location = 'niiri:e86bfb71232ecd6e43bcb633d2431b88',
+        prov:value = "5.02838468551636" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.19151815181806" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000707636089146368" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.051650625154872" %% xsd:float])
+    entity(niiri:e86bfb71232ecd6e43bcb633d2431b88,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0087" %% xsd:string,
+        nidm_coordinateVector: = "[-44,-40,42]" %% xsd:string])
+    wasDerivedFrom(niiri:f5ef66098a9f9c1e70f89f697490eeaf, niiri:08144c2f2914ca0e8f2d5090a382dd9c, -, -, -)
+    entity(niiri:f701ebe269b6e286af398dc8db3aa776,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0088" %% xsd:string,
+        prov:location = 'niiri:5e45ebc90297b83e805af2fa5c27599d',
+        prov:value = "5.02759695053101" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.19114302879552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00070855553886906" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0516996133446043" %% xsd:float])
+    entity(niiri:5e45ebc90297b83e805af2fa5c27599d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0088" %% xsd:string,
+        nidm_coordinateVector: = "[-44,54,-6]" %% xsd:string])
+    wasDerivedFrom(niiri:f701ebe269b6e286af398dc8db3aa776, niiri:20fdb21c4b6e1b56aba03dc17e6e0cad, -, -, -)
+    entity(niiri:ea882a65b0dfd559a13cfe9234c2c24d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0089" %% xsd:string,
+        prov:location = 'niiri:ea22c84ed8e7c73c83ed6c329b8aa7db',
+        prov:value = "5.00743103027344" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.18152691683286" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000732504543232371" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0526896959368281" %% xsd:float])
+    entity(niiri:ea22c84ed8e7c73c83ed6c329b8aa7db,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0089" %% xsd:string,
+        nidm_coordinateVector: = "[36,58,18]" %% xsd:string])
+    wasDerivedFrom(niiri:ea882a65b0dfd559a13cfe9234c2c24d, niiri:b16302312e147e9c8ce1bdd421f19045, -, -, -)
+    entity(niiri:a610e963c32e5f537ce4379d79a33677,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0090" %% xsd:string,
+        prov:location = 'niiri:e137a7aa81cf8b25e12262b0d38b2162',
+        prov:value = "4.99766159057617" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.17685933085535" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000744396146822202" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0532506765476335" %% xsd:float])
+    entity(niiri:e137a7aa81cf8b25e12262b0d38b2162,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0090" %% xsd:string,
+        nidm_coordinateVector: = "[-44,22,40]" %% xsd:string])
+    wasDerivedFrom(niiri:a610e963c32e5f537ce4379d79a33677, niiri:9e57216b41802f20cbaf2104bd85f6ec, -, -, -)
+    entity(niiri:8a5fcc105ffc1799aa129242dff957a1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0091" %% xsd:string,
+        prov:location = 'niiri:9189a192e96af6b4e8a8d551eda8ce86',
+        prov:value = "4.98628282546997" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.1714153864203" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00075849026901309" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0537320048825192" %% xsd:float])
+    entity(niiri:9189a192e96af6b4e8a8d551eda8ce86,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0091" %% xsd:string,
+        nidm_coordinateVector: = "[32,-24,72]" %% xsd:string])
+    wasDerivedFrom(niiri:8a5fcc105ffc1799aa129242dff957a1, niiri:002e00007a510fe7b30fd39adc263872, -, -, -)
+    entity(niiri:048dfb27e0ec2f8c989f283aa5001023,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0092" %% xsd:string,
+        prov:location = 'niiri:730207a65b3cc9b8b3494340623e3fad',
+        prov:value = "4.97769069671631" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.16729931357798" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000769309331678514" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0542313534025412" %% xsd:float])
+    entity(niiri:730207a65b3cc9b8b3494340623e3fad,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0092" %% xsd:string,
+        nidm_coordinateVector: = "[50,-30,60]" %% xsd:string])
+    wasDerivedFrom(niiri:048dfb27e0ec2f8c989f283aa5001023, niiri:2b00f1f0bcfadf17e4e74a633d9cbe02, -, -, -)
+    entity(niiri:4a609db5a795868ef47abe1fb286fd19,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0093" %% xsd:string,
+        prov:location = 'niiri:dfeb92f46265f28e2d20e5b1a396299e',
+        prov:value = "4.95973443984985" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.15868244743865" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000792420371319991" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.05524320395595" %% xsd:float])
+    entity(niiri:dfeb92f46265f28e2d20e5b1a396299e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0093" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-74,-28]" %% xsd:string])
+    wasDerivedFrom(niiri:4a609db5a795868ef47abe1fb286fd19, niiri:0a99da6db6ffdb6abd70dfec062dacc6, -, -, -)
+    entity(niiri:72e747c045e6ce18c7ea2d8872ec01bd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0094" %% xsd:string,
+        prov:location = 'niiri:3d10b3a98099f6ac7bd61e8504591520',
+        prov:value = "4.95515823364258" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.15648318111342" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000798420481037398" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0553418612137989" %% xsd:float])
+    entity(niiri:3d10b3a98099f6ac7bd61e8504591520,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0094" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-86,40]" %% xsd:string])
+    wasDerivedFrom(niiri:72e747c045e6ce18c7ea2d8872ec01bd, niiri:ee9edf2a051832c657f8417f27f95a8f, -, -, -)
+    entity(niiri:26738ed1bfc7ad05331c2ac978006528,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0095" %% xsd:string,
+        prov:location = 'niiri:80998b0375b4ec6cd6d7875df2f956d9',
+        prov:value = "4.93855857849121" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.14849453487417" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000820568960055779" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0562262327439451" %% xsd:float])
+    entity(niiri:80998b0375b4ec6cd6d7875df2f956d9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0095" %% xsd:string,
+        nidm_coordinateVector: = "[-10,8,6]" %% xsd:string])
+    wasDerivedFrom(niiri:26738ed1bfc7ad05331c2ac978006528, niiri:db1e7cd2ec53abce67f4898eb3c88730, -, -, -)
+    entity(niiri:4b0a6177d3028a1d196d8e8644c68f46,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0096" %% xsd:string,
+        prov:location = 'niiri:e2315b6373bae1a1a264e9e11bacd9c2',
+        prov:value = "4.90264129638672" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.13114947632107" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000870617549853403" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.058320641241518" %% xsd:float])
+    entity(niiri:e2315b6373bae1a1a264e9e11bacd9c2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0096" %% xsd:string,
+        nidm_coordinateVector: = "[14,8,10]" %% xsd:string])
+    wasDerivedFrom(niiri:4b0a6177d3028a1d196d8e8644c68f46, niiri:1066c8d3aa41693bfd354d1824cc7afe, -, -, -)
+    entity(niiri:6c657d496e9b2f580793789f0903637f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0097" %% xsd:string,
+        prov:location = 'niiri:92223eda5bee2fa6366d50cdb0ad17ae',
+        prov:value = "4.90243864059448" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.1310513773308" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000870908426383377" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.058320641241518" %% xsd:float])
+    entity(niiri:92223eda5bee2fa6366d50cdb0ad17ae,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0097" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-54,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:6c657d496e9b2f580793789f0903637f, niiri:176e7ef375f6f1d2e26f1a064f8f6d39, -, -, -)
+    entity(niiri:a9f12b36f390508d489680fa6cd977ef,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0098" %% xsd:string,
+        prov:location = 'niiri:400d143354fecfac34d7ed6f2f74e6d2',
+        prov:value = "4.88119602203369" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.12075392909771" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000901943498395119" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0594947205600118" %% xsd:float])
+    entity(niiri:400d143354fecfac34d7ed6f2f74e6d2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0098" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-84,44]" %% xsd:string])
+    wasDerivedFrom(niiri:a9f12b36f390508d489680fa6cd977ef, niiri:08a3f7b7f6c942ab91160dfccbb968f2, -, -, -)
+    entity(niiri:41ef706109f70aebe1bd69047789d6e8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0099" %% xsd:string,
+        prov:location = 'niiri:832aed24b7e9f89f7aac213df0041827',
+        prov:value = "4.86706686019897" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.11388868389685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000923195680083033" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0603762016821821" %% xsd:float])
+    entity(niiri:832aed24b7e9f89f7aac213df0041827,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0099" %% xsd:string,
+        nidm_coordinateVector: = "[-54,22,10]" %% xsd:string])
+    wasDerivedFrom(niiri:41ef706109f70aebe1bd69047789d6e8, niiri:bddc2499a043f720b9c5a3c2a309f42c, -, -, -)
+    entity(niiri:b47830006cf1b3f215bc9fd3e64ca371,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0100" %% xsd:string,
+        prov:location = 'niiri:d9dbb81cee63c9d429edaac681bad88e',
+        prov:value = "4.84812355041504" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.10466401400555" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000952476397051205" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0616422795595169" %% xsd:float])
+    entity(niiri:d9dbb81cee63c9d429edaac681bad88e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0100" %% xsd:string,
+        nidm_coordinateVector: = "[32,-80,-24]" %% xsd:string])
+    wasDerivedFrom(niiri:b47830006cf1b3f215bc9fd3e64ca371, niiri:189d9d696ac51ec44003eb5f973b6c64, -, -, -)
+    entity(niiri:e92e382c720879269b6002714e4a16ac,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0101" %% xsd:string,
+        prov:location = 'niiri:dde3f75099fb3b6b61a79003461a2d21',
+        prov:value = "4.82597017288208" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.09384653195936" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00098789830908641" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0629671631402158" %% xsd:float])
+    entity(niiri:dde3f75099fb3b6b61a79003461a2d21,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0101" %% xsd:string,
+        nidm_coordinateVector: = "[10,-80,4]" %% xsd:string])
+    wasDerivedFrom(niiri:e92e382c720879269b6002714e4a16ac, niiri:5d37a307684854af5c2a17ddbdb8f17f, -, -, -)
+    entity(niiri:b3a2d1e439fbf61d76d02cbdc713f8d9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0102" %% xsd:string,
+        prov:location = 'niiri:434dda457215299529b6e3b3f80e543c',
+        prov:value = "4.82537364959717" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.09355480628341" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000988870098138084" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0629727239584754" %% xsd:float])
+    entity(niiri:434dda457215299529b6e3b3f80e543c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0102" %% xsd:string,
+        nidm_coordinateVector: = "[16,-50,-50]" %% xsd:string])
+    wasDerivedFrom(niiri:b3a2d1e439fbf61d76d02cbdc713f8d9, niiri:df310d7fb2c5397364d68a8d3fa65bc0, -, -, -)
+    entity(niiri:5c2c228fe7c73da50c74454b38d9ce4f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0103" %% xsd:string,
+        prov:location = 'niiri:83a52daf4eb7997573701f3945da1301',
+        prov:value = "4.82024002075195" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.09104327517968" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000997272813291428" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.0632678542871923" %% xsd:float])
+    entity(niiri:83a52daf4eb7997573701f3945da1301,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0103" %% xsd:string,
+        nidm_coordinateVector: = "[-12,-20,12]" %% xsd:string])
+    wasDerivedFrom(niiri:5c2c228fe7c73da50c74454b38d9ce4f, niiri:d0abba065cadfdf673c1ba317a4155ef, -, -, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_f_test/nidm.provn
+++ b/spmexport/ex_spm_f_test/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:21b3c4311946920c7bb866cb7241f06a,
+  entity(niiri:e7c622c060f6ce4999c83cd4e7d504a2,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:26e4ed7e4ca9f8d6f69ba2608dc2bb2b,
+  agent(niiri:64a0a1e03c4e2566a0c7d5a14157ea25,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:cfc5d5cf6de0f5ccfe313e6d43587323,
+  activity(niiri:4547ccdcb0181d8f245befc50dcc96be,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:cfc5d5cf6de0f5ccfe313e6d43587323, niiri:26e4ed7e4ca9f8d6f69ba2608dc2bb2b, -)
-  wasGeneratedBy(niiri:21b3c4311946920c7bb866cb7241f06a, niiri:cfc5d5cf6de0f5ccfe313e6d43587323, 2016-01-11T10:11:24)
-  bundle niiri:21b3c4311946920c7bb866cb7241f06a
+  wasAssociatedWith(niiri:4547ccdcb0181d8f245befc50dcc96be, niiri:64a0a1e03c4e2566a0c7d5a14157ea25, -)
+  wasGeneratedBy(niiri:e7c622c060f6ce4999c83cd4e7d504a2, niiri:4547ccdcb0181d8f245befc50dcc96be, 2016-01-11T10:33:38)
+  bundle niiri:e7c622c060f6ce4999c83cd4e7d504a2
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -127,12 +127,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:43a3ee53f98ee35a82fd6af9eebbd163,
+    agent(niiri:a9aa267d850571686083e814acacec85,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:6cbc3e147cf7f32be569d44f46d94c1f,
+    entity(niiri:8631110ecbf1ae2c61c651d3c345e53a,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -141,189 +141,189 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:e3676e8eec4990ea33ab365f41819e4c,
+    entity(niiri:4065e9c0832a79eea2d7f48f6837481b,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:a4aacd65a7c45519a9f2f3175def869f,
+    entity(niiri:6aef7089ce827a6b71f19c009ab15a95,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:3769ef4c5efe49a97295e3959f9dc7ad,
+    entity(niiri:ea225237d5825ad08d76e698758e674b,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:e95fdfe90dea233f4527fc2ab0df8f98',
+        dc:description = 'niiri:1a0a5cc4df2739bc50811b7823bb401e',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:a4aacd65a7c45519a9f2f3175def869f',
+        nidm_hasDriftModel: = 'niiri:6aef7089ce827a6b71f19c009ab15a95',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:e95fdfe90dea233f4527fc2ab0df8f98,
+    entity(niiri:1a0a5cc4df2739bc50811b7823bb401e,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:b2fe7439c407fcd2dde1efc329a7b0f3,
+    entity(niiri:b5697884a43743feb7d20368b80f55a9,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:403063ca7469ea436c4ddd80ac3e76cd,
+    activity(niiri:3c0b88356def21e2b7fe83f740cf597b,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:403063ca7469ea436c4ddd80ac3e76cd, niiri:43a3ee53f98ee35a82fd6af9eebbd163, -)
-    used(niiri:403063ca7469ea436c4ddd80ac3e76cd, niiri:3769ef4c5efe49a97295e3959f9dc7ad, -)
-    used(niiri:403063ca7469ea436c4ddd80ac3e76cd, niiri:e3676e8eec4990ea33ab365f41819e4c, -)
-    used(niiri:403063ca7469ea436c4ddd80ac3e76cd, niiri:b2fe7439c407fcd2dde1efc329a7b0f3, -)
-    entity(niiri:2dfea426e8928d3252adb676004ffb9d,
+    wasAssociatedWith(niiri:3c0b88356def21e2b7fe83f740cf597b, niiri:a9aa267d850571686083e814acacec85, -)
+    used(niiri:3c0b88356def21e2b7fe83f740cf597b, niiri:ea225237d5825ad08d76e698758e674b, -)
+    used(niiri:3c0b88356def21e2b7fe83f740cf597b, niiri:4065e9c0832a79eea2d7f48f6837481b, -)
+    used(niiri:3c0b88356def21e2b7fe83f740cf597b, niiri:b5697884a43743feb7d20368b80f55a9, -)
+    entity(niiri:dd3a1b34bce9178ca5eb9e0c6f64572b,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    entity(niiri:9791d34c6aacce2cfbb27ce2f9075562,
+    entity(niiri:f081077fa790becea31f832bed0ad762,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
-    wasDerivedFrom(niiri:2dfea426e8928d3252adb676004ffb9d, niiri:9791d34c6aacce2cfbb27ce2f9075562, -, -, -)
-    wasGeneratedBy(niiri:2dfea426e8928d3252adb676004ffb9d, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:fe1de7f78c02a415bd4ad2098cae4f59,
+    wasDerivedFrom(niiri:dd3a1b34bce9178ca5eb9e0c6f64572b, niiri:f081077fa790becea31f832bed0ad762, -, -, -)
+    wasGeneratedBy(niiri:dd3a1b34bce9178ca5eb9e0c6f64572b, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:a45718cdddcc1f52a7095a49c028bc7b,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "108.038318634033" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
         crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
-    wasGeneratedBy(niiri:fe1de7f78c02a415bd4ad2098cae4f59, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7,
+    wasGeneratedBy(niiri:a45718cdddcc1f52a7095a49c028bc7b, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:855ff1743625270dda4931a04ecd1031,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
-    entity(niiri:335e2de27a1a351eae295b2d6aba0ccc,
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
+    entity(niiri:97dfe474f83a8bb5d149d855133a64bc,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "11c208792e1874b4837ea90ec03320c8eeb702ad3966ee5912aa2e33b5bdb17b0e88caa31ed546f7f601160ced8eceebdf5db6449df6ec3ffbd17e27917ec328" %% xsd:string])
-    wasDerivedFrom(niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7, niiri:335e2de27a1a351eae295b2d6aba0ccc, -, -, -)
-    wasGeneratedBy(niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:40508269ce9f0c03d9af35c886882e23,
+    wasDerivedFrom(niiri:855ff1743625270dda4931a04ecd1031, niiri:97dfe474f83a8bb5d149d855133a64bc, -, -, -)
+    wasGeneratedBy(niiri:855ff1743625270dda4931a04ecd1031, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:4fbc59d57cc5244670a944301b75c49e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
-    entity(niiri:493248b59478ddca0df41a77bc6f1482,
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
+    entity(niiri:552b132ff1cb3c6356eed45cfba091e2,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
-    wasDerivedFrom(niiri:40508269ce9f0c03d9af35c886882e23, niiri:493248b59478ddca0df41a77bc6f1482, -, -, -)
-    wasGeneratedBy(niiri:40508269ce9f0c03d9af35c886882e23, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:336fa6f65e23fda5fa34e118d1c9a0e1,
+    wasDerivedFrom(niiri:4fbc59d57cc5244670a944301b75c49e, niiri:552b132ff1cb3c6356eed45cfba091e2, -, -, -)
+    wasGeneratedBy(niiri:4fbc59d57cc5244670a944301b75c49e, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:4fcd0feb226f491d94d19ede647cf6df,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
-    entity(niiri:7fd42856ebc39326ecf3d9c7336203ad,
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
+    entity(niiri:47beaf2666652e2dfc40b9d59975b754,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "833a477bd4e758bdde7fcc9e6682186e9e38c1eeaa2a66de7d67e5f3c57cbaed7bddd45a7f7c86db713a8aa708790eaa31e0d8f0d0af9db9e87b545990b9e91e" %% xsd:string])
-    wasDerivedFrom(niiri:336fa6f65e23fda5fa34e118d1c9a0e1, niiri:7fd42856ebc39326ecf3d9c7336203ad, -, -, -)
-    wasGeneratedBy(niiri:336fa6f65e23fda5fa34e118d1c9a0e1, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:16e0178c267997ead20f777bffe45894,
+    wasDerivedFrom(niiri:4fcd0feb226f491d94d19ede647cf6df, niiri:47beaf2666652e2dfc40b9d59975b754, -, -, -)
+    wasGeneratedBy(niiri:4fcd0feb226f491d94d19ede647cf6df, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:b1423cdb1726cd9674ebf1bcab3bcf56,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
-    entity(niiri:ffb56ac43e312f7d862bd04227ca2771,
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
+    entity(niiri:8e1176bdcc74a45839a55e6b1d4afb84,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "8044c2e517efad185114b1d5478983a5073547d99f6b5778bcefe9caa7d243b89824b69841e3e5aa05e1da5393c9d1a34fec9a050b6a1e8a87da31cad99bfe69" %% xsd:string])
-    wasDerivedFrom(niiri:16e0178c267997ead20f777bffe45894, niiri:ffb56ac43e312f7d862bd04227ca2771, -, -, -)
-    wasGeneratedBy(niiri:16e0178c267997ead20f777bffe45894, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:717d24f6fc8fcd6daeec2603e49ed740,
+    wasDerivedFrom(niiri:b1423cdb1726cd9674ebf1bcab3bcf56, niiri:8e1176bdcc74a45839a55e6b1d4afb84, -, -, -)
+    wasGeneratedBy(niiri:b1423cdb1726cd9674ebf1bcab3bcf56, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:15b31a17ded6db8183340b7bf088bf97,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
-    entity(niiri:67d86f251b1b458908a8aee56a029301,
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
+    entity(niiri:345e3096159163131e4b2fc7f1ed4857,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "15551a7f3970720338fd0643bd017ba2f7f5db09c16b38909560b0479aa69eb74cd746fa98b2adc796153af88fba9b2ddd4eb5713b6f6011e62b7efb6531426d" %% xsd:string])
-    wasDerivedFrom(niiri:717d24f6fc8fcd6daeec2603e49ed740, niiri:67d86f251b1b458908a8aee56a029301, -, -, -)
-    wasGeneratedBy(niiri:717d24f6fc8fcd6daeec2603e49ed740, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:b8e1b2bd6e02f1d74415b3190da5e6ce,
+    wasDerivedFrom(niiri:15b31a17ded6db8183340b7bf088bf97, niiri:345e3096159163131e4b2fc7f1ed4857, -, -, -)
+    wasGeneratedBy(niiri:15b31a17ded6db8183340b7bf088bf97, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:08de3e9dd167da4e0236e06f6ffa9f7a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 6" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f'])
-    entity(niiri:0f227926cc2656b6333cd6e70b59bef0,
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
+    entity(niiri:77879d25adca01d9f67bf80353db2ca6,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0006.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
-    wasDerivedFrom(niiri:b8e1b2bd6e02f1d74415b3190da5e6ce, niiri:0f227926cc2656b6333cd6e70b59bef0, -, -, -)
-    wasGeneratedBy(niiri:b8e1b2bd6e02f1d74415b3190da5e6ce, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:f446aad676c7f507c6dfdb3e65bd6cb3,
+    wasDerivedFrom(niiri:08de3e9dd167da4e0236e06f6ffa9f7a, niiri:77879d25adca01d9f67bf80353db2ca6, -, -, -)
+    wasGeneratedBy(niiri:08de3e9dd167da4e0236e06f6ffa9f7a, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:3406078060d97913cb8d424d34703ab9,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
         crypto:sha512 = "9f1acf4f335317f388cc8adcc04086aa4e6bc6d19d5633a6a8d8dd85716386748c7ed700ef8031c7a3733228557d5ecf96eb6a889e2d36ad065e7bc852ae0b8c" %% xsd:string])
-    entity(niiri:7dc7be1e08841016c50f481df400db45,
+    entity(niiri:c636630fb563318d5b35ab4a8b0a34c0,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "641184631587ff0ed74f92302d94dd40f2802efab358753eade14667fb6ee74fe64f3090b02fdf20e4a99d444610a61a1ae8a684628c9b2037535fbed9d53a12" %% xsd:string])
-    wasDerivedFrom(niiri:f446aad676c7f507c6dfdb3e65bd6cb3, niiri:7dc7be1e08841016c50f481df400db45, -, -, -)
-    wasGeneratedBy(niiri:f446aad676c7f507c6dfdb3e65bd6cb3, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:952c39e2aa9fff43b62bbe9b77405227,
+    wasDerivedFrom(niiri:3406078060d97913cb8d424d34703ab9, niiri:c636630fb563318d5b35ab4a8b0a34c0, -, -, -)
+    wasGeneratedBy(niiri:3406078060d97913cb8d424d34703ab9, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:345400b745ebe143b4f453e4c217c209,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
         crypto:sha512 = "a093dd7a9dd81e95f3696221e49cbb3ad8080b1f316ece53c9aafcb5cc9b767e55c594b7131d933e31231744c65db07483e64245480afd95075b76ccd2432789" %% xsd:string])
-    entity(niiri:48a4ebca3d7eaf837f3c511ad76b8b82,
+    entity(niiri:774ad877e270db9e46dc564231f1b2e3,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "6ccf9e1895f8a26549f392b1d1a3676888cd729a207c6a93bcda6d549de2d4f133c0b2847bd2e839a462f3ba74cb9d9525eddb9f8499b99fb452b93cd713a158" %% xsd:string])
-    wasDerivedFrom(niiri:952c39e2aa9fff43b62bbe9b77405227, niiri:48a4ebca3d7eaf837f3c511ad76b8b82, -, -, -)
-    wasGeneratedBy(niiri:952c39e2aa9fff43b62bbe9b77405227, niiri:403063ca7469ea436c4ddd80ac3e76cd, -)
-    entity(niiri:eaf42d3560a64658c65dfc990556d651,
+    wasDerivedFrom(niiri:345400b745ebe143b4f453e4c217c209, niiri:774ad877e270db9e46dc564231f1b2e3, -, -, -)
+    wasGeneratedBy(niiri:345400b745ebe143b4f453e4c217c209, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
+    entity(niiri:c9f72062391a92f26280783481f9d41e,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_FStatistic:',
         nidm_contrastName: = "F Contrast Test" %% xsd:string,
         prov:label = "Contrast: F Contrast Test" %% xsd:string,
         prov:value = "[[1, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0],[0, 0, 0, 1, 0, 0]]" %% xsd:string])
-    activity(niiri:b6fffa4c3247dbca41c70d6abf376201,
+    activity(niiri:aedde2b1a02ad24ed234029b5dc86c0e,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:43a3ee53f98ee35a82fd6af9eebbd163, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:2dfea426e8928d3252adb676004ffb9d, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:f446aad676c7f507c6dfdb3e65bd6cb3, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:3769ef4c5efe49a97295e3959f9dc7ad, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:eaf42d3560a64658c65dfc990556d651, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:40508269ce9f0c03d9af35c886882e23, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:336fa6f65e23fda5fa34e118d1c9a0e1, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:16e0178c267997ead20f777bffe45894, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:717d24f6fc8fcd6daeec2603e49ed740, -)
-    used(niiri:b6fffa4c3247dbca41c70d6abf376201, niiri:b8e1b2bd6e02f1d74415b3190da5e6ce, -)
-    entity(niiri:b61012119e0a476f635df26d721e8c30,
+    wasAssociatedWith(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:a9aa267d850571686083e814acacec85, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:dd3a1b34bce9178ca5eb9e0c6f64572b, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:3406078060d97913cb8d424d34703ab9, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:ea225237d5825ad08d76e698758e674b, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:c9f72062391a92f26280783481f9d41e, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:855ff1743625270dda4931a04ecd1031, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:4fbc59d57cc5244670a944301b75c49e, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:4fcd0feb226f491d94d19ede647cf6df, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:b1423cdb1726cd9674ebf1bcab3bcf56, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:15b31a17ded6db8183340b7bf088bf97, -)
+    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:08de3e9dd167da4e0236e06f6ffa9f7a, -)
+    entity(niiri:b0e7b8f9e020e8724283e6191e2da703,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "FStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "FStatistic.nii.gz" %% xsd:string,
@@ -333,87 +333,87 @@ document
         nidm_contrastName: = "F Contrast Test" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.999999999651" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "3.99999999999962" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
         crypto:sha512 = "ca31a667d26797ee68a3709a8fa04f799ad113f17e6eff75ad6e88f53c44aa9e158a0d007354d454ad01df82d6b0f25f07b324cc3baa32f7623096a92ee6f304" %% xsd:string])
-    entity(niiri:7a977781f43baadb29a7109b66db5c80,
+    entity(niiri:27281b97c78d257b22887871c6a68112,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmF_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "db6d4200b2e060c1fbd3e5c71011ac95ce60024087239685545954651a68733ec2d949c56520d2637add9e91c8e7883742c7d307667ad83c4ebe2a8531a1cc53" %% xsd:string])
-    wasDerivedFrom(niiri:b61012119e0a476f635df26d721e8c30, niiri:7a977781f43baadb29a7109b66db5c80, -, -, -)
-    wasGeneratedBy(niiri:b61012119e0a476f635df26d721e8c30, niiri:b6fffa4c3247dbca41c70d6abf376201, -)
-    entity(niiri:5da9115bb9224fc27deb59c4db51293d,
+    wasDerivedFrom(niiri:b0e7b8f9e020e8724283e6191e2da703, niiri:27281b97c78d257b22887871c6a68112, -, -, -)
+    wasGeneratedBy(niiri:b0e7b8f9e020e8724283e6191e2da703, niiri:aedde2b1a02ad24ed234029b5dc86c0e, -)
+    entity(niiri:0c51bc0fe4411e7dcd2abb844e9d9483,
         [prov:type = 'nidm_ContrastExplainedMeanSquareMap:',
         prov:location = "ContrastExplainedMeanSquare.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastExplainedMeanSquare.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Explained Mean Square Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
         crypto:sha512 = "a4b2ff6f792524a027a625aba962b798c3ea321cdd6636193ab521acf5dafa8ceb7fd4cb99a450ab7872359d0e6dac97f82b7523d609747780623b5077e02588" %% xsd:string])
-    wasGeneratedBy(niiri:5da9115bb9224fc27deb59c4db51293d, niiri:b6fffa4c3247dbca41c70d6abf376201, -)
-    entity(niiri:790a0bb2d27b9d88e6869e877e73216b,
+    wasGeneratedBy(niiri:0c51bc0fe4411e7dcd2abb844e9d9483, niiri:aedde2b1a02ad24ed234029b5dc86c0e, -)
+    entity(niiri:7f46ae22cdc5ee6822a2f2f5b2ca2f2b,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500086842908" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:cdc27d5485a25b98dc806d64eab06294',
-        nidm_equivalentThreshold: = 'niiri:3a45a7e93b85e390a50cf7b33998e058'])
-    entity(niiri:cdc27d5485a25b98dc806d64eab06294,
+        nidm_equivalentThreshold: = 'niiri:0b8b0ea120e66e277cc906e8c638f4a1',
+        nidm_equivalentThreshold: = 'niiri:01b61d5a54d124c25b0dfe4842452479'])
+    entity(niiri:0b8b0ea120e66e277cc906e8c638f4a1,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.81888651656205" %% xsd:float])
-    entity(niiri:3a45a7e93b85e390a50cf7b33998e058,
+    entity(niiri:01b61d5a54d124c25b0dfe4842452479,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:311c74b903cbe301d2ea1ed406ef3819,
+    entity(niiri:5c63a2de98701908b773b73724aa2e6c,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:d03c098b559b5d8b940ae0e6f4e45ac2',
-        nidm_equivalentThreshold: = 'niiri:1256253b1ec8513cc907a598b85b5d25'])
-    entity(niiri:d03c098b559b5d8b940ae0e6f4e45ac2,
+        nidm_equivalentThreshold: = 'niiri:eb923f6975373720518450d07547dba1',
+        nidm_equivalentThreshold: = 'niiri:c6c498af368977c112799bfa72671339'])
+    entity(niiri:eb923f6975373720518450d07547dba1,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:1256253b1ec8513cc907a598b85b5d25,
+    entity(niiri:c6c498af368977c112799bfa72671339,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:0499a436458abc172a88ee306d18a605,
+    entity(niiri:0b2c9ff1807f3f9bd6728cc73ddb271a,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:83fc9ee7c0ea36a7bd88d4420b89b29c,
+    entity(niiri:ee02bfd0ffe03ca3e43583cd21adab51,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c,
+    activity(niiri:87b5e03e41975da7e1db9bc068fc452a,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:43a3ee53f98ee35a82fd6af9eebbd163, -)
-    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:790a0bb2d27b9d88e6869e877e73216b, -)
-    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:311c74b903cbe301d2ea1ed406ef3819, -)
-    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:b61012119e0a476f635df26d721e8c30, -)
-    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:952c39e2aa9fff43b62bbe9b77405227, -)
-    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:2dfea426e8928d3252adb676004ffb9d, -)
-    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:0499a436458abc172a88ee306d18a605, -)
-    used(niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, niiri:83fc9ee7c0ea36a7bd88d4420b89b29c, -)
-    entity(niiri:0bd153c871e44425ad2d0d70154ff868,
+    wasAssociatedWith(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:a9aa267d850571686083e814acacec85, -)
+    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:7f46ae22cdc5ee6822a2f2f5b2ca2f2b, -)
+    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:5c63a2de98701908b773b73724aa2e6c, -)
+    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:b0e7b8f9e020e8724283e6191e2da703, -)
+    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:345400b745ebe143b4f453e4c217c209, -)
+    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:dd3a1b34bce9178ca5eb9e0c6f64572b, -)
+    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:0b2c9ff1807f3f9bd6728cc73ddb271a, -)
+    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:ee02bfd0ffe03ca3e43583cd21adab51, -)
+    entity(niiri:6fa69d1e83da07700b4a4ed4fdff8fa4,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
         nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
         nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
         nidm_reselSizeInVoxels: = "68.4409986586639" %% xsd:float,
@@ -429,8 +429,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "68" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "51" %% xsd:int,
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    wasGeneratedBy(niiri:0bd153c871e44425ad2d0d70154ff868, niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, -)
-    entity(niiri:1f1a3d63428e4d2bf1696942c7dcd71e,
+    wasGeneratedBy(niiri:6fa69d1e83da07700b4a4ed4fdff8fa4, niiri:87b5e03e41975da7e1db9bc068fc452a, -)
+    entity(niiri:bfc22c098dc267a88d326bbf0e6793e3,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -438,22 +438,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "89" %% xsd:int,
         nidm_pValue: = "1.20671430625663e-08" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:ea2c3c814c10994917dd56bc9fe21873',
-        nidm_hasMaximumIntensityProjection: = 'niiri:dd34657f27860de0933d54ae20a5bde9',
-        nidm_inCoordinateSpace: = 'niiri:6cbc3e147cf7f32be569d44f46d94c1f',
+        nidm_hasClusterLabelsMap: = 'niiri:c872c243f35f93570da8e3e8bb2b7ead',
+        nidm_hasMaximumIntensityProjection: = 'niiri:9fea03d98e6320e3400bb3c188004db8',
+        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
         crypto:sha512 = "7655b200bdcbba72ab5ab79029728a420df3f3368bcb553410540390e1372e99531cb91885edbdd03945d7e2391516a3d8dc537da81527730e866035d4af7894" %% xsd:string])
-    entity(niiri:ea2c3c814c10994917dd56bc9fe21873,
+    entity(niiri:c872c243f35f93570da8e3e8bb2b7ead,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:dd34657f27860de0933d54ae20a5bde9,
+    entity(niiri:9fea03d98e6320e3400bb3c188004db8,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:1f1a3d63428e4d2bf1696942c7dcd71e, niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c, -)
-    entity(niiri:0af3c1dadf9b022bafb92d73c4057be6,
+    wasGeneratedBy(niiri:bfc22c098dc267a88d326bbf0e6793e3, niiri:87b5e03e41975da7e1db9bc068fc452a, -)
+    entity(niiri:8337790d11808f2fb788ee8093e46afe,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1078" %% xsd:int,
@@ -462,8 +462,8 @@ document
         nidm_pValueFWER: = "0" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:0af3c1dadf9b022bafb92d73c4057be6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:1f6332db35b31af3ee6ca935dfaeba0c,
+    wasDerivedFrom(niiri:8337790d11808f2fb788ee8093e46afe, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:2e44272daecb8718b2883f84f352fc62,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "930" %% xsd:int,
@@ -472,8 +472,8 @@ document
         nidm_pValueFWER: = "1.11022302462516e-16" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:1f6332db35b31af3ee6ca935dfaeba0c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:0d4bf8c640cd15c305d2e49ef14b9ac6,
+    wasDerivedFrom(niiri:2e44272daecb8718b2883f84f352fc62, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:c893d69da88fea01efe542f9787608c5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "61" %% xsd:int,
@@ -482,8 +482,8 @@ document
         nidm_pValueFWER: = "0.0625404056276491" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:0d4bf8c640cd15c305d2e49ef14b9ac6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:32439b88059be589d0e2a8586ea799ec,
+    wasDerivedFrom(niiri:c893d69da88fea01efe542f9787608c5, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:fafaf22f396d11e8355f5d1e7a7367ea,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "51" %% xsd:int,
@@ -492,8 +492,8 @@ document
         nidm_pValueFWER: = "0.126476639623878" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:32439b88059be589d0e2a8586ea799ec, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:d8b9846e25000609adbc385c634a1be0,
+    wasDerivedFrom(niiri:fafaf22f396d11e8355f5d1e7a7367ea, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:0820636de884fe0d783c5385916ab101,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "102" %% xsd:int,
@@ -502,8 +502,8 @@ document
         nidm_pValueFWER: = "0.00439690541625271" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:d8b9846e25000609adbc385c634a1be0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:f8e22d4c567142a3ab813140dd91551e,
+    wasDerivedFrom(niiri:0820636de884fe0d783c5385916ab101, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:1e3c8c027b813bda7df5358a8ab4f63a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "69" %% xsd:int,
@@ -512,8 +512,8 @@ document
         nidm_pValueFWER: = "0.0361338614001637" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:f8e22d4c567142a3ab813140dd91551e, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:96a2e290f72fc28530510650c52e2805,
+    wasDerivedFrom(niiri:1e3c8c027b813bda7df5358a8ab4f63a, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:e24e457b7371fd1bac7d4cb391bb9432,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "81" %% xsd:int,
@@ -522,8 +522,8 @@ document
         nidm_pValueFWER: = "0.0163292644152585" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:96a2e290f72fc28530510650c52e2805, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:1062efea331d3022773f16c049f8543d,
+    wasDerivedFrom(niiri:e24e457b7371fd1bac7d4cb391bb9432, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:2f5fcfc4453f648ede4260a16cff5960,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "62" %% xsd:int,
@@ -532,8 +532,8 @@ document
         nidm_pValueFWER: = "0.0583486858266125" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:1062efea331d3022773f16c049f8543d, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:5577dc13c7013d8bb90b8dd111792d46,
+    wasDerivedFrom(niiri:2f5fcfc4453f648ede4260a16cff5960, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:dbbddbece734ef2c5ed154985b15ffe8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "27" %% xsd:int,
@@ -542,8 +542,8 @@ document
         nidm_pValueFWER: = "0.637047204368496" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:5577dc13c7013d8bb90b8dd111792d46, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:64ae5737521bbc7fe14f0c862379e927,
+    wasDerivedFrom(niiri:dbbddbece734ef2c5ed154985b15ffe8, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:6aecc2d95fe5ba4cd2d39d16afe85407,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "69" %% xsd:int,
@@ -552,8 +552,8 @@ document
         nidm_pValueFWER: = "0.0361338614001637" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:64ae5737521bbc7fe14f0c862379e927, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:900846b4c16bba4a9b8a34762cba2da0,
+    wasDerivedFrom(niiri:6aecc2d95fe5ba4cd2d39d16afe85407, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:a9c284c82bc4ef4eba48570f53c9c9c4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "34" %% xsd:int,
@@ -562,8 +562,8 @@ document
         nidm_pValueFWER: = "0.41596704628578" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:900846b4c16bba4a9b8a34762cba2da0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:7ede1db6987922a4806abc265aecda62,
+    wasDerivedFrom(niiri:a9c284c82bc4ef4eba48570f53c9c9c4, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:0637af2e34d8b1c842ae7d1386357498,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -572,8 +572,8 @@ document
         nidm_pValueFWER: = "0.955688665756324" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:7ede1db6987922a4806abc265aecda62, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:9287b2a8106c3ffe3abf93837cfbd61c,
+    wasDerivedFrom(niiri:0637af2e34d8b1c842ae7d1386357498, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:1cd4117828f514ec0fff4b67f780d6b9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "33" %% xsd:int,
@@ -582,8 +582,8 @@ document
         nidm_pValueFWER: = "0.444043105508432" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:9287b2a8106c3ffe3abf93837cfbd61c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:c515278968596a92906ae29ffad63511,
+    wasDerivedFrom(niiri:1cd4117828f514ec0fff4b67f780d6b9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:d85063f48080f770ca548748f7419e12,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "29" %% xsd:int,
@@ -592,8 +592,8 @@ document
         nidm_pValueFWER: = "0.568879964907834" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:c515278968596a92906ae29ffad63511, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:0493a379c4735cda662e56229168b8a9,
+    wasDerivedFrom(niiri:d85063f48080f770ca548748f7419e12, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:ec3fc3cfa0c303c00f68f5986e44044e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "52" %% xsd:int,
@@ -602,8 +602,8 @@ document
         nidm_pValueFWER: = "0.117795392093901" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:0493a379c4735cda662e56229168b8a9, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:6f915c93d573d9f832d05fb003dcbfb0,
+    wasDerivedFrom(niiri:ec3fc3cfa0c303c00f68f5986e44044e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:23c6e94e6643122dcb458402a972758e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -612,8 +612,8 @@ document
         nidm_pValueFWER: = "0.894389812698126" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:6f915c93d573d9f832d05fb003dcbfb0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:2344710a34a75f050910ebd48e1159af,
+    wasDerivedFrom(niiri:23c6e94e6643122dcb458402a972758e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:68f9a66ca71f514199366c398a2831ab,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "15" %% xsd:int,
@@ -622,8 +622,8 @@ document
         nidm_pValueFWER: = "0.969514797834504" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:2344710a34a75f050910ebd48e1159af, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:a904380f9b13e67a2253c5f952a57f9f,
+    wasDerivedFrom(niiri:68f9a66ca71f514199366c398a2831ab, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:6f303953fe538a2a99d9b754b92e311e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -632,8 +632,8 @@ document
         nidm_pValueFWER: = "0.938523680835064" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:a904380f9b13e67a2253c5f952a57f9f, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:8348fc8e7248e46840dad7df7f8763bf,
+    wasDerivedFrom(niiri:6f303953fe538a2a99d9b754b92e311e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:b32513dc3cebea135a4227a2ff2989c6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "37" %% xsd:int,
@@ -642,8 +642,8 @@ document
         nidm_pValueFWER: = "0.340003071301302" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:8348fc8e7248e46840dad7df7f8763bf, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:db6eb647802a5fc531c369aa668af574,
+    wasDerivedFrom(niiri:b32513dc3cebea135a4227a2ff2989c6, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:b7301eccecd4c049bbeed4467b530024,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -652,8 +652,8 @@ document
         nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:db6eb647802a5fc531c369aa668af574, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:efddc25357ec7a4b9a063a62f5a2c864,
+    wasDerivedFrom(niiri:b7301eccecd4c049bbeed4467b530024, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:765e5201ffb06ca1f162ea8d7d3f0abd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "27" %% xsd:int,
@@ -662,8 +662,8 @@ document
         nidm_pValueFWER: = "0.637047204368496" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:efddc25357ec7a4b9a063a62f5a2c864, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:92832eb3b91834fca357233c33e92d47,
+    wasDerivedFrom(niiri:765e5201ffb06ca1f162ea8d7d3f0abd, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:aeb5ca84ea986c7559b385b24d2806c0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -672,8 +672,8 @@ document
         nidm_pValueFWER: = "0.741232640256625" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:92832eb3b91834fca357233c33e92d47, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:27a928cca18b5d563bf58797f306d0e0,
+    wasDerivedFrom(niiri:aeb5ca84ea986c7559b385b24d2806c0, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:d36b472817f6888ac2860c8f78cda4e9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "30" %% xsd:int,
@@ -682,8 +682,8 @@ document
         nidm_pValueFWER: = "0.535986190221124" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:27a928cca18b5d563bf58797f306d0e0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:9197197694f96c553e0e78334284b0c7,
+    wasDerivedFrom(niiri:d36b472817f6888ac2860c8f78cda4e9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:e1375ee26540e9328da498ca97a69cb4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -692,8 +692,8 @@ document
         nidm_pValueFWER: = "0.894389812698126" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:9197197694f96c553e0e78334284b0c7, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:4babeddab7c30570f5f7bca47ad8e349,
+    wasDerivedFrom(niiri:e1375ee26540e9328da498ca97a69cb4, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:d5f1c18934146a18337779acd9486123,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "68" %% xsd:int,
@@ -702,8 +702,8 @@ document
         nidm_pValueFWER: = "0.0386667510721175" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:4babeddab7c30570f5f7bca47ad8e349, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:abcdfa125cb9a6705001908f8633bf90,
+    wasDerivedFrom(niiri:d5f1c18934146a18337779acd9486123, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:275de6b748d7ad0f11eed3004edbf892,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -712,8 +712,8 @@ document
         nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:abcdfa125cb9a6705001908f8633bf90, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:2583f6b74e4ca256d5338bb9b9f07a29,
+    wasDerivedFrom(niiri:275de6b748d7ad0f11eed3004edbf892, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:2dd4cb8812c93538b5902225b29e0471,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -722,8 +722,8 @@ document
         nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:2583f6b74e4ca256d5338bb9b9f07a29, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:9656cbf27ba556542b025f2f8e45acfd,
+    wasDerivedFrom(niiri:2dd4cb8812c93538b5902225b29e0471, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:67ae07e7ee0396386eefce6ed5341a79,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "15" %% xsd:int,
@@ -732,8 +732,8 @@ document
         nidm_pValueFWER: = "0.969514797834504" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:9656cbf27ba556542b025f2f8e45acfd, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:52cafab6790abfb27ec51f00e747fe9a,
+    wasDerivedFrom(niiri:67ae07e7ee0396386eefce6ed5341a79, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:c589ee96ca2b908bdd9d337ca523d5af,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -742,8 +742,8 @@ document
         nidm_pValueFWER: = "0.938523680835064" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:52cafab6790abfb27ec51f00e747fe9a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:4c64b57b636863b3e947522d1311c0f1,
+    wasDerivedFrom(niiri:c589ee96ca2b908bdd9d337ca523d5af, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:e43455a02504b9d87a4939904a0ca976,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -752,8 +752,8 @@ document
         nidm_pValueFWER: = "0.993158154960398" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:4c64b57b636863b3e947522d1311c0f1, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:a8236e3bfdb590d4516edd326dbac95d,
+    wasDerivedFrom(niiri:e43455a02504b9d87a4939904a0ca976, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:5dc937975dc687d7eb55e11a685cdd94,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -762,8 +762,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "31" %% xsd:int])
-    wasDerivedFrom(niiri:a8236e3bfdb590d4516edd326dbac95d, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:90dce13e46266944c40d12f4f1a86219,
+    wasDerivedFrom(niiri:5dc937975dc687d7eb55e11a685cdd94, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:30c5174c5d495474060913c40bab0961,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -772,8 +772,8 @@ document
         nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "32" %% xsd:int])
-    wasDerivedFrom(niiri:90dce13e46266944c40d12f4f1a86219, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:4b569159d1ddc968752a57917503c6f4,
+    wasDerivedFrom(niiri:30c5174c5d495474060913c40bab0961, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:ea999779ae02d5714142530d4b2e638b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -782,8 +782,8 @@ document
         nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "33" %% xsd:int])
-    wasDerivedFrom(niiri:4b569159d1ddc968752a57917503c6f4, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:674c9062dc421a541e91be283cce8f16,
+    wasDerivedFrom(niiri:ea999779ae02d5714142530d4b2e638b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:15b2530019f1c4c6d5e910962b35274b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -792,8 +792,8 @@ document
         nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "34" %% xsd:int])
-    wasDerivedFrom(niiri:674c9062dc421a541e91be283cce8f16, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:d3a1762138c1b259db52c75933757662,
+    wasDerivedFrom(niiri:15b2530019f1c4c6d5e910962b35274b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:5782e52657a04683a9d9acc635ffc74a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -802,8 +802,8 @@ document
         nidm_pValueFWER: = "0.999783165932851" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "35" %% xsd:int])
-    wasDerivedFrom(niiri:d3a1762138c1b259db52c75933757662, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:9dc472e5df63cfbf55f8afa2ad7233f1,
+    wasDerivedFrom(niiri:5782e52657a04683a9d9acc635ffc74a, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:e26340fcd624896679dd2542ec2348be,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -812,8 +812,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "36" %% xsd:int])
-    wasDerivedFrom(niiri:9dc472e5df63cfbf55f8afa2ad7233f1, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:3fd667ca8587427124fe4b4ff80af21a,
+    wasDerivedFrom(niiri:e26340fcd624896679dd2542ec2348be, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:e4e5f6e0de1fb1456effbec6ec82e736,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -822,8 +822,8 @@ document
         nidm_pValueFWER: = "0.993158154960398" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "37" %% xsd:int])
-    wasDerivedFrom(niiri:3fd667ca8587427124fe4b4ff80af21a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:c60cf8d223f50376ab05520bb51598af,
+    wasDerivedFrom(niiri:e4e5f6e0de1fb1456effbec6ec82e736, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:5cf9ae44dc03a8c6493baf09bed014d4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -832,8 +832,8 @@ document
         nidm_pValueFWER: = "0.987884145093703" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "38" %% xsd:int])
-    wasDerivedFrom(niiri:c60cf8d223f50376ab05520bb51598af, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:f551110d12542058bdc59cae03013010,
+    wasDerivedFrom(niiri:5cf9ae44dc03a8c6493baf09bed014d4, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:dfe1466699f719841d6d98d1188da0c8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -842,8 +842,8 @@ document
         nidm_pValueFWER: = "0.999988123335902" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "39" %% xsd:int])
-    wasDerivedFrom(niiri:f551110d12542058bdc59cae03013010, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:fb9120500eef24a89fb5e84238991362,
+    wasDerivedFrom(niiri:dfe1466699f719841d6d98d1188da0c8, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:e69a5e282ae0346ca803f55371164aa7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -852,8 +852,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "40" %% xsd:int])
-    wasDerivedFrom(niiri:fb9120500eef24a89fb5e84238991362, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:dde8bc734b1e70c777683f3419f9b22a,
+    wasDerivedFrom(niiri:e69a5e282ae0346ca803f55371164aa7, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:d168d4b61807fc13619ad56c31dad174,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -862,8 +862,8 @@ document
         nidm_pValueFWER: = "0.999988123335902" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "41" %% xsd:int])
-    wasDerivedFrom(niiri:dde8bc734b1e70c777683f3419f9b22a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:89223f01a7e676c300c22c8da4a82ef8,
+    wasDerivedFrom(niiri:d168d4b61807fc13619ad56c31dad174, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:522e011a3a54e833c99dc9315f577dfe,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -872,8 +872,8 @@ document
         nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "42" %% xsd:int])
-    wasDerivedFrom(niiri:89223f01a7e676c300c22c8da4a82ef8, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:7ac6ced5ac5b95c88fbe93f4ad51726c,
+    wasDerivedFrom(niiri:522e011a3a54e833c99dc9315f577dfe, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:bcc290b739057f6cb5c02dcc79c4b5bc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
         nidm_clusterSizeInVoxels: = "14" %% xsd:int,
@@ -882,8 +882,8 @@ document
         nidm_pValueFWER: = "0.980146451443566" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "43" %% xsd:int])
-    wasDerivedFrom(niiri:7ac6ced5ac5b95c88fbe93f4ad51726c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:5d05848ec2715382392265640fc9d57e,
+    wasDerivedFrom(niiri:bcc290b739057f6cb5c02dcc79c4b5bc, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:6f3de48dca5b4c3a6aca0be63ddd27cd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -892,8 +892,8 @@ document
         nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "44" %% xsd:int])
-    wasDerivedFrom(niiri:5d05848ec2715382392265640fc9d57e, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:ca24bdc833f185dc48a439c9bd8cfea6,
+    wasDerivedFrom(niiri:6f3de48dca5b4c3a6aca0be63ddd27cd, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:f77f344a47f917de9a802b78319c354f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -902,8 +902,8 @@ document
         nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "45" %% xsd:int])
-    wasDerivedFrom(niiri:ca24bdc833f185dc48a439c9bd8cfea6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:302ad243c21e156bc35f157e2595460d,
+    wasDerivedFrom(niiri:f77f344a47f917de9a802b78319c354f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:9df645a4ce3520ee828e35a6dac32f9f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -912,8 +912,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "46" %% xsd:int])
-    wasDerivedFrom(niiri:302ad243c21e156bc35f157e2595460d, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:b0e84ab2cd541b237634e56ebf391609,
+    wasDerivedFrom(niiri:9df645a4ce3520ee828e35a6dac32f9f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:1dea88b1f0062ddb01809c2f336aff3f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -922,8 +922,8 @@ document
         nidm_pValueFWER: = "0.999783165932851" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "47" %% xsd:int])
-    wasDerivedFrom(niiri:b0e84ab2cd541b237634e56ebf391609, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:27969eb0dc2d34026b32c881a0f07667,
+    wasDerivedFrom(niiri:1dea88b1f0062ddb01809c2f336aff3f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:f424b0ee093c7ca1771bb8144718087b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -932,8 +932,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "48" %% xsd:int])
-    wasDerivedFrom(niiri:27969eb0dc2d34026b32c881a0f07667, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:488053a695a16e1621e578a90cd45d96,
+    wasDerivedFrom(niiri:f424b0ee093c7ca1771bb8144718087b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:258ff3de07e51a57d0b27d6699fb2508,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -942,8 +942,8 @@ document
         nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "49" %% xsd:int])
-    wasDerivedFrom(niiri:488053a695a16e1621e578a90cd45d96, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:ed908db943ba3e97ea5826f9b78e251e,
+    wasDerivedFrom(niiri:258ff3de07e51a57d0b27d6699fb2508, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:fd669f02bbb8da3eff612dc0d4b807f6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -952,8 +952,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "50" %% xsd:int])
-    wasDerivedFrom(niiri:ed908db943ba3e97ea5826f9b78e251e, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:f5e02329544635d1b1ebf65b366251dc,
+    wasDerivedFrom(niiri:fd669f02bbb8da3eff612dc0d4b807f6, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:2560564a14e0250f709b385639d02fb9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -962,8 +962,8 @@ document
         nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "51" %% xsd:int])
-    wasDerivedFrom(niiri:f5e02329544635d1b1ebf65b366251dc, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:48785ebe53244b67446462ca165511f6,
+    wasDerivedFrom(niiri:2560564a14e0250f709b385639d02fb9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:589d688bdb65a26f0e5afdd4ff33865b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -972,8 +972,8 @@ document
         nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "52" %% xsd:int])
-    wasDerivedFrom(niiri:48785ebe53244b67446462ca165511f6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:dd83d9e917f614f418e9401cdb99e43c,
+    wasDerivedFrom(niiri:589d688bdb65a26f0e5afdd4ff33865b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:b1e45a95e3b162cbfbb274efa0609a1a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -982,8 +982,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "53" %% xsd:int])
-    wasDerivedFrom(niiri:dd83d9e917f614f418e9401cdb99e43c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:f9dfccb5b804ef9741131141e3190a4b,
+    wasDerivedFrom(niiri:b1e45a95e3b162cbfbb274efa0609a1a, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:5ac022b3dd1da9d78456eb9feccbe272,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -992,8 +992,8 @@ document
         nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "54" %% xsd:int])
-    wasDerivedFrom(niiri:f9dfccb5b804ef9741131141e3190a4b, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5,
+    wasDerivedFrom(niiri:5ac022b3dd1da9d78456eb9feccbe272, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:0aa8942e14fb246e8d24f1826bdd073f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -1002,8 +1002,8 @@ document
         nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "55" %% xsd:int])
-    wasDerivedFrom(niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:024c443604af80b2271c971bd66fc9a0,
+    wasDerivedFrom(niiri:0aa8942e14fb246e8d24f1826bdd073f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:47175a90c2a865c8e7cb888b760d6bf8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1012,8 +1012,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "56" %% xsd:int])
-    wasDerivedFrom(niiri:024c443604af80b2271c971bd66fc9a0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:bd7d210916ff0d725f61db0ca48f5d05,
+    wasDerivedFrom(niiri:47175a90c2a865c8e7cb888b760d6bf8, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:d3f621d08874a1c4b62c86623e9e9780,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1022,8 +1022,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "57" %% xsd:int])
-    wasDerivedFrom(niiri:bd7d210916ff0d725f61db0ca48f5d05, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:7925cec36e37f32d88f7027ba176a2e1,
+    wasDerivedFrom(niiri:d3f621d08874a1c4b62c86623e9e9780, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1032,8 +1032,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "58" %% xsd:int])
-    wasDerivedFrom(niiri:7925cec36e37f32d88f7027ba176a2e1, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:11d4226a2f26d5d215e759b0b4e1b65c,
+    wasDerivedFrom(niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:730bd100bdb468af0d3821d0d42d24a3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -1042,8 +1042,8 @@ document
         nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "59" %% xsd:int])
-    wasDerivedFrom(niiri:11d4226a2f26d5d215e759b0b4e1b65c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:cd265e81b525edcdebe748129d48fb9f,
+    wasDerivedFrom(niiri:730bd100bdb468af0d3821d0d42d24a3, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:c30c1334c3597905fbc441edbc3d5ada,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1052,8 +1052,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "60" %% xsd:int])
-    wasDerivedFrom(niiri:cd265e81b525edcdebe748129d48fb9f, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:aa2c86e9352626823ca6bb3bbda5947a,
+    wasDerivedFrom(niiri:c30c1334c3597905fbc441edbc3d5ada, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:f3476be8b24ab5bb218fe71d0b0daed0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1062,8 +1062,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "61" %% xsd:int])
-    wasDerivedFrom(niiri:aa2c86e9352626823ca6bb3bbda5947a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:8d3a03589611da3ed8127a06d493acd6,
+    wasDerivedFrom(niiri:f3476be8b24ab5bb218fe71d0b0daed0, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:e129e49f77be02735062a975f639c82e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1072,8 +1072,8 @@ document
         nidm_pValueFWER: = "0.999999994589484" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "62" %% xsd:int])
-    wasDerivedFrom(niiri:8d3a03589611da3ed8127a06d493acd6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:3f311421a632e712f70cc6839f7e9489,
+    wasDerivedFrom(niiri:e129e49f77be02735062a975f639c82e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:f445b49b9174ce8611d41a7cc11e1717,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1082,8 +1082,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "63" %% xsd:int])
-    wasDerivedFrom(niiri:3f311421a632e712f70cc6839f7e9489, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:bcc132262f6d7297d1d28a6f0a171093,
+    wasDerivedFrom(niiri:f445b49b9174ce8611d41a7cc11e1717, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:5ca600306779ba8f48c5d087d9fac9a9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1092,8 +1092,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "64" %% xsd:int])
-    wasDerivedFrom(niiri:bcc132262f6d7297d1d28a6f0a171093, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:3bdec6eb0b5535174fa631dd70795a7e,
+    wasDerivedFrom(niiri:5ca600306779ba8f48c5d087d9fac9a9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:40bbe1b7b060c1d54f113fd9fcf154aa,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1102,8 +1102,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "65" %% xsd:int])
-    wasDerivedFrom(niiri:3bdec6eb0b5535174fa631dd70795a7e, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:f1946d8aa4c75dc6c7b6e735e96e1847,
+    wasDerivedFrom(niiri:40bbe1b7b060c1d54f113fd9fcf154aa, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:5d9d1b3e1bbc6746185f53561c74bace,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1112,8 +1112,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "66" %% xsd:int])
-    wasDerivedFrom(niiri:f1946d8aa4c75dc6c7b6e735e96e1847, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:3592a75cac312314b4a818b743916efd,
+    wasDerivedFrom(niiri:5d9d1b3e1bbc6746185f53561c74bace, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:4c53636a1293cd4482cb63ff70691d79,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1122,8 +1122,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "67" %% xsd:int])
-    wasDerivedFrom(niiri:3592a75cac312314b4a818b743916efd, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:a457cd8f3b3381f0a12661e0907b556a,
+    wasDerivedFrom(niiri:4c53636a1293cd4482cb63ff70691d79, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:2b3b2f5817481e92102b214f3bf33995,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1132,8 +1132,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "68" %% xsd:int])
-    wasDerivedFrom(niiri:a457cd8f3b3381f0a12661e0907b556a, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:698306b72f010c2b2851ac92120e72d6,
+    wasDerivedFrom(niiri:2b3b2f5817481e92102b214f3bf33995, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:86437031e803eee8517a97d2e8420009,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1142,8 +1142,8 @@ document
         nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "69" %% xsd:int])
-    wasDerivedFrom(niiri:698306b72f010c2b2851ac92120e72d6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:5d9c59bbe6ff835dfd7a715340e2d8b7,
+    wasDerivedFrom(niiri:86437031e803eee8517a97d2e8420009, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:927385c4b1c66020878360a5006a3e3b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1152,8 +1152,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "70" %% xsd:int])
-    wasDerivedFrom(niiri:5d9c59bbe6ff835dfd7a715340e2d8b7, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:8cb05ce5ff1f36539390753e60f586ff,
+    wasDerivedFrom(niiri:927385c4b1c66020878360a5006a3e3b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:0087c0fa9854a20b9b26757b4c0e9a68,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1162,8 +1162,8 @@ document
         nidm_pValueFWER: = "0.999999994589484" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "71" %% xsd:int])
-    wasDerivedFrom(niiri:8cb05ce5ff1f36539390753e60f586ff, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5,
+    wasDerivedFrom(niiri:0087c0fa9854a20b9b26757b4c0e9a68, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:679d2ced08c3de3ec63ab76190f2d86d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0072" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1172,8 +1172,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "72" %% xsd:int])
-    wasDerivedFrom(niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:08144c2f2914ca0e8f2d5090a382dd9c,
+    wasDerivedFrom(niiri:679d2ced08c3de3ec63ab76190f2d86d, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:302d0ae98bffba69292672583d115e8c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0073" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1182,8 +1182,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "73" %% xsd:int])
-    wasDerivedFrom(niiri:08144c2f2914ca0e8f2d5090a382dd9c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:20fdb21c4b6e1b56aba03dc17e6e0cad,
+    wasDerivedFrom(niiri:302d0ae98bffba69292672583d115e8c, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:f443e4b03660a8ad618e307479bf8a95,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0074" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1192,8 +1192,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "74" %% xsd:int])
-    wasDerivedFrom(niiri:20fdb21c4b6e1b56aba03dc17e6e0cad, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:b16302312e147e9c8ce1bdd421f19045,
+    wasDerivedFrom(niiri:f443e4b03660a8ad618e307479bf8a95, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:80e9d7b2bd34593272f3fb19fc9254e9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0075" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1202,8 +1202,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "75" %% xsd:int])
-    wasDerivedFrom(niiri:b16302312e147e9c8ce1bdd421f19045, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:9e57216b41802f20cbaf2104bd85f6ec,
+    wasDerivedFrom(niiri:80e9d7b2bd34593272f3fb19fc9254e9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:91bc3a2972b2938504904a8d68057f2e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0076" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1212,8 +1212,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "76" %% xsd:int])
-    wasDerivedFrom(niiri:9e57216b41802f20cbaf2104bd85f6ec, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:002e00007a510fe7b30fd39adc263872,
+    wasDerivedFrom(niiri:91bc3a2972b2938504904a8d68057f2e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:681cc93cdfd04b41012417cfd725953f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0077" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1222,8 +1222,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "77" %% xsd:int])
-    wasDerivedFrom(niiri:002e00007a510fe7b30fd39adc263872, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:2b00f1f0bcfadf17e4e74a633d9cbe02,
+    wasDerivedFrom(niiri:681cc93cdfd04b41012417cfd725953f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:1288217d5c8b70c54915067a87402187,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0078" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1232,8 +1232,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "78" %% xsd:int])
-    wasDerivedFrom(niiri:2b00f1f0bcfadf17e4e74a633d9cbe02, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:0a99da6db6ffdb6abd70dfec062dacc6,
+    wasDerivedFrom(niiri:1288217d5c8b70c54915067a87402187, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:9a33ec7dcbaf4c333c9be7973d3674ae,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0079" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1242,8 +1242,8 @@ document
         nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "79" %% xsd:int])
-    wasDerivedFrom(niiri:0a99da6db6ffdb6abd70dfec062dacc6, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:ee9edf2a051832c657f8417f27f95a8f,
+    wasDerivedFrom(niiri:9a33ec7dcbaf4c333c9be7973d3674ae, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0080" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1252,8 +1252,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "80" %% xsd:int])
-    wasDerivedFrom(niiri:ee9edf2a051832c657f8417f27f95a8f, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:db1e7cd2ec53abce67f4898eb3c88730,
+    wasDerivedFrom(niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:99af69862e054a4c62b8e6066ff12cfd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0081" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1262,8 +1262,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "81" %% xsd:int])
-    wasDerivedFrom(niiri:db1e7cd2ec53abce67f4898eb3c88730, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:1066c8d3aa41693bfd354d1824cc7afe,
+    wasDerivedFrom(niiri:99af69862e054a4c62b8e6066ff12cfd, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:20fc427845c2a14183959299a0d233ce,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0082" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1272,8 +1272,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "82" %% xsd:int])
-    wasDerivedFrom(niiri:1066c8d3aa41693bfd354d1824cc7afe, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:176e7ef375f6f1d2e26f1a064f8f6d39,
+    wasDerivedFrom(niiri:20fc427845c2a14183959299a0d233ce, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:0294b8b1f3c4b525a18397bf17d17d63,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0083" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1282,8 +1282,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "83" %% xsd:int])
-    wasDerivedFrom(niiri:176e7ef375f6f1d2e26f1a064f8f6d39, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:08a3f7b7f6c942ab91160dfccbb968f2,
+    wasDerivedFrom(niiri:0294b8b1f3c4b525a18397bf17d17d63, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:3dc796cbf0403561b0e6ea42b96ea1a9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0084" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1292,8 +1292,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "84" %% xsd:int])
-    wasDerivedFrom(niiri:08a3f7b7f6c942ab91160dfccbb968f2, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:bddc2499a043f720b9c5a3c2a309f42c,
+    wasDerivedFrom(niiri:3dc796cbf0403561b0e6ea42b96ea1a9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:14518885ee853fba951013cf73f66bed,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0085" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1302,8 +1302,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "85" %% xsd:int])
-    wasDerivedFrom(niiri:bddc2499a043f720b9c5a3c2a309f42c, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:189d9d696ac51ec44003eb5f973b6c64,
+    wasDerivedFrom(niiri:14518885ee853fba951013cf73f66bed, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:7666b1a689a3839cdadb86af5e5c7c39,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0086" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1312,8 +1312,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "86" %% xsd:int])
-    wasDerivedFrom(niiri:189d9d696ac51ec44003eb5f973b6c64, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:5d37a307684854af5c2a17ddbdb8f17f,
+    wasDerivedFrom(niiri:7666b1a689a3839cdadb86af5e5c7c39, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:2cac2c4baab8136a53bdf03e74fdc1c5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0087" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1322,8 +1322,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "87" %% xsd:int])
-    wasDerivedFrom(niiri:5d37a307684854af5c2a17ddbdb8f17f, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:df310d7fb2c5397364d68a8d3fa65bc0,
+    wasDerivedFrom(niiri:2cac2c4baab8136a53bdf03e74fdc1c5, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:8768acb96e7e44e4cd45548f0d52dd3f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0088" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1332,8 +1332,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "88" %% xsd:int])
-    wasDerivedFrom(niiri:df310d7fb2c5397364d68a8d3fa65bc0, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:d0abba065cadfdf673c1ba317a4155ef,
+    wasDerivedFrom(niiri:8768acb96e7e44e4cd45548f0d52dd3f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:816f19a8ef8789235a9bd7bfe4396a14,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0089" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1342,1551 +1342,1551 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "89" %% xsd:int])
-    wasDerivedFrom(niiri:d0abba065cadfdf673c1ba317a4155ef, niiri:1f1a3d63428e4d2bf1696942c7dcd71e, -, -, -)
-    entity(niiri:cd9309db3e1c88a98ba96314ae5579f0,
+    wasDerivedFrom(niiri:816f19a8ef8789235a9bd7bfe4396a14, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
+    entity(niiri:06a391660f148983b073bfec11e5afdd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:4bc98dbacc7bcd13b355272508d662cd',
+        prov:location = 'niiri:aeb3f38bf9d2106bcfc97930c448be4f',
         prov:value = "16.0820484161377" %% xsd:float,
         nidm_equivalentZStatistic: = "6.58928757769047" %% xsd:float,
         nidm_pValueUncorrected: = "2.20971019260219e-11" %% xsd:float,
         nidm_pValueFWER: = "4.59341100222943e-06" %% xsd:float,
         nidm_qValueFDR: = "2.11792501803032e-06" %% xsd:float])
-    entity(niiri:4bc98dbacc7bcd13b355272508d662cd,
+    entity(niiri:aeb3f38bf9d2106bcfc97930c448be4f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[-14,-84,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:cd9309db3e1c88a98ba96314ae5579f0, niiri:0af3c1dadf9b022bafb92d73c4057be6, -, -, -)
-    entity(niiri:89156d76de8aafb9c0d7504b45de19a1,
+    wasDerivedFrom(niiri:06a391660f148983b073bfec11e5afdd, niiri:8337790d11808f2fb788ee8093e46afe, -, -, -)
+    entity(niiri:a1abcbfeadef1ab9d090cb0dfd0c65f9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:0692b895967968b5ad50805b77073b6f',
+        prov:location = 'niiri:6040359f287941d8765b5d153e53b7e8',
         prov:value = "13.9779033660889" %% xsd:float,
         nidm_equivalentZStatistic: = "6.11142244434854" %% xsd:float,
         nidm_pValueUncorrected: = "4.93734941819923e-10" %% xsd:float,
         nidm_pValueFWER: = "0.000102635598608014" %% xsd:float,
         nidm_qValueFDR: = "5.60210458059015e-06" %% xsd:float])
-    entity(niiri:0692b895967968b5ad50805b77073b6f,
+    entity(niiri:6040359f287941d8765b5d153e53b7e8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[-42,-76,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:89156d76de8aafb9c0d7504b45de19a1, niiri:0af3c1dadf9b022bafb92d73c4057be6, -, -, -)
-    entity(niiri:3cc1aa7c32068139da6b5f92edd82cb6,
+    wasDerivedFrom(niiri:a1abcbfeadef1ab9d090cb0dfd0c65f9, niiri:8337790d11808f2fb788ee8093e46afe, -, -, -)
+    entity(niiri:f209e76751ccdefc0e9bde5e236ee184,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:5dfe29da2cb5f0c3c504895aeba5f33f',
+        prov:location = 'niiri:feb1ef85bf7a38f519d22d70f35dd611',
         prov:value = "10.3123865127563" %% xsd:float,
         nidm_equivalentZStatistic: = "5.1402197604635" %% xsd:float,
         nidm_pValueUncorrected: = "1.3720866187672e-07" %% xsd:float,
         nidm_pValueFWER: = "0.0248386091747108" %% xsd:float,
         nidm_qValueFDR: = "0.000165827847161811" %% xsd:float])
-    entity(niiri:5dfe29da2cb5f0c3c504895aeba5f33f,
+    entity(niiri:feb1ef85bf7a38f519d22d70f35dd611,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[-20,-90,8]" %% xsd:string])
-    wasDerivedFrom(niiri:3cc1aa7c32068139da6b5f92edd82cb6, niiri:0af3c1dadf9b022bafb92d73c4057be6, -, -, -)
-    entity(niiri:92bb19c86792f383f51524cf04efcf6f,
+    wasDerivedFrom(niiri:f209e76751ccdefc0e9bde5e236ee184, niiri:8337790d11808f2fb788ee8093e46afe, -, -, -)
+    entity(niiri:f066c96dd3c7c0996c0629c5c10cdb17,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:9872f9d3dc8e27014ef5a3559e09b981',
+        prov:location = 'niiri:3183606049158bc6420e12358dd06fd9',
         prov:value = "13.7427864074707" %% xsd:float,
         nidm_equivalentZStatistic: = "6.05489626279796" %% xsd:float,
         nidm_pValueUncorrected: = "7.02540914332417e-10" %% xsd:float,
         nidm_pValueFWER: = "0.000146041348950021" %% xsd:float,
         nidm_qValueFDR: = "5.84165395800085e-06" %% xsd:float])
-    entity(niiri:9872f9d3dc8e27014ef5a3559e09b981,
+    entity(niiri:3183606049158bc6420e12358dd06fd9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[22,-98,10]" %% xsd:string])
-    wasDerivedFrom(niiri:92bb19c86792f383f51524cf04efcf6f, niiri:1f6332db35b31af3ee6ca935dfaeba0c, -, -, -)
-    entity(niiri:20e1e7c992a4871fb508554d0585da06,
+    wasDerivedFrom(niiri:f066c96dd3c7c0996c0629c5c10cdb17, niiri:2e44272daecb8718b2883f84f352fc62, -, -, -)
+    entity(niiri:69750f3f4beb1c6336b85f6351e576c5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:db23149ad95a1fe9c4c1cd4d7de870aa',
+        prov:location = 'niiri:b63737d1991f399dbba4dd7ae8a8acec',
         prov:value = "12.7449989318848" %% xsd:float,
         nidm_equivalentZStatistic: = "5.80709618365418" %% xsd:float,
         nidm_pValueUncorrected: = "3.17828119378305e-09" %% xsd:float,
         nidm_pValueFWER: = "0.000660688335281101" %% xsd:float,
         nidm_qValueFDR: = "1.54333527599919e-05" %% xsd:float])
-    entity(niiri:db23149ad95a1fe9c4c1cd4d7de870aa,
+    entity(niiri:b63737d1991f399dbba4dd7ae8a8acec,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[40,-76,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:20e1e7c992a4871fb508554d0585da06, niiri:1f6332db35b31af3ee6ca935dfaeba0c, -, -, -)
-    entity(niiri:9b0669d94cf1e0b09df66fa7a674c7e3,
+    wasDerivedFrom(niiri:69750f3f4beb1c6336b85f6351e576c5, niiri:2e44272daecb8718b2883f84f352fc62, -, -, -)
+    entity(niiri:e91a1a3ae11967bf367aa53b9ee31c18,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:241eddcd45421fb2df8644ec543399de',
+        prov:location = 'niiri:98e8748b9e902155aaca94b50263bba1',
         prov:value = "11.9460592269897" %% xsd:float,
         nidm_equivalentZStatistic: = "5.59865646408728" %% xsd:float,
         nidm_pValueUncorrected: = "1.08009692301181e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00224526225660115" %% xsd:float,
         nidm_qValueFDR: = "3.11841980083494e-05" %% xsd:float])
-    entity(niiri:241eddcd45421fb2df8644ec543399de,
+    entity(niiri:98e8748b9e902155aaca94b50263bba1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[36,-86,8]" %% xsd:string])
-    wasDerivedFrom(niiri:9b0669d94cf1e0b09df66fa7a674c7e3, niiri:1f6332db35b31af3ee6ca935dfaeba0c, -, -, -)
-    entity(niiri:fd3df422ba6b5a2312c81b7470fa4ce8,
+    wasDerivedFrom(niiri:e91a1a3ae11967bf367aa53b9ee31c18, niiri:2e44272daecb8718b2883f84f352fc62, -, -, -)
+    entity(niiri:e5c7f01e47c1fbb085b416d97ceddbba,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:785ed6e870cebde278aee39c7b6befdd',
+        prov:location = 'niiri:7f0badb64e663c1f3676cffc717236fa',
         prov:value = "10.8997001647949" %% xsd:float,
         nidm_equivalentZStatistic: = "5.31044487629651" %% xsd:float,
         nidm_pValueUncorrected: = "5.46789791222579e-08" %% xsd:float,
         nidm_pValueFWER: = "0.0109446324802115" %% xsd:float,
         nidm_qValueFDR: = "8.7562484520721e-05" %% xsd:float])
-    entity(niiri:785ed6e870cebde278aee39c7b6befdd,
+    entity(niiri:7f0badb64e663c1f3676cffc717236fa,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[32,-66,32]" %% xsd:string])
-    wasDerivedFrom(niiri:fd3df422ba6b5a2312c81b7470fa4ce8, niiri:0d4bf8c640cd15c305d2e49ef14b9ac6, -, -, -)
-    entity(niiri:53ee6d1cb132259d2b6100b015ee9dce,
+    wasDerivedFrom(niiri:e5c7f01e47c1fbb085b416d97ceddbba, niiri:c893d69da88fea01efe542f9787608c5, -, -, -)
+    entity(niiri:2f7f807c988a3521e2049074aa842731,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:72b3ecc6501f7b746bb979c1808000d5',
+        prov:location = 'niiri:396e2c008744ecbc64a33278a34fcdbe',
         prov:value = "5.45807838439941" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39070148271528" %% xsd:float,
         nidm_pValueUncorrected: = "0.000348569950826771" %% xsd:float,
         nidm_pValueFWER: = "0.999999998685327" %% xsd:float,
         nidm_qValueFDR: = "0.0335543570769498" %% xsd:float])
-    entity(niiri:72b3ecc6501f7b746bb979c1808000d5,
+    entity(niiri:396e2c008744ecbc64a33278a34fcdbe,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[32,-74,38]" %% xsd:string])
-    wasDerivedFrom(niiri:53ee6d1cb132259d2b6100b015ee9dce, niiri:0d4bf8c640cd15c305d2e49ef14b9ac6, -, -, -)
-    entity(niiri:c8c92c4cb3dd742ebdf460a03d8ef227,
+    wasDerivedFrom(niiri:2f7f807c988a3521e2049074aa842731, niiri:c893d69da88fea01efe542f9787608c5, -, -, -)
+    entity(niiri:2726200f9b0dcba5079dca1eb1a27ebd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:b66031c85008481c6c52a889639df78f',
+        prov:location = 'niiri:575563e9436156ad59d10591a352d56d',
         prov:value = "10.0041055679321" %% xsd:float,
         nidm_equivalentZStatistic: = "5.04819646859005" %% xsd:float,
         nidm_pValueUncorrected: = "2.23000182986155e-07" %% xsd:float,
         nidm_pValueFWER: = "0.0380835451252286" %% xsd:float,
         nidm_qValueFDR: = "0.000232018725953295" %% xsd:float])
-    entity(niiri:b66031c85008481c6c52a889639df78f,
+    entity(niiri:575563e9436156ad59d10591a352d56d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[-30,-74,26]" %% xsd:string])
-    wasDerivedFrom(niiri:c8c92c4cb3dd742ebdf460a03d8ef227, niiri:32439b88059be589d0e2a8586ea799ec, -, -, -)
-    entity(niiri:915c8684b1426b41a850e906a6cb7e51,
+    wasDerivedFrom(niiri:2726200f9b0dcba5079dca1eb1a27ebd, niiri:fafaf22f396d11e8355f5d1e7a7367ea, -, -, -)
+    entity(niiri:432182ae1dd08fbc638748dae384100d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:fc9bb7ec98d0292b3cf09ece5735cbf7',
+        prov:location = 'niiri:49cfb4906f7511441f7faddc5a5b8413',
         prov:value = "9.62718677520752" %% xsd:float,
         nidm_equivalentZStatistic: = "4.933015925023" %% xsd:float,
         nidm_pValueUncorrected: = "4.04847753543436e-07" %% xsd:float,
         nidm_pValueFWER: = "0.063890884133409" %% xsd:float,
         nidm_qValueFDR: = "0.000364320989617512" %% xsd:float])
-    entity(niiri:fc9bb7ec98d0292b3cf09ece5735cbf7,
+    entity(niiri:49cfb4906f7511441f7faddc5a5b8413,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[-42,24,20]" %% xsd:string])
-    wasDerivedFrom(niiri:915c8684b1426b41a850e906a6cb7e51, niiri:d8b9846e25000609adbc385c634a1be0, -, -, -)
-    entity(niiri:50922e240192f8efd5ba7edc5395921e,
+    wasDerivedFrom(niiri:432182ae1dd08fbc638748dae384100d, niiri:0820636de884fe0d783c5385916ab101, -, -, -)
+    entity(niiri:85988a2f55e19fb0932bdaac88d56310,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:0090ece1129de1a64a6093a76eead257',
+        prov:location = 'niiri:53ed64c5e6de9d8d444e92f8219ed73e',
         prov:value = "8.07208061218262" %% xsd:float,
         nidm_equivalentZStatistic: = "4.42255808855286" %% xsd:float,
         nidm_pValueUncorrected: = "4.87695566220303e-06" %% xsd:float,
         nidm_pValueFWER: = "0.443484796305441" %% xsd:float,
         nidm_qValueFDR: = "0.00197238230997959" %% xsd:float])
-    entity(niiri:0090ece1129de1a64a6093a76eead257,
+    entity(niiri:53ed64c5e6de9d8d444e92f8219ed73e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[-50,28,22]" %% xsd:string])
-    wasDerivedFrom(niiri:50922e240192f8efd5ba7edc5395921e, niiri:d8b9846e25000609adbc385c634a1be0, -, -, -)
-    entity(niiri:7d5e6a7fd65e7845a2f6021bbbfe1474,
+    wasDerivedFrom(niiri:85988a2f55e19fb0932bdaac88d56310, niiri:0820636de884fe0d783c5385916ab101, -, -, -)
+    entity(niiri:b4e90605b1ad8e708a5878d78afbd5df,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:a94285933cf50e277523e5b72912eebe',
+        prov:location = 'niiri:7191009d584b787e22408325fb584516',
         prov:value = "9.20645141601562" %% xsd:float,
         nidm_equivalentZStatistic: = "4.80076510146651" %% xsd:float,
         nidm_pValueUncorrected: = "7.90302914999153e-07" %% xsd:float,
         nidm_pValueFWER: = "0.112525268059434" %% xsd:float,
         nidm_qValueFDR: = "0.000576835659463966" %% xsd:float])
-    entity(niiri:a94285933cf50e277523e5b72912eebe,
+    entity(niiri:7191009d584b787e22408325fb584516,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[-50,8,42]" %% xsd:string])
-    wasDerivedFrom(niiri:7d5e6a7fd65e7845a2f6021bbbfe1474, niiri:f8e22d4c567142a3ab813140dd91551e, -, -, -)
-    entity(niiri:48d52b482ad32267090b771eef9d8a13,
+    wasDerivedFrom(niiri:b4e90605b1ad8e708a5878d78afbd5df, niiri:1e3c8c027b813bda7df5358a8ab4f63a, -, -, -)
+    entity(niiri:18479155c0b9f7007a2606ee355335a9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:3f8983479e0d587591c1816f757bfb40',
+        prov:location = 'niiri:8563cb38a4e5f284711af2f862727bd9',
         prov:value = "7.18871355056763" %% xsd:float,
         nidm_equivalentZStatistic: = "4.10255932739581" %% xsd:float,
         nidm_pValueUncorrected: = "2.04302517635702e-05" %% xsd:float,
         nidm_pValueFWER: = "0.864381142749573" %% xsd:float,
         nidm_qValueFDR: = "0.00518559511521378" %% xsd:float])
-    entity(niiri:3f8983479e0d587591c1816f757bfb40,
+    entity(niiri:8563cb38a4e5f284711af2f862727bd9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[-52,2,48]" %% xsd:string])
-    wasDerivedFrom(niiri:48d52b482ad32267090b771eef9d8a13, niiri:f8e22d4c567142a3ab813140dd91551e, -, -, -)
-    entity(niiri:6bc27ded8e7208b5260f9cfa18a8c8c7,
+    wasDerivedFrom(niiri:18479155c0b9f7007a2606ee355335a9, niiri:1e3c8c027b813bda7df5358a8ab4f63a, -, -, -)
+    entity(niiri:d3c08577d483b22d049b7eb0c6572b7f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:a58791ee2a73dbe92a31d79f5a887db7',
+        prov:location = 'niiri:cbf1b8ec0d607ae0da2d1270f1e5401a',
         prov:value = "8.94470500946045" %% xsd:float,
         nidm_equivalentZStatistic: = "4.71641138081763" %% xsd:float,
         nidm_pValueUncorrected: = "1.20020424165812e-06" %% xsd:float,
         nidm_pValueFWER: = "0.158435738485403" %% xsd:float,
         nidm_qValueFDR: = "0.000760651849406736" %% xsd:float])
-    entity(niiri:a58791ee2a73dbe92a31d79f5a887db7,
+    entity(niiri:cbf1b8ec0d607ae0da2d1270f1e5401a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[-24,-64,66]" %% xsd:string])
-    wasDerivedFrom(niiri:6bc27ded8e7208b5260f9cfa18a8c8c7, niiri:96a2e290f72fc28530510650c52e2805, -, -, -)
-    entity(niiri:3f894ae7abee049abdc170030b86694a,
+    wasDerivedFrom(niiri:d3c08577d483b22d049b7eb0c6572b7f, niiri:e24e457b7371fd1bac7d4cb391bb9432, -, -, -)
+    entity(niiri:b22647ec49d2b0b297e2ac1f30758018,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:5ee690d78930edfd59a3872c7c5bbdaf',
+        prov:location = 'niiri:26c07862039b52fa08db4cc5880af9e4',
         prov:value = "7.5668888092041" %% xsd:float,
         nidm_equivalentZStatistic: = "4.24258939908316" %% xsd:float,
         nidm_pValueUncorrected: = "1.10477738578529e-05" %% xsd:float,
         nidm_pValueFWER: = "0.693995702855766" %% xsd:float,
         nidm_qValueFDR: = "0.0033973072847523" %% xsd:float])
-    entity(niiri:5ee690d78930edfd59a3872c7c5bbdaf,
+    entity(niiri:26c07862039b52fa08db4cc5880af9e4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[-32,-56,62]" %% xsd:string])
-    wasDerivedFrom(niiri:3f894ae7abee049abdc170030b86694a, niiri:96a2e290f72fc28530510650c52e2805, -, -, -)
-    entity(niiri:8aed68850a4238bd9003356dee5c1046,
+    wasDerivedFrom(niiri:b22647ec49d2b0b297e2ac1f30758018, niiri:e24e457b7371fd1bac7d4cb391bb9432, -, -, -)
+    entity(niiri:17cf8165ad43953b2998aec1ca9ddd0f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:fa9d9d6751bc279dd4c31bcc4b3c5b6f',
+        prov:location = 'niiri:2945a0dad8e64bb13fdb60092f3a3334',
         prov:value = "8.42212200164795" %% xsd:float,
         nidm_equivalentZStatistic: = "4.54288070436711" %% xsd:float,
         nidm_pValueUncorrected: = "2.77453287811369e-06" %% xsd:float,
         nidm_pValueFWER: = "0.301737952159247" %% xsd:float,
         nidm_qValueFDR: = "0.00135672565933354" %% xsd:float])
-    entity(niiri:fa9d9d6751bc279dd4c31bcc4b3c5b6f,
+    entity(niiri:2945a0dad8e64bb13fdb60092f3a3334,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[22,-52,4]" %% xsd:string])
-    wasDerivedFrom(niiri:8aed68850a4238bd9003356dee5c1046, niiri:1062efea331d3022773f16c049f8543d, -, -, -)
-    entity(niiri:17a00ab62ce14cefa4ccb65ef36cb0a3,
+    wasDerivedFrom(niiri:17cf8165ad43953b2998aec1ca9ddd0f, niiri:2f5fcfc4453f648ede4260a16cff5960, -, -, -)
+    entity(niiri:8a3dd8fbf2b47192a3e6b6d6690a00b5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:2e878a68f59b4166e7af126a1d092dd7',
+        prov:location = 'niiri:f4392121feaef697f908988f9d45a7b3',
         prov:value = "8.14441299438477" %% xsd:float,
         nidm_equivalentZStatistic: = "4.44770400954001" %% xsd:float,
         nidm_pValueUncorrected: = "4.33965069324138e-06" %% xsd:float,
         nidm_pValueFWER: = "0.411238149698711" %% xsd:float,
         nidm_qValueFDR: = "0.00180683059312593" %% xsd:float])
-    entity(niiri:2e878a68f59b4166e7af126a1d092dd7,
+    entity(niiri:f4392121feaef697f908988f9d45a7b3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[-36,-54,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:17a00ab62ce14cefa4ccb65ef36cb0a3, niiri:5577dc13c7013d8bb90b8dd111792d46, -, -, -)
-    entity(niiri:df246b9f6ad9be0fa1598d6017c22c17,
+    wasDerivedFrom(niiri:8a3dd8fbf2b47192a3e6b6d6690a00b5, niiri:dbbddbece734ef2c5ed154985b15ffe8, -, -, -)
+    entity(niiri:b173db6dde57bc22f0de6bac75f47a5e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:dbfef4bdf74855624e49b48413b48527',
+        prov:location = 'niiri:9f0f16d82e93cbe816f1c8f4ac5e2aa9',
         prov:value = "7.75212860107422" %% xsd:float,
         nidm_equivalentZStatistic: = "4.30948435197428" %% xsd:float,
         nidm_pValueUncorrected: = "8.18178178840778e-06" %% xsd:float,
         nidm_pValueFWER: = "0.599664226758408" %% xsd:float,
         nidm_qValueFDR: = "0.00278317762946249" %% xsd:float])
-    entity(niiri:dbfef4bdf74855624e49b48413b48527,
+    entity(niiri:9f0f16d82e93cbe816f1c8f4ac5e2aa9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[10,-66,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:df246b9f6ad9be0fa1598d6017c22c17, niiri:64ae5737521bbc7fe14f0c862379e927, -, -, -)
-    entity(niiri:0f733836ed39e3d5c7c881ba1d4b0f3c,
+    wasDerivedFrom(niiri:b173db6dde57bc22f0de6bac75f47a5e, niiri:6aecc2d95fe5ba4cd2d39d16afe85407, -, -, -)
+    entity(niiri:956544123ed8213df5fbc7f8d6973e3c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:2d648076c6516fc9f5b180d7e46bd38d',
+        prov:location = 'niiri:c5abac533b273ee4b7bab22f1b00ed76',
         prov:value = "6.59869337081909" %% xsd:float,
         nidm_equivalentZStatistic: = "3.87398612970452" %% xsd:float,
         nidm_pValueUncorrected: = "5.35347545974618e-05" %% xsd:float,
         nidm_pValueFWER: = "0.988687386127249" %% xsd:float,
         nidm_qValueFDR: = "0.0099990013840748" %% xsd:float])
-    entity(niiri:2d648076c6516fc9f5b180d7e46bd38d,
+    entity(niiri:c5abac533b273ee4b7bab22f1b00ed76,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[26,-72,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:0f733836ed39e3d5c7c881ba1d4b0f3c, niiri:64ae5737521bbc7fe14f0c862379e927, -, -, -)
-    entity(niiri:fccb01f20ca9740796a77be1dc284607,
+    wasDerivedFrom(niiri:956544123ed8213df5fbc7f8d6973e3c, niiri:6aecc2d95fe5ba4cd2d39d16afe85407, -, -, -)
+    entity(niiri:f4dea2e696793591088d280fed0f0584,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:de5ae9445107927a2f321f5cb43d375a',
+        prov:location = 'niiri:e2a291ea227f61911be316ee6108a55f',
         prov:value = "6.09796094894409" %% xsd:float,
         nidm_equivalentZStatistic: = "3.6691747416434" %% xsd:float,
         nidm_pValueUncorrected: = "0.000121667358184974" %% xsd:float,
         nidm_pValueFWER: = "0.999849800966092" %% xsd:float,
         nidm_qValueFDR: = "0.0170443244379802" %% xsd:float])
-    entity(niiri:de5ae9445107927a2f321f5cb43d375a,
+    entity(niiri:e2a291ea227f61911be316ee6108a55f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[16,-72,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:fccb01f20ca9740796a77be1dc284607, niiri:64ae5737521bbc7fe14f0c862379e927, -, -, -)
-    entity(niiri:73c78b95c93f862d2d03440138b1b31d,
+    wasDerivedFrom(niiri:f4dea2e696793591088d280fed0f0584, niiri:6aecc2d95fe5ba4cd2d39d16afe85407, -, -, -)
+    entity(niiri:d88a4b6a1eb63bac84a9f87e0794ba20,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:f70e1a4652c056f2ce720d0c047e4050',
+        prov:location = 'niiri:2281a2b45d8f90027211445c926232e2',
         prov:value = "7.67598438262939" %% xsd:float,
         nidm_equivalentZStatistic: = "4.28211703257948" %% xsd:float,
         nidm_pValueUncorrected: = "9.25617831770698e-06" %% xsd:float,
         nidm_pValueFWER: = "0.638571937641115" %% xsd:float,
         nidm_qValueFDR: = "0.00302106969058158" %% xsd:float])
-    entity(niiri:f70e1a4652c056f2ce720d0c047e4050,
+    entity(niiri:2281a2b45d8f90027211445c926232e2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[42,-22,66]" %% xsd:string])
-    wasDerivedFrom(niiri:73c78b95c93f862d2d03440138b1b31d, niiri:900846b4c16bba4a9b8a34762cba2da0, -, -, -)
-    entity(niiri:b6efabc36e950249575e4d4ac70621f0,
+    wasDerivedFrom(niiri:d88a4b6a1eb63bac84a9f87e0794ba20, niiri:a9c284c82bc4ef4eba48570f53c9c9c4, -, -, -)
+    entity(niiri:bfba970dca807cd42c369bc26d27f3eb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:4dbfbaac273513d9f226876fdf8b306f',
+        prov:location = 'niiri:3253ad166d45aa411a00a879e94115b6',
         prov:value = "6.16005897521973" %% xsd:float,
         nidm_equivalentZStatistic: = "3.6951610937944" %% xsd:float,
         nidm_pValueUncorrected: = "0.000109873708078023" %% xsd:float,
         nidm_pValueFWER: = "0.999696971784475" %% xsd:float,
         nidm_qValueFDR: = "0.0160177852706299" %% xsd:float])
-    entity(niiri:4dbfbaac273513d9f226876fdf8b306f,
+    entity(niiri:3253ad166d45aa411a00a879e94115b6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[48,-18,62]" %% xsd:string])
-    wasDerivedFrom(niiri:b6efabc36e950249575e4d4ac70621f0, niiri:900846b4c16bba4a9b8a34762cba2da0, -, -, -)
-    entity(niiri:ce78c1d328ebf373304efd0ad0d63b55,
+    wasDerivedFrom(niiri:bfba970dca807cd42c369bc26d27f3eb, niiri:a9c284c82bc4ef4eba48570f53c9c9c4, -, -, -)
+    entity(niiri:70cf11cb9bc7570fce0e5ed7c0993493,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:b48d465b5d910dd4c05a26a988a8418b',
+        prov:location = 'niiri:73acbe399f2ef5551e28416ff0886e25',
         prov:value = "7.57218790054321" %% xsd:float,
         nidm_equivalentZStatistic: = "4.24451811148991" %% xsd:float,
         nidm_pValueUncorrected: = "1.09531837353405e-05" %% xsd:float,
         nidm_pValueFWER: = "0.691329596120285" %% xsd:float,
         nidm_qValueFDR: = "0.00338801480937036" %% xsd:float])
-    entity(niiri:b48d465b5d910dd4c05a26a988a8418b,
+    entity(niiri:73acbe399f2ef5551e28416ff0886e25,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[30,-36,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:ce78c1d328ebf373304efd0ad0d63b55, niiri:7ede1db6987922a4806abc265aecda62, -, -, -)
-    entity(niiri:1cd13c2942d906be09937adb3135674a,
+    wasDerivedFrom(niiri:70cf11cb9bc7570fce0e5ed7c0993493, niiri:0637af2e34d8b1c842ae7d1386357498, -, -, -)
+    entity(niiri:a37c7f3e671f54bf1aeb9e2159fc0ead,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:4c8fbc4e92f73c6bb61d3f66d9c3c99e',
+        prov:location = 'niiri:44277e00fc4cc3cf8ea164e5d184e84d',
         prov:value = "7.4740514755249" %% xsd:float,
         nidm_equivalentZStatistic: = "4.20865253327564" %% xsd:float,
         nidm_pValueUncorrected: = "1.28449040975864e-05" %% xsd:float,
         nidm_pValueFWER: = "0.739935004547452" %% xsd:float,
         nidm_qValueFDR: = "0.00374497115452541" %% xsd:float])
-    entity(niiri:4c8fbc4e92f73c6bb61d3f66d9c3c99e,
+    entity(niiri:44277e00fc4cc3cf8ea164e5d184e84d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[22,-70,60]" %% xsd:string])
-    wasDerivedFrom(niiri:1cd13c2942d906be09937adb3135674a, niiri:9287b2a8106c3ffe3abf93837cfbd61c, -, -, -)
-    entity(niiri:3121dd1ff9adac7ae75e440df583fb9d,
+    wasDerivedFrom(niiri:a37c7f3e671f54bf1aeb9e2159fc0ead, niiri:1cd4117828f514ec0fff4b67f780d6b9, -, -, -)
+    entity(niiri:95b5e8d1b0a6b737f8baac185d017d03,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:939c1c6e7eee0ff04a1bae0f1e2b3a44',
+        prov:location = 'niiri:bcdd17c062f969757a86cbe2d236afea',
         prov:value = "7.42476272583008" %% xsd:float,
         nidm_equivalentZStatistic: = "4.19052086074216" %% xsd:float,
         nidm_pValueUncorrected: = "1.39157412012425e-05" %% xsd:float,
         nidm_pValueFWER: = "0.76353829505901" %% xsd:float,
         nidm_qValueFDR: = "0.00397904916843096" %% xsd:float])
-    entity(niiri:939c1c6e7eee0ff04a1bae0f1e2b3a44,
+    entity(niiri:bcdd17c062f969757a86cbe2d236afea,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[14,-44,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:3121dd1ff9adac7ae75e440df583fb9d, niiri:c515278968596a92906ae29ffad63511, -, -, -)
-    entity(niiri:2cde520c847515e95346b9608b4b29b1,
+    wasDerivedFrom(niiri:95b5e8d1b0a6b737f8baac185d017d03, niiri:d85063f48080f770ca548748f7419e12, -, -, -)
+    entity(niiri:376402188bdf566830cafa900c2e2777,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:fec739a9148832b2f9f9f6df4c90ef60',
+        prov:location = 'niiri:40631caf86fdb1eb06dd8fb89e5e0cdf',
         prov:value = "7.41156482696533" %% xsd:float,
         nidm_equivalentZStatistic: = "4.1856522195161" %% xsd:float,
         nidm_pValueUncorrected: = "1.42174217934166e-05" %% xsd:float,
         nidm_pValueFWER: = "0.76974170216107" %% xsd:float,
         nidm_qValueFDR: = "0.00404779744790916" %% xsd:float])
-    entity(niiri:fec739a9148832b2f9f9f6df4c90ef60,
+    entity(niiri:40631caf86fdb1eb06dd8fb89e5e0cdf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[0,-22,66]" %% xsd:string])
-    wasDerivedFrom(niiri:2cde520c847515e95346b9608b4b29b1, niiri:0493a379c4735cda662e56229168b8a9, -, -, -)
-    entity(niiri:435b54b1b98826b7c51b454f604d72e2,
+    wasDerivedFrom(niiri:376402188bdf566830cafa900c2e2777, niiri:ec3fc3cfa0c303c00f68f5986e44044e, -, -, -)
+    entity(niiri:e7535b3f1b2924d6cc2cc7dd1021e6ff,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:f5083c9588b5eb1d38e2b68f14c48ec5',
+        prov:location = 'niiri:1009ccfd64bd14bdf04f231ec38d83db',
         prov:value = "7.3316125869751" %% xsd:float,
         nidm_equivalentZStatistic: = "4.15603434431885" %% xsd:float,
         nidm_pValueUncorrected: = "1.61909583913378e-05" %% xsd:float,
         nidm_pValueFWER: = "0.806071531912271" %% xsd:float,
         nidm_qValueFDR: = "0.00442558415624652" %% xsd:float])
-    entity(niiri:f5083c9588b5eb1d38e2b68f14c48ec5,
+    entity(niiri:1009ccfd64bd14bdf04f231ec38d83db,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[-40,-26,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:435b54b1b98826b7c51b454f604d72e2, niiri:6f915c93d573d9f832d05fb003dcbfb0, -, -, -)
-    entity(niiri:ff2cc94456764baf2e5e407f30f996e8,
+    wasDerivedFrom(niiri:e7535b3f1b2924d6cc2cc7dd1021e6ff, niiri:23c6e94e6643122dcb458402a972758e, -, -, -)
+    entity(niiri:e8318652b9767749a7b94884a6faf52e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:bfdee7cfc8fffe98250a78af5abdc715',
+        prov:location = 'niiri:62333962f96d79e4ca7c4f1585c5e395',
         prov:value = "7.15871143341064" %% xsd:float,
         nidm_equivalentZStatistic: = "4.09124266610495" %% xsd:float,
         nidm_pValueUncorrected: = "2.14533936502281e-05" %% xsd:float,
         nidm_pValueFWER: = "0.875348981068006" %% xsd:float,
         nidm_qValueFDR: = "0.00534735431216318" %% xsd:float])
-    entity(niiri:bfdee7cfc8fffe98250a78af5abdc715,
+    entity(niiri:62333962f96d79e4ca7c4f1585c5e395,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[-48,-42,58]" %% xsd:string])
-    wasDerivedFrom(niiri:ff2cc94456764baf2e5e407f30f996e8, niiri:2344710a34a75f050910ebd48e1159af, -, -, -)
-    entity(niiri:1d8688390cefe3ad6af53ca62e203d1f,
+    wasDerivedFrom(niiri:e8318652b9767749a7b94884a6faf52e, niiri:68f9a66ca71f514199366c398a2831ab, -, -, -)
+    entity(niiri:79db57175bcf213e5f77bd451afdb6fe,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:05d5987ec004e7f8a055c0e0f8991383',
+        prov:location = 'niiri:4601ef775986b40077d71682573b43a7',
         prov:value = "7.11809158325195" %% xsd:float,
         nidm_equivalentZStatistic: = "4.075870818357" %% xsd:float,
         nidm_pValueUncorrected: = "2.29212322924166e-05" %% xsd:float,
         nidm_pValueFWER: = "0.889420975253515" %% xsd:float,
         nidm_qValueFDR: = "0.00557942469794563" %% xsd:float])
-    entity(niiri:05d5987ec004e7f8a055c0e0f8991383,
+    entity(niiri:4601ef775986b40077d71682573b43a7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[-40,-34,66]" %% xsd:string])
-    wasDerivedFrom(niiri:1d8688390cefe3ad6af53ca62e203d1f, niiri:a904380f9b13e67a2253c5f952a57f9f, -, -, -)
-    entity(niiri:458ec12f9ad36a91b5eaa2f1aae4c164,
+    wasDerivedFrom(niiri:79db57175bcf213e5f77bd451afdb6fe, niiri:6f303953fe538a2a99d9b754b92e311e, -, -, -)
+    entity(niiri:36ca195508a8e637007acd8f768fa1c9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:7021fdf0169b26db50952433ad70adc0',
+        prov:location = 'niiri:9ca689f733bdaa0f890c8fe7e51b6224',
         prov:value = "7.07621002197266" %% xsd:float,
         nidm_equivalentZStatistic: = "4.05996049269805" %% xsd:float,
         nidm_pValueUncorrected: = "2.45405099345009e-05" %% xsd:float,
         nidm_pValueFWER: = "0.902960652497904" %% xsd:float,
         nidm_qValueFDR: = "0.00587047829619361" %% xsd:float])
-    entity(niiri:7021fdf0169b26db50952433ad70adc0,
+    entity(niiri:9ca689f733bdaa0f890c8fe7e51b6224,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[-28,-64,36]" %% xsd:string])
-    wasDerivedFrom(niiri:458ec12f9ad36a91b5eaa2f1aae4c164, niiri:8348fc8e7248e46840dad7df7f8763bf, -, -, -)
-    entity(niiri:d4cd299a7933f93390ebcea529b036b0,
+    wasDerivedFrom(niiri:36ca195508a8e637007acd8f768fa1c9, niiri:b32513dc3cebea135a4227a2ff2989c6, -, -, -)
+    entity(niiri:93964149cf1de70007b3d65bb04b9cd8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:000b610104b25fcabfd24c7ac9c414e9',
+        prov:location = 'niiri:bfbd55e8f2473bad1c11d7526e7f8cbb',
         prov:value = "6.77566051483154" %% xsd:float,
         nidm_equivalentZStatistic: = "3.94391444392688" %% xsd:float,
         nidm_pValueUncorrected: = "4.0081133562353e-05" %% xsd:float,
         nidm_pValueFWER: = "0.970449378854534" %% xsd:float,
         nidm_qValueFDR: = "0.0083237489519884" %% xsd:float])
-    entity(niiri:000b610104b25fcabfd24c7ac9c414e9,
+    entity(niiri:bfbd55e8f2473bad1c11d7526e7f8cbb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[56,-14,52]" %% xsd:string])
-    wasDerivedFrom(niiri:d4cd299a7933f93390ebcea529b036b0, niiri:db6eb647802a5fc531c369aa668af574, -, -, -)
-    entity(niiri:c18aee0f08a51ffb9a71f22087ef50c5,
+    wasDerivedFrom(niiri:93964149cf1de70007b3d65bb04b9cd8, niiri:b7301eccecd4c049bbeed4467b530024, -, -, -)
+    entity(niiri:3e906297c3e2890ce6abb1f2cb9be561,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:58fc0101181c3b004a7dd3b51e2ceb83',
+        prov:location = 'niiri:c0d2a2f16c1d44209d3e0ceba1cc405d',
         prov:value = "6.75197219848633" %% xsd:float,
         nidm_equivalentZStatistic: = "3.9346244929229" %% xsd:float,
         nidm_pValueUncorrected: = "4.16634347842892e-05" %% xsd:float,
         nidm_pValueFWER: = "0.973679338420771" %% xsd:float,
         nidm_qValueFDR: = "0.00848286835858746" %% xsd:float])
-    entity(niiri:58fc0101181c3b004a7dd3b51e2ceb83,
+    entity(niiri:c0d2a2f16c1d44209d3e0ceba1cc405d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[-40,56,6]" %% xsd:string])
-    wasDerivedFrom(niiri:c18aee0f08a51ffb9a71f22087ef50c5, niiri:efddc25357ec7a4b9a063a62f5a2c864, -, -, -)
-    entity(niiri:94d6c08508093e713ac4415d0a932884,
+    wasDerivedFrom(niiri:3e906297c3e2890ce6abb1f2cb9be561, niiri:765e5201ffb06ca1f162ea8d7d3f0abd, -, -, -)
+    entity(niiri:e0515f336cbd787507ad3edf70116d4e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0033" %% xsd:string,
-        prov:location = 'niiri:bf7aac775c73f4c943e7eaf5e718d980',
+        prov:location = 'niiri:9c7564398039623209ebb464e1410345',
         prov:value = "5.62889766693115" %% xsd:float,
         nidm_equivalentZStatistic: = "3.4670438729023" %% xsd:float,
         nidm_pValueUncorrected: = "0.000263107996845591" %% xsd:float,
         nidm_pValueFWER: = "0.999999922471127" %% xsd:float,
         nidm_qValueFDR: = "0.0280636167791234" %% xsd:float])
-    entity(niiri:bf7aac775c73f4c943e7eaf5e718d980,
+    entity(niiri:9c7564398039623209ebb464e1410345,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0033" %% xsd:string,
         nidm_coordinateVector: = "[-34,62,8]" %% xsd:string])
-    wasDerivedFrom(niiri:94d6c08508093e713ac4415d0a932884, niiri:efddc25357ec7a4b9a063a62f5a2c864, -, -, -)
-    entity(niiri:68ee8476808402fcd35123f92e1fe86d,
+    wasDerivedFrom(niiri:e0515f336cbd787507ad3edf70116d4e, niiri:765e5201ffb06ca1f162ea8d7d3f0abd, -, -, -)
+    entity(niiri:68d840be62a1d1171faf588a66b45a69,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0034" %% xsd:string,
-        prov:location = 'niiri:97631cb919ed750fce6fd5369d603724',
+        prov:location = 'niiri:9020819036c441bf53457a8d05805fd2',
         prov:value = "6.72361373901367" %% xsd:float,
         nidm_equivalentZStatistic: = "3.92347467532863" %% xsd:float,
         nidm_pValueUncorrected: = "4.3640471964479e-05" %% xsd:float,
         nidm_pValueFWER: = "0.977197537328254" %% xsd:float,
         nidm_qValueFDR: = "0.00877369894078824" %% xsd:float])
-    entity(niiri:97631cb919ed750fce6fd5369d603724,
+    entity(niiri:9020819036c441bf53457a8d05805fd2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0034" %% xsd:string,
         nidm_coordinateVector: = "[-4,-52,6]" %% xsd:string])
-    wasDerivedFrom(niiri:68ee8476808402fcd35123f92e1fe86d, niiri:92832eb3b91834fca357233c33e92d47, -, -, -)
-    entity(niiri:97c0b234b24d4cfa8426c9b127f1426a,
+    wasDerivedFrom(niiri:68d840be62a1d1171faf588a66b45a69, niiri:aeb5ca84ea986c7559b385b24d2806c0, -, -, -)
+    entity(niiri:fa083ea775134c459dc1bb371ed1dded,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0035" %% xsd:string,
-        prov:location = 'niiri:07a69af261f8c7ce9c1e9223b91c2b3f',
+        prov:location = 'niiri:4ead7fcdda63c83da247a2a82f447618',
         prov:value = "5.89449167251587" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58279190167641" %% xsd:float,
         nidm_pValueUncorrected: = "0.000169970706923372" %% xsd:float,
         nidm_pValueFWER: = "0.999990278549049" %% xsd:float,
         nidm_qValueFDR: = "0.0210834330463974" %% xsd:float])
-    entity(niiri:07a69af261f8c7ce9c1e9223b91c2b3f,
+    entity(niiri:4ead7fcdda63c83da247a2a82f447618,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0035" %% xsd:string,
         nidm_coordinateVector: = "[-8,-56,0]" %% xsd:string])
-    wasDerivedFrom(niiri:97c0b234b24d4cfa8426c9b127f1426a, niiri:92832eb3b91834fca357233c33e92d47, -, -, -)
-    entity(niiri:208bd0fa9e65bd7ecda2f9025fbf5026,
+    wasDerivedFrom(niiri:fa083ea775134c459dc1bb371ed1dded, niiri:aeb5ca84ea986c7559b385b24d2806c0, -, -, -)
+    entity(niiri:bc11584c2cc9c15970a76804b11b842b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0036" %% xsd:string,
-        prov:location = 'niiri:8a98506f0a361325cf3279d2ee5df080',
+        prov:location = 'niiri:6f14c51367b87703537f776c0c0dbdf5',
         prov:value = "6.7043924331665" %% xsd:float,
         nidm_equivalentZStatistic: = "3.91589968256295" %% xsd:float,
         nidm_pValueUncorrected: = "4.5033848123488e-05" %% xsd:float,
         nidm_pValueFWER: = "0.979375630051391" %% xsd:float,
         nidm_qValueFDR: = "0.00887748685076858" %% xsd:float])
-    entity(niiri:8a98506f0a361325cf3279d2ee5df080,
+    entity(niiri:6f14c51367b87703537f776c0c0dbdf5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0036" %% xsd:string,
         nidm_coordinateVector: = "[50,-64,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:208bd0fa9e65bd7ecda2f9025fbf5026, niiri:27a928cca18b5d563bf58797f306d0e0, -, -, -)
-    entity(niiri:b0078cef21c117e25080fc7b68a2e9f6,
+    wasDerivedFrom(niiri:bc11584c2cc9c15970a76804b11b842b, niiri:d36b472817f6888ac2860c8f78cda4e9, -, -, -)
+    entity(niiri:8975ccf5a69b1e5ce196d5d0e24ee229,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0037" %% xsd:string,
-        prov:location = 'niiri:4b3286c3a11f909de28869ea7523656c',
+        prov:location = 'niiri:c035e1c674ce2f5002c7510f276ba0d9',
         prov:value = "6.67913484573364" %% xsd:float,
         nidm_equivalentZStatistic: = "3.90592399967592" %% xsd:float,
         nidm_pValueUncorrected: = "4.6933006303207e-05" %% xsd:float,
         nidm_pValueFWER: = "0.981996459937482" %% xsd:float,
         nidm_qValueFDR: = "0.00914383746051283" %% xsd:float])
-    entity(niiri:4b3286c3a11f909de28869ea7523656c,
+    entity(niiri:c035e1c674ce2f5002c7510f276ba0d9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0037" %% xsd:string,
         nidm_coordinateVector: = "[-34,-40,36]" %% xsd:string])
-    wasDerivedFrom(niiri:b0078cef21c117e25080fc7b68a2e9f6, niiri:9197197694f96c553e0e78334284b0c7, -, -, -)
-    entity(niiri:51561d272cfbd20b578e0d0cb999769c,
+    wasDerivedFrom(niiri:8975ccf5a69b1e5ce196d5d0e24ee229, niiri:e1375ee26540e9328da498ca97a69cb4, -, -, -)
+    entity(niiri:e667e51e095b6fa110b25e9400332357,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0038" %% xsd:string,
-        prov:location = 'niiri:7391c47b3ce0a5295cfbe1d0b7dfa35c',
+        prov:location = 'niiri:d10ee59dc87f8fe64f5ed1f2ea11a4cd',
         prov:value = "6.64170026779175" %% xsd:float,
         nidm_equivalentZStatistic: = "3.89109301638303" %% xsd:float,
         nidm_pValueUncorrected: = "4.98968323957572e-05" %% xsd:float,
         nidm_pValueFWER: = "0.985407255166263" %% xsd:float,
         nidm_qValueFDR: = "0.00949872959107623" %% xsd:float])
-    entity(niiri:7391c47b3ce0a5295cfbe1d0b7dfa35c,
+    entity(niiri:d10ee59dc87f8fe64f5ed1f2ea11a4cd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0038" %% xsd:string,
         nidm_coordinateVector: = "[22,10,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:51561d272cfbd20b578e0d0cb999769c, niiri:4babeddab7c30570f5f7bca47ad8e349, -, -, -)
-    entity(niiri:462393ac68491f3db8a262b5078fc9a9,
+    wasDerivedFrom(niiri:e667e51e095b6fa110b25e9400332357, niiri:d5f1c18934146a18337779acd9486123, -, -, -)
+    entity(niiri:1221262de1e5620b40e4bdfbdeb36776,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0039" %% xsd:string,
-        prov:location = 'niiri:86657e11e856b1fdbc9692e7270e9f36',
+        prov:location = 'niiri:843685ded7e6608a0699d60b38b277bd',
         prov:value = "5.66292333602905" %% xsd:float,
         nidm_equivalentZStatistic: = "3.48206928174656" %% xsd:float,
         nidm_pValueUncorrected: = "0.000248777471726358" %% xsd:float,
         nidm_pValueFWER: = "0.999999841793879" %% xsd:float,
         nidm_qValueFDR: = "0.0270792144117247" %% xsd:float])
-    entity(niiri:86657e11e856b1fdbc9692e7270e9f36,
+    entity(niiri:843685ded7e6608a0699d60b38b277bd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0039" %% xsd:string,
         nidm_coordinateVector: = "[22,10,2]" %% xsd:string])
-    wasDerivedFrom(niiri:462393ac68491f3db8a262b5078fc9a9, niiri:4babeddab7c30570f5f7bca47ad8e349, -, -, -)
-    entity(niiri:662a754e5ebb07a4f3658f0ab369277c,
+    wasDerivedFrom(niiri:1221262de1e5620b40e4bdfbdeb36776, niiri:d5f1c18934146a18337779acd9486123, -, -, -)
+    entity(niiri:b35552ce359f982307861566bbcc356c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0040" %% xsd:string,
-        prov:location = 'niiri:dce98efb340c18452b3198b7a9d43ec6',
+        prov:location = 'niiri:769e88496004ebf67fff73d31693db58',
         prov:value = "6.58932304382324" %% xsd:float,
         nidm_equivalentZStatistic: = "3.87024913662237" %% xsd:float,
         nidm_pValueUncorrected: = "5.43620931486855e-05" %% xsd:float,
         nidm_pValueFWER: = "0.9893188063809" %% xsd:float,
         nidm_qValueFDR: = "0.0101197978315716" %% xsd:float])
-    entity(niiri:dce98efb340c18452b3198b7a9d43ec6,
+    entity(niiri:769e88496004ebf67fff73d31693db58,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0040" %% xsd:string,
         nidm_coordinateVector: = "[16,-8,20]" %% xsd:string])
-    wasDerivedFrom(niiri:662a754e5ebb07a4f3658f0ab369277c, niiri:abcdfa125cb9a6705001908f8633bf90, -, -, -)
-    entity(niiri:21f4ad1561991121f81c93c4a406ef8b,
+    wasDerivedFrom(niiri:b35552ce359f982307861566bbcc356c, niiri:275de6b748d7ad0f11eed3004edbf892, -, -, -)
+    entity(niiri:0d369bc39b99736fd4f8e779bf6ac134,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0041" %% xsd:string,
-        prov:location = 'niiri:ea0358caee1ca0292b7b7a8d309dd06c',
+        prov:location = 'niiri:f6c77de876bf3849b6cec31bea5642c4',
         prov:value = "6.53873300552368" %% xsd:float,
         nidm_equivalentZStatistic: = "3.8500124840786" %% xsd:float,
         nidm_pValueUncorrected: = "5.90559022480841e-05" %% xsd:float,
         nidm_pValueFWER: = "0.992265133018752" %% xsd:float,
         nidm_qValueFDR: = "0.0107045232421608" %% xsd:float])
-    entity(niiri:ea0358caee1ca0292b7b7a8d309dd06c,
+    entity(niiri:f6c77de876bf3849b6cec31bea5642c4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0041" %% xsd:string,
         nidm_coordinateVector: = "[28,-48,72]" %% xsd:string])
-    wasDerivedFrom(niiri:21f4ad1561991121f81c93c4a406ef8b, niiri:2583f6b74e4ca256d5338bb9b9f07a29, -, -, -)
-    entity(niiri:1babf001e3351aeb7fac6dc5454363cc,
+    wasDerivedFrom(niiri:0d369bc39b99736fd4f8e779bf6ac134, niiri:2dd4cb8812c93538b5902225b29e0471, -, -, -)
+    entity(niiri:203aed58b8f81dce0ecac8be5e863bda,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0042" %% xsd:string,
-        prov:location = 'niiri:a42f9f1e579000b2dc77292a8cf2acb7',
+        prov:location = 'niiri:219472c226c1003f926096d10ddea706',
         prov:value = "6.41633129119873" %% xsd:float,
         nidm_equivalentZStatistic: = "3.80061969992356" %% xsd:float,
         nidm_pValueUncorrected: = "7.2167337301976e-05" %% xsd:float,
         nidm_pValueFWER: = "0.996780557608903" %% xsd:float,
         nidm_qValueFDR: = "0.0122368668491247" %% xsd:float])
-    entity(niiri:a42f9f1e579000b2dc77292a8cf2acb7,
+    entity(niiri:219472c226c1003f926096d10ddea706,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0042" %% xsd:string,
         nidm_coordinateVector: = "[30,-48,-18]" %% xsd:string])
-    wasDerivedFrom(niiri:1babf001e3351aeb7fac6dc5454363cc, niiri:9656cbf27ba556542b025f2f8e45acfd, -, -, -)
-    entity(niiri:b338a4dd4022769457498158e6091888,
+    wasDerivedFrom(niiri:203aed58b8f81dce0ecac8be5e863bda, niiri:67ae07e7ee0396386eefce6ed5341a79, -, -, -)
+    entity(niiri:79605721ecfe71b7f89e29aabbca94a0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0043" %% xsd:string,
-        prov:location = 'niiri:3e89e3f7a8baa5ac4d836dcdac1c0bda',
+        prov:location = 'niiri:8aee97ed0bdda3e3420c52669ffbedb8',
         prov:value = "6.32824850082397" %% xsd:float,
         nidm_equivalentZStatistic: = "3.764690456476" %% xsd:float,
         nidm_pValueUncorrected: = "8.33777634952071e-05" %% xsd:float,
         nidm_pValueFWER: = "0.998439799137585" %% xsd:float,
         nidm_qValueFDR: = "0.0133433091347082" %% xsd:float])
-    entity(niiri:3e89e3f7a8baa5ac4d836dcdac1c0bda,
+    entity(niiri:8aee97ed0bdda3e3420c52669ffbedb8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0043" %% xsd:string,
         nidm_coordinateVector: = "[34,64,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:b338a4dd4022769457498158e6091888, niiri:52cafab6790abfb27ec51f00e747fe9a, -, -, -)
-    entity(niiri:e6169278f433610ff37f3974658c92df,
+    wasDerivedFrom(niiri:79605721ecfe71b7f89e29aabbca94a0, niiri:c589ee96ca2b908bdd9d337ca523d5af, -, -, -)
+    entity(niiri:7fae1b8bdbfa6d7b6e2b7098b3c6e4d9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0044" %% xsd:string,
-        prov:location = 'niiri:c70c80c37a08562550518b4cd4541c41',
+        prov:location = 'niiri:fac73b3e372e29b6987b728b1ee5fbbf',
         prov:value = "6.23233604431152" %% xsd:float,
         nidm_equivalentZStatistic: = "3.72519134385979" %% xsd:float,
         nidm_pValueUncorrected: = "9.75835625125487e-05" %% xsd:float,
         nidm_pValueFWER: = "0.999359408722565" %% xsd:float,
         nidm_qValueFDR: = "0.0147821614629234" %% xsd:float])
-    entity(niiri:c70c80c37a08562550518b4cd4541c41,
+    entity(niiri:fac73b3e372e29b6987b728b1ee5fbbf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0044" %% xsd:string,
         nidm_coordinateVector: = "[-42,44,26]" %% xsd:string])
-    wasDerivedFrom(niiri:e6169278f433610ff37f3974658c92df, niiri:4c64b57b636863b3e947522d1311c0f1, -, -, -)
-    entity(niiri:07af75e3341c3d93da4de231688d5549,
+    wasDerivedFrom(niiri:7fae1b8bdbfa6d7b6e2b7098b3c6e4d9, niiri:e43455a02504b9d87a4939904a0ca976, -, -, -)
+    entity(niiri:c2191d22002dea13759e4534d2a99bb2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0045" %% xsd:string,
-        prov:location = 'niiri:b7f3f00892f46b6b0ce77c4037087b40',
+        prov:location = 'niiri:1cd3744caef20860f929658348b743ab',
         prov:value = "6.06225728988647" %% xsd:float,
         nidm_equivalentZStatistic: = "3.6541549978965" %% xsd:float,
         nidm_pValueUncorrected: = "0.000129015181687619" %% xsd:float,
         nidm_pValueFWER: = "0.999902284410057" %% xsd:float,
         nidm_qValueFDR: = "0.0177419633224147" %% xsd:float])
-    entity(niiri:b7f3f00892f46b6b0ce77c4037087b40,
+    entity(niiri:1cd3744caef20860f929658348b743ab,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0045" %% xsd:string,
         nidm_coordinateVector: = "[0,-10,76]" %% xsd:string])
-    wasDerivedFrom(niiri:07af75e3341c3d93da4de231688d5549, niiri:a8236e3bfdb590d4516edd326dbac95d, -, -, -)
-    entity(niiri:41260b633b6a2691ee72574f2598723a,
+    wasDerivedFrom(niiri:c2191d22002dea13759e4534d2a99bb2, niiri:5dc937975dc687d7eb55e11a685cdd94, -, -, -)
+    entity(niiri:8e3e340d146c5b9659376513d4c922c7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0046" %% xsd:string,
-        prov:location = 'niiri:e5d27e5d68b5b3c32ee4902f86477d7a',
+        prov:location = 'niiri:7cf3a56c9ff943e6f0580b9ef6f6505c',
         prov:value = "6.03189373016357" %% xsd:float,
         nidm_equivalentZStatistic: = "3.64133598155782" %% xsd:float,
         nidm_pValueUncorrected: = "0.000135613449379846" %% xsd:float,
         nidm_pValueFWER: = "0.999933280387137" %% xsd:float,
         nidm_qValueFDR: = "0.0183426760576609" %% xsd:float])
-    entity(niiri:e5d27e5d68b5b3c32ee4902f86477d7a,
+    entity(niiri:7cf3a56c9ff943e6f0580b9ef6f6505c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0046" %% xsd:string,
         nidm_coordinateVector: = "[34,-16,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:41260b633b6a2691ee72574f2598723a, niiri:90dce13e46266944c40d12f4f1a86219, -, -, -)
-    entity(niiri:2ec9227f9219716d869254e96c9d0037,
+    wasDerivedFrom(niiri:8e3e340d146c5b9659376513d4c922c7, niiri:30c5174c5d495474060913c40bab0961, -, -, -)
+    entity(niiri:8766ac26c208ff8612c72111c2100871,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0047" %% xsd:string,
-        prov:location = 'niiri:b099faca4ffbe79b539a9a37c0fecc5b',
+        prov:location = 'niiri:ac6145a41b42dd4e0f5c9807aaabc438',
         prov:value = "6.02538537979126" %% xsd:float,
         nidm_equivalentZStatistic: = "3.63858275251093" %% xsd:float,
         nidm_pValueUncorrected: = "0.000137071270502886" %% xsd:float,
         nidm_pValueFWER: = "0.999938640797957" %% xsd:float,
         nidm_qValueFDR: = "0.0183962430264957" %% xsd:float])
-    entity(niiri:b099faca4ffbe79b539a9a37c0fecc5b,
+    entity(niiri:ac6145a41b42dd4e0f5c9807aaabc438,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0047" %% xsd:string,
         nidm_coordinateVector: = "[6,-80,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:2ec9227f9219716d869254e96c9d0037, niiri:4b569159d1ddc968752a57917503c6f4, -, -, -)
-    entity(niiri:0c5f2ba8ccadcaf3990cf555adbad737,
+    wasDerivedFrom(niiri:8766ac26c208ff8612c72111c2100871, niiri:ea999779ae02d5714142530d4b2e638b, -, -, -)
+    entity(niiri:a6e97fb09e03600e49705c493a878db7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0048" %% xsd:string,
-        prov:location = 'niiri:aa874dbac7a9c1e02e0a4e28bd39dfb7',
+        prov:location = 'niiri:e01d6c7223e76ffbae5e844b5dbe79aa',
         prov:value = "5.95283126831055" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60775727167743" %% xsd:float,
         nidm_pValueUncorrected: = "0.000154427613028529" %% xsd:float,
         nidm_pValueFWER: = "0.999977036852347" %% xsd:float,
         nidm_qValueFDR: = "0.0199653441808624" %% xsd:float])
-    entity(niiri:aa874dbac7a9c1e02e0a4e28bd39dfb7,
+    entity(niiri:e01d6c7223e76ffbae5e844b5dbe79aa,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0048" %% xsd:string,
         nidm_coordinateVector: = "[-26,-38,-52]" %% xsd:string])
-    wasDerivedFrom(niiri:0c5f2ba8ccadcaf3990cf555adbad737, niiri:674c9062dc421a541e91be283cce8f16, -, -, -)
-    entity(niiri:3d268b9ac3f787ed4e0702d7f1ec3eb8,
+    wasDerivedFrom(niiri:a6e97fb09e03600e49705c493a878db7, niiri:15b2530019f1c4c6d5e910962b35274b, -, -, -)
+    entity(niiri:8bcc743e85db485e4a2986804c97c77b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0049" %% xsd:string,
-        prov:location = 'niiri:d0604d3ccc8739eebfb0264b562dd48c',
+        prov:location = 'niiri:26a3a76d924a3533d4779f0959a1fbaf',
         prov:value = "5.9493842124939" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60628663469786" %% xsd:float,
         nidm_pValueUncorrected: = "0.000155305014835405" %% xsd:float,
         nidm_pValueFWER: = "0.999978135328144" %% xsd:float,
         nidm_qValueFDR: = "0.0200343508975978" %% xsd:float])
-    entity(niiri:d0604d3ccc8739eebfb0264b562dd48c,
+    entity(niiri:26a3a76d924a3533d4779f0959a1fbaf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0049" %% xsd:string,
         nidm_coordinateVector: = "[32,-52,46]" %% xsd:string])
-    wasDerivedFrom(niiri:3d268b9ac3f787ed4e0702d7f1ec3eb8, niiri:d3a1762138c1b259db52c75933757662, -, -, -)
-    entity(niiri:110d36e0f43c3b73543fd2a54c15fcef,
+    wasDerivedFrom(niiri:8bcc743e85db485e4a2986804c97c77b, niiri:5782e52657a04683a9d9acc635ffc74a, -, -, -)
+    entity(niiri:f70cbe313f78f3bc26491805e90defbf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0050" %% xsd:string,
-        prov:location = 'niiri:6f51bb746dc99583cc8e3bccd8b52a17',
+        prov:location = 'niiri:60032f6ce2504b4763622044467988e0',
         prov:value = "5.90739822387695" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58832892416593" %% xsd:float,
         nidm_pValueUncorrected: = "0.00016640212943575" %% xsd:float,
         nidm_pValueFWER: = "0.999988176695278" %% xsd:float,
         nidm_qValueFDR: = "0.0208396911967648" %% xsd:float])
-    entity(niiri:6f51bb746dc99583cc8e3bccd8b52a17,
+    entity(niiri:60032f6ce2504b4763622044467988e0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0050" %% xsd:string,
         nidm_coordinateVector: = "[20,58,6]" %% xsd:string])
-    wasDerivedFrom(niiri:110d36e0f43c3b73543fd2a54c15fcef, niiri:9dc472e5df63cfbf55f8afa2ad7233f1, -, -, -)
-    entity(niiri:5c65ee8dd873a043b1b0ce011fed4f35,
+    wasDerivedFrom(niiri:f70cbe313f78f3bc26491805e90defbf, niiri:e26340fcd624896679dd2542ec2348be, -, -, -)
+    entity(niiri:3349878166a538e7a54b1390c105c88b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0051" %% xsd:string,
-        prov:location = 'niiri:89b9ae5151cd9b1561aaf8ff96b4b6ec',
+        prov:location = 'niiri:ddefff6ce2c505804cc2f308814149f9',
         prov:value = "5.88568687438965" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57901000852841" %% xsd:float,
         nidm_pValueUncorrected: = "0.000172449130450447" %% xsd:float,
         nidm_pValueFWER: = "0.999991509605729" %% xsd:float,
         nidm_qValueFDR: = "0.0213019172775607" %% xsd:float])
-    entity(niiri:89b9ae5151cd9b1561aaf8ff96b4b6ec,
+    entity(niiri:ddefff6ce2c505804cc2f308814149f9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0051" %% xsd:string,
         nidm_coordinateVector: = "[-28,-70,-52]" %% xsd:string])
-    wasDerivedFrom(niiri:5c65ee8dd873a043b1b0ce011fed4f35, niiri:3fd667ca8587427124fe4b4ff80af21a, -, -, -)
-    entity(niiri:57c990b6ba31385d10715d6c40e7aa55,
+    wasDerivedFrom(niiri:3349878166a538e7a54b1390c105c88b, niiri:e4e5f6e0de1fb1456effbec6ec82e736, -, -, -)
+    entity(niiri:8345510a279773a85dbd456831121d91,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0052" %% xsd:string,
-        prov:location = 'niiri:9ebb93a3d4e207e403dbaa5999a1be35',
+        prov:location = 'niiri:3b9c2d356ee88a92c830323a0d5af7c1',
         prov:value = "5.88288545608521" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57780594841694" %% xsd:float,
         nidm_pValueUncorrected: = "0.000173245266573252" %% xsd:float,
         nidm_pValueFWER: = "0.999991870214044" %% xsd:float,
         nidm_qValueFDR: = "0.0213621903805226" %% xsd:float])
-    entity(niiri:9ebb93a3d4e207e403dbaa5999a1be35,
+    entity(niiri:3b9c2d356ee88a92c830323a0d5af7c1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0052" %% xsd:string,
         nidm_coordinateVector: = "[-16,-58,-38]" %% xsd:string])
-    wasDerivedFrom(niiri:57c990b6ba31385d10715d6c40e7aa55, niiri:c60cf8d223f50376ab05520bb51598af, -, -, -)
-    entity(niiri:2098d30ab385854e90d3cb8115b3a9b2,
+    wasDerivedFrom(niiri:8345510a279773a85dbd456831121d91, niiri:5cf9ae44dc03a8c6493baf09bed014d4, -, -, -)
+    entity(niiri:4bff1d01552bc126cd2623ad4ebf3b9a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0053" %% xsd:string,
-        prov:location = 'niiri:c3eb4272d1ec05c8e84a0681eea459bd',
+        prov:location = 'niiri:a9399ad6017a33693100cb9d9a9888f2',
         prov:value = "5.87665224075317" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57512554105657" %% xsd:float,
         nidm_pValueUncorrected: = "0.000175029940004845" %% xsd:float,
         nidm_pValueFWER: = "0.999992622705061" %% xsd:float,
         nidm_qValueFDR: = "0.0214921236782135" %% xsd:float])
-    entity(niiri:c3eb4272d1ec05c8e84a0681eea459bd,
+    entity(niiri:a9399ad6017a33693100cb9d9a9888f2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0053" %% xsd:string,
         nidm_coordinateVector: = "[-10,-82,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:2098d30ab385854e90d3cb8115b3a9b2, niiri:f551110d12542058bdc59cae03013010, -, -, -)
-    entity(niiri:3e504483f4e511a366bffb06b50ca097,
+    wasDerivedFrom(niiri:4bff1d01552bc126cd2623ad4ebf3b9a, niiri:dfe1466699f719841d6d98d1188da0c8, -, -, -)
+    entity(niiri:061bf720e78be5f38a4d203be70999ba,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0054" %% xsd:string,
-        prov:location = 'niiri:7c66d78243fad1b742ee22ad32e56f1b',
+        prov:location = 'niiri:029afc2516914e2a77271d16e01d5717',
         prov:value = "5.86712741851807" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57102607807387" %% xsd:float,
         nidm_pValueUncorrected: = "0.000177792742607208" %% xsd:float,
         nidm_pValueFWER: = "0.999993649803941" %% xsd:float,
         nidm_qValueFDR: = "0.0216816267105749" %% xsd:float])
-    entity(niiri:7c66d78243fad1b742ee22ad32e56f1b,
+    entity(niiri:029afc2516914e2a77271d16e01d5717,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0054" %% xsd:string,
         nidm_coordinateVector: = "[50,50,8]" %% xsd:string])
-    wasDerivedFrom(niiri:3e504483f4e511a366bffb06b50ca097, niiri:fb9120500eef24a89fb5e84238991362, -, -, -)
-    entity(niiri:38cfaeebf97d0d2b0b71a5f0ba640e98,
+    wasDerivedFrom(niiri:061bf720e78be5f38a4d203be70999ba, niiri:e69a5e282ae0346ca803f55371164aa7, -, -, -)
+    entity(niiri:b356784762f635ac6a6625d03f3fd1d5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0055" %% xsd:string,
-        prov:location = 'niiri:83fb05512223e38d67cb83a805cd00b3',
+        prov:location = 'niiri:6879e2b7fd420a16198270a7fda0c0ec',
         prov:value = "5.85824680328369" %% xsd:float,
         nidm_equivalentZStatistic: = "3.56719995255891" %% xsd:float,
         nidm_pValueUncorrected: = "0.000180408078987448" %% xsd:float,
         nidm_pValueFWER: = "0.999994487319543" %% xsd:float,
         nidm_qValueFDR: = "0.0217930814133279" %% xsd:float])
-    entity(niiri:83fb05512223e38d67cb83a805cd00b3,
+    entity(niiri:6879e2b7fd420a16198270a7fda0c0ec,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0055" %% xsd:string,
         nidm_coordinateVector: = "[-6,-78,56]" %% xsd:string])
-    wasDerivedFrom(niiri:38cfaeebf97d0d2b0b71a5f0ba640e98, niiri:dde8bc734b1e70c777683f3419f9b22a, -, -, -)
-    entity(niiri:6bed9eb8c16b5bfc1b7f13853ba3719d,
+    wasDerivedFrom(niiri:b356784762f635ac6a6625d03f3fd1d5, niiri:d168d4b61807fc13619ad56c31dad174, -, -, -)
+    entity(niiri:52474a24c82a42c438dfac7f6b6ebe74,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0056" %% xsd:string,
-        prov:location = 'niiri:07d1fc16b4011bf11b157bc94038717f',
+        prov:location = 'niiri:b536ab3bffaed62ccb1ca6267c85947b',
         prov:value = "5.81644201278687" %% xsd:float,
         nidm_equivalentZStatistic: = "3.54913757298709" %% xsd:float,
         nidm_pValueUncorrected: = "0.000193247549691744" %% xsd:float,
         nidm_pValueFWER: = "0.99999722874557" %% xsd:float,
         nidm_qValueFDR: = "0.022905022613713" %% xsd:float])
-    entity(niiri:07d1fc16b4011bf11b157bc94038717f,
+    entity(niiri:b536ab3bffaed62ccb1ca6267c85947b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0056" %% xsd:string,
         nidm_coordinateVector: = "[44,50,20]" %% xsd:string])
-    wasDerivedFrom(niiri:6bed9eb8c16b5bfc1b7f13853ba3719d, niiri:89223f01a7e676c300c22c8da4a82ef8, -, -, -)
-    entity(niiri:13789ff64ea178d4dd930d5649ad0efa,
+    wasDerivedFrom(niiri:52474a24c82a42c438dfac7f6b6ebe74, niiri:522e011a3a54e833c99dc9315f577dfe, -, -, -)
+    entity(niiri:63d794c7a20b8c3844c02909a430c400,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0057" %% xsd:string,
-        prov:location = 'niiri:09872dc9def2ebbedbd2d8b56d8ccec8',
+        prov:location = 'niiri:c04e40e59d081babf861f27fff0bc656',
         prov:value = "5.75350570678711" %% xsd:float,
         nidm_equivalentZStatistic: = "3.52178406559812" %% xsd:float,
         nidm_pValueUncorrected: = "0.000214326572548162" %% xsd:float,
         nidm_pValueFWER: = "0.999999083879168" %% xsd:float,
         nidm_qValueFDR: = "0.0245474913207941" %% xsd:float])
-    entity(niiri:09872dc9def2ebbedbd2d8b56d8ccec8,
+    entity(niiri:c04e40e59d081babf861f27fff0bc656,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0057" %% xsd:string,
         nidm_coordinateVector: = "[-30,-58,-52]" %% xsd:string])
-    wasDerivedFrom(niiri:13789ff64ea178d4dd930d5649ad0efa, niiri:7ac6ced5ac5b95c88fbe93f4ad51726c, -, -, -)
-    entity(niiri:9d748709970f09ad37966b4ebd88970d,
+    wasDerivedFrom(niiri:63d794c7a20b8c3844c02909a430c400, niiri:bcc290b739057f6cb5c02dcc79c4b5bc, -, -, -)
+    entity(niiri:341c565fefe9949adb1369f3da7a2a11,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0058" %% xsd:string,
-        prov:location = 'niiri:a8566c5632b9f7d195407d5bbeb8d694',
+        prov:location = 'niiri:6f522d3d3123b608cd947c46fdc012a6',
         prov:value = "5.74829816818237" %% xsd:float,
         nidm_equivalentZStatistic: = "3.51951200270118" %% xsd:float,
         nidm_pValueUncorrected: = "0.000216170736607735" %% xsd:float,
         nidm_pValueFWER: = "0.999999167412893" %% xsd:float,
         nidm_qValueFDR: = "0.0246525319493899" %% xsd:float])
-    entity(niiri:a8566c5632b9f7d195407d5bbeb8d694,
+    entity(niiri:6f522d3d3123b608cd947c46fdc012a6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0058" %% xsd:string,
         nidm_coordinateVector: = "[-38,36,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:9d748709970f09ad37966b4ebd88970d, niiri:5d05848ec2715382392265640fc9d57e, -, -, -)
-    entity(niiri:8f1086c487206beee6166192435ccbb7,
+    wasDerivedFrom(niiri:341c565fefe9949adb1369f3da7a2a11, niiri:6f3de48dca5b4c3a6aca0be63ddd27cd, -, -, -)
+    entity(niiri:511b02a8bf4a6e0270aa9e4d8188cf98,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0059" %% xsd:string,
-        prov:location = 'niiri:7bd2497735bee9acdd922777fd6b5af3',
+        prov:location = 'niiri:08733586f578952e07d3ef0bedd783e7',
         prov:value = "5.7312970161438" %% xsd:float,
         nidm_equivalentZStatistic: = "3.51208496979963" %% xsd:float,
         nidm_pValueUncorrected: = "0.000222302913436612" %% xsd:float,
         nidm_pValueFWER: = "0.99999939333845" %% xsd:float,
         nidm_qValueFDR: = "0.0250806761204491" %% xsd:float])
-    entity(niiri:7bd2497735bee9acdd922777fd6b5af3,
+    entity(niiri:08733586f578952e07d3ef0bedd783e7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0059" %% xsd:string,
         nidm_coordinateVector: = "[-50,12,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:8f1086c487206beee6166192435ccbb7, niiri:ca24bdc833f185dc48a439c9bd8cfea6, -, -, -)
-    entity(niiri:9622cbdc321584d153d90164a7e3a512,
+    wasDerivedFrom(niiri:511b02a8bf4a6e0270aa9e4d8188cf98, niiri:f77f344a47f917de9a802b78319c354f, -, -, -)
+    entity(niiri:2f69fd65193eb1b02e7f447cca5b3d63,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0060" %% xsd:string,
-        prov:location = 'niiri:ab618775ab67eaf9567d2f85e813dc0d',
+        prov:location = 'niiri:ca4ad108c221d6463345f5410c20d1b6',
         prov:value = "5.61407613754272" %% xsd:float,
         nidm_equivalentZStatistic: = "3.46048027314539" %% xsd:float,
         nidm_pValueUncorrected: = "0.000269606369816766" %% xsd:float,
         nidm_pValueFWER: = "0.999999943721802" %% xsd:float,
         nidm_qValueFDR: = "0.0285650985701987" %% xsd:float])
-    entity(niiri:ab618775ab67eaf9567d2f85e813dc0d,
+    entity(niiri:ca4ad108c221d6463345f5410c20d1b6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0060" %% xsd:string,
         nidm_coordinateVector: = "[-52,38,14]" %% xsd:string])
-    wasDerivedFrom(niiri:9622cbdc321584d153d90164a7e3a512, niiri:302ad243c21e156bc35f157e2595460d, -, -, -)
-    entity(niiri:dafa541111dbf27389241fc1622583e6,
+    wasDerivedFrom(niiri:2f69fd65193eb1b02e7f447cca5b3d63, niiri:9df645a4ce3520ee828e35a6dac32f9f, -, -, -)
+    entity(niiri:6fb432a65a1864ebc7f79bd73139967a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0061" %% xsd:string,
-        prov:location = 'niiri:8a2dcced4bbeb2d604abdc206edbd812',
+        prov:location = 'niiri:05b2d9da6ce7b779041ee7d321cee8e3',
         prov:value = "5.53163862228394" %% xsd:float,
         nidm_equivalentZStatistic: = "3.42376539987989" %% xsd:float,
         nidm_pValueUncorrected: = "0.000308799561745898" %% xsd:float,
         nidm_pValueFWER: = "0.999999991534363" %% xsd:float,
         nidm_qValueFDR: = "0.0312013208214028" %% xsd:float])
-    entity(niiri:8a2dcced4bbeb2d604abdc206edbd812,
+    entity(niiri:05b2d9da6ce7b779041ee7d321cee8e3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0061" %% xsd:string,
         nidm_coordinateVector: = "[-14,-80,10]" %% xsd:string])
-    wasDerivedFrom(niiri:dafa541111dbf27389241fc1622583e6, niiri:b0e84ab2cd541b237634e56ebf391609, -, -, -)
-    entity(niiri:a1b7280bae7cb27c5d032057b5e5ee6a,
+    wasDerivedFrom(niiri:6fb432a65a1864ebc7f79bd73139967a, niiri:1dea88b1f0062ddb01809c2f336aff3f, -, -, -)
+    entity(niiri:ef1964afa02d57f263805ebae4d754c5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0062" %% xsd:string,
-        prov:location = 'niiri:c15f83bf0af7227fccfcc19a8ff53a78',
+        prov:location = 'niiri:0d2cac5a83e96f9282820e4e4438c966',
         prov:value = "5.52454996109009" %% xsd:float,
         nidm_equivalentZStatistic: = "3.42059171809414" %% xsd:float,
         nidm_pValueUncorrected: = "0.000312425309546338" %% xsd:float,
         nidm_pValueFWER: = "0.999999992873262" %% xsd:float,
         nidm_qValueFDR: = "0.0313644959462665" %% xsd:float])
-    entity(niiri:c15f83bf0af7227fccfcc19a8ff53a78,
+    entity(niiri:0d2cac5a83e96f9282820e4e4438c966,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0062" %% xsd:string,
         nidm_coordinateVector: = "[-66,-40,18]" %% xsd:string])
-    wasDerivedFrom(niiri:a1b7280bae7cb27c5d032057b5e5ee6a, niiri:27969eb0dc2d34026b32c881a0f07667, -, -, -)
-    entity(niiri:3240ad2c7b4c375b2ffb7def8241fc33,
+    wasDerivedFrom(niiri:ef1964afa02d57f263805ebae4d754c5, niiri:f424b0ee093c7ca1771bb8144718087b, -, -, -)
+    entity(niiri:bd558d7e2f31e68ed9630cf47a3dc77f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0063" %% xsd:string,
-        prov:location = 'niiri:8977a52fd8fb3c0c00a547480b793cb2',
+        prov:location = 'niiri:d292d5aee905fd862dc0c678e3fe9df2',
         prov:value = "5.51989889144897" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41850793238069" %% xsd:float,
         nidm_pValueUncorrected: = "0.000314827412227103" %% xsd:float,
         nidm_pValueFWER: = "0.99999999363976" %% xsd:float,
         nidm_qValueFDR: = "0.0315295603356192" %% xsd:float])
-    entity(niiri:8977a52fd8fb3c0c00a547480b793cb2,
+    entity(niiri:d292d5aee905fd862dc0c678e3fe9df2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0063" %% xsd:string,
         nidm_coordinateVector: = "[-2,-90,16]" %% xsd:string])
-    wasDerivedFrom(niiri:3240ad2c7b4c375b2ffb7def8241fc33, niiri:488053a695a16e1621e578a90cd45d96, -, -, -)
-    entity(niiri:e98e410c62ad05bb4759e8520048a9be,
+    wasDerivedFrom(niiri:bd558d7e2f31e68ed9630cf47a3dc77f, niiri:258ff3de07e51a57d0b27d6699fb2508, -, -, -)
+    entity(niiri:cbcc21fd20778a31e84881bfab50ee09,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0064" %% xsd:string,
-        prov:location = 'niiri:c244d6cda3ac6e6dc81d3a691f072524',
+        prov:location = 'niiri:4abf0e8985243764b8b4d826d3ff3cac',
         prov:value = "5.50013113021851" %% xsd:float,
         nidm_equivalentZStatistic: = "3.40963871850162" %% xsd:float,
         nidm_pValueUncorrected: = "0.000325244937404157" %% xsd:float,
         nidm_pValueFWER: = "0.99999999610751" %% xsd:float,
         nidm_qValueFDR: = "0.0320937892728011" %% xsd:float])
-    entity(niiri:c244d6cda3ac6e6dc81d3a691f072524,
+    entity(niiri:4abf0e8985243764b8b4d826d3ff3cac,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0064" %% xsd:string,
         nidm_coordinateVector: = "[48,-68,24]" %% xsd:string])
-    wasDerivedFrom(niiri:e98e410c62ad05bb4759e8520048a9be, niiri:ed908db943ba3e97ea5826f9b78e251e, -, -, -)
-    entity(niiri:028200a0f3330e69e713e62343e4c118,
+    wasDerivedFrom(niiri:cbcc21fd20778a31e84881bfab50ee09, niiri:fd669f02bbb8da3eff612dc0d4b807f6, -, -, -)
+    entity(niiri:76de7fa6ab94ab4a76284547a4e3f1aa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0065" %% xsd:string,
-        prov:location = 'niiri:6672ab9c3b56f3def7af8a2d31e7bf6b',
+        prov:location = 'niiri:91f9c5e62fe3707f1980b1138c4853ca',
         prov:value = "5.47258329391479" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39724406479958" %% xsd:float,
         nidm_pValueUncorrected: = "0.000340341137511579" %% xsd:float,
         nidm_pValueFWER: = "0.999999998076035" %% xsd:float,
         nidm_qValueFDR: = "0.0330219418190176" %% xsd:float])
-    entity(niiri:6672ab9c3b56f3def7af8a2d31e7bf6b,
+    entity(niiri:91f9c5e62fe3707f1980b1138c4853ca,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0065" %% xsd:string,
         nidm_coordinateVector: = "[-66,-52,14]" %% xsd:string])
-    wasDerivedFrom(niiri:028200a0f3330e69e713e62343e4c118, niiri:f5e02329544635d1b1ebf65b366251dc, -, -, -)
-    entity(niiri:83b5e42ee4a22a019efa3ad1b7c43432,
+    wasDerivedFrom(niiri:76de7fa6ab94ab4a76284547a4e3f1aa, niiri:2560564a14e0250f709b385639d02fb9, -, -, -)
+    entity(niiri:9e085633b6f20c82d2de1068c8944127,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0066" %% xsd:string,
-        prov:location = 'niiri:1365efa4ae8395b0cf5121fab0888e16',
+        prov:location = 'niiri:8940c35372a329a691f251d5f01211da',
         prov:value = "5.47253847122192" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39722386451209" %% xsd:float,
         nidm_pValueUncorrected: = "0.000340366263790748" %% xsd:float,
         nidm_pValueFWER: = "0.999999998078278" %% xsd:float,
         nidm_qValueFDR: = "0.0330219418190176" %% xsd:float])
-    entity(niiri:1365efa4ae8395b0cf5121fab0888e16,
+    entity(niiri:8940c35372a329a691f251d5f01211da,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0066" %% xsd:string,
         nidm_coordinateVector: = "[-24,-70,-40]" %% xsd:string])
-    wasDerivedFrom(niiri:83b5e42ee4a22a019efa3ad1b7c43432, niiri:48785ebe53244b67446462ca165511f6, -, -, -)
-    entity(niiri:4d855c9b2c870365cbdf9a1cf976b2f7,
+    wasDerivedFrom(niiri:9e085633b6f20c82d2de1068c8944127, niiri:589d688bdb65a26f0e5afdd4ff33865b, -, -, -)
+    entity(niiri:584625db35fd1e69dc1aeb8466d8899b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0067" %% xsd:string,
-        prov:location = 'niiri:bc66a863068c99d04a911bb1348a178e',
+        prov:location = 'niiri:56067390bd867fbe6b52bf178e0f2d8f',
         prov:value = "5.40879058837891" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36838466104027" %% xsd:float,
         nidm_pValueUncorrected: = "0.00037805012668235" %% xsd:float,
         nidm_pValueFWER: = "0.999999999657857" %% xsd:float,
         nidm_qValueFDR: = "0.0351846046980527" %% xsd:float])
-    entity(niiri:bc66a863068c99d04a911bb1348a178e,
+    entity(niiri:56067390bd867fbe6b52bf178e0f2d8f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0067" %% xsd:string,
         nidm_coordinateVector: = "[-52,28,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:4d855c9b2c870365cbdf9a1cf976b2f7, niiri:dd83d9e917f614f418e9401cdb99e43c, -, -, -)
-    entity(niiri:086b014ac09ab4e4ea973ffddfa71a22,
+    wasDerivedFrom(niiri:584625db35fd1e69dc1aeb8466d8899b, niiri:b1e45a95e3b162cbfbb274efa0609a1a, -, -, -)
+    entity(niiri:923ab0d2b10cd0fb1178741e5f7e4d80,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0068" %% xsd:string,
-        prov:location = 'niiri:06cfc8651ab4c54efee830c631e39857',
+        prov:location = 'niiri:297f004b78125a381f4cc1a5fa03cfa7',
         prov:value = "5.40180397033691" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36521050637541" %% xsd:float,
         nidm_pValueUncorrected: = "0.000382426408436776" %% xsd:float,
         nidm_pValueFWER: = "0.999999999719179" %% xsd:float,
         nidm_qValueFDR: = "0.0353860600288775" %% xsd:float])
-    entity(niiri:06cfc8651ab4c54efee830c631e39857,
+    entity(niiri:297f004b78125a381f4cc1a5fa03cfa7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0068" %% xsd:string,
         nidm_coordinateVector: = "[46,40,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:086b014ac09ab4e4ea973ffddfa71a22, niiri:f9dfccb5b804ef9741131141e3190a4b, -, -, -)
-    entity(niiri:53c569adbfc5ab366e0314685b165853,
+    wasDerivedFrom(niiri:923ab0d2b10cd0fb1178741e5f7e4d80, niiri:5ac022b3dd1da9d78456eb9feccbe272, -, -, -)
+    entity(niiri:d2e0beea05ad13eb0757a2f7874a5c30,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0069" %% xsd:string,
-        prov:location = 'niiri:13c44e2155af4ee2e20a16ec29b76a47',
+        prov:location = 'niiri:f086d252f5f4c91e62368d78b62ac58b',
         prov:value = "5.37467432022095" %% xsd:float,
         nidm_equivalentZStatistic: = "3.35285956111335" %% xsd:float,
         nidm_pValueUncorrected: = "0.000399906393667493" %% xsd:float,
         nidm_pValueFWER: = "0.999999999871685" %% xsd:float,
         nidm_qValueFDR: = "0.0362799194266732" %% xsd:float])
-    entity(niiri:13c44e2155af4ee2e20a16ec29b76a47,
+    entity(niiri:f086d252f5f4c91e62368d78b62ac58b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0069" %% xsd:string,
         nidm_coordinateVector: = "[-24,-64,-26]" %% xsd:string])
-    wasDerivedFrom(niiri:53c569adbfc5ab366e0314685b165853, niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5, -, -, -)
-    entity(niiri:be4788197353dff3599d99682ec3031b,
+    wasDerivedFrom(niiri:d2e0beea05ad13eb0757a2f7874a5c30, niiri:0aa8942e14fb246e8d24f1826bdd073f, -, -, -)
+    entity(niiri:71949ac8bb1d34c0f6a227d787830b42,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0070" %% xsd:string,
-        prov:location = 'niiri:917e6352e6ae3e3613ae739c3f135a19',
+        prov:location = 'niiri:4faa09a4da27e254773d00b12e8ce476',
         prov:value = "5.37411737442017" %% xsd:float,
         nidm_equivalentZStatistic: = "3.35260558298398" %% xsd:float,
         nidm_pValueUncorrected: = "0.00040027350203431" %% xsd:float,
         nidm_pValueFWER: = "0.999999999873767" %% xsd:float,
         nidm_qValueFDR: = "0.0362799194266732" %% xsd:float])
-    entity(niiri:917e6352e6ae3e3613ae739c3f135a19,
+    entity(niiri:4faa09a4da27e254773d00b12e8ce476,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0070" %% xsd:string,
         nidm_coordinateVector: = "[6,-78,4]" %% xsd:string])
-    wasDerivedFrom(niiri:be4788197353dff3599d99682ec3031b, niiri:024c443604af80b2271c971bd66fc9a0, -, -, -)
-    entity(niiri:3f93410e4f041c83e4b8d8a0e0adbfff,
+    wasDerivedFrom(niiri:71949ac8bb1d34c0f6a227d787830b42, niiri:47175a90c2a865c8e7cb888b760d6bf8, -, -, -)
+    entity(niiri:102e3f4f656d62e79230957d3c5b9d14,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0071" %% xsd:string,
-        prov:location = 'niiri:0b950426b4901232779f3393314e29d9',
+        prov:location = 'niiri:a9650048b29ccca030a5ee54b9940e46',
         prov:value = "5.30396842956543" %% xsd:float,
         nidm_equivalentZStatistic: = "3.32047825714677" %% xsd:float,
         nidm_pValueUncorrected: = "0.000449316793136201" %% xsd:float,
         nidm_pValueFWER: = "0.999999999985317" %% xsd:float,
         nidm_qValueFDR: = "0.038893908226916" %% xsd:float])
-    entity(niiri:0b950426b4901232779f3393314e29d9,
+    entity(niiri:a9650048b29ccca030a5ee54b9940e46,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0071" %% xsd:string,
         nidm_coordinateVector: = "[-18,6,-16]" %% xsd:string])
-    wasDerivedFrom(niiri:3f93410e4f041c83e4b8d8a0e0adbfff, niiri:bd7d210916ff0d725f61db0ca48f5d05, -, -, -)
-    entity(niiri:5f9a78d502e9bb9f0b83b39b814fcb68,
+    wasDerivedFrom(niiri:102e3f4f656d62e79230957d3c5b9d14, niiri:d3f621d08874a1c4b62c86623e9e9780, -, -, -)
+    entity(niiri:1c9771ed932e3bdfafbe567879a399d9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0072" %% xsd:string,
-        prov:location = 'niiri:b466f652f73aa477a6d1a60f80c8435c',
+        prov:location = 'niiri:df34c6eabebd48e7dc695cf8cd35940f',
         prov:value = "5.3003044128418" %% xsd:float,
         nidm_equivalentZStatistic: = "3.31879260124815" %% xsd:float,
         nidm_pValueUncorrected: = "0.000452037748311596" %% xsd:float,
         nidm_pValueFWER: = "0.999999999986945" %% xsd:float,
         nidm_qValueFDR: = "0.0390806835204476" %% xsd:float])
-    entity(niiri:b466f652f73aa477a6d1a60f80c8435c,
+    entity(niiri:df34c6eabebd48e7dc695cf8cd35940f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0072" %% xsd:string,
         nidm_coordinateVector: = "[44,34,22]" %% xsd:string])
-    wasDerivedFrom(niiri:5f9a78d502e9bb9f0b83b39b814fcb68, niiri:7925cec36e37f32d88f7027ba176a2e1, -, -, -)
-    entity(niiri:d0e4dbe4e90bfbe444d4822b9a651afc,
+    wasDerivedFrom(niiri:1c9771ed932e3bdfafbe567879a399d9, niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56, -, -, -)
+    entity(niiri:6e63ab7247516f8dc04092e22e2759ec,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0073" %% xsd:string,
-        prov:location = 'niiri:be4116def5b2ec22ad63aa256b25428e',
+        prov:location = 'niiri:51436c3b224aac45c74640b1163904f9',
         prov:value = "5.2790060043335" %% xsd:float,
         nidm_equivalentZStatistic: = "3.30897907487843" %% xsd:float,
         nidm_pValueUncorrected: = "0.000468184175549835" %% xsd:float,
         nidm_pValueFWER: = "0.999999999993475" %% xsd:float,
         nidm_qValueFDR: = "0.0399946769218688" %% xsd:float])
-    entity(niiri:be4116def5b2ec22ad63aa256b25428e,
+    entity(niiri:51436c3b224aac45c74640b1163904f9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0073" %% xsd:string,
         nidm_coordinateVector: = "[-16,-70,62]" %% xsd:string])
-    wasDerivedFrom(niiri:d0e4dbe4e90bfbe444d4822b9a651afc, niiri:11d4226a2f26d5d215e759b0b4e1b65c, -, -, -)
-    entity(niiri:7ab232ff50649870750ccc2d7f5c4da3,
+    wasDerivedFrom(niiri:6e63ab7247516f8dc04092e22e2759ec, niiri:730bd100bdb468af0d3821d0d42d24a3, -, -, -)
+    entity(niiri:86c90a2f51f1ad8289191c43b5d97061,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0074" %% xsd:string,
-        prov:location = 'niiri:6f88478d05d4710af9b94706fcfdcacb',
+        prov:location = 'niiri:e46fca08428611170031546e4ef81393',
         prov:value = "5.22220420837402" %% xsd:float,
         nidm_equivalentZStatistic: = "3.28268028866984" %% xsd:float,
         nidm_pValueUncorrected: = "0.000514126053509312" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999062" %% xsd:float,
         nidm_qValueFDR: = "0.0424551034128408" %% xsd:float])
-    entity(niiri:6f88478d05d4710af9b94706fcfdcacb,
+    entity(niiri:e46fca08428611170031546e4ef81393,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0074" %% xsd:string,
         nidm_coordinateVector: = "[-18,-90,34]" %% xsd:string])
-    wasDerivedFrom(niiri:7ab232ff50649870750ccc2d7f5c4da3, niiri:cd265e81b525edcdebe748129d48fb9f, -, -, -)
-    entity(niiri:dbaf7dcfae21971052a8c4d8630590a6,
+    wasDerivedFrom(niiri:86c90a2f51f1ad8289191c43b5d97061, niiri:c30c1334c3597905fbc441edbc3d5ada, -, -, -)
+    entity(niiri:545e517cd64f442db87872d4a27b47f7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0075" %% xsd:string,
-        prov:location = 'niiri:803c967b5027caa5ecf5d2a6fc5e8db2',
+        prov:location = 'niiri:1042007b111f87e5138bb438f2ae2bc0',
         prov:value = "5.1730318069458" %% xsd:float,
         nidm_equivalentZStatistic: = "3.25976321879304" %% xsd:float,
         nidm_pValueUncorrected: = "0.000557526302441769" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999843" %% xsd:float,
         nidm_qValueFDR: = "0.0447389446131481" %% xsd:float])
-    entity(niiri:803c967b5027caa5ecf5d2a6fc5e8db2,
+    entity(niiri:1042007b111f87e5138bb438f2ae2bc0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0075" %% xsd:string,
         nidm_coordinateVector: = "[36,62,8]" %% xsd:string])
-    wasDerivedFrom(niiri:dbaf7dcfae21971052a8c4d8630590a6, niiri:aa2c86e9352626823ca6bb3bbda5947a, -, -, -)
-    entity(niiri:4cc71160f45e34b952ca323ad055c180,
+    wasDerivedFrom(niiri:545e517cd64f442db87872d4a27b47f7, niiri:f3476be8b24ab5bb218fe71d0b0daed0, -, -, -)
+    entity(niiri:f3f05a481523891d44824beadda448ee,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0076" %% xsd:string,
-        prov:location = 'niiri:c7f8ed36a2e92d11b23926f9debb338a',
+        prov:location = 'niiri:194bdcb422ae39cd8096994d6fce64ac',
         prov:value = "5.17224788665771" %% xsd:float,
         nidm_equivalentZStatistic: = "3.25939672404754" %% xsd:float,
         nidm_pValueUncorrected: = "0.000558247108556009" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999848" %% xsd:float,
         nidm_qValueFDR: = "0.0447389446131481" %% xsd:float])
-    entity(niiri:c7f8ed36a2e92d11b23926f9debb338a,
+    entity(niiri:194bdcb422ae39cd8096994d6fce64ac,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0076" %% xsd:string,
         nidm_coordinateVector: = "[44,46,-18]" %% xsd:string])
-    wasDerivedFrom(niiri:4cc71160f45e34b952ca323ad055c180, niiri:8d3a03589611da3ed8127a06d493acd6, -, -, -)
-    entity(niiri:fbddf0f56adf238723f50586d9383121,
+    wasDerivedFrom(niiri:f3f05a481523891d44824beadda448ee, niiri:e129e49f77be02735062a975f639c82e, -, -, -)
+    entity(niiri:62b1a35b9b004426fc8baefb3985fe01,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0077" %% xsd:string,
-        prov:location = 'niiri:827b144eb0409183e6f5e65935ea8fac',
+        prov:location = 'niiri:bbea39448c6107a5d4ad5ddee203d4d2',
         prov:value = "5.13746070861816" %% xsd:float,
         nidm_equivalentZStatistic: = "3.24309671226403" %% xsd:float,
         nidm_pValueUncorrected: = "0.000591190343014691" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999996" %% xsd:float,
         nidm_qValueFDR: = "0.0465822754926653" %% xsd:float])
-    entity(niiri:827b144eb0409183e6f5e65935ea8fac,
+    entity(niiri:bbea39448c6107a5d4ad5ddee203d4d2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0077" %% xsd:string,
         nidm_coordinateVector: = "[22,-18,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:fbddf0f56adf238723f50586d9383121, niiri:3f311421a632e712f70cc6839f7e9489, -, -, -)
-    entity(niiri:f7fbd57305037f549d9fa2567e5b8559,
+    wasDerivedFrom(niiri:62b1a35b9b004426fc8baefb3985fe01, niiri:f445b49b9174ce8611d41a7cc11e1717, -, -, -)
+    entity(niiri:7e86c6411e52fa0a7b9b20dcbb6e36b0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0078" %% xsd:string,
-        prov:location = 'niiri:82ccce4a7354b15f17bc0943ef2b529c',
+        prov:location = 'niiri:5f9f0cd6ac7c81914637716591108924',
         prov:value = "5.11799764633179" %% xsd:float,
         nidm_equivalentZStatistic: = "3.23394572778211" %% xsd:float,
         nidm_pValueUncorrected: = "0.000610463272072148" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999981" %% xsd:float,
         nidm_qValueFDR: = "0.0474717326152994" %% xsd:float])
-    entity(niiri:82ccce4a7354b15f17bc0943ef2b529c,
+    entity(niiri:5f9f0cd6ac7c81914637716591108924,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0078" %% xsd:string,
         nidm_coordinateVector: = "[-54,34,4]" %% xsd:string])
-    wasDerivedFrom(niiri:f7fbd57305037f549d9fa2567e5b8559, niiri:bcc132262f6d7297d1d28a6f0a171093, -, -, -)
-    entity(niiri:dbb595cffa04de52d8f33921efbecc84,
+    wasDerivedFrom(niiri:7e86c6411e52fa0a7b9b20dcbb6e36b0, niiri:5ca600306779ba8f48c5d087d9fac9a9, -, -, -)
+    entity(niiri:97c62dc69d6cfc9480ed5f2d7063dc28,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0079" %% xsd:string,
-        prov:location = 'niiri:27b2020b2732af62cc07a03a8002f7be',
+        prov:location = 'niiri:34c95820a8a121e8a225fd9376361242',
         prov:value = "5.10930299758911" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22985044435181" %% xsd:float,
         nidm_pValueUncorrected: = "0.000619274939217984" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999987" %% xsd:float,
         nidm_qValueFDR: = "0.047852944668371" %% xsd:float])
-    entity(niiri:27b2020b2732af62cc07a03a8002f7be,
+    entity(niiri:34c95820a8a121e8a225fd9376361242,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0079" %% xsd:string,
         nidm_coordinateVector: = "[-30,-64,-52]" %% xsd:string])
-    wasDerivedFrom(niiri:dbb595cffa04de52d8f33921efbecc84, niiri:3bdec6eb0b5535174fa631dd70795a7e, -, -, -)
-    entity(niiri:49c1e9ef96178d1e9db83a47b1907de9,
+    wasDerivedFrom(niiri:97c62dc69d6cfc9480ed5f2d7063dc28, niiri:40bbe1b7b060c1d54f113fd9fcf154aa, -, -, -)
+    entity(niiri:fd255fdebba34e1d3d741757f42127cb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0080" %% xsd:string,
-        prov:location = 'niiri:dc95edb06b3ad737ba9ce90d974a8f91',
+        prov:location = 'niiri:e2093ea5a4830bc016df153a1447adb3',
         prov:value = "5.10401487350464" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22735746106492" %% xsd:float,
         nidm_pValueUncorrected: = "0.000624696357977461" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999989" %% xsd:float,
         nidm_qValueFDR: = "0.0480043833565767" %% xsd:float])
-    entity(niiri:dc95edb06b3ad737ba9ce90d974a8f91,
+    entity(niiri:e2093ea5a4830bc016df153a1447adb3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0080" %% xsd:string,
         nidm_coordinateVector: = "[-48,-78,18]" %% xsd:string])
-    wasDerivedFrom(niiri:49c1e9ef96178d1e9db83a47b1907de9, niiri:f1946d8aa4c75dc6c7b6e735e96e1847, -, -, -)
-    entity(niiri:c4b0c9d7d5bf10ed940aa36f9a2898fc,
+    wasDerivedFrom(niiri:fd255fdebba34e1d3d741757f42127cb, niiri:5d9d1b3e1bbc6746185f53561c74bace, -, -, -)
+    entity(niiri:d03d3f46620d80d545af7b487f982e5b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0081" %% xsd:string,
-        prov:location = 'niiri:690f349d00c402f64f9afef69a04d47d',
+        prov:location = 'niiri:8beacede341a47f3167389d2db31c511',
         prov:value = "5.09518003463745" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22318870378714" %% xsd:float,
         nidm_pValueUncorrected: = "0.000633860042171808" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999993" %% xsd:float,
         nidm_qValueFDR: = "0.0483657513246105" %% xsd:float])
-    entity(niiri:690f349d00c402f64f9afef69a04d47d,
+    entity(niiri:8beacede341a47f3167389d2db31c511,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0081" %% xsd:string,
         nidm_coordinateVector: = "[4,-86,38]" %% xsd:string])
-    wasDerivedFrom(niiri:c4b0c9d7d5bf10ed940aa36f9a2898fc, niiri:3592a75cac312314b4a818b743916efd, -, -, -)
-    entity(niiri:6f1dcaa9702ce8b1e56004f2e154bcc7,
+    wasDerivedFrom(niiri:d03d3f46620d80d545af7b487f982e5b, niiri:4c53636a1293cd4482cb63ff70691d79, -, -, -)
+    entity(niiri:26a9a6f6ecb327e047fbdaf46b98bd6e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0082" %% xsd:string,
-        prov:location = 'niiri:6579bb9b7980bc6caf30f72d161dccb3',
+        prov:location = 'niiri:1be4f6ad62254ca44faf09f21e98b4ef',
         prov:value = "5.08291101455688" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21739172198432" %% xsd:float,
         nidm_pValueUncorrected: = "0.000646809225746448" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999996" %% xsd:float,
         nidm_qValueFDR: = "0.0489980390158314" %% xsd:float])
-    entity(niiri:6579bb9b7980bc6caf30f72d161dccb3,
+    entity(niiri:1be4f6ad62254ca44faf09f21e98b4ef,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0082" %% xsd:string,
         nidm_coordinateVector: = "[-14,-50,-36]" %% xsd:string])
-    wasDerivedFrom(niiri:6f1dcaa9702ce8b1e56004f2e154bcc7, niiri:a457cd8f3b3381f0a12661e0907b556a, -, -, -)
-    entity(niiri:bb4e0dcfa0ad034c05e92f6d076501cb,
+    wasDerivedFrom(niiri:26a9a6f6ecb327e047fbdaf46b98bd6e, niiri:2b3b2f5817481e92102b214f3bf33995, -, -, -)
+    entity(niiri:eed8b6f60fa2ab238d44784bc24f49fc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0083" %% xsd:string,
-        prov:location = 'niiri:1a121ade9e841ce8da6580e606ec3b7b',
+        prov:location = 'niiri:f840d99aa197bd8d4fa2aca6525dd6b6',
         prov:value = "5.0689902305603" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21080328886987" %% xsd:float,
         nidm_pValueUncorrected: = "0.000661822545445001" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
         nidm_qValueFDR: = "0.0496832380294054" %% xsd:float])
-    entity(niiri:1a121ade9e841ce8da6580e606ec3b7b,
+    entity(niiri:f840d99aa197bd8d4fa2aca6525dd6b6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0083" %% xsd:string,
         nidm_coordinateVector: = "[30,68,10]" %% xsd:string])
-    wasDerivedFrom(niiri:bb4e0dcfa0ad034c05e92f6d076501cb, niiri:698306b72f010c2b2851ac92120e72d6, -, -, -)
-    entity(niiri:77969ad2ea1b902a3de4c5dfa8bce613,
+    wasDerivedFrom(niiri:eed8b6f60fa2ab238d44784bc24f49fc, niiri:86437031e803eee8517a97d2e8420009, -, -, -)
+    entity(niiri:5e7cb532886034b9c21ce9230724cf4e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0084" %% xsd:string,
-        prov:location = 'niiri:ee032b83f3abbbdb30b2a62197d9e399',
+        prov:location = 'niiri:fa765c1dff998dba8cec43964f9fd0ac',
         prov:value = "5.05907249450684" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20610225272296" %% xsd:float,
         nidm_pValueUncorrected: = "0.000672730842027125" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
         nidm_qValueFDR: = "0.0501943510982274" %% xsd:float])
-    entity(niiri:ee032b83f3abbbdb30b2a62197d9e399,
+    entity(niiri:fa765c1dff998dba8cec43964f9fd0ac,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0084" %% xsd:string,
         nidm_coordinateVector: = "[10,-30,80]" %% xsd:string])
-    wasDerivedFrom(niiri:77969ad2ea1b902a3de4c5dfa8bce613, niiri:5d9c59bbe6ff835dfd7a715340e2d8b7, -, -, -)
-    entity(niiri:0bc108a04fa102d651c09d417f06163e,
+    wasDerivedFrom(niiri:5e7cb532886034b9c21ce9230724cf4e, niiri:927385c4b1c66020878360a5006a3e3b, -, -, -)
+    entity(niiri:3b0256e0257667bc847e43ec82712c6a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0085" %% xsd:string,
-        prov:location = 'niiri:85320af157905fd663b941a235d3c218',
+        prov:location = 'niiri:0513413f42049f48fad742e27fa4823c',
         prov:value = "5.05790328979492" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20554765226523" %% xsd:float,
         nidm_pValueUncorrected: = "0.000674028618936839" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
         nidm_qValueFDR: = "0.0502551505802037" %% xsd:float])
-    entity(niiri:85320af157905fd663b941a235d3c218,
+    entity(niiri:0513413f42049f48fad742e27fa4823c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0085" %% xsd:string,
         nidm_coordinateVector: = "[44,-76,8]" %% xsd:string])
-    wasDerivedFrom(niiri:0bc108a04fa102d651c09d417f06163e, niiri:8cb05ce5ff1f36539390753e60f586ff, -, -, -)
-    entity(niiri:9ad0a5fb1e4870a3f1763d5f1630bf32,
+    wasDerivedFrom(niiri:3b0256e0257667bc847e43ec82712c6a, niiri:0087c0fa9854a20b9b26757b4c0e9a68, -, -, -)
+    entity(niiri:546a3ae2919066aba8b04feb7eaf222b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0086" %% xsd:string,
-        prov:location = 'niiri:3906fb2e94c751bdf7ed2d37f73381e1',
+        prov:location = 'niiri:711f068fef9833519c8dc8540cb0ba53',
         prov:value = "5.04969549179077" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20165202224461" %% xsd:float,
         nidm_pValueUncorrected: = "0.000683209765197312" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999999" %% xsd:float,
         nidm_qValueFDR: = "0.050613270744433" %% xsd:float])
-    entity(niiri:3906fb2e94c751bdf7ed2d37f73381e1,
+    entity(niiri:711f068fef9833519c8dc8540cb0ba53,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0086" %% xsd:string,
         nidm_coordinateVector: = "[-52,-36,44]" %% xsd:string])
-    wasDerivedFrom(niiri:9ad0a5fb1e4870a3f1763d5f1630bf32, niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5, -, -, -)
-    entity(niiri:f5ef66098a9f9c1e70f89f697490eeaf,
+    wasDerivedFrom(niiri:546a3ae2919066aba8b04feb7eaf222b, niiri:679d2ced08c3de3ec63ab76190f2d86d, -, -, -)
+    entity(niiri:3c565a898ce1cb8d1a32498833886420,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0087" %% xsd:string,
-        prov:location = 'niiri:e86bfb71232ecd6e43bcb633d2431b88',
+        prov:location = 'niiri:d1361e7764f4b544072c31608b9db437',
         prov:value = "5.02838468551636" %% xsd:float,
         nidm_equivalentZStatistic: = "3.19151815181806" %% xsd:float,
         nidm_pValueUncorrected: = "0.000707636089146368" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.051650625154872" %% xsd:float])
-    entity(niiri:e86bfb71232ecd6e43bcb633d2431b88,
+    entity(niiri:d1361e7764f4b544072c31608b9db437,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0087" %% xsd:string,
         nidm_coordinateVector: = "[-44,-40,42]" %% xsd:string])
-    wasDerivedFrom(niiri:f5ef66098a9f9c1e70f89f697490eeaf, niiri:08144c2f2914ca0e8f2d5090a382dd9c, -, -, -)
-    entity(niiri:f701ebe269b6e286af398dc8db3aa776,
+    wasDerivedFrom(niiri:3c565a898ce1cb8d1a32498833886420, niiri:302d0ae98bffba69292672583d115e8c, -, -, -)
+    entity(niiri:895ab0cb66ad5fe2b8f0ccfda413020f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0088" %% xsd:string,
-        prov:location = 'niiri:5e45ebc90297b83e805af2fa5c27599d',
+        prov:location = 'niiri:f2b167b359b019d6526e5256b4b2a4e7',
         prov:value = "5.02759695053101" %% xsd:float,
         nidm_equivalentZStatistic: = "3.19114302879552" %% xsd:float,
         nidm_pValueUncorrected: = "0.00070855553886906" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0516996133446043" %% xsd:float])
-    entity(niiri:5e45ebc90297b83e805af2fa5c27599d,
+    entity(niiri:f2b167b359b019d6526e5256b4b2a4e7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0088" %% xsd:string,
         nidm_coordinateVector: = "[-44,54,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:f701ebe269b6e286af398dc8db3aa776, niiri:20fdb21c4b6e1b56aba03dc17e6e0cad, -, -, -)
-    entity(niiri:ea882a65b0dfd559a13cfe9234c2c24d,
+    wasDerivedFrom(niiri:895ab0cb66ad5fe2b8f0ccfda413020f, niiri:f443e4b03660a8ad618e307479bf8a95, -, -, -)
+    entity(niiri:38744d312469d30ea2aad6e112efd815,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0089" %% xsd:string,
-        prov:location = 'niiri:ea22c84ed8e7c73c83ed6c329b8aa7db',
+        prov:location = 'niiri:4e8ff56debee785959e0deb820ab4223',
         prov:value = "5.00743103027344" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18152691683286" %% xsd:float,
         nidm_pValueUncorrected: = "0.000732504543232371" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0526896959368281" %% xsd:float])
-    entity(niiri:ea22c84ed8e7c73c83ed6c329b8aa7db,
+    entity(niiri:4e8ff56debee785959e0deb820ab4223,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0089" %% xsd:string,
         nidm_coordinateVector: = "[36,58,18]" %% xsd:string])
-    wasDerivedFrom(niiri:ea882a65b0dfd559a13cfe9234c2c24d, niiri:b16302312e147e9c8ce1bdd421f19045, -, -, -)
-    entity(niiri:a610e963c32e5f537ce4379d79a33677,
+    wasDerivedFrom(niiri:38744d312469d30ea2aad6e112efd815, niiri:80e9d7b2bd34593272f3fb19fc9254e9, -, -, -)
+    entity(niiri:6d61e7dcb92b6e6b6f64536ea335f5e2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0090" %% xsd:string,
-        prov:location = 'niiri:e137a7aa81cf8b25e12262b0d38b2162',
+        prov:location = 'niiri:19af79f4d565155ceba8d4b51e598b73',
         prov:value = "4.99766159057617" %% xsd:float,
         nidm_equivalentZStatistic: = "3.17685933085535" %% xsd:float,
         nidm_pValueUncorrected: = "0.000744396146822202" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0532506765476335" %% xsd:float])
-    entity(niiri:e137a7aa81cf8b25e12262b0d38b2162,
+    entity(niiri:19af79f4d565155ceba8d4b51e598b73,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0090" %% xsd:string,
         nidm_coordinateVector: = "[-44,22,40]" %% xsd:string])
-    wasDerivedFrom(niiri:a610e963c32e5f537ce4379d79a33677, niiri:9e57216b41802f20cbaf2104bd85f6ec, -, -, -)
-    entity(niiri:8a5fcc105ffc1799aa129242dff957a1,
+    wasDerivedFrom(niiri:6d61e7dcb92b6e6b6f64536ea335f5e2, niiri:91bc3a2972b2938504904a8d68057f2e, -, -, -)
+    entity(niiri:9a1ce2e69e3dbc416c997bb0ba8cf8fa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0091" %% xsd:string,
-        prov:location = 'niiri:9189a192e96af6b4e8a8d551eda8ce86',
+        prov:location = 'niiri:ddbc2b5e1f26927e114e09c84b260fdd',
         prov:value = "4.98628282546997" %% xsd:float,
         nidm_equivalentZStatistic: = "3.1714153864203" %% xsd:float,
         nidm_pValueUncorrected: = "0.00075849026901309" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0537320048825192" %% xsd:float])
-    entity(niiri:9189a192e96af6b4e8a8d551eda8ce86,
+    entity(niiri:ddbc2b5e1f26927e114e09c84b260fdd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0091" %% xsd:string,
         nidm_coordinateVector: = "[32,-24,72]" %% xsd:string])
-    wasDerivedFrom(niiri:8a5fcc105ffc1799aa129242dff957a1, niiri:002e00007a510fe7b30fd39adc263872, -, -, -)
-    entity(niiri:048dfb27e0ec2f8c989f283aa5001023,
+    wasDerivedFrom(niiri:9a1ce2e69e3dbc416c997bb0ba8cf8fa, niiri:681cc93cdfd04b41012417cfd725953f, -, -, -)
+    entity(niiri:1e37e838816ab673f5b1a0e528a618fb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0092" %% xsd:string,
-        prov:location = 'niiri:730207a65b3cc9b8b3494340623e3fad',
+        prov:location = 'niiri:b33af54063165da162cc0a06d18506f6',
         prov:value = "4.97769069671631" %% xsd:float,
         nidm_equivalentZStatistic: = "3.16729931357798" %% xsd:float,
         nidm_pValueUncorrected: = "0.000769309331678514" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0542313534025412" %% xsd:float])
-    entity(niiri:730207a65b3cc9b8b3494340623e3fad,
+    entity(niiri:b33af54063165da162cc0a06d18506f6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0092" %% xsd:string,
         nidm_coordinateVector: = "[50,-30,60]" %% xsd:string])
-    wasDerivedFrom(niiri:048dfb27e0ec2f8c989f283aa5001023, niiri:2b00f1f0bcfadf17e4e74a633d9cbe02, -, -, -)
-    entity(niiri:4a609db5a795868ef47abe1fb286fd19,
+    wasDerivedFrom(niiri:1e37e838816ab673f5b1a0e528a618fb, niiri:1288217d5c8b70c54915067a87402187, -, -, -)
+    entity(niiri:af091ddb51f232e6c9bd315c31128cde,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0093" %% xsd:string,
-        prov:location = 'niiri:dfeb92f46265f28e2d20e5b1a396299e',
+        prov:location = 'niiri:a3d5999988833de22efee90511c9be29',
         prov:value = "4.95973443984985" %% xsd:float,
         nidm_equivalentZStatistic: = "3.15868244743865" %% xsd:float,
         nidm_pValueUncorrected: = "0.000792420371319991" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.05524320395595" %% xsd:float])
-    entity(niiri:dfeb92f46265f28e2d20e5b1a396299e,
+    entity(niiri:a3d5999988833de22efee90511c9be29,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0093" %% xsd:string,
         nidm_coordinateVector: = "[-32,-74,-28]" %% xsd:string])
-    wasDerivedFrom(niiri:4a609db5a795868ef47abe1fb286fd19, niiri:0a99da6db6ffdb6abd70dfec062dacc6, -, -, -)
-    entity(niiri:72e747c045e6ce18c7ea2d8872ec01bd,
+    wasDerivedFrom(niiri:af091ddb51f232e6c9bd315c31128cde, niiri:9a33ec7dcbaf4c333c9be7973d3674ae, -, -, -)
+    entity(niiri:040db063243906b03c972dbf813f1e8f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0094" %% xsd:string,
-        prov:location = 'niiri:3d10b3a98099f6ac7bd61e8504591520',
+        prov:location = 'niiri:c2ea305012d99e2652d0a3896a349455',
         prov:value = "4.95515823364258" %% xsd:float,
         nidm_equivalentZStatistic: = "3.15648318111342" %% xsd:float,
         nidm_pValueUncorrected: = "0.000798420481037398" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0553418612137989" %% xsd:float])
-    entity(niiri:3d10b3a98099f6ac7bd61e8504591520,
+    entity(niiri:c2ea305012d99e2652d0a3896a349455,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0094" %% xsd:string,
         nidm_coordinateVector: = "[-26,-86,40]" %% xsd:string])
-    wasDerivedFrom(niiri:72e747c045e6ce18c7ea2d8872ec01bd, niiri:ee9edf2a051832c657f8417f27f95a8f, -, -, -)
-    entity(niiri:26738ed1bfc7ad05331c2ac978006528,
+    wasDerivedFrom(niiri:040db063243906b03c972dbf813f1e8f, niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73, -, -, -)
+    entity(niiri:5eaeb3f75f7650cb74f379ed173f7e58,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0095" %% xsd:string,
-        prov:location = 'niiri:80998b0375b4ec6cd6d7875df2f956d9',
+        prov:location = 'niiri:c72bbf109b350d78e64ee37ee86ef87a',
         prov:value = "4.93855857849121" %% xsd:float,
         nidm_equivalentZStatistic: = "3.14849453487417" %% xsd:float,
         nidm_pValueUncorrected: = "0.000820568960055779" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0562262327439451" %% xsd:float])
-    entity(niiri:80998b0375b4ec6cd6d7875df2f956d9,
+    entity(niiri:c72bbf109b350d78e64ee37ee86ef87a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0095" %% xsd:string,
         nidm_coordinateVector: = "[-10,8,6]" %% xsd:string])
-    wasDerivedFrom(niiri:26738ed1bfc7ad05331c2ac978006528, niiri:db1e7cd2ec53abce67f4898eb3c88730, -, -, -)
-    entity(niiri:4b0a6177d3028a1d196d8e8644c68f46,
+    wasDerivedFrom(niiri:5eaeb3f75f7650cb74f379ed173f7e58, niiri:99af69862e054a4c62b8e6066ff12cfd, -, -, -)
+    entity(niiri:3716c38360149956c53c557239c91fd7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0096" %% xsd:string,
-        prov:location = 'niiri:e2315b6373bae1a1a264e9e11bacd9c2',
+        prov:location = 'niiri:8947ac3de97fe88382a65c163f842436',
         prov:value = "4.90264129638672" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13114947632107" %% xsd:float,
         nidm_pValueUncorrected: = "0.000870617549853403" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.058320641241518" %% xsd:float])
-    entity(niiri:e2315b6373bae1a1a264e9e11bacd9c2,
+    entity(niiri:8947ac3de97fe88382a65c163f842436,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0096" %% xsd:string,
         nidm_coordinateVector: = "[14,8,10]" %% xsd:string])
-    wasDerivedFrom(niiri:4b0a6177d3028a1d196d8e8644c68f46, niiri:1066c8d3aa41693bfd354d1824cc7afe, -, -, -)
-    entity(niiri:6c657d496e9b2f580793789f0903637f,
+    wasDerivedFrom(niiri:3716c38360149956c53c557239c91fd7, niiri:20fc427845c2a14183959299a0d233ce, -, -, -)
+    entity(niiri:17f311b4781af2c645292f1b0c08e56c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0097" %% xsd:string,
-        prov:location = 'niiri:92223eda5bee2fa6366d50cdb0ad17ae',
+        prov:location = 'niiri:90f614e5e280a7d031215612221686fb',
         prov:value = "4.90243864059448" %% xsd:float,
         nidm_equivalentZStatistic: = "3.1310513773308" %% xsd:float,
         nidm_pValueUncorrected: = "0.000870908426383377" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.058320641241518" %% xsd:float])
-    entity(niiri:92223eda5bee2fa6366d50cdb0ad17ae,
+    entity(niiri:90f614e5e280a7d031215612221686fb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0097" %% xsd:string,
         nidm_coordinateVector: = "[-20,-54,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:6c657d496e9b2f580793789f0903637f, niiri:176e7ef375f6f1d2e26f1a064f8f6d39, -, -, -)
-    entity(niiri:a9f12b36f390508d489680fa6cd977ef,
+    wasDerivedFrom(niiri:17f311b4781af2c645292f1b0c08e56c, niiri:0294b8b1f3c4b525a18397bf17d17d63, -, -, -)
+    entity(niiri:261827ec7c4ac6d56b850bf7be1a0995,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0098" %% xsd:string,
-        prov:location = 'niiri:400d143354fecfac34d7ed6f2f74e6d2',
+        prov:location = 'niiri:0dc46ac23cbc0284b413f46af5e9b5bf',
         prov:value = "4.88119602203369" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12075392909771" %% xsd:float,
         nidm_pValueUncorrected: = "0.000901943498395119" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0594947205600118" %% xsd:float])
-    entity(niiri:400d143354fecfac34d7ed6f2f74e6d2,
+    entity(niiri:0dc46ac23cbc0284b413f46af5e9b5bf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0098" %% xsd:string,
         nidm_coordinateVector: = "[-26,-84,44]" %% xsd:string])
-    wasDerivedFrom(niiri:a9f12b36f390508d489680fa6cd977ef, niiri:08a3f7b7f6c942ab91160dfccbb968f2, -, -, -)
-    entity(niiri:41ef706109f70aebe1bd69047789d6e8,
+    wasDerivedFrom(niiri:261827ec7c4ac6d56b850bf7be1a0995, niiri:3dc796cbf0403561b0e6ea42b96ea1a9, -, -, -)
+    entity(niiri:2ae246317f788cd3eeea499f36da2784,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0099" %% xsd:string,
-        prov:location = 'niiri:832aed24b7e9f89f7aac213df0041827',
+        prov:location = 'niiri:ba8c00af87b3e78bc9d96bf0d493697c',
         prov:value = "4.86706686019897" %% xsd:float,
         nidm_equivalentZStatistic: = "3.11388868389685" %% xsd:float,
         nidm_pValueUncorrected: = "0.000923195680083033" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0603762016821821" %% xsd:float])
-    entity(niiri:832aed24b7e9f89f7aac213df0041827,
+    entity(niiri:ba8c00af87b3e78bc9d96bf0d493697c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0099" %% xsd:string,
         nidm_coordinateVector: = "[-54,22,10]" %% xsd:string])
-    wasDerivedFrom(niiri:41ef706109f70aebe1bd69047789d6e8, niiri:bddc2499a043f720b9c5a3c2a309f42c, -, -, -)
-    entity(niiri:b47830006cf1b3f215bc9fd3e64ca371,
+    wasDerivedFrom(niiri:2ae246317f788cd3eeea499f36da2784, niiri:14518885ee853fba951013cf73f66bed, -, -, -)
+    entity(niiri:e7bbc2a18733379b4ba6e4c9b9da44fa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0100" %% xsd:string,
-        prov:location = 'niiri:d9dbb81cee63c9d429edaac681bad88e',
+        prov:location = 'niiri:8726957d4cdde9d04e29bbe51a70e336',
         prov:value = "4.84812355041504" %% xsd:float,
         nidm_equivalentZStatistic: = "3.10466401400555" %% xsd:float,
         nidm_pValueUncorrected: = "0.000952476397051205" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0616422795595169" %% xsd:float])
-    entity(niiri:d9dbb81cee63c9d429edaac681bad88e,
+    entity(niiri:8726957d4cdde9d04e29bbe51a70e336,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0100" %% xsd:string,
         nidm_coordinateVector: = "[32,-80,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:b47830006cf1b3f215bc9fd3e64ca371, niiri:189d9d696ac51ec44003eb5f973b6c64, -, -, -)
-    entity(niiri:e92e382c720879269b6002714e4a16ac,
+    wasDerivedFrom(niiri:e7bbc2a18733379b4ba6e4c9b9da44fa, niiri:7666b1a689a3839cdadb86af5e5c7c39, -, -, -)
+    entity(niiri:38f3fc0e0c53bc3fde20e9f5bbf1c52d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0101" %% xsd:string,
-        prov:location = 'niiri:dde3f75099fb3b6b61a79003461a2d21',
+        prov:location = 'niiri:97cc916bbf9c73be7bceb77865458446',
         prov:value = "4.82597017288208" %% xsd:float,
         nidm_equivalentZStatistic: = "3.09384653195936" %% xsd:float,
         nidm_pValueUncorrected: = "0.00098789830908641" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0629671631402158" %% xsd:float])
-    entity(niiri:dde3f75099fb3b6b61a79003461a2d21,
+    entity(niiri:97cc916bbf9c73be7bceb77865458446,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0101" %% xsd:string,
         nidm_coordinateVector: = "[10,-80,4]" %% xsd:string])
-    wasDerivedFrom(niiri:e92e382c720879269b6002714e4a16ac, niiri:5d37a307684854af5c2a17ddbdb8f17f, -, -, -)
-    entity(niiri:b3a2d1e439fbf61d76d02cbdc713f8d9,
+    wasDerivedFrom(niiri:38f3fc0e0c53bc3fde20e9f5bbf1c52d, niiri:2cac2c4baab8136a53bdf03e74fdc1c5, -, -, -)
+    entity(niiri:c9916a684f8ab6fd7ebe1ce3907a9b34,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0102" %% xsd:string,
-        prov:location = 'niiri:434dda457215299529b6e3b3f80e543c',
+        prov:location = 'niiri:302777c17a3ab317d1e6b6ffd24666ff',
         prov:value = "4.82537364959717" %% xsd:float,
         nidm_equivalentZStatistic: = "3.09355480628341" %% xsd:float,
         nidm_pValueUncorrected: = "0.000988870098138084" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0629727239584754" %% xsd:float])
-    entity(niiri:434dda457215299529b6e3b3f80e543c,
+    entity(niiri:302777c17a3ab317d1e6b6ffd24666ff,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0102" %% xsd:string,
         nidm_coordinateVector: = "[16,-50,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:b3a2d1e439fbf61d76d02cbdc713f8d9, niiri:df310d7fb2c5397364d68a8d3fa65bc0, -, -, -)
-    entity(niiri:5c2c228fe7c73da50c74454b38d9ce4f,
+    wasDerivedFrom(niiri:c9916a684f8ab6fd7ebe1ce3907a9b34, niiri:8768acb96e7e44e4cd45548f0d52dd3f, -, -, -)
+    entity(niiri:380422cca8da791d72bac3c9bd4f903f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0103" %% xsd:string,
-        prov:location = 'niiri:83a52daf4eb7997573701f3945da1301',
+        prov:location = 'niiri:6f88b65eb9c9991d816265aa7f3ca79a',
         prov:value = "4.82024002075195" %% xsd:float,
         nidm_equivalentZStatistic: = "3.09104327517968" %% xsd:float,
         nidm_pValueUncorrected: = "0.000997272813291428" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0632678542871923" %% xsd:float])
-    entity(niiri:83a52daf4eb7997573701f3945da1301,
+    entity(niiri:6f88b65eb9c9991d816265aa7f3ca79a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0103" %% xsd:string,
         nidm_coordinateVector: = "[-12,-20,12]" %% xsd:string])
-    wasDerivedFrom(niiri:5c2c228fe7c73da50c74454b38d9ce4f, niiri:d0abba065cadfdf673c1ba317a4155ef, -, -, -)
+    wasDerivedFrom(niiri:380422cca8da791d72bac3c9bd4f903f, niiri:816f19a8ef8789235a9bd7bfe4396a14, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_f_test/nidm.provn
+++ b/spmexport/ex_spm_f_test/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:e7c622c060f6ce4999c83cd4e7d504a2,
+  entity(niiri:94350a30508710a81c55188bdb54b3a9,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:64a0a1e03c4e2566a0c7d5a14157ea25,
+  agent(niiri:c3ce6e8455b93d01b003f62798403114,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:4547ccdcb0181d8f245befc50dcc96be,
+  activity(niiri:b12f70ab92b50ab520c458bd3f6fcd10,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:4547ccdcb0181d8f245befc50dcc96be, niiri:64a0a1e03c4e2566a0c7d5a14157ea25, -)
-  wasGeneratedBy(niiri:e7c622c060f6ce4999c83cd4e7d504a2, niiri:4547ccdcb0181d8f245befc50dcc96be, 2016-01-11T10:33:38)
-  bundle niiri:e7c622c060f6ce4999c83cd4e7d504a2
+  wasAssociatedWith(niiri:b12f70ab92b50ab520c458bd3f6fcd10, niiri:c3ce6e8455b93d01b003f62798403114, -)
+  wasGeneratedBy(niiri:94350a30508710a81c55188bdb54b3a9, niiri:b12f70ab92b50ab520c458bd3f6fcd10, 2016-01-11T10:43:58)
+  bundle niiri:94350a30508710a81c55188bdb54b3a9
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -127,12 +127,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:a9aa267d850571686083e814acacec85,
+    agent(niiri:ea8d144ccce6489b92b187acdc792bec,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:8631110ecbf1ae2c61c651d3c345e53a,
+    entity(niiri:3afab7fbc0c106b802099cf168ca0377,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -141,189 +141,189 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:4065e9c0832a79eea2d7f48f6837481b,
+    entity(niiri:680b19ae5cf36bf681e8dbe95af38dc2,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:6aef7089ce827a6b71f19c009ab15a95,
+    entity(niiri:3af050cd6585ce5a06f1b07cb80ed0e0,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:ea225237d5825ad08d76e698758e674b,
+    entity(niiri:a0660d4d7fa510f658959260466e1e3e,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:1a0a5cc4df2739bc50811b7823bb401e',
+        dc:description = 'niiri:eaa7306a1252a08b865632eb736793e2',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:6aef7089ce827a6b71f19c009ab15a95',
+        nidm_hasDriftModel: = 'niiri:3af050cd6585ce5a06f1b07cb80ed0e0',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:1a0a5cc4df2739bc50811b7823bb401e,
+    entity(niiri:eaa7306a1252a08b865632eb736793e2,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:b5697884a43743feb7d20368b80f55a9,
+    entity(niiri:0bd8aede66fc8be9ae3875eb95a27342,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:3c0b88356def21e2b7fe83f740cf597b,
+    activity(niiri:9d8cf492466560d50918318864025c61,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:3c0b88356def21e2b7fe83f740cf597b, niiri:a9aa267d850571686083e814acacec85, -)
-    used(niiri:3c0b88356def21e2b7fe83f740cf597b, niiri:ea225237d5825ad08d76e698758e674b, -)
-    used(niiri:3c0b88356def21e2b7fe83f740cf597b, niiri:4065e9c0832a79eea2d7f48f6837481b, -)
-    used(niiri:3c0b88356def21e2b7fe83f740cf597b, niiri:b5697884a43743feb7d20368b80f55a9, -)
-    entity(niiri:dd3a1b34bce9178ca5eb9e0c6f64572b,
+    wasAssociatedWith(niiri:9d8cf492466560d50918318864025c61, niiri:ea8d144ccce6489b92b187acdc792bec, -)
+    used(niiri:9d8cf492466560d50918318864025c61, niiri:a0660d4d7fa510f658959260466e1e3e, -)
+    used(niiri:9d8cf492466560d50918318864025c61, niiri:680b19ae5cf36bf681e8dbe95af38dc2, -)
+    used(niiri:9d8cf492466560d50918318864025c61, niiri:0bd8aede66fc8be9ae3875eb95a27342, -)
+    entity(niiri:4a2baf3c1d8fbb1b78319c1483b1b28e,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377',
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    entity(niiri:f081077fa790becea31f832bed0ad762,
+    entity(niiri:c6ef8881327f7dbd655c5bd684eddd5f,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
-    wasDerivedFrom(niiri:dd3a1b34bce9178ca5eb9e0c6f64572b, niiri:f081077fa790becea31f832bed0ad762, -, -, -)
-    wasGeneratedBy(niiri:dd3a1b34bce9178ca5eb9e0c6f64572b, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:a45718cdddcc1f52a7095a49c028bc7b,
+    wasDerivedFrom(niiri:4a2baf3c1d8fbb1b78319c1483b1b28e, niiri:c6ef8881327f7dbd655c5bd684eddd5f, -, -, -)
+    wasGeneratedBy(niiri:4a2baf3c1d8fbb1b78319c1483b1b28e, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:e32ad7d6a1d3a7b17810d670e8fd072a,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "108.038318634033" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377',
         crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
-    wasGeneratedBy(niiri:a45718cdddcc1f52a7095a49c028bc7b, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:855ff1743625270dda4931a04ecd1031,
+    wasGeneratedBy(niiri:e32ad7d6a1d3a7b17810d670e8fd072a, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:fc7a2a7c4dc5f4907189ccf4e254bef8,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
-    entity(niiri:97dfe474f83a8bb5d149d855133a64bc,
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377'])
+    entity(niiri:0b1ee3d8ddfaddb3225d71c6fa48f10d,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "11c208792e1874b4837ea90ec03320c8eeb702ad3966ee5912aa2e33b5bdb17b0e88caa31ed546f7f601160ced8eceebdf5db6449df6ec3ffbd17e27917ec328" %% xsd:string])
-    wasDerivedFrom(niiri:855ff1743625270dda4931a04ecd1031, niiri:97dfe474f83a8bb5d149d855133a64bc, -, -, -)
-    wasGeneratedBy(niiri:855ff1743625270dda4931a04ecd1031, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:4fbc59d57cc5244670a944301b75c49e,
+    wasDerivedFrom(niiri:fc7a2a7c4dc5f4907189ccf4e254bef8, niiri:0b1ee3d8ddfaddb3225d71c6fa48f10d, -, -, -)
+    wasGeneratedBy(niiri:fc7a2a7c4dc5f4907189ccf4e254bef8, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:7f0262e97145372a803588a6101fa2ae,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
-    entity(niiri:552b132ff1cb3c6356eed45cfba091e2,
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377'])
+    entity(niiri:e157b91be2875d773dbb473a64e2fe41,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
-    wasDerivedFrom(niiri:4fbc59d57cc5244670a944301b75c49e, niiri:552b132ff1cb3c6356eed45cfba091e2, -, -, -)
-    wasGeneratedBy(niiri:4fbc59d57cc5244670a944301b75c49e, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:4fcd0feb226f491d94d19ede647cf6df,
+    wasDerivedFrom(niiri:7f0262e97145372a803588a6101fa2ae, niiri:e157b91be2875d773dbb473a64e2fe41, -, -, -)
+    wasGeneratedBy(niiri:7f0262e97145372a803588a6101fa2ae, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:52b5f0dfeef5a989ceb73981bb38aea1,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
-    entity(niiri:47beaf2666652e2dfc40b9d59975b754,
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377'])
+    entity(niiri:5a6aaf833cfaf0d24c2ee98156b45a17,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "833a477bd4e758bdde7fcc9e6682186e9e38c1eeaa2a66de7d67e5f3c57cbaed7bddd45a7f7c86db713a8aa708790eaa31e0d8f0d0af9db9e87b545990b9e91e" %% xsd:string])
-    wasDerivedFrom(niiri:4fcd0feb226f491d94d19ede647cf6df, niiri:47beaf2666652e2dfc40b9d59975b754, -, -, -)
-    wasGeneratedBy(niiri:4fcd0feb226f491d94d19ede647cf6df, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:b1423cdb1726cd9674ebf1bcab3bcf56,
+    wasDerivedFrom(niiri:52b5f0dfeef5a989ceb73981bb38aea1, niiri:5a6aaf833cfaf0d24c2ee98156b45a17, -, -, -)
+    wasGeneratedBy(niiri:52b5f0dfeef5a989ceb73981bb38aea1, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:54d1aded0ce58fe08df4293d8ceddadf,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
-    entity(niiri:8e1176bdcc74a45839a55e6b1d4afb84,
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377'])
+    entity(niiri:917bda9ca5a5cd276b5de3dd367e6ec4,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "8044c2e517efad185114b1d5478983a5073547d99f6b5778bcefe9caa7d243b89824b69841e3e5aa05e1da5393c9d1a34fec9a050b6a1e8a87da31cad99bfe69" %% xsd:string])
-    wasDerivedFrom(niiri:b1423cdb1726cd9674ebf1bcab3bcf56, niiri:8e1176bdcc74a45839a55e6b1d4afb84, -, -, -)
-    wasGeneratedBy(niiri:b1423cdb1726cd9674ebf1bcab3bcf56, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:15b31a17ded6db8183340b7bf088bf97,
+    wasDerivedFrom(niiri:54d1aded0ce58fe08df4293d8ceddadf, niiri:917bda9ca5a5cd276b5de3dd367e6ec4, -, -, -)
+    wasGeneratedBy(niiri:54d1aded0ce58fe08df4293d8ceddadf, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:c17ccb3d27e2d45265ebedf07304238f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
-    entity(niiri:345e3096159163131e4b2fc7f1ed4857,
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377'])
+    entity(niiri:1de788620c205e069ddf02ffd1a53060,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "15551a7f3970720338fd0643bd017ba2f7f5db09c16b38909560b0479aa69eb74cd746fa98b2adc796153af88fba9b2ddd4eb5713b6f6011e62b7efb6531426d" %% xsd:string])
-    wasDerivedFrom(niiri:15b31a17ded6db8183340b7bf088bf97, niiri:345e3096159163131e4b2fc7f1ed4857, -, -, -)
-    wasGeneratedBy(niiri:15b31a17ded6db8183340b7bf088bf97, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:08de3e9dd167da4e0236e06f6ffa9f7a,
+    wasDerivedFrom(niiri:c17ccb3d27e2d45265ebedf07304238f, niiri:1de788620c205e069ddf02ffd1a53060, -, -, -)
+    wasGeneratedBy(niiri:c17ccb3d27e2d45265ebedf07304238f, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:4851c787a436167f4a71edf42259ba00,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 6" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a'])
-    entity(niiri:77879d25adca01d9f67bf80353db2ca6,
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377'])
+    entity(niiri:1d9572dddd28e78581bf46f4943a00b3,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0006.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
-    wasDerivedFrom(niiri:08de3e9dd167da4e0236e06f6ffa9f7a, niiri:77879d25adca01d9f67bf80353db2ca6, -, -, -)
-    wasGeneratedBy(niiri:08de3e9dd167da4e0236e06f6ffa9f7a, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:3406078060d97913cb8d424d34703ab9,
+    wasDerivedFrom(niiri:4851c787a436167f4a71edf42259ba00, niiri:1d9572dddd28e78581bf46f4943a00b3, -, -, -)
+    wasGeneratedBy(niiri:4851c787a436167f4a71edf42259ba00, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:044de1fe963ba759e42829a1aa90a533,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377',
         crypto:sha512 = "9f1acf4f335317f388cc8adcc04086aa4e6bc6d19d5633a6a8d8dd85716386748c7ed700ef8031c7a3733228557d5ecf96eb6a889e2d36ad065e7bc852ae0b8c" %% xsd:string])
-    entity(niiri:c636630fb563318d5b35ab4a8b0a34c0,
+    entity(niiri:e7cb96c8612281b1aa20712f5ab8d78a,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "641184631587ff0ed74f92302d94dd40f2802efab358753eade14667fb6ee74fe64f3090b02fdf20e4a99d444610a61a1ae8a684628c9b2037535fbed9d53a12" %% xsd:string])
-    wasDerivedFrom(niiri:3406078060d97913cb8d424d34703ab9, niiri:c636630fb563318d5b35ab4a8b0a34c0, -, -, -)
-    wasGeneratedBy(niiri:3406078060d97913cb8d424d34703ab9, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:345400b745ebe143b4f453e4c217c209,
+    wasDerivedFrom(niiri:044de1fe963ba759e42829a1aa90a533, niiri:e7cb96c8612281b1aa20712f5ab8d78a, -, -, -)
+    wasGeneratedBy(niiri:044de1fe963ba759e42829a1aa90a533, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:fde6c201825e0d228d8f071226d6df72,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377',
         crypto:sha512 = "a093dd7a9dd81e95f3696221e49cbb3ad8080b1f316ece53c9aafcb5cc9b767e55c594b7131d933e31231744c65db07483e64245480afd95075b76ccd2432789" %% xsd:string])
-    entity(niiri:774ad877e270db9e46dc564231f1b2e3,
+    entity(niiri:bb6e9ede0fb10dff1545bbf67b08e145,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "6ccf9e1895f8a26549f392b1d1a3676888cd729a207c6a93bcda6d549de2d4f133c0b2847bd2e839a462f3ba74cb9d9525eddb9f8499b99fb452b93cd713a158" %% xsd:string])
-    wasDerivedFrom(niiri:345400b745ebe143b4f453e4c217c209, niiri:774ad877e270db9e46dc564231f1b2e3, -, -, -)
-    wasGeneratedBy(niiri:345400b745ebe143b4f453e4c217c209, niiri:3c0b88356def21e2b7fe83f740cf597b, -)
-    entity(niiri:c9f72062391a92f26280783481f9d41e,
+    wasDerivedFrom(niiri:fde6c201825e0d228d8f071226d6df72, niiri:bb6e9ede0fb10dff1545bbf67b08e145, -, -, -)
+    wasGeneratedBy(niiri:fde6c201825e0d228d8f071226d6df72, niiri:9d8cf492466560d50918318864025c61, -)
+    entity(niiri:11535783db3c16f234c0a9a9c08eeff7,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_FStatistic:',
         nidm_contrastName: = "F Contrast Test" %% xsd:string,
         prov:label = "Contrast: F Contrast Test" %% xsd:string,
         prov:value = "[[1, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0],[0, 0, 0, 1, 0, 0]]" %% xsd:string])
-    activity(niiri:aedde2b1a02ad24ed234029b5dc86c0e,
+    activity(niiri:01c79625dd156fe0cc39d295e9a1bc02,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:a9aa267d850571686083e814acacec85, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:dd3a1b34bce9178ca5eb9e0c6f64572b, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:3406078060d97913cb8d424d34703ab9, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:ea225237d5825ad08d76e698758e674b, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:c9f72062391a92f26280783481f9d41e, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:855ff1743625270dda4931a04ecd1031, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:4fbc59d57cc5244670a944301b75c49e, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:4fcd0feb226f491d94d19ede647cf6df, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:b1423cdb1726cd9674ebf1bcab3bcf56, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:15b31a17ded6db8183340b7bf088bf97, -)
-    used(niiri:aedde2b1a02ad24ed234029b5dc86c0e, niiri:08de3e9dd167da4e0236e06f6ffa9f7a, -)
-    entity(niiri:b0e7b8f9e020e8724283e6191e2da703,
+    wasAssociatedWith(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:ea8d144ccce6489b92b187acdc792bec, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:4a2baf3c1d8fbb1b78319c1483b1b28e, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:044de1fe963ba759e42829a1aa90a533, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:a0660d4d7fa510f658959260466e1e3e, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:11535783db3c16f234c0a9a9c08eeff7, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:fc7a2a7c4dc5f4907189ccf4e254bef8, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:7f0262e97145372a803588a6101fa2ae, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:52b5f0dfeef5a989ceb73981bb38aea1, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:54d1aded0ce58fe08df4293d8ceddadf, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:c17ccb3d27e2d45265ebedf07304238f, -)
+    used(niiri:01c79625dd156fe0cc39d295e9a1bc02, niiri:4851c787a436167f4a71edf42259ba00, -)
+    entity(niiri:445e63a4c2b814664d88bb41eb6a0e93,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "FStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "FStatistic.nii.gz" %% xsd:string,
@@ -333,87 +333,87 @@ document
         nidm_contrastName: = "F Contrast Test" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.999999999651" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "3.99999999999962" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377',
         crypto:sha512 = "ca31a667d26797ee68a3709a8fa04f799ad113f17e6eff75ad6e88f53c44aa9e158a0d007354d454ad01df82d6b0f25f07b324cc3baa32f7623096a92ee6f304" %% xsd:string])
-    entity(niiri:27281b97c78d257b22887871c6a68112,
+    entity(niiri:b7a13b645ead1cd72ae3434790f2a7c3,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmF_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "db6d4200b2e060c1fbd3e5c71011ac95ce60024087239685545954651a68733ec2d949c56520d2637add9e91c8e7883742c7d307667ad83c4ebe2a8531a1cc53" %% xsd:string])
-    wasDerivedFrom(niiri:b0e7b8f9e020e8724283e6191e2da703, niiri:27281b97c78d257b22887871c6a68112, -, -, -)
-    wasGeneratedBy(niiri:b0e7b8f9e020e8724283e6191e2da703, niiri:aedde2b1a02ad24ed234029b5dc86c0e, -)
-    entity(niiri:0c51bc0fe4411e7dcd2abb844e9d9483,
+    wasDerivedFrom(niiri:445e63a4c2b814664d88bb41eb6a0e93, niiri:b7a13b645ead1cd72ae3434790f2a7c3, -, -, -)
+    wasGeneratedBy(niiri:445e63a4c2b814664d88bb41eb6a0e93, niiri:01c79625dd156fe0cc39d295e9a1bc02, -)
+    entity(niiri:b84b557c73a4800ede8eb4970d8fbd08,
         [prov:type = 'nidm_ContrastExplainedMeanSquareMap:',
         prov:location = "ContrastExplainedMeanSquare.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastExplainedMeanSquare.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Explained Mean Square Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377',
         crypto:sha512 = "a4b2ff6f792524a027a625aba962b798c3ea321cdd6636193ab521acf5dafa8ceb7fd4cb99a450ab7872359d0e6dac97f82b7523d609747780623b5077e02588" %% xsd:string])
-    wasGeneratedBy(niiri:0c51bc0fe4411e7dcd2abb844e9d9483, niiri:aedde2b1a02ad24ed234029b5dc86c0e, -)
-    entity(niiri:7f46ae22cdc5ee6822a2f2f5b2ca2f2b,
+    wasGeneratedBy(niiri:b84b557c73a4800ede8eb4970d8fbd08, niiri:01c79625dd156fe0cc39d295e9a1bc02, -)
+    entity(niiri:9cd223dcc0ec8314815147f964be2fee,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500086842908" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:0b8b0ea120e66e277cc906e8c638f4a1',
-        nidm_equivalentThreshold: = 'niiri:01b61d5a54d124c25b0dfe4842452479'])
-    entity(niiri:0b8b0ea120e66e277cc906e8c638f4a1,
+        nidm_equivalentThreshold: = 'niiri:a369c40ba876dd1b11662a065f62caba',
+        nidm_equivalentThreshold: = 'niiri:acc7ca43aa3ae020f2992ce6646c4d82'])
+    entity(niiri:a369c40ba876dd1b11662a065f62caba,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.81888651656205" %% xsd:float])
-    entity(niiri:01b61d5a54d124c25b0dfe4842452479,
+    entity(niiri:acc7ca43aa3ae020f2992ce6646c4d82,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:5c63a2de98701908b773b73724aa2e6c,
+    entity(niiri:1bf6a1379f676d90935a4c9cba3549dd,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:eb923f6975373720518450d07547dba1',
-        nidm_equivalentThreshold: = 'niiri:c6c498af368977c112799bfa72671339'])
-    entity(niiri:eb923f6975373720518450d07547dba1,
+        nidm_equivalentThreshold: = 'niiri:8a8890213f87d19045b69e60f0fea2a3',
+        nidm_equivalentThreshold: = 'niiri:5bddf3675665070262f012165db26554'])
+    entity(niiri:8a8890213f87d19045b69e60f0fea2a3,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:c6c498af368977c112799bfa72671339,
+    entity(niiri:5bddf3675665070262f012165db26554,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:0b2c9ff1807f3f9bd6728cc73ddb271a,
+    entity(niiri:5f51c5b8d9b08bb6dfc880cd6a7406f0,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:ee02bfd0ffe03ca3e43583cd21adab51,
+    entity(niiri:4cd73eb3fe73378073fd798331a4a363,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:87b5e03e41975da7e1db9bc068fc452a,
+    activity(niiri:b7277b9b56644163330bef68a876971a,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:a9aa267d850571686083e814acacec85, -)
-    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:7f46ae22cdc5ee6822a2f2f5b2ca2f2b, -)
-    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:5c63a2de98701908b773b73724aa2e6c, -)
-    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:b0e7b8f9e020e8724283e6191e2da703, -)
-    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:345400b745ebe143b4f453e4c217c209, -)
-    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:dd3a1b34bce9178ca5eb9e0c6f64572b, -)
-    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:0b2c9ff1807f3f9bd6728cc73ddb271a, -)
-    used(niiri:87b5e03e41975da7e1db9bc068fc452a, niiri:ee02bfd0ffe03ca3e43583cd21adab51, -)
-    entity(niiri:6fa69d1e83da07700b4a4ed4fdff8fa4,
+    wasAssociatedWith(niiri:b7277b9b56644163330bef68a876971a, niiri:ea8d144ccce6489b92b187acdc792bec, -)
+    used(niiri:b7277b9b56644163330bef68a876971a, niiri:9cd223dcc0ec8314815147f964be2fee, -)
+    used(niiri:b7277b9b56644163330bef68a876971a, niiri:1bf6a1379f676d90935a4c9cba3549dd, -)
+    used(niiri:b7277b9b56644163330bef68a876971a, niiri:445e63a4c2b814664d88bb41eb6a0e93, -)
+    used(niiri:b7277b9b56644163330bef68a876971a, niiri:fde6c201825e0d228d8f071226d6df72, -)
+    used(niiri:b7277b9b56644163330bef68a876971a, niiri:4a2baf3c1d8fbb1b78319c1483b1b28e, -)
+    used(niiri:b7277b9b56644163330bef68a876971a, niiri:5f51c5b8d9b08bb6dfc880cd6a7406f0, -)
+    used(niiri:b7277b9b56644163330bef68a876971a, niiri:4cd73eb3fe73378073fd798331a4a363, -)
+    entity(niiri:213f699536a3c6b036ed7516495f25af,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377',
         nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
         nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
         nidm_reselSizeInVoxels: = "68.4409986586639" %% xsd:float,
@@ -429,8 +429,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "68" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "51" %% xsd:int,
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    wasGeneratedBy(niiri:6fa69d1e83da07700b4a4ed4fdff8fa4, niiri:87b5e03e41975da7e1db9bc068fc452a, -)
-    entity(niiri:bfc22c098dc267a88d326bbf0e6793e3,
+    wasGeneratedBy(niiri:213f699536a3c6b036ed7516495f25af, niiri:b7277b9b56644163330bef68a876971a, -)
+    entity(niiri:693cbd3283b68002fb1375c234a7ba13,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -438,22 +438,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "89" %% xsd:int,
         nidm_pValue: = "1.20671430625663e-08" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:c872c243f35f93570da8e3e8bb2b7ead',
-        nidm_hasMaximumIntensityProjection: = 'niiri:9fea03d98e6320e3400bb3c188004db8',
-        nidm_inCoordinateSpace: = 'niiri:8631110ecbf1ae2c61c651d3c345e53a',
+        nidm_hasClusterLabelsMap: = 'niiri:5f008af65afcb63ce31164ba65ba7611',
+        nidm_hasMaximumIntensityProjection: = 'niiri:fa74373bbf11f8977e622e922390906d',
+        nidm_inCoordinateSpace: = 'niiri:3afab7fbc0c106b802099cf168ca0377',
         crypto:sha512 = "7655b200bdcbba72ab5ab79029728a420df3f3368bcb553410540390e1372e99531cb91885edbdd03945d7e2391516a3d8dc537da81527730e866035d4af7894" %% xsd:string])
-    entity(niiri:c872c243f35f93570da8e3e8bb2b7ead,
+    entity(niiri:5f008af65afcb63ce31164ba65ba7611,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:9fea03d98e6320e3400bb3c188004db8,
+    entity(niiri:fa74373bbf11f8977e622e922390906d,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:bfc22c098dc267a88d326bbf0e6793e3, niiri:87b5e03e41975da7e1db9bc068fc452a, -)
-    entity(niiri:8337790d11808f2fb788ee8093e46afe,
+    wasGeneratedBy(niiri:693cbd3283b68002fb1375c234a7ba13, niiri:b7277b9b56644163330bef68a876971a, -)
+    entity(niiri:70b2003559708458bd92e73d3d3c7bf4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1078" %% xsd:int,
@@ -462,8 +462,8 @@ document
         nidm_pValueFWER: = "0" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:8337790d11808f2fb788ee8093e46afe, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:2e44272daecb8718b2883f84f352fc62,
+    wasDerivedFrom(niiri:70b2003559708458bd92e73d3d3c7bf4, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:e2b47f512f66716985aee0fe421c3346,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "930" %% xsd:int,
@@ -472,8 +472,8 @@ document
         nidm_pValueFWER: = "1.11022302462516e-16" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:2e44272daecb8718b2883f84f352fc62, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:c893d69da88fea01efe542f9787608c5,
+    wasDerivedFrom(niiri:e2b47f512f66716985aee0fe421c3346, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:3c6dd5e94db642fc0c6313fade61752c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "61" %% xsd:int,
@@ -482,8 +482,8 @@ document
         nidm_pValueFWER: = "0.0625404056276491" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:c893d69da88fea01efe542f9787608c5, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:fafaf22f396d11e8355f5d1e7a7367ea,
+    wasDerivedFrom(niiri:3c6dd5e94db642fc0c6313fade61752c, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:13dc91c36d42d9c0075971b7e2e4340a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "51" %% xsd:int,
@@ -492,8 +492,8 @@ document
         nidm_pValueFWER: = "0.126476639623878" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:fafaf22f396d11e8355f5d1e7a7367ea, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:0820636de884fe0d783c5385916ab101,
+    wasDerivedFrom(niiri:13dc91c36d42d9c0075971b7e2e4340a, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:63baaa25c1850e25ff8b59437cf378c6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "102" %% xsd:int,
@@ -502,8 +502,8 @@ document
         nidm_pValueFWER: = "0.00439690541625271" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:0820636de884fe0d783c5385916ab101, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:1e3c8c027b813bda7df5358a8ab4f63a,
+    wasDerivedFrom(niiri:63baaa25c1850e25ff8b59437cf378c6, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:938d8c88ecfbbf04abff04ec2e6740f3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "69" %% xsd:int,
@@ -512,8 +512,8 @@ document
         nidm_pValueFWER: = "0.0361338614001637" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:1e3c8c027b813bda7df5358a8ab4f63a, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:e24e457b7371fd1bac7d4cb391bb9432,
+    wasDerivedFrom(niiri:938d8c88ecfbbf04abff04ec2e6740f3, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:86d427d519cd54a38aa4d9fc15de80c3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "81" %% xsd:int,
@@ -522,8 +522,8 @@ document
         nidm_pValueFWER: = "0.0163292644152585" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:e24e457b7371fd1bac7d4cb391bb9432, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:2f5fcfc4453f648ede4260a16cff5960,
+    wasDerivedFrom(niiri:86d427d519cd54a38aa4d9fc15de80c3, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:d23334e15ca989a88f18103920c37202,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "62" %% xsd:int,
@@ -532,8 +532,8 @@ document
         nidm_pValueFWER: = "0.0583486858266125" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:2f5fcfc4453f648ede4260a16cff5960, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:dbbddbece734ef2c5ed154985b15ffe8,
+    wasDerivedFrom(niiri:d23334e15ca989a88f18103920c37202, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:34d7407deceb41bb05814c58f568aa8a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "27" %% xsd:int,
@@ -542,8 +542,8 @@ document
         nidm_pValueFWER: = "0.637047204368496" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:dbbddbece734ef2c5ed154985b15ffe8, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:6aecc2d95fe5ba4cd2d39d16afe85407,
+    wasDerivedFrom(niiri:34d7407deceb41bb05814c58f568aa8a, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:f11390729469ff5ad94b49a0bdfa4678,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "69" %% xsd:int,
@@ -552,8 +552,8 @@ document
         nidm_pValueFWER: = "0.0361338614001637" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:6aecc2d95fe5ba4cd2d39d16afe85407, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:a9c284c82bc4ef4eba48570f53c9c9c4,
+    wasDerivedFrom(niiri:f11390729469ff5ad94b49a0bdfa4678, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:ccdacac7fbef86b94a12c5dabbf08bc2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "34" %% xsd:int,
@@ -562,8 +562,8 @@ document
         nidm_pValueFWER: = "0.41596704628578" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:a9c284c82bc4ef4eba48570f53c9c9c4, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:0637af2e34d8b1c842ae7d1386357498,
+    wasDerivedFrom(niiri:ccdacac7fbef86b94a12c5dabbf08bc2, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:13403d7573cd820266b83ff32d0e9707,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -572,8 +572,8 @@ document
         nidm_pValueFWER: = "0.955688665756324" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:0637af2e34d8b1c842ae7d1386357498, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:1cd4117828f514ec0fff4b67f780d6b9,
+    wasDerivedFrom(niiri:13403d7573cd820266b83ff32d0e9707, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:d86187d8105730183f4e8c029a41bf61,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "33" %% xsd:int,
@@ -582,8 +582,8 @@ document
         nidm_pValueFWER: = "0.444043105508432" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:1cd4117828f514ec0fff4b67f780d6b9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:d85063f48080f770ca548748f7419e12,
+    wasDerivedFrom(niiri:d86187d8105730183f4e8c029a41bf61, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:67556c87393c94a727ee0b764b5d8856,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "29" %% xsd:int,
@@ -592,8 +592,8 @@ document
         nidm_pValueFWER: = "0.568879964907834" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:d85063f48080f770ca548748f7419e12, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:ec3fc3cfa0c303c00f68f5986e44044e,
+    wasDerivedFrom(niiri:67556c87393c94a727ee0b764b5d8856, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:8832fdb39eea98ef7aabb68883c63c22,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "52" %% xsd:int,
@@ -602,8 +602,8 @@ document
         nidm_pValueFWER: = "0.117795392093901" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:ec3fc3cfa0c303c00f68f5986e44044e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:23c6e94e6643122dcb458402a972758e,
+    wasDerivedFrom(niiri:8832fdb39eea98ef7aabb68883c63c22, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:0a733ee37ab9d8fc5554d22235fb2ebb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -612,8 +612,8 @@ document
         nidm_pValueFWER: = "0.894389812698126" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:23c6e94e6643122dcb458402a972758e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:68f9a66ca71f514199366c398a2831ab,
+    wasDerivedFrom(niiri:0a733ee37ab9d8fc5554d22235fb2ebb, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:20f7a6809dd02ee80d08c981d7533384,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "15" %% xsd:int,
@@ -622,8 +622,8 @@ document
         nidm_pValueFWER: = "0.969514797834504" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:68f9a66ca71f514199366c398a2831ab, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:6f303953fe538a2a99d9b754b92e311e,
+    wasDerivedFrom(niiri:20f7a6809dd02ee80d08c981d7533384, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:c1ebe6af3636d8119b6c8c898bc0b9cd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -632,8 +632,8 @@ document
         nidm_pValueFWER: = "0.938523680835064" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:6f303953fe538a2a99d9b754b92e311e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:b32513dc3cebea135a4227a2ff2989c6,
+    wasDerivedFrom(niiri:c1ebe6af3636d8119b6c8c898bc0b9cd, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:f967cba917487022842df44264a09b9a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "37" %% xsd:int,
@@ -642,8 +642,8 @@ document
         nidm_pValueFWER: = "0.340003071301302" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:b32513dc3cebea135a4227a2ff2989c6, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:b7301eccecd4c049bbeed4467b530024,
+    wasDerivedFrom(niiri:f967cba917487022842df44264a09b9a, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:dead248e9a831f2d39ed43c1307d7a6f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -652,8 +652,8 @@ document
         nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:b7301eccecd4c049bbeed4467b530024, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:765e5201ffb06ca1f162ea8d7d3f0abd,
+    wasDerivedFrom(niiri:dead248e9a831f2d39ed43c1307d7a6f, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:63395ba4fe844e99193e44b8b12c407b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "27" %% xsd:int,
@@ -662,8 +662,8 @@ document
         nidm_pValueFWER: = "0.637047204368496" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:765e5201ffb06ca1f162ea8d7d3f0abd, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:aeb5ca84ea986c7559b385b24d2806c0,
+    wasDerivedFrom(niiri:63395ba4fe844e99193e44b8b12c407b, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:9e473a48bfa3001fcf429b2b016fa5ea,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -672,8 +672,8 @@ document
         nidm_pValueFWER: = "0.741232640256625" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:aeb5ca84ea986c7559b385b24d2806c0, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:d36b472817f6888ac2860c8f78cda4e9,
+    wasDerivedFrom(niiri:9e473a48bfa3001fcf429b2b016fa5ea, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:66117305de42f7fc8878b963008d257b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "30" %% xsd:int,
@@ -682,8 +682,8 @@ document
         nidm_pValueFWER: = "0.535986190221124" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:d36b472817f6888ac2860c8f78cda4e9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:e1375ee26540e9328da498ca97a69cb4,
+    wasDerivedFrom(niiri:66117305de42f7fc8878b963008d257b, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:4b2de1d700d8a7f369f0417da0db1e66,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -692,8 +692,8 @@ document
         nidm_pValueFWER: = "0.894389812698126" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:e1375ee26540e9328da498ca97a69cb4, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:d5f1c18934146a18337779acd9486123,
+    wasDerivedFrom(niiri:4b2de1d700d8a7f369f0417da0db1e66, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:f5ac935852ea4b1b9fed377c2aeb3b18,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "68" %% xsd:int,
@@ -702,8 +702,8 @@ document
         nidm_pValueFWER: = "0.0386667510721175" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:d5f1c18934146a18337779acd9486123, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:275de6b748d7ad0f11eed3004edbf892,
+    wasDerivedFrom(niiri:f5ac935852ea4b1b9fed377c2aeb3b18, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:e0f3dfa1c85357af4b401994ac38769b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -712,8 +712,8 @@ document
         nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:275de6b748d7ad0f11eed3004edbf892, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:2dd4cb8812c93538b5902225b29e0471,
+    wasDerivedFrom(niiri:e0f3dfa1c85357af4b401994ac38769b, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:614c41139aa842cbd80a44616011d080,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -722,8 +722,8 @@ document
         nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:2dd4cb8812c93538b5902225b29e0471, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:67ae07e7ee0396386eefce6ed5341a79,
+    wasDerivedFrom(niiri:614c41139aa842cbd80a44616011d080, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:c8f3c9da99d7be6a54c536483f0ca346,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "15" %% xsd:int,
@@ -732,8 +732,8 @@ document
         nidm_pValueFWER: = "0.969514797834504" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:67ae07e7ee0396386eefce6ed5341a79, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:c589ee96ca2b908bdd9d337ca523d5af,
+    wasDerivedFrom(niiri:c8f3c9da99d7be6a54c536483f0ca346, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:cf1f683799f80f149702b64601072e25,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -742,8 +742,8 @@ document
         nidm_pValueFWER: = "0.938523680835064" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:c589ee96ca2b908bdd9d337ca523d5af, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:e43455a02504b9d87a4939904a0ca976,
+    wasDerivedFrom(niiri:cf1f683799f80f149702b64601072e25, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:fcfdc3edc7e7cbb46b2a5e7bd6a60b5a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -752,8 +752,8 @@ document
         nidm_pValueFWER: = "0.993158154960398" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:e43455a02504b9d87a4939904a0ca976, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:5dc937975dc687d7eb55e11a685cdd94,
+    wasDerivedFrom(niiri:fcfdc3edc7e7cbb46b2a5e7bd6a60b5a, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:c6b09785e79116c69c0d566f14508194,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -762,8 +762,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "31" %% xsd:int])
-    wasDerivedFrom(niiri:5dc937975dc687d7eb55e11a685cdd94, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:30c5174c5d495474060913c40bab0961,
+    wasDerivedFrom(niiri:c6b09785e79116c69c0d566f14508194, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:b62d08e7f48d3b48c3d3470c4864b0f5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -772,8 +772,8 @@ document
         nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "32" %% xsd:int])
-    wasDerivedFrom(niiri:30c5174c5d495474060913c40bab0961, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:ea999779ae02d5714142530d4b2e638b,
+    wasDerivedFrom(niiri:b62d08e7f48d3b48c3d3470c4864b0f5, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:820eae4f2ecfa96c61f16f68989e60f2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -782,8 +782,8 @@ document
         nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "33" %% xsd:int])
-    wasDerivedFrom(niiri:ea999779ae02d5714142530d4b2e638b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:15b2530019f1c4c6d5e910962b35274b,
+    wasDerivedFrom(niiri:820eae4f2ecfa96c61f16f68989e60f2, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:0c814c8aa73eb23edb6b0bdf05d875b9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -792,8 +792,8 @@ document
         nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "34" %% xsd:int])
-    wasDerivedFrom(niiri:15b2530019f1c4c6d5e910962b35274b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:5782e52657a04683a9d9acc635ffc74a,
+    wasDerivedFrom(niiri:0c814c8aa73eb23edb6b0bdf05d875b9, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:3237418b7d965d5533963a3817c7547f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -802,8 +802,8 @@ document
         nidm_pValueFWER: = "0.999783165932851" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "35" %% xsd:int])
-    wasDerivedFrom(niiri:5782e52657a04683a9d9acc635ffc74a, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:e26340fcd624896679dd2542ec2348be,
+    wasDerivedFrom(niiri:3237418b7d965d5533963a3817c7547f, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:479583c290f59d278781273768ba65dc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -812,8 +812,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "36" %% xsd:int])
-    wasDerivedFrom(niiri:e26340fcd624896679dd2542ec2348be, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:e4e5f6e0de1fb1456effbec6ec82e736,
+    wasDerivedFrom(niiri:479583c290f59d278781273768ba65dc, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:609da3fb63ae9918c3e77a08cdb6cfc2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -822,8 +822,8 @@ document
         nidm_pValueFWER: = "0.993158154960398" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "37" %% xsd:int])
-    wasDerivedFrom(niiri:e4e5f6e0de1fb1456effbec6ec82e736, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:5cf9ae44dc03a8c6493baf09bed014d4,
+    wasDerivedFrom(niiri:609da3fb63ae9918c3e77a08cdb6cfc2, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:76f32299041fc5f4d0b950c566a0624b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -832,8 +832,8 @@ document
         nidm_pValueFWER: = "0.987884145093703" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "38" %% xsd:int])
-    wasDerivedFrom(niiri:5cf9ae44dc03a8c6493baf09bed014d4, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:dfe1466699f719841d6d98d1188da0c8,
+    wasDerivedFrom(niiri:76f32299041fc5f4d0b950c566a0624b, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:9e864aa27a55745175707c98d46a334c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -842,8 +842,8 @@ document
         nidm_pValueFWER: = "0.999988123335902" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "39" %% xsd:int])
-    wasDerivedFrom(niiri:dfe1466699f719841d6d98d1188da0c8, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:e69a5e282ae0346ca803f55371164aa7,
+    wasDerivedFrom(niiri:9e864aa27a55745175707c98d46a334c, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:628a97ee4df64877d84868107814f955,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -852,8 +852,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "40" %% xsd:int])
-    wasDerivedFrom(niiri:e69a5e282ae0346ca803f55371164aa7, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:d168d4b61807fc13619ad56c31dad174,
+    wasDerivedFrom(niiri:628a97ee4df64877d84868107814f955, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:52a2c6444b10fca5e154fba0b3e62d50,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -862,8 +862,8 @@ document
         nidm_pValueFWER: = "0.999988123335902" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "41" %% xsd:int])
-    wasDerivedFrom(niiri:d168d4b61807fc13619ad56c31dad174, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:522e011a3a54e833c99dc9315f577dfe,
+    wasDerivedFrom(niiri:52a2c6444b10fca5e154fba0b3e62d50, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:a9bc5d8a6d734a19d1ee638ddfa9e34f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -872,8 +872,8 @@ document
         nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "42" %% xsd:int])
-    wasDerivedFrom(niiri:522e011a3a54e833c99dc9315f577dfe, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:bcc290b739057f6cb5c02dcc79c4b5bc,
+    wasDerivedFrom(niiri:a9bc5d8a6d734a19d1ee638ddfa9e34f, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:cf869ef162fc61878c8c7fbac7157264,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
         nidm_clusterSizeInVoxels: = "14" %% xsd:int,
@@ -882,8 +882,8 @@ document
         nidm_pValueFWER: = "0.980146451443566" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "43" %% xsd:int])
-    wasDerivedFrom(niiri:bcc290b739057f6cb5c02dcc79c4b5bc, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:6f3de48dca5b4c3a6aca0be63ddd27cd,
+    wasDerivedFrom(niiri:cf869ef162fc61878c8c7fbac7157264, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:404edd754b52ba04b35f56d4e502f8ce,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -892,8 +892,8 @@ document
         nidm_pValueFWER: = "0.998383943752383" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "44" %% xsd:int])
-    wasDerivedFrom(niiri:6f3de48dca5b4c3a6aca0be63ddd27cd, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:f77f344a47f917de9a802b78319c354f,
+    wasDerivedFrom(niiri:404edd754b52ba04b35f56d4e502f8ce, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:646c9634927ecdb2332ab5dfe7a28006,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -902,8 +902,8 @@ document
         nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "45" %% xsd:int])
-    wasDerivedFrom(niiri:f77f344a47f917de9a802b78319c354f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:9df645a4ce3520ee828e35a6dac32f9f,
+    wasDerivedFrom(niiri:646c9634927ecdb2332ab5dfe7a28006, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:c0fd049d894fca767270c43b39b70df9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -912,8 +912,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "46" %% xsd:int])
-    wasDerivedFrom(niiri:9df645a4ce3520ee828e35a6dac32f9f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:1dea88b1f0062ddb01809c2f336aff3f,
+    wasDerivedFrom(niiri:c0fd049d894fca767270c43b39b70df9, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:9552b4dbfe0833d9f21d39cf5a3f531c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -922,8 +922,8 @@ document
         nidm_pValueFWER: = "0.999783165932851" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "47" %% xsd:int])
-    wasDerivedFrom(niiri:1dea88b1f0062ddb01809c2f336aff3f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:f424b0ee093c7ca1771bb8144718087b,
+    wasDerivedFrom(niiri:9552b4dbfe0833d9f21d39cf5a3f531c, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:4cb0bf65605055716432884893e5e9c2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -932,8 +932,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "48" %% xsd:int])
-    wasDerivedFrom(niiri:f424b0ee093c7ca1771bb8144718087b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:258ff3de07e51a57d0b27d6699fb2508,
+    wasDerivedFrom(niiri:4cb0bf65605055716432884893e5e9c2, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:d6b37cc773edb870bb55c2d6372f256b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -942,8 +942,8 @@ document
         nidm_pValueFWER: = "0.999354408004913" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "49" %% xsd:int])
-    wasDerivedFrom(niiri:258ff3de07e51a57d0b27d6699fb2508, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:fd669f02bbb8da3eff612dc0d4b807f6,
+    wasDerivedFrom(niiri:d6b37cc773edb870bb55c2d6372f256b, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:27724b6869441a042387c9d5c13942d2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -952,8 +952,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "50" %% xsd:int])
-    wasDerivedFrom(niiri:fd669f02bbb8da3eff612dc0d4b807f6, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:2560564a14e0250f709b385639d02fb9,
+    wasDerivedFrom(niiri:27724b6869441a042387c9d5c13942d2, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:6c4baced41f2f8c3fb0cb36e9ec2f421,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -962,8 +962,8 @@ document
         nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "51" %% xsd:int])
-    wasDerivedFrom(niiri:2560564a14e0250f709b385639d02fb9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:589d688bdb65a26f0e5afdd4ff33865b,
+    wasDerivedFrom(niiri:6c4baced41f2f8c3fb0cb36e9ec2f421, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:8b632dcc185547a7f8ad04edead2291a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -972,8 +972,8 @@ document
         nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "52" %% xsd:int])
-    wasDerivedFrom(niiri:589d688bdb65a26f0e5afdd4ff33865b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:b1e45a95e3b162cbfbb274efa0609a1a,
+    wasDerivedFrom(niiri:8b632dcc185547a7f8ad04edead2291a, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:0b81b51c15877094ca33c61a79325340,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -982,8 +982,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "53" %% xsd:int])
-    wasDerivedFrom(niiri:b1e45a95e3b162cbfbb274efa0609a1a, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:5ac022b3dd1da9d78456eb9feccbe272,
+    wasDerivedFrom(niiri:0b81b51c15877094ca33c61a79325340, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:39734aff0e8ba70db0c48ce245fe4c87,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -992,8 +992,8 @@ document
         nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "54" %% xsd:int])
-    wasDerivedFrom(niiri:5ac022b3dd1da9d78456eb9feccbe272, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:0aa8942e14fb246e8d24f1826bdd073f,
+    wasDerivedFrom(niiri:39734aff0e8ba70db0c48ce245fe4c87, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:715173a69633af936b825645f63d4b6e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -1002,8 +1002,8 @@ document
         nidm_pValueFWER: = "0.996480799224121" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "55" %% xsd:int])
-    wasDerivedFrom(niiri:0aa8942e14fb246e8d24f1826bdd073f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:47175a90c2a865c8e7cb888b760d6bf8,
+    wasDerivedFrom(niiri:715173a69633af936b825645f63d4b6e, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:1c44f60f8e5351b0a92c492ed60e2137,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1012,8 +1012,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "56" %% xsd:int])
-    wasDerivedFrom(niiri:47175a90c2a865c8e7cb888b760d6bf8, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:d3f621d08874a1c4b62c86623e9e9780,
+    wasDerivedFrom(niiri:1c44f60f8e5351b0a92c492ed60e2137, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:f2443d4e5be8deae8260b1f1dedfc174,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1022,8 +1022,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "57" %% xsd:int])
-    wasDerivedFrom(niiri:d3f621d08874a1c4b62c86623e9e9780, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56,
+    wasDerivedFrom(niiri:f2443d4e5be8deae8260b1f1dedfc174, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:de6358617bfe8f7769d05d29a4316925,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1032,8 +1032,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "58" %% xsd:int])
-    wasDerivedFrom(niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:730bd100bdb468af0d3821d0d42d24a3,
+    wasDerivedFrom(niiri:de6358617bfe8f7769d05d29a4316925, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:28b00390010cb45d9a423be0d041e4eb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -1042,8 +1042,8 @@ document
         nidm_pValueFWER: = "0.999941524907657" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "59" %% xsd:int])
-    wasDerivedFrom(niiri:730bd100bdb468af0d3821d0d42d24a3, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:c30c1334c3597905fbc441edbc3d5ada,
+    wasDerivedFrom(niiri:28b00390010cb45d9a423be0d041e4eb, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:6f2458f857e5301314e4c49c53ddab5c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1052,8 +1052,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "60" %% xsd:int])
-    wasDerivedFrom(niiri:c30c1334c3597905fbc441edbc3d5ada, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:f3476be8b24ab5bb218fe71d0b0daed0,
+    wasDerivedFrom(niiri:6f2458f857e5301314e4c49c53ddab5c, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:a5ccd12af883dc80ecb285cbc7d90996,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1062,8 +1062,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "61" %% xsd:int])
-    wasDerivedFrom(niiri:f3476be8b24ab5bb218fe71d0b0daed0, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:e129e49f77be02735062a975f639c82e,
+    wasDerivedFrom(niiri:a5ccd12af883dc80ecb285cbc7d90996, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:075cefbcdab0306f76e523f39577afc9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1072,8 +1072,8 @@ document
         nidm_pValueFWER: = "0.999999994589484" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "62" %% xsd:int])
-    wasDerivedFrom(niiri:e129e49f77be02735062a975f639c82e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:f445b49b9174ce8611d41a7cc11e1717,
+    wasDerivedFrom(niiri:075cefbcdab0306f76e523f39577afc9, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:67b2de2f1c8c8f1c6308f97901012c85,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1082,8 +1082,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "63" %% xsd:int])
-    wasDerivedFrom(niiri:f445b49b9174ce8611d41a7cc11e1717, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:5ca600306779ba8f48c5d087d9fac9a9,
+    wasDerivedFrom(niiri:67b2de2f1c8c8f1c6308f97901012c85, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:3e4aab372e14b498f67d8f3af7fe64d4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1092,8 +1092,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "64" %% xsd:int])
-    wasDerivedFrom(niiri:5ca600306779ba8f48c5d087d9fac9a9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:40bbe1b7b060c1d54f113fd9fcf154aa,
+    wasDerivedFrom(niiri:3e4aab372e14b498f67d8f3af7fe64d4, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:4e46f866f0c4c884a98d67ad4f286185,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1102,8 +1102,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "65" %% xsd:int])
-    wasDerivedFrom(niiri:40bbe1b7b060c1d54f113fd9fcf154aa, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:5d9d1b3e1bbc6746185f53561c74bace,
+    wasDerivedFrom(niiri:4e46f866f0c4c884a98d67ad4f286185, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:0c4f8238e0d8817ab291795ad931058d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1112,8 +1112,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "66" %% xsd:int])
-    wasDerivedFrom(niiri:5d9d1b3e1bbc6746185f53561c74bace, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:4c53636a1293cd4482cb63ff70691d79,
+    wasDerivedFrom(niiri:0c4f8238e0d8817ab291795ad931058d, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:45b239a4d9c3d2d8505e69c949d3d8e8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1122,8 +1122,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "67" %% xsd:int])
-    wasDerivedFrom(niiri:4c53636a1293cd4482cb63ff70691d79, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:2b3b2f5817481e92102b214f3bf33995,
+    wasDerivedFrom(niiri:45b239a4d9c3d2d8505e69c949d3d8e8, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:d81ab34b3d15a5e83dcac601860e2c67,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1132,8 +1132,8 @@ document
         nidm_pValueFWER: = "0.99999986229194" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "68" %% xsd:int])
-    wasDerivedFrom(niiri:2b3b2f5817481e92102b214f3bf33995, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:86437031e803eee8517a97d2e8420009,
+    wasDerivedFrom(niiri:d81ab34b3d15a5e83dcac601860e2c67, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:17915a4b4045396b3dc9e808d4f43fff,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1142,8 +1142,8 @@ document
         nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "69" %% xsd:int])
-    wasDerivedFrom(niiri:86437031e803eee8517a97d2e8420009, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:927385c4b1c66020878360a5006a3e3b,
+    wasDerivedFrom(niiri:17915a4b4045396b3dc9e808d4f43fff, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:fb337b3deac825168c6547e71cdf45e4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1152,8 +1152,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "70" %% xsd:int])
-    wasDerivedFrom(niiri:927385c4b1c66020878360a5006a3e3b, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:0087c0fa9854a20b9b26757b4c0e9a68,
+    wasDerivedFrom(niiri:fb337b3deac825168c6547e71cdf45e4, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:d1e644390766d6283debb5ff26e27399,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1162,8 +1162,8 @@ document
         nidm_pValueFWER: = "0.999999994589484" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "71" %% xsd:int])
-    wasDerivedFrom(niiri:0087c0fa9854a20b9b26757b4c0e9a68, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:679d2ced08c3de3ec63ab76190f2d86d,
+    wasDerivedFrom(niiri:d1e644390766d6283debb5ff26e27399, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:f2c41aa526c7ecfe683fb5b1f2a7588a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0072" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1172,8 +1172,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "72" %% xsd:int])
-    wasDerivedFrom(niiri:679d2ced08c3de3ec63ab76190f2d86d, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:302d0ae98bffba69292672583d115e8c,
+    wasDerivedFrom(niiri:f2c41aa526c7ecfe683fb5b1f2a7588a, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:b6e3adf39b177b2fe3b6833a47713718,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0073" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1182,8 +1182,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "73" %% xsd:int])
-    wasDerivedFrom(niiri:302d0ae98bffba69292672583d115e8c, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:f443e4b03660a8ad618e307479bf8a95,
+    wasDerivedFrom(niiri:b6e3adf39b177b2fe3b6833a47713718, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:ac9ee3188f787257a289a9904e28a0df,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0074" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1192,8 +1192,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "74" %% xsd:int])
-    wasDerivedFrom(niiri:f443e4b03660a8ad618e307479bf8a95, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:80e9d7b2bd34593272f3fb19fc9254e9,
+    wasDerivedFrom(niiri:ac9ee3188f787257a289a9904e28a0df, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:499c553f4f05bed3bf262435de53d3b1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0075" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1202,8 +1202,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "75" %% xsd:int])
-    wasDerivedFrom(niiri:80e9d7b2bd34593272f3fb19fc9254e9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:91bc3a2972b2938504904a8d68057f2e,
+    wasDerivedFrom(niiri:499c553f4f05bed3bf262435de53d3b1, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:425b3b59bb1a3d7b86c2c5264b8a6627,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0076" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1212,8 +1212,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "76" %% xsd:int])
-    wasDerivedFrom(niiri:91bc3a2972b2938504904a8d68057f2e, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:681cc93cdfd04b41012417cfd725953f,
+    wasDerivedFrom(niiri:425b3b59bb1a3d7b86c2c5264b8a6627, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:9c92e09c369b8211d4e65fbfbb9c9aa4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0077" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1222,8 +1222,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "77" %% xsd:int])
-    wasDerivedFrom(niiri:681cc93cdfd04b41012417cfd725953f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:1288217d5c8b70c54915067a87402187,
+    wasDerivedFrom(niiri:9c92e09c369b8211d4e65fbfbb9c9aa4, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:d76384fac79adab2f8bcdd74e38b05e5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0078" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1232,8 +1232,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "78" %% xsd:int])
-    wasDerivedFrom(niiri:1288217d5c8b70c54915067a87402187, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:9a33ec7dcbaf4c333c9be7973d3674ae,
+    wasDerivedFrom(niiri:d76384fac79adab2f8bcdd74e38b05e5, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:66b4285fcdb2a68d01ddbdfea09445d1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0079" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1242,8 +1242,8 @@ document
         nidm_pValueFWER: = "0.999998343785323" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "79" %% xsd:int])
-    wasDerivedFrom(niiri:9a33ec7dcbaf4c333c9be7973d3674ae, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73,
+    wasDerivedFrom(niiri:66b4285fcdb2a68d01ddbdfea09445d1, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:ce2fd9609bbaf4260567fecf8334f73a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0080" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1252,8 +1252,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "80" %% xsd:int])
-    wasDerivedFrom(niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:99af69862e054a4c62b8e6066ff12cfd,
+    wasDerivedFrom(niiri:ce2fd9609bbaf4260567fecf8334f73a, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:a482e942f85057c7e6150a9211c470d5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0081" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1262,8 +1262,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "81" %% xsd:int])
-    wasDerivedFrom(niiri:99af69862e054a4c62b8e6066ff12cfd, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:20fc427845c2a14183959299a0d233ce,
+    wasDerivedFrom(niiri:a482e942f85057c7e6150a9211c470d5, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:72e4e5b0d793f6bdd394586ab7b319ae,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0082" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1272,8 +1272,8 @@ document
         nidm_pValueFWER: = "0.999999999934903" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "82" %% xsd:int])
-    wasDerivedFrom(niiri:20fc427845c2a14183959299a0d233ce, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:0294b8b1f3c4b525a18397bf17d17d63,
+    wasDerivedFrom(niiri:72e4e5b0d793f6bdd394586ab7b319ae, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:698f920512e0bc86196ac5bdf9403706,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0083" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1282,8 +1282,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "83" %% xsd:int])
-    wasDerivedFrom(niiri:0294b8b1f3c4b525a18397bf17d17d63, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:3dc796cbf0403561b0e6ea42b96ea1a9,
+    wasDerivedFrom(niiri:698f920512e0bc86196ac5bdf9403706, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:ad1cd56f7d143bd776b5691683c59add,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0084" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1292,8 +1292,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "84" %% xsd:int])
-    wasDerivedFrom(niiri:3dc796cbf0403561b0e6ea42b96ea1a9, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:14518885ee853fba951013cf73f66bed,
+    wasDerivedFrom(niiri:ad1cd56f7d143bd776b5691683c59add, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:eaa184888e18a33c4f8a743428f908be,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0085" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1302,8 +1302,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "85" %% xsd:int])
-    wasDerivedFrom(niiri:14518885ee853fba951013cf73f66bed, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:7666b1a689a3839cdadb86af5e5c7c39,
+    wasDerivedFrom(niiri:eaa184888e18a33c4f8a743428f908be, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:7a8727b45ba0d1d9809d83d6afaba387,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0086" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1312,8 +1312,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "86" %% xsd:int])
-    wasDerivedFrom(niiri:7666b1a689a3839cdadb86af5e5c7c39, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:2cac2c4baab8136a53bdf03e74fdc1c5,
+    wasDerivedFrom(niiri:7a8727b45ba0d1d9809d83d6afaba387, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:e37d9920261de8039f51fb95dfc921a4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0087" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1322,8 +1322,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "87" %% xsd:int])
-    wasDerivedFrom(niiri:2cac2c4baab8136a53bdf03e74fdc1c5, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:8768acb96e7e44e4cd45548f0d52dd3f,
+    wasDerivedFrom(niiri:e37d9920261de8039f51fb95dfc921a4, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:69d9b433456370b7c1a9673758c8fe93,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0088" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1332,8 +1332,8 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "88" %% xsd:int])
-    wasDerivedFrom(niiri:8768acb96e7e44e4cd45548f0d52dd3f, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:816f19a8ef8789235a9bd7bfe4396a14,
+    wasDerivedFrom(niiri:69d9b433456370b7c1a9673758c8fe93, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:f8f9f105adf5f8aecb1ef2a7b71b7a33,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0089" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1342,1551 +1342,1551 @@ document
         nidm_pValueFWER: = "0.999999999999914" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "89" %% xsd:int])
-    wasDerivedFrom(niiri:816f19a8ef8789235a9bd7bfe4396a14, niiri:bfc22c098dc267a88d326bbf0e6793e3, -, -, -)
-    entity(niiri:06a391660f148983b073bfec11e5afdd,
+    wasDerivedFrom(niiri:f8f9f105adf5f8aecb1ef2a7b71b7a33, niiri:693cbd3283b68002fb1375c234a7ba13, -, -, -)
+    entity(niiri:93496da83c58096fe3cadb5c0a487eb8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:aeb3f38bf9d2106bcfc97930c448be4f',
+        prov:location = 'niiri:42ca6d43b5feb478f133427c1a06d1fa',
         prov:value = "16.0820484161377" %% xsd:float,
         nidm_equivalentZStatistic: = "6.58928757769047" %% xsd:float,
         nidm_pValueUncorrected: = "2.20971019260219e-11" %% xsd:float,
         nidm_pValueFWER: = "4.59341100222943e-06" %% xsd:float,
         nidm_qValueFDR: = "2.11792501803032e-06" %% xsd:float])
-    entity(niiri:aeb3f38bf9d2106bcfc97930c448be4f,
+    entity(niiri:42ca6d43b5feb478f133427c1a06d1fa,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[-14,-84,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:06a391660f148983b073bfec11e5afdd, niiri:8337790d11808f2fb788ee8093e46afe, -, -, -)
-    entity(niiri:a1abcbfeadef1ab9d090cb0dfd0c65f9,
+    wasDerivedFrom(niiri:93496da83c58096fe3cadb5c0a487eb8, niiri:70b2003559708458bd92e73d3d3c7bf4, -, -, -)
+    entity(niiri:9aa03bdba011795f1f4d5ac002e49c6c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:6040359f287941d8765b5d153e53b7e8',
+        prov:location = 'niiri:a54d946bc00da59c9cfa1ed1e4c0a194',
         prov:value = "13.9779033660889" %% xsd:float,
         nidm_equivalentZStatistic: = "6.11142244434854" %% xsd:float,
         nidm_pValueUncorrected: = "4.93734941819923e-10" %% xsd:float,
         nidm_pValueFWER: = "0.000102635598608014" %% xsd:float,
         nidm_qValueFDR: = "5.60210458059015e-06" %% xsd:float])
-    entity(niiri:6040359f287941d8765b5d153e53b7e8,
+    entity(niiri:a54d946bc00da59c9cfa1ed1e4c0a194,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[-42,-76,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:a1abcbfeadef1ab9d090cb0dfd0c65f9, niiri:8337790d11808f2fb788ee8093e46afe, -, -, -)
-    entity(niiri:f209e76751ccdefc0e9bde5e236ee184,
+    wasDerivedFrom(niiri:9aa03bdba011795f1f4d5ac002e49c6c, niiri:70b2003559708458bd92e73d3d3c7bf4, -, -, -)
+    entity(niiri:bf83c25f85dbf8414669cb3b0b1360b4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:feb1ef85bf7a38f519d22d70f35dd611',
+        prov:location = 'niiri:c9f1ea6c398da29c68d0d98d7cd0a738',
         prov:value = "10.3123865127563" %% xsd:float,
         nidm_equivalentZStatistic: = "5.1402197604635" %% xsd:float,
         nidm_pValueUncorrected: = "1.3720866187672e-07" %% xsd:float,
         nidm_pValueFWER: = "0.0248386091747108" %% xsd:float,
         nidm_qValueFDR: = "0.000165827847161811" %% xsd:float])
-    entity(niiri:feb1ef85bf7a38f519d22d70f35dd611,
+    entity(niiri:c9f1ea6c398da29c68d0d98d7cd0a738,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[-20,-90,8]" %% xsd:string])
-    wasDerivedFrom(niiri:f209e76751ccdefc0e9bde5e236ee184, niiri:8337790d11808f2fb788ee8093e46afe, -, -, -)
-    entity(niiri:f066c96dd3c7c0996c0629c5c10cdb17,
+    wasDerivedFrom(niiri:bf83c25f85dbf8414669cb3b0b1360b4, niiri:70b2003559708458bd92e73d3d3c7bf4, -, -, -)
+    entity(niiri:01f425e6980b230ac084a97aaea6f38b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:3183606049158bc6420e12358dd06fd9',
+        prov:location = 'niiri:cf65d0a1b44e4d21b33bf5348cb46c49',
         prov:value = "13.7427864074707" %% xsd:float,
         nidm_equivalentZStatistic: = "6.05489626279796" %% xsd:float,
         nidm_pValueUncorrected: = "7.02540914332417e-10" %% xsd:float,
         nidm_pValueFWER: = "0.000146041348950021" %% xsd:float,
         nidm_qValueFDR: = "5.84165395800085e-06" %% xsd:float])
-    entity(niiri:3183606049158bc6420e12358dd06fd9,
+    entity(niiri:cf65d0a1b44e4d21b33bf5348cb46c49,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[22,-98,10]" %% xsd:string])
-    wasDerivedFrom(niiri:f066c96dd3c7c0996c0629c5c10cdb17, niiri:2e44272daecb8718b2883f84f352fc62, -, -, -)
-    entity(niiri:69750f3f4beb1c6336b85f6351e576c5,
+    wasDerivedFrom(niiri:01f425e6980b230ac084a97aaea6f38b, niiri:e2b47f512f66716985aee0fe421c3346, -, -, -)
+    entity(niiri:9ce1726d88e8e968130e7c320e9c5c3c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:b63737d1991f399dbba4dd7ae8a8acec',
+        prov:location = 'niiri:3d64faa35ffe99daeb08c99ca68b0f5b',
         prov:value = "12.7449989318848" %% xsd:float,
         nidm_equivalentZStatistic: = "5.80709618365418" %% xsd:float,
         nidm_pValueUncorrected: = "3.17828119378305e-09" %% xsd:float,
         nidm_pValueFWER: = "0.000660688335281101" %% xsd:float,
         nidm_qValueFDR: = "1.54333527599919e-05" %% xsd:float])
-    entity(niiri:b63737d1991f399dbba4dd7ae8a8acec,
+    entity(niiri:3d64faa35ffe99daeb08c99ca68b0f5b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[40,-76,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:69750f3f4beb1c6336b85f6351e576c5, niiri:2e44272daecb8718b2883f84f352fc62, -, -, -)
-    entity(niiri:e91a1a3ae11967bf367aa53b9ee31c18,
+    wasDerivedFrom(niiri:9ce1726d88e8e968130e7c320e9c5c3c, niiri:e2b47f512f66716985aee0fe421c3346, -, -, -)
+    entity(niiri:4b1eff73e32776f0e2fb32014c8cb1a0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:98e8748b9e902155aaca94b50263bba1',
+        prov:location = 'niiri:ae8b9eff557540ff9e2d82be8ca44920',
         prov:value = "11.9460592269897" %% xsd:float,
         nidm_equivalentZStatistic: = "5.59865646408728" %% xsd:float,
         nidm_pValueUncorrected: = "1.08009692301181e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00224526225660115" %% xsd:float,
         nidm_qValueFDR: = "3.11841980083494e-05" %% xsd:float])
-    entity(niiri:98e8748b9e902155aaca94b50263bba1,
+    entity(niiri:ae8b9eff557540ff9e2d82be8ca44920,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[36,-86,8]" %% xsd:string])
-    wasDerivedFrom(niiri:e91a1a3ae11967bf367aa53b9ee31c18, niiri:2e44272daecb8718b2883f84f352fc62, -, -, -)
-    entity(niiri:e5c7f01e47c1fbb085b416d97ceddbba,
+    wasDerivedFrom(niiri:4b1eff73e32776f0e2fb32014c8cb1a0, niiri:e2b47f512f66716985aee0fe421c3346, -, -, -)
+    entity(niiri:ce6df4e02afb3fb751ea9337acc129e5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:7f0badb64e663c1f3676cffc717236fa',
+        prov:location = 'niiri:fdb17142e8776e5e09fa077af54505c1',
         prov:value = "10.8997001647949" %% xsd:float,
         nidm_equivalentZStatistic: = "5.31044487629651" %% xsd:float,
         nidm_pValueUncorrected: = "5.46789791222579e-08" %% xsd:float,
         nidm_pValueFWER: = "0.0109446324802115" %% xsd:float,
         nidm_qValueFDR: = "8.7562484520721e-05" %% xsd:float])
-    entity(niiri:7f0badb64e663c1f3676cffc717236fa,
+    entity(niiri:fdb17142e8776e5e09fa077af54505c1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[32,-66,32]" %% xsd:string])
-    wasDerivedFrom(niiri:e5c7f01e47c1fbb085b416d97ceddbba, niiri:c893d69da88fea01efe542f9787608c5, -, -, -)
-    entity(niiri:2f7f807c988a3521e2049074aa842731,
+    wasDerivedFrom(niiri:ce6df4e02afb3fb751ea9337acc129e5, niiri:3c6dd5e94db642fc0c6313fade61752c, -, -, -)
+    entity(niiri:cf1ae1b8dbb977bd43ccd87582ce99ef,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:396e2c008744ecbc64a33278a34fcdbe',
+        prov:location = 'niiri:9f73dfd775133cf752b6fee383b6a816',
         prov:value = "5.45807838439941" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39070148271528" %% xsd:float,
         nidm_pValueUncorrected: = "0.000348569950826771" %% xsd:float,
         nidm_pValueFWER: = "0.999999998685327" %% xsd:float,
         nidm_qValueFDR: = "0.0335543570769498" %% xsd:float])
-    entity(niiri:396e2c008744ecbc64a33278a34fcdbe,
+    entity(niiri:9f73dfd775133cf752b6fee383b6a816,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[32,-74,38]" %% xsd:string])
-    wasDerivedFrom(niiri:2f7f807c988a3521e2049074aa842731, niiri:c893d69da88fea01efe542f9787608c5, -, -, -)
-    entity(niiri:2726200f9b0dcba5079dca1eb1a27ebd,
+    wasDerivedFrom(niiri:cf1ae1b8dbb977bd43ccd87582ce99ef, niiri:3c6dd5e94db642fc0c6313fade61752c, -, -, -)
+    entity(niiri:feca1010bcfc4933755ffba31c61684b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:575563e9436156ad59d10591a352d56d',
+        prov:location = 'niiri:e405f5885f3ea041f0fbd1d1a38116d6',
         prov:value = "10.0041055679321" %% xsd:float,
         nidm_equivalentZStatistic: = "5.04819646859005" %% xsd:float,
         nidm_pValueUncorrected: = "2.23000182986155e-07" %% xsd:float,
         nidm_pValueFWER: = "0.0380835451252286" %% xsd:float,
         nidm_qValueFDR: = "0.000232018725953295" %% xsd:float])
-    entity(niiri:575563e9436156ad59d10591a352d56d,
+    entity(niiri:e405f5885f3ea041f0fbd1d1a38116d6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[-30,-74,26]" %% xsd:string])
-    wasDerivedFrom(niiri:2726200f9b0dcba5079dca1eb1a27ebd, niiri:fafaf22f396d11e8355f5d1e7a7367ea, -, -, -)
-    entity(niiri:432182ae1dd08fbc638748dae384100d,
+    wasDerivedFrom(niiri:feca1010bcfc4933755ffba31c61684b, niiri:13dc91c36d42d9c0075971b7e2e4340a, -, -, -)
+    entity(niiri:bb52dac57682aa53c4dcc159d57cd756,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:49cfb4906f7511441f7faddc5a5b8413',
+        prov:location = 'niiri:60ef24b2768423f042d35e46f16fce54',
         prov:value = "9.62718677520752" %% xsd:float,
         nidm_equivalentZStatistic: = "4.933015925023" %% xsd:float,
         nidm_pValueUncorrected: = "4.04847753543436e-07" %% xsd:float,
         nidm_pValueFWER: = "0.063890884133409" %% xsd:float,
         nidm_qValueFDR: = "0.000364320989617512" %% xsd:float])
-    entity(niiri:49cfb4906f7511441f7faddc5a5b8413,
+    entity(niiri:60ef24b2768423f042d35e46f16fce54,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[-42,24,20]" %% xsd:string])
-    wasDerivedFrom(niiri:432182ae1dd08fbc638748dae384100d, niiri:0820636de884fe0d783c5385916ab101, -, -, -)
-    entity(niiri:85988a2f55e19fb0932bdaac88d56310,
+    wasDerivedFrom(niiri:bb52dac57682aa53c4dcc159d57cd756, niiri:63baaa25c1850e25ff8b59437cf378c6, -, -, -)
+    entity(niiri:1bec17a9f9ed5b6df70b776d93da494f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:53ed64c5e6de9d8d444e92f8219ed73e',
+        prov:location = 'niiri:ec0b37c67b2fb07a2714322846d4b004',
         prov:value = "8.07208061218262" %% xsd:float,
         nidm_equivalentZStatistic: = "4.42255808855286" %% xsd:float,
         nidm_pValueUncorrected: = "4.87695566220303e-06" %% xsd:float,
         nidm_pValueFWER: = "0.443484796305441" %% xsd:float,
         nidm_qValueFDR: = "0.00197238230997959" %% xsd:float])
-    entity(niiri:53ed64c5e6de9d8d444e92f8219ed73e,
+    entity(niiri:ec0b37c67b2fb07a2714322846d4b004,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[-50,28,22]" %% xsd:string])
-    wasDerivedFrom(niiri:85988a2f55e19fb0932bdaac88d56310, niiri:0820636de884fe0d783c5385916ab101, -, -, -)
-    entity(niiri:b4e90605b1ad8e708a5878d78afbd5df,
+    wasDerivedFrom(niiri:1bec17a9f9ed5b6df70b776d93da494f, niiri:63baaa25c1850e25ff8b59437cf378c6, -, -, -)
+    entity(niiri:4398173eefb4e1c6b6311db6e2849a12,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:7191009d584b787e22408325fb584516',
+        prov:location = 'niiri:640ace8062dc20b9f4349cee1bffe196',
         prov:value = "9.20645141601562" %% xsd:float,
         nidm_equivalentZStatistic: = "4.80076510146651" %% xsd:float,
         nidm_pValueUncorrected: = "7.90302914999153e-07" %% xsd:float,
         nidm_pValueFWER: = "0.112525268059434" %% xsd:float,
         nidm_qValueFDR: = "0.000576835659463966" %% xsd:float])
-    entity(niiri:7191009d584b787e22408325fb584516,
+    entity(niiri:640ace8062dc20b9f4349cee1bffe196,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[-50,8,42]" %% xsd:string])
-    wasDerivedFrom(niiri:b4e90605b1ad8e708a5878d78afbd5df, niiri:1e3c8c027b813bda7df5358a8ab4f63a, -, -, -)
-    entity(niiri:18479155c0b9f7007a2606ee355335a9,
+    wasDerivedFrom(niiri:4398173eefb4e1c6b6311db6e2849a12, niiri:938d8c88ecfbbf04abff04ec2e6740f3, -, -, -)
+    entity(niiri:894a5ac410c5e9f3cf47f79619bb0060,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:8563cb38a4e5f284711af2f862727bd9',
+        prov:location = 'niiri:641ff8bf09bceeb5eaacb8a965cbdf20',
         prov:value = "7.18871355056763" %% xsd:float,
         nidm_equivalentZStatistic: = "4.10255932739581" %% xsd:float,
         nidm_pValueUncorrected: = "2.04302517635702e-05" %% xsd:float,
         nidm_pValueFWER: = "0.864381142749573" %% xsd:float,
         nidm_qValueFDR: = "0.00518559511521378" %% xsd:float])
-    entity(niiri:8563cb38a4e5f284711af2f862727bd9,
+    entity(niiri:641ff8bf09bceeb5eaacb8a965cbdf20,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[-52,2,48]" %% xsd:string])
-    wasDerivedFrom(niiri:18479155c0b9f7007a2606ee355335a9, niiri:1e3c8c027b813bda7df5358a8ab4f63a, -, -, -)
-    entity(niiri:d3c08577d483b22d049b7eb0c6572b7f,
+    wasDerivedFrom(niiri:894a5ac410c5e9f3cf47f79619bb0060, niiri:938d8c88ecfbbf04abff04ec2e6740f3, -, -, -)
+    entity(niiri:ac4cea7f8f1bb0436e917fcc6be779b5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:cbf1b8ec0d607ae0da2d1270f1e5401a',
+        prov:location = 'niiri:8dc4cf1d1a8139a657dd64adfcd3144a',
         prov:value = "8.94470500946045" %% xsd:float,
         nidm_equivalentZStatistic: = "4.71641138081763" %% xsd:float,
         nidm_pValueUncorrected: = "1.20020424165812e-06" %% xsd:float,
         nidm_pValueFWER: = "0.158435738485403" %% xsd:float,
         nidm_qValueFDR: = "0.000760651849406736" %% xsd:float])
-    entity(niiri:cbf1b8ec0d607ae0da2d1270f1e5401a,
+    entity(niiri:8dc4cf1d1a8139a657dd64adfcd3144a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[-24,-64,66]" %% xsd:string])
-    wasDerivedFrom(niiri:d3c08577d483b22d049b7eb0c6572b7f, niiri:e24e457b7371fd1bac7d4cb391bb9432, -, -, -)
-    entity(niiri:b22647ec49d2b0b297e2ac1f30758018,
+    wasDerivedFrom(niiri:ac4cea7f8f1bb0436e917fcc6be779b5, niiri:86d427d519cd54a38aa4d9fc15de80c3, -, -, -)
+    entity(niiri:fd225bac392b7701cbc27894453e59cd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:26c07862039b52fa08db4cc5880af9e4',
+        prov:location = 'niiri:9fa66d81c9808501c94e931069a39ba8',
         prov:value = "7.5668888092041" %% xsd:float,
         nidm_equivalentZStatistic: = "4.24258939908316" %% xsd:float,
         nidm_pValueUncorrected: = "1.10477738578529e-05" %% xsd:float,
         nidm_pValueFWER: = "0.693995702855766" %% xsd:float,
         nidm_qValueFDR: = "0.0033973072847523" %% xsd:float])
-    entity(niiri:26c07862039b52fa08db4cc5880af9e4,
+    entity(niiri:9fa66d81c9808501c94e931069a39ba8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[-32,-56,62]" %% xsd:string])
-    wasDerivedFrom(niiri:b22647ec49d2b0b297e2ac1f30758018, niiri:e24e457b7371fd1bac7d4cb391bb9432, -, -, -)
-    entity(niiri:17cf8165ad43953b2998aec1ca9ddd0f,
+    wasDerivedFrom(niiri:fd225bac392b7701cbc27894453e59cd, niiri:86d427d519cd54a38aa4d9fc15de80c3, -, -, -)
+    entity(niiri:ff15ef5ba6e10aebe3cbaa8d04230787,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:2945a0dad8e64bb13fdb60092f3a3334',
+        prov:location = 'niiri:5fde917c842a1c2f12d320e49a0fe31b',
         prov:value = "8.42212200164795" %% xsd:float,
         nidm_equivalentZStatistic: = "4.54288070436711" %% xsd:float,
         nidm_pValueUncorrected: = "2.77453287811369e-06" %% xsd:float,
         nidm_pValueFWER: = "0.301737952159247" %% xsd:float,
         nidm_qValueFDR: = "0.00135672565933354" %% xsd:float])
-    entity(niiri:2945a0dad8e64bb13fdb60092f3a3334,
+    entity(niiri:5fde917c842a1c2f12d320e49a0fe31b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[22,-52,4]" %% xsd:string])
-    wasDerivedFrom(niiri:17cf8165ad43953b2998aec1ca9ddd0f, niiri:2f5fcfc4453f648ede4260a16cff5960, -, -, -)
-    entity(niiri:8a3dd8fbf2b47192a3e6b6d6690a00b5,
+    wasDerivedFrom(niiri:ff15ef5ba6e10aebe3cbaa8d04230787, niiri:d23334e15ca989a88f18103920c37202, -, -, -)
+    entity(niiri:9bd16aac89c993320304c9eb63a87b57,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:f4392121feaef697f908988f9d45a7b3',
+        prov:location = 'niiri:48c2cd130bbd6d709ab32816cec618a4',
         prov:value = "8.14441299438477" %% xsd:float,
         nidm_equivalentZStatistic: = "4.44770400954001" %% xsd:float,
         nidm_pValueUncorrected: = "4.33965069324138e-06" %% xsd:float,
         nidm_pValueFWER: = "0.411238149698711" %% xsd:float,
         nidm_qValueFDR: = "0.00180683059312593" %% xsd:float])
-    entity(niiri:f4392121feaef697f908988f9d45a7b3,
+    entity(niiri:48c2cd130bbd6d709ab32816cec618a4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[-36,-54,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:8a3dd8fbf2b47192a3e6b6d6690a00b5, niiri:dbbddbece734ef2c5ed154985b15ffe8, -, -, -)
-    entity(niiri:b173db6dde57bc22f0de6bac75f47a5e,
+    wasDerivedFrom(niiri:9bd16aac89c993320304c9eb63a87b57, niiri:34d7407deceb41bb05814c58f568aa8a, -, -, -)
+    entity(niiri:fb27062a0582a1fce60d6928817c662a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:9f0f16d82e93cbe816f1c8f4ac5e2aa9',
+        prov:location = 'niiri:bdb8026c36f785eb5ec07f08ef6cfdc0',
         prov:value = "7.75212860107422" %% xsd:float,
         nidm_equivalentZStatistic: = "4.30948435197428" %% xsd:float,
         nidm_pValueUncorrected: = "8.18178178840778e-06" %% xsd:float,
         nidm_pValueFWER: = "0.599664226758408" %% xsd:float,
         nidm_qValueFDR: = "0.00278317762946249" %% xsd:float])
-    entity(niiri:9f0f16d82e93cbe816f1c8f4ac5e2aa9,
+    entity(niiri:bdb8026c36f785eb5ec07f08ef6cfdc0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[10,-66,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:b173db6dde57bc22f0de6bac75f47a5e, niiri:6aecc2d95fe5ba4cd2d39d16afe85407, -, -, -)
-    entity(niiri:956544123ed8213df5fbc7f8d6973e3c,
+    wasDerivedFrom(niiri:fb27062a0582a1fce60d6928817c662a, niiri:f11390729469ff5ad94b49a0bdfa4678, -, -, -)
+    entity(niiri:657347798992bf8f9378fd7636cc0927,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:c5abac533b273ee4b7bab22f1b00ed76',
+        prov:location = 'niiri:0b4836f180573c7e2a074a4b6a46c52f',
         prov:value = "6.59869337081909" %% xsd:float,
         nidm_equivalentZStatistic: = "3.87398612970452" %% xsd:float,
         nidm_pValueUncorrected: = "5.35347545974618e-05" %% xsd:float,
         nidm_pValueFWER: = "0.988687386127249" %% xsd:float,
         nidm_qValueFDR: = "0.0099990013840748" %% xsd:float])
-    entity(niiri:c5abac533b273ee4b7bab22f1b00ed76,
+    entity(niiri:0b4836f180573c7e2a074a4b6a46c52f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[26,-72,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:956544123ed8213df5fbc7f8d6973e3c, niiri:6aecc2d95fe5ba4cd2d39d16afe85407, -, -, -)
-    entity(niiri:f4dea2e696793591088d280fed0f0584,
+    wasDerivedFrom(niiri:657347798992bf8f9378fd7636cc0927, niiri:f11390729469ff5ad94b49a0bdfa4678, -, -, -)
+    entity(niiri:a44b6a2efc6f9acbbcaf0464ac5a681d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:e2a291ea227f61911be316ee6108a55f',
+        prov:location = 'niiri:56f5ddfaab043af81b9608b017d7f1b7',
         prov:value = "6.09796094894409" %% xsd:float,
         nidm_equivalentZStatistic: = "3.6691747416434" %% xsd:float,
         nidm_pValueUncorrected: = "0.000121667358184974" %% xsd:float,
         nidm_pValueFWER: = "0.999849800966092" %% xsd:float,
         nidm_qValueFDR: = "0.0170443244379802" %% xsd:float])
-    entity(niiri:e2a291ea227f61911be316ee6108a55f,
+    entity(niiri:56f5ddfaab043af81b9608b017d7f1b7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[16,-72,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:f4dea2e696793591088d280fed0f0584, niiri:6aecc2d95fe5ba4cd2d39d16afe85407, -, -, -)
-    entity(niiri:d88a4b6a1eb63bac84a9f87e0794ba20,
+    wasDerivedFrom(niiri:a44b6a2efc6f9acbbcaf0464ac5a681d, niiri:f11390729469ff5ad94b49a0bdfa4678, -, -, -)
+    entity(niiri:c23aa344df3dfb68c6df15d4b9de0b49,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:2281a2b45d8f90027211445c926232e2',
+        prov:location = 'niiri:98a12d2cc55f8a4d4c0966b703d77ddc',
         prov:value = "7.67598438262939" %% xsd:float,
         nidm_equivalentZStatistic: = "4.28211703257948" %% xsd:float,
         nidm_pValueUncorrected: = "9.25617831770698e-06" %% xsd:float,
         nidm_pValueFWER: = "0.638571937641115" %% xsd:float,
         nidm_qValueFDR: = "0.00302106969058158" %% xsd:float])
-    entity(niiri:2281a2b45d8f90027211445c926232e2,
+    entity(niiri:98a12d2cc55f8a4d4c0966b703d77ddc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[42,-22,66]" %% xsd:string])
-    wasDerivedFrom(niiri:d88a4b6a1eb63bac84a9f87e0794ba20, niiri:a9c284c82bc4ef4eba48570f53c9c9c4, -, -, -)
-    entity(niiri:bfba970dca807cd42c369bc26d27f3eb,
+    wasDerivedFrom(niiri:c23aa344df3dfb68c6df15d4b9de0b49, niiri:ccdacac7fbef86b94a12c5dabbf08bc2, -, -, -)
+    entity(niiri:10eae58327bef44f83f5eadf77bf2b29,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:3253ad166d45aa411a00a879e94115b6',
+        prov:location = 'niiri:37e955e48e516a624990fe7106e561e6',
         prov:value = "6.16005897521973" %% xsd:float,
         nidm_equivalentZStatistic: = "3.6951610937944" %% xsd:float,
         nidm_pValueUncorrected: = "0.000109873708078023" %% xsd:float,
         nidm_pValueFWER: = "0.999696971784475" %% xsd:float,
         nidm_qValueFDR: = "0.0160177852706299" %% xsd:float])
-    entity(niiri:3253ad166d45aa411a00a879e94115b6,
+    entity(niiri:37e955e48e516a624990fe7106e561e6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[48,-18,62]" %% xsd:string])
-    wasDerivedFrom(niiri:bfba970dca807cd42c369bc26d27f3eb, niiri:a9c284c82bc4ef4eba48570f53c9c9c4, -, -, -)
-    entity(niiri:70cf11cb9bc7570fce0e5ed7c0993493,
+    wasDerivedFrom(niiri:10eae58327bef44f83f5eadf77bf2b29, niiri:ccdacac7fbef86b94a12c5dabbf08bc2, -, -, -)
+    entity(niiri:cd26ddfc926406425c12a65ed0b6edd3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:73acbe399f2ef5551e28416ff0886e25',
+        prov:location = 'niiri:4fc105ae0a05d4f9532f7a6138101892',
         prov:value = "7.57218790054321" %% xsd:float,
         nidm_equivalentZStatistic: = "4.24451811148991" %% xsd:float,
         nidm_pValueUncorrected: = "1.09531837353405e-05" %% xsd:float,
         nidm_pValueFWER: = "0.691329596120285" %% xsd:float,
         nidm_qValueFDR: = "0.00338801480937036" %% xsd:float])
-    entity(niiri:73acbe399f2ef5551e28416ff0886e25,
+    entity(niiri:4fc105ae0a05d4f9532f7a6138101892,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[30,-36,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:70cf11cb9bc7570fce0e5ed7c0993493, niiri:0637af2e34d8b1c842ae7d1386357498, -, -, -)
-    entity(niiri:a37c7f3e671f54bf1aeb9e2159fc0ead,
+    wasDerivedFrom(niiri:cd26ddfc926406425c12a65ed0b6edd3, niiri:13403d7573cd820266b83ff32d0e9707, -, -, -)
+    entity(niiri:e2ba3fc6a82344eb16652a1045af15c4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:44277e00fc4cc3cf8ea164e5d184e84d',
+        prov:location = 'niiri:415b77645b7cdae17b8ad758f5eb8b8d',
         prov:value = "7.4740514755249" %% xsd:float,
         nidm_equivalentZStatistic: = "4.20865253327564" %% xsd:float,
         nidm_pValueUncorrected: = "1.28449040975864e-05" %% xsd:float,
         nidm_pValueFWER: = "0.739935004547452" %% xsd:float,
         nidm_qValueFDR: = "0.00374497115452541" %% xsd:float])
-    entity(niiri:44277e00fc4cc3cf8ea164e5d184e84d,
+    entity(niiri:415b77645b7cdae17b8ad758f5eb8b8d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[22,-70,60]" %% xsd:string])
-    wasDerivedFrom(niiri:a37c7f3e671f54bf1aeb9e2159fc0ead, niiri:1cd4117828f514ec0fff4b67f780d6b9, -, -, -)
-    entity(niiri:95b5e8d1b0a6b737f8baac185d017d03,
+    wasDerivedFrom(niiri:e2ba3fc6a82344eb16652a1045af15c4, niiri:d86187d8105730183f4e8c029a41bf61, -, -, -)
+    entity(niiri:082452054c3dd5d2af374fa654347080,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:bcdd17c062f969757a86cbe2d236afea',
+        prov:location = 'niiri:799c9d89567bb44e19c70580446205dc',
         prov:value = "7.42476272583008" %% xsd:float,
         nidm_equivalentZStatistic: = "4.19052086074216" %% xsd:float,
         nidm_pValueUncorrected: = "1.39157412012425e-05" %% xsd:float,
         nidm_pValueFWER: = "0.76353829505901" %% xsd:float,
         nidm_qValueFDR: = "0.00397904916843096" %% xsd:float])
-    entity(niiri:bcdd17c062f969757a86cbe2d236afea,
+    entity(niiri:799c9d89567bb44e19c70580446205dc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[14,-44,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:95b5e8d1b0a6b737f8baac185d017d03, niiri:d85063f48080f770ca548748f7419e12, -, -, -)
-    entity(niiri:376402188bdf566830cafa900c2e2777,
+    wasDerivedFrom(niiri:082452054c3dd5d2af374fa654347080, niiri:67556c87393c94a727ee0b764b5d8856, -, -, -)
+    entity(niiri:76c802f08b9291304a2b64e88d09d6f7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:40631caf86fdb1eb06dd8fb89e5e0cdf',
+        prov:location = 'niiri:7163eea4c853502750a9407c735c9e3c',
         prov:value = "7.41156482696533" %% xsd:float,
         nidm_equivalentZStatistic: = "4.1856522195161" %% xsd:float,
         nidm_pValueUncorrected: = "1.42174217934166e-05" %% xsd:float,
         nidm_pValueFWER: = "0.76974170216107" %% xsd:float,
         nidm_qValueFDR: = "0.00404779744790916" %% xsd:float])
-    entity(niiri:40631caf86fdb1eb06dd8fb89e5e0cdf,
+    entity(niiri:7163eea4c853502750a9407c735c9e3c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[0,-22,66]" %% xsd:string])
-    wasDerivedFrom(niiri:376402188bdf566830cafa900c2e2777, niiri:ec3fc3cfa0c303c00f68f5986e44044e, -, -, -)
-    entity(niiri:e7535b3f1b2924d6cc2cc7dd1021e6ff,
+    wasDerivedFrom(niiri:76c802f08b9291304a2b64e88d09d6f7, niiri:8832fdb39eea98ef7aabb68883c63c22, -, -, -)
+    entity(niiri:cca01f107697356a1cefd866ab455a05,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:1009ccfd64bd14bdf04f231ec38d83db',
+        prov:location = 'niiri:0153ac1615e7c9789d415c65e4851eae',
         prov:value = "7.3316125869751" %% xsd:float,
         nidm_equivalentZStatistic: = "4.15603434431885" %% xsd:float,
         nidm_pValueUncorrected: = "1.61909583913378e-05" %% xsd:float,
         nidm_pValueFWER: = "0.806071531912271" %% xsd:float,
         nidm_qValueFDR: = "0.00442558415624652" %% xsd:float])
-    entity(niiri:1009ccfd64bd14bdf04f231ec38d83db,
+    entity(niiri:0153ac1615e7c9789d415c65e4851eae,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[-40,-26,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:e7535b3f1b2924d6cc2cc7dd1021e6ff, niiri:23c6e94e6643122dcb458402a972758e, -, -, -)
-    entity(niiri:e8318652b9767749a7b94884a6faf52e,
+    wasDerivedFrom(niiri:cca01f107697356a1cefd866ab455a05, niiri:0a733ee37ab9d8fc5554d22235fb2ebb, -, -, -)
+    entity(niiri:f91b302604a192f5e4846ca6deb35991,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:62333962f96d79e4ca7c4f1585c5e395',
+        prov:location = 'niiri:e6c18a21b0838652b0739046d24d8b3c',
         prov:value = "7.15871143341064" %% xsd:float,
         nidm_equivalentZStatistic: = "4.09124266610495" %% xsd:float,
         nidm_pValueUncorrected: = "2.14533936502281e-05" %% xsd:float,
         nidm_pValueFWER: = "0.875348981068006" %% xsd:float,
         nidm_qValueFDR: = "0.00534735431216318" %% xsd:float])
-    entity(niiri:62333962f96d79e4ca7c4f1585c5e395,
+    entity(niiri:e6c18a21b0838652b0739046d24d8b3c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[-48,-42,58]" %% xsd:string])
-    wasDerivedFrom(niiri:e8318652b9767749a7b94884a6faf52e, niiri:68f9a66ca71f514199366c398a2831ab, -, -, -)
-    entity(niiri:79db57175bcf213e5f77bd451afdb6fe,
+    wasDerivedFrom(niiri:f91b302604a192f5e4846ca6deb35991, niiri:20f7a6809dd02ee80d08c981d7533384, -, -, -)
+    entity(niiri:71d9ea403ed4487a2c2fcef870a5a99d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:4601ef775986b40077d71682573b43a7',
+        prov:location = 'niiri:1dcc0de807471f00991bddcea168b316',
         prov:value = "7.11809158325195" %% xsd:float,
         nidm_equivalentZStatistic: = "4.075870818357" %% xsd:float,
         nidm_pValueUncorrected: = "2.29212322924166e-05" %% xsd:float,
         nidm_pValueFWER: = "0.889420975253515" %% xsd:float,
         nidm_qValueFDR: = "0.00557942469794563" %% xsd:float])
-    entity(niiri:4601ef775986b40077d71682573b43a7,
+    entity(niiri:1dcc0de807471f00991bddcea168b316,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[-40,-34,66]" %% xsd:string])
-    wasDerivedFrom(niiri:79db57175bcf213e5f77bd451afdb6fe, niiri:6f303953fe538a2a99d9b754b92e311e, -, -, -)
-    entity(niiri:36ca195508a8e637007acd8f768fa1c9,
+    wasDerivedFrom(niiri:71d9ea403ed4487a2c2fcef870a5a99d, niiri:c1ebe6af3636d8119b6c8c898bc0b9cd, -, -, -)
+    entity(niiri:2a3f1962b93cf1ec51d9f9ce82b5b379,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:9ca689f733bdaa0f890c8fe7e51b6224',
+        prov:location = 'niiri:4f5bb05f88295472d544372f5353ad67',
         prov:value = "7.07621002197266" %% xsd:float,
         nidm_equivalentZStatistic: = "4.05996049269805" %% xsd:float,
         nidm_pValueUncorrected: = "2.45405099345009e-05" %% xsd:float,
         nidm_pValueFWER: = "0.902960652497904" %% xsd:float,
         nidm_qValueFDR: = "0.00587047829619361" %% xsd:float])
-    entity(niiri:9ca689f733bdaa0f890c8fe7e51b6224,
+    entity(niiri:4f5bb05f88295472d544372f5353ad67,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[-28,-64,36]" %% xsd:string])
-    wasDerivedFrom(niiri:36ca195508a8e637007acd8f768fa1c9, niiri:b32513dc3cebea135a4227a2ff2989c6, -, -, -)
-    entity(niiri:93964149cf1de70007b3d65bb04b9cd8,
+    wasDerivedFrom(niiri:2a3f1962b93cf1ec51d9f9ce82b5b379, niiri:f967cba917487022842df44264a09b9a, -, -, -)
+    entity(niiri:b06959bff99e3cecbbed58938eb1d757,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:bfbd55e8f2473bad1c11d7526e7f8cbb',
+        prov:location = 'niiri:8a18e9b312dde5cee1fe6ad6a5724104',
         prov:value = "6.77566051483154" %% xsd:float,
         nidm_equivalentZStatistic: = "3.94391444392688" %% xsd:float,
         nidm_pValueUncorrected: = "4.0081133562353e-05" %% xsd:float,
         nidm_pValueFWER: = "0.970449378854534" %% xsd:float,
         nidm_qValueFDR: = "0.0083237489519884" %% xsd:float])
-    entity(niiri:bfbd55e8f2473bad1c11d7526e7f8cbb,
+    entity(niiri:8a18e9b312dde5cee1fe6ad6a5724104,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[56,-14,52]" %% xsd:string])
-    wasDerivedFrom(niiri:93964149cf1de70007b3d65bb04b9cd8, niiri:b7301eccecd4c049bbeed4467b530024, -, -, -)
-    entity(niiri:3e906297c3e2890ce6abb1f2cb9be561,
+    wasDerivedFrom(niiri:b06959bff99e3cecbbed58938eb1d757, niiri:dead248e9a831f2d39ed43c1307d7a6f, -, -, -)
+    entity(niiri:881cc335773de76e9b8662888bd13ac4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:c0d2a2f16c1d44209d3e0ceba1cc405d',
+        prov:location = 'niiri:7ef0341d12f7ee676f32a2804a1f717b',
         prov:value = "6.75197219848633" %% xsd:float,
         nidm_equivalentZStatistic: = "3.9346244929229" %% xsd:float,
         nidm_pValueUncorrected: = "4.16634347842892e-05" %% xsd:float,
         nidm_pValueFWER: = "0.973679338420771" %% xsd:float,
         nidm_qValueFDR: = "0.00848286835858746" %% xsd:float])
-    entity(niiri:c0d2a2f16c1d44209d3e0ceba1cc405d,
+    entity(niiri:7ef0341d12f7ee676f32a2804a1f717b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[-40,56,6]" %% xsd:string])
-    wasDerivedFrom(niiri:3e906297c3e2890ce6abb1f2cb9be561, niiri:765e5201ffb06ca1f162ea8d7d3f0abd, -, -, -)
-    entity(niiri:e0515f336cbd787507ad3edf70116d4e,
+    wasDerivedFrom(niiri:881cc335773de76e9b8662888bd13ac4, niiri:63395ba4fe844e99193e44b8b12c407b, -, -, -)
+    entity(niiri:09bb3c77498b130e8126aa61c345d374,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0033" %% xsd:string,
-        prov:location = 'niiri:9c7564398039623209ebb464e1410345',
+        prov:location = 'niiri:0d5aad91f5d1c2bbd1f6c0c9a4531565',
         prov:value = "5.62889766693115" %% xsd:float,
         nidm_equivalentZStatistic: = "3.4670438729023" %% xsd:float,
         nidm_pValueUncorrected: = "0.000263107996845591" %% xsd:float,
         nidm_pValueFWER: = "0.999999922471127" %% xsd:float,
         nidm_qValueFDR: = "0.0280636167791234" %% xsd:float])
-    entity(niiri:9c7564398039623209ebb464e1410345,
+    entity(niiri:0d5aad91f5d1c2bbd1f6c0c9a4531565,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0033" %% xsd:string,
         nidm_coordinateVector: = "[-34,62,8]" %% xsd:string])
-    wasDerivedFrom(niiri:e0515f336cbd787507ad3edf70116d4e, niiri:765e5201ffb06ca1f162ea8d7d3f0abd, -, -, -)
-    entity(niiri:68d840be62a1d1171faf588a66b45a69,
+    wasDerivedFrom(niiri:09bb3c77498b130e8126aa61c345d374, niiri:63395ba4fe844e99193e44b8b12c407b, -, -, -)
+    entity(niiri:e045c46e40d2c8576a9a4ec0c1c78184,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0034" %% xsd:string,
-        prov:location = 'niiri:9020819036c441bf53457a8d05805fd2',
+        prov:location = 'niiri:372489fa8f3b978b7aed90c95f4b72f1',
         prov:value = "6.72361373901367" %% xsd:float,
         nidm_equivalentZStatistic: = "3.92347467532863" %% xsd:float,
         nidm_pValueUncorrected: = "4.3640471964479e-05" %% xsd:float,
         nidm_pValueFWER: = "0.977197537328254" %% xsd:float,
         nidm_qValueFDR: = "0.00877369894078824" %% xsd:float])
-    entity(niiri:9020819036c441bf53457a8d05805fd2,
+    entity(niiri:372489fa8f3b978b7aed90c95f4b72f1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0034" %% xsd:string,
         nidm_coordinateVector: = "[-4,-52,6]" %% xsd:string])
-    wasDerivedFrom(niiri:68d840be62a1d1171faf588a66b45a69, niiri:aeb5ca84ea986c7559b385b24d2806c0, -, -, -)
-    entity(niiri:fa083ea775134c459dc1bb371ed1dded,
+    wasDerivedFrom(niiri:e045c46e40d2c8576a9a4ec0c1c78184, niiri:9e473a48bfa3001fcf429b2b016fa5ea, -, -, -)
+    entity(niiri:78929640a7507b3952794c1ba644e2bc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0035" %% xsd:string,
-        prov:location = 'niiri:4ead7fcdda63c83da247a2a82f447618',
+        prov:location = 'niiri:26d159fdd349355fe8abf9a0d1ce02cb',
         prov:value = "5.89449167251587" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58279190167641" %% xsd:float,
         nidm_pValueUncorrected: = "0.000169970706923372" %% xsd:float,
         nidm_pValueFWER: = "0.999990278549049" %% xsd:float,
         nidm_qValueFDR: = "0.0210834330463974" %% xsd:float])
-    entity(niiri:4ead7fcdda63c83da247a2a82f447618,
+    entity(niiri:26d159fdd349355fe8abf9a0d1ce02cb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0035" %% xsd:string,
         nidm_coordinateVector: = "[-8,-56,0]" %% xsd:string])
-    wasDerivedFrom(niiri:fa083ea775134c459dc1bb371ed1dded, niiri:aeb5ca84ea986c7559b385b24d2806c0, -, -, -)
-    entity(niiri:bc11584c2cc9c15970a76804b11b842b,
+    wasDerivedFrom(niiri:78929640a7507b3952794c1ba644e2bc, niiri:9e473a48bfa3001fcf429b2b016fa5ea, -, -, -)
+    entity(niiri:b818f50374f62975097a22b686287afc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0036" %% xsd:string,
-        prov:location = 'niiri:6f14c51367b87703537f776c0c0dbdf5',
+        prov:location = 'niiri:fc3fb595563fd02fd5c9c620a0e410ac',
         prov:value = "6.7043924331665" %% xsd:float,
         nidm_equivalentZStatistic: = "3.91589968256295" %% xsd:float,
         nidm_pValueUncorrected: = "4.5033848123488e-05" %% xsd:float,
         nidm_pValueFWER: = "0.979375630051391" %% xsd:float,
         nidm_qValueFDR: = "0.00887748685076858" %% xsd:float])
-    entity(niiri:6f14c51367b87703537f776c0c0dbdf5,
+    entity(niiri:fc3fb595563fd02fd5c9c620a0e410ac,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0036" %% xsd:string,
         nidm_coordinateVector: = "[50,-64,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:bc11584c2cc9c15970a76804b11b842b, niiri:d36b472817f6888ac2860c8f78cda4e9, -, -, -)
-    entity(niiri:8975ccf5a69b1e5ce196d5d0e24ee229,
+    wasDerivedFrom(niiri:b818f50374f62975097a22b686287afc, niiri:66117305de42f7fc8878b963008d257b, -, -, -)
+    entity(niiri:657fc4be25ff87694be73a716d31ee88,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0037" %% xsd:string,
-        prov:location = 'niiri:c035e1c674ce2f5002c7510f276ba0d9',
+        prov:location = 'niiri:d579053f7af762590e2159cb63c3702b',
         prov:value = "6.67913484573364" %% xsd:float,
         nidm_equivalentZStatistic: = "3.90592399967592" %% xsd:float,
         nidm_pValueUncorrected: = "4.6933006303207e-05" %% xsd:float,
         nidm_pValueFWER: = "0.981996459937482" %% xsd:float,
         nidm_qValueFDR: = "0.00914383746051283" %% xsd:float])
-    entity(niiri:c035e1c674ce2f5002c7510f276ba0d9,
+    entity(niiri:d579053f7af762590e2159cb63c3702b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0037" %% xsd:string,
         nidm_coordinateVector: = "[-34,-40,36]" %% xsd:string])
-    wasDerivedFrom(niiri:8975ccf5a69b1e5ce196d5d0e24ee229, niiri:e1375ee26540e9328da498ca97a69cb4, -, -, -)
-    entity(niiri:e667e51e095b6fa110b25e9400332357,
+    wasDerivedFrom(niiri:657fc4be25ff87694be73a716d31ee88, niiri:4b2de1d700d8a7f369f0417da0db1e66, -, -, -)
+    entity(niiri:404282759712923e7380deda715286f5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0038" %% xsd:string,
-        prov:location = 'niiri:d10ee59dc87f8fe64f5ed1f2ea11a4cd',
+        prov:location = 'niiri:b42605abec5347a0ce7def763b3054e4',
         prov:value = "6.64170026779175" %% xsd:float,
         nidm_equivalentZStatistic: = "3.89109301638303" %% xsd:float,
         nidm_pValueUncorrected: = "4.98968323957572e-05" %% xsd:float,
         nidm_pValueFWER: = "0.985407255166263" %% xsd:float,
         nidm_qValueFDR: = "0.00949872959107623" %% xsd:float])
-    entity(niiri:d10ee59dc87f8fe64f5ed1f2ea11a4cd,
+    entity(niiri:b42605abec5347a0ce7def763b3054e4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0038" %% xsd:string,
         nidm_coordinateVector: = "[22,10,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:e667e51e095b6fa110b25e9400332357, niiri:d5f1c18934146a18337779acd9486123, -, -, -)
-    entity(niiri:1221262de1e5620b40e4bdfbdeb36776,
+    wasDerivedFrom(niiri:404282759712923e7380deda715286f5, niiri:f5ac935852ea4b1b9fed377c2aeb3b18, -, -, -)
+    entity(niiri:445cd2ad209dc7d0f5567e57dbfdbe57,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0039" %% xsd:string,
-        prov:location = 'niiri:843685ded7e6608a0699d60b38b277bd',
+        prov:location = 'niiri:04c6ede1d05f4dda32d567b98428ef09',
         prov:value = "5.66292333602905" %% xsd:float,
         nidm_equivalentZStatistic: = "3.48206928174656" %% xsd:float,
         nidm_pValueUncorrected: = "0.000248777471726358" %% xsd:float,
         nidm_pValueFWER: = "0.999999841793879" %% xsd:float,
         nidm_qValueFDR: = "0.0270792144117247" %% xsd:float])
-    entity(niiri:843685ded7e6608a0699d60b38b277bd,
+    entity(niiri:04c6ede1d05f4dda32d567b98428ef09,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0039" %% xsd:string,
         nidm_coordinateVector: = "[22,10,2]" %% xsd:string])
-    wasDerivedFrom(niiri:1221262de1e5620b40e4bdfbdeb36776, niiri:d5f1c18934146a18337779acd9486123, -, -, -)
-    entity(niiri:b35552ce359f982307861566bbcc356c,
+    wasDerivedFrom(niiri:445cd2ad209dc7d0f5567e57dbfdbe57, niiri:f5ac935852ea4b1b9fed377c2aeb3b18, -, -, -)
+    entity(niiri:94f93090d947e5f3aba6f6e0ea3e792c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0040" %% xsd:string,
-        prov:location = 'niiri:769e88496004ebf67fff73d31693db58',
+        prov:location = 'niiri:3a2a3e242401e1324c7a782c7dac5ea8',
         prov:value = "6.58932304382324" %% xsd:float,
         nidm_equivalentZStatistic: = "3.87024913662237" %% xsd:float,
         nidm_pValueUncorrected: = "5.43620931486855e-05" %% xsd:float,
         nidm_pValueFWER: = "0.9893188063809" %% xsd:float,
         nidm_qValueFDR: = "0.0101197978315716" %% xsd:float])
-    entity(niiri:769e88496004ebf67fff73d31693db58,
+    entity(niiri:3a2a3e242401e1324c7a782c7dac5ea8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0040" %% xsd:string,
         nidm_coordinateVector: = "[16,-8,20]" %% xsd:string])
-    wasDerivedFrom(niiri:b35552ce359f982307861566bbcc356c, niiri:275de6b748d7ad0f11eed3004edbf892, -, -, -)
-    entity(niiri:0d369bc39b99736fd4f8e779bf6ac134,
+    wasDerivedFrom(niiri:94f93090d947e5f3aba6f6e0ea3e792c, niiri:e0f3dfa1c85357af4b401994ac38769b, -, -, -)
+    entity(niiri:22544d4fd0e5f5fc386047416e17946e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0041" %% xsd:string,
-        prov:location = 'niiri:f6c77de876bf3849b6cec31bea5642c4',
+        prov:location = 'niiri:bc0e92bfb4bdfcd2e81499112ddfb5ad',
         prov:value = "6.53873300552368" %% xsd:float,
         nidm_equivalentZStatistic: = "3.8500124840786" %% xsd:float,
         nidm_pValueUncorrected: = "5.90559022480841e-05" %% xsd:float,
         nidm_pValueFWER: = "0.992265133018752" %% xsd:float,
         nidm_qValueFDR: = "0.0107045232421608" %% xsd:float])
-    entity(niiri:f6c77de876bf3849b6cec31bea5642c4,
+    entity(niiri:bc0e92bfb4bdfcd2e81499112ddfb5ad,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0041" %% xsd:string,
         nidm_coordinateVector: = "[28,-48,72]" %% xsd:string])
-    wasDerivedFrom(niiri:0d369bc39b99736fd4f8e779bf6ac134, niiri:2dd4cb8812c93538b5902225b29e0471, -, -, -)
-    entity(niiri:203aed58b8f81dce0ecac8be5e863bda,
+    wasDerivedFrom(niiri:22544d4fd0e5f5fc386047416e17946e, niiri:614c41139aa842cbd80a44616011d080, -, -, -)
+    entity(niiri:b4dcf253fb98a7d02af8a6095383dec3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0042" %% xsd:string,
-        prov:location = 'niiri:219472c226c1003f926096d10ddea706',
+        prov:location = 'niiri:8e8dae887c8bcbc322df68e9e8618d47',
         prov:value = "6.41633129119873" %% xsd:float,
         nidm_equivalentZStatistic: = "3.80061969992356" %% xsd:float,
         nidm_pValueUncorrected: = "7.2167337301976e-05" %% xsd:float,
         nidm_pValueFWER: = "0.996780557608903" %% xsd:float,
         nidm_qValueFDR: = "0.0122368668491247" %% xsd:float])
-    entity(niiri:219472c226c1003f926096d10ddea706,
+    entity(niiri:8e8dae887c8bcbc322df68e9e8618d47,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0042" %% xsd:string,
         nidm_coordinateVector: = "[30,-48,-18]" %% xsd:string])
-    wasDerivedFrom(niiri:203aed58b8f81dce0ecac8be5e863bda, niiri:67ae07e7ee0396386eefce6ed5341a79, -, -, -)
-    entity(niiri:79605721ecfe71b7f89e29aabbca94a0,
+    wasDerivedFrom(niiri:b4dcf253fb98a7d02af8a6095383dec3, niiri:c8f3c9da99d7be6a54c536483f0ca346, -, -, -)
+    entity(niiri:8fce2c8eb72bd4713a99a07479eb885c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0043" %% xsd:string,
-        prov:location = 'niiri:8aee97ed0bdda3e3420c52669ffbedb8',
+        prov:location = 'niiri:9663f7df7f5469003782e730408ea356',
         prov:value = "6.32824850082397" %% xsd:float,
         nidm_equivalentZStatistic: = "3.764690456476" %% xsd:float,
         nidm_pValueUncorrected: = "8.33777634952071e-05" %% xsd:float,
         nidm_pValueFWER: = "0.998439799137585" %% xsd:float,
         nidm_qValueFDR: = "0.0133433091347082" %% xsd:float])
-    entity(niiri:8aee97ed0bdda3e3420c52669ffbedb8,
+    entity(niiri:9663f7df7f5469003782e730408ea356,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0043" %% xsd:string,
         nidm_coordinateVector: = "[34,64,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:79605721ecfe71b7f89e29aabbca94a0, niiri:c589ee96ca2b908bdd9d337ca523d5af, -, -, -)
-    entity(niiri:7fae1b8bdbfa6d7b6e2b7098b3c6e4d9,
+    wasDerivedFrom(niiri:8fce2c8eb72bd4713a99a07479eb885c, niiri:cf1f683799f80f149702b64601072e25, -, -, -)
+    entity(niiri:6375e0c71e69ce7d6e7030ad6eedc08c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0044" %% xsd:string,
-        prov:location = 'niiri:fac73b3e372e29b6987b728b1ee5fbbf',
+        prov:location = 'niiri:2812d75f861602f532b1d54b4fb4714b',
         prov:value = "6.23233604431152" %% xsd:float,
         nidm_equivalentZStatistic: = "3.72519134385979" %% xsd:float,
         nidm_pValueUncorrected: = "9.75835625125487e-05" %% xsd:float,
         nidm_pValueFWER: = "0.999359408722565" %% xsd:float,
         nidm_qValueFDR: = "0.0147821614629234" %% xsd:float])
-    entity(niiri:fac73b3e372e29b6987b728b1ee5fbbf,
+    entity(niiri:2812d75f861602f532b1d54b4fb4714b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0044" %% xsd:string,
         nidm_coordinateVector: = "[-42,44,26]" %% xsd:string])
-    wasDerivedFrom(niiri:7fae1b8bdbfa6d7b6e2b7098b3c6e4d9, niiri:e43455a02504b9d87a4939904a0ca976, -, -, -)
-    entity(niiri:c2191d22002dea13759e4534d2a99bb2,
+    wasDerivedFrom(niiri:6375e0c71e69ce7d6e7030ad6eedc08c, niiri:fcfdc3edc7e7cbb46b2a5e7bd6a60b5a, -, -, -)
+    entity(niiri:82ccc891a4305f319cce2fc0f607ed1d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0045" %% xsd:string,
-        prov:location = 'niiri:1cd3744caef20860f929658348b743ab',
+        prov:location = 'niiri:e8db766a541deb9a4c6852ac44059437',
         prov:value = "6.06225728988647" %% xsd:float,
         nidm_equivalentZStatistic: = "3.6541549978965" %% xsd:float,
         nidm_pValueUncorrected: = "0.000129015181687619" %% xsd:float,
         nidm_pValueFWER: = "0.999902284410057" %% xsd:float,
         nidm_qValueFDR: = "0.0177419633224147" %% xsd:float])
-    entity(niiri:1cd3744caef20860f929658348b743ab,
+    entity(niiri:e8db766a541deb9a4c6852ac44059437,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0045" %% xsd:string,
         nidm_coordinateVector: = "[0,-10,76]" %% xsd:string])
-    wasDerivedFrom(niiri:c2191d22002dea13759e4534d2a99bb2, niiri:5dc937975dc687d7eb55e11a685cdd94, -, -, -)
-    entity(niiri:8e3e340d146c5b9659376513d4c922c7,
+    wasDerivedFrom(niiri:82ccc891a4305f319cce2fc0f607ed1d, niiri:c6b09785e79116c69c0d566f14508194, -, -, -)
+    entity(niiri:4bc015637a25e94d5335a5387464938f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0046" %% xsd:string,
-        prov:location = 'niiri:7cf3a56c9ff943e6f0580b9ef6f6505c',
+        prov:location = 'niiri:c5afe2e92d4baf5644d912e4354b4143',
         prov:value = "6.03189373016357" %% xsd:float,
         nidm_equivalentZStatistic: = "3.64133598155782" %% xsd:float,
         nidm_pValueUncorrected: = "0.000135613449379846" %% xsd:float,
         nidm_pValueFWER: = "0.999933280387137" %% xsd:float,
         nidm_qValueFDR: = "0.0183426760576609" %% xsd:float])
-    entity(niiri:7cf3a56c9ff943e6f0580b9ef6f6505c,
+    entity(niiri:c5afe2e92d4baf5644d912e4354b4143,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0046" %% xsd:string,
         nidm_coordinateVector: = "[34,-16,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:8e3e340d146c5b9659376513d4c922c7, niiri:30c5174c5d495474060913c40bab0961, -, -, -)
-    entity(niiri:8766ac26c208ff8612c72111c2100871,
+    wasDerivedFrom(niiri:4bc015637a25e94d5335a5387464938f, niiri:b62d08e7f48d3b48c3d3470c4864b0f5, -, -, -)
+    entity(niiri:c7e58eb2aceb0dab12765c4d98d82b9e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0047" %% xsd:string,
-        prov:location = 'niiri:ac6145a41b42dd4e0f5c9807aaabc438',
+        prov:location = 'niiri:8f1b0a8e1b537455e75ed1f53fc5590f',
         prov:value = "6.02538537979126" %% xsd:float,
         nidm_equivalentZStatistic: = "3.63858275251093" %% xsd:float,
         nidm_pValueUncorrected: = "0.000137071270502886" %% xsd:float,
         nidm_pValueFWER: = "0.999938640797957" %% xsd:float,
         nidm_qValueFDR: = "0.0183962430264957" %% xsd:float])
-    entity(niiri:ac6145a41b42dd4e0f5c9807aaabc438,
+    entity(niiri:8f1b0a8e1b537455e75ed1f53fc5590f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0047" %% xsd:string,
         nidm_coordinateVector: = "[6,-80,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:8766ac26c208ff8612c72111c2100871, niiri:ea999779ae02d5714142530d4b2e638b, -, -, -)
-    entity(niiri:a6e97fb09e03600e49705c493a878db7,
+    wasDerivedFrom(niiri:c7e58eb2aceb0dab12765c4d98d82b9e, niiri:820eae4f2ecfa96c61f16f68989e60f2, -, -, -)
+    entity(niiri:7c6c80d6afc552a312faa863484d1e87,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0048" %% xsd:string,
-        prov:location = 'niiri:e01d6c7223e76ffbae5e844b5dbe79aa',
+        prov:location = 'niiri:ed391688f38f5280aa723ad94fb9890d',
         prov:value = "5.95283126831055" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60775727167743" %% xsd:float,
         nidm_pValueUncorrected: = "0.000154427613028529" %% xsd:float,
         nidm_pValueFWER: = "0.999977036852347" %% xsd:float,
         nidm_qValueFDR: = "0.0199653441808624" %% xsd:float])
-    entity(niiri:e01d6c7223e76ffbae5e844b5dbe79aa,
+    entity(niiri:ed391688f38f5280aa723ad94fb9890d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0048" %% xsd:string,
         nidm_coordinateVector: = "[-26,-38,-52]" %% xsd:string])
-    wasDerivedFrom(niiri:a6e97fb09e03600e49705c493a878db7, niiri:15b2530019f1c4c6d5e910962b35274b, -, -, -)
-    entity(niiri:8bcc743e85db485e4a2986804c97c77b,
+    wasDerivedFrom(niiri:7c6c80d6afc552a312faa863484d1e87, niiri:0c814c8aa73eb23edb6b0bdf05d875b9, -, -, -)
+    entity(niiri:4ab14068789abfafe4a80670e95fbd0f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0049" %% xsd:string,
-        prov:location = 'niiri:26a3a76d924a3533d4779f0959a1fbaf',
+        prov:location = 'niiri:99fa92cce75080e4308b5d4b51ae0f66',
         prov:value = "5.9493842124939" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60628663469786" %% xsd:float,
         nidm_pValueUncorrected: = "0.000155305014835405" %% xsd:float,
         nidm_pValueFWER: = "0.999978135328144" %% xsd:float,
         nidm_qValueFDR: = "0.0200343508975978" %% xsd:float])
-    entity(niiri:26a3a76d924a3533d4779f0959a1fbaf,
+    entity(niiri:99fa92cce75080e4308b5d4b51ae0f66,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0049" %% xsd:string,
         nidm_coordinateVector: = "[32,-52,46]" %% xsd:string])
-    wasDerivedFrom(niiri:8bcc743e85db485e4a2986804c97c77b, niiri:5782e52657a04683a9d9acc635ffc74a, -, -, -)
-    entity(niiri:f70cbe313f78f3bc26491805e90defbf,
+    wasDerivedFrom(niiri:4ab14068789abfafe4a80670e95fbd0f, niiri:3237418b7d965d5533963a3817c7547f, -, -, -)
+    entity(niiri:c5e8312043c11a120970a62496ae9d72,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0050" %% xsd:string,
-        prov:location = 'niiri:60032f6ce2504b4763622044467988e0',
+        prov:location = 'niiri:0e6a5cde3992a2f46e103d9f26d781ee',
         prov:value = "5.90739822387695" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58832892416593" %% xsd:float,
         nidm_pValueUncorrected: = "0.00016640212943575" %% xsd:float,
         nidm_pValueFWER: = "0.999988176695278" %% xsd:float,
         nidm_qValueFDR: = "0.0208396911967648" %% xsd:float])
-    entity(niiri:60032f6ce2504b4763622044467988e0,
+    entity(niiri:0e6a5cde3992a2f46e103d9f26d781ee,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0050" %% xsd:string,
         nidm_coordinateVector: = "[20,58,6]" %% xsd:string])
-    wasDerivedFrom(niiri:f70cbe313f78f3bc26491805e90defbf, niiri:e26340fcd624896679dd2542ec2348be, -, -, -)
-    entity(niiri:3349878166a538e7a54b1390c105c88b,
+    wasDerivedFrom(niiri:c5e8312043c11a120970a62496ae9d72, niiri:479583c290f59d278781273768ba65dc, -, -, -)
+    entity(niiri:b6a20083300f6de427709519fa96ff08,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0051" %% xsd:string,
-        prov:location = 'niiri:ddefff6ce2c505804cc2f308814149f9',
+        prov:location = 'niiri:1fbdc4f79b52339c73cb35f1986d9dbd',
         prov:value = "5.88568687438965" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57901000852841" %% xsd:float,
         nidm_pValueUncorrected: = "0.000172449130450447" %% xsd:float,
         nidm_pValueFWER: = "0.999991509605729" %% xsd:float,
         nidm_qValueFDR: = "0.0213019172775607" %% xsd:float])
-    entity(niiri:ddefff6ce2c505804cc2f308814149f9,
+    entity(niiri:1fbdc4f79b52339c73cb35f1986d9dbd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0051" %% xsd:string,
         nidm_coordinateVector: = "[-28,-70,-52]" %% xsd:string])
-    wasDerivedFrom(niiri:3349878166a538e7a54b1390c105c88b, niiri:e4e5f6e0de1fb1456effbec6ec82e736, -, -, -)
-    entity(niiri:8345510a279773a85dbd456831121d91,
+    wasDerivedFrom(niiri:b6a20083300f6de427709519fa96ff08, niiri:609da3fb63ae9918c3e77a08cdb6cfc2, -, -, -)
+    entity(niiri:31767e616570435641f143cae011f953,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0052" %% xsd:string,
-        prov:location = 'niiri:3b9c2d356ee88a92c830323a0d5af7c1',
+        prov:location = 'niiri:080ac45360879294e37c6287d22fd8b3',
         prov:value = "5.88288545608521" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57780594841694" %% xsd:float,
         nidm_pValueUncorrected: = "0.000173245266573252" %% xsd:float,
         nidm_pValueFWER: = "0.999991870214044" %% xsd:float,
         nidm_qValueFDR: = "0.0213621903805226" %% xsd:float])
-    entity(niiri:3b9c2d356ee88a92c830323a0d5af7c1,
+    entity(niiri:080ac45360879294e37c6287d22fd8b3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0052" %% xsd:string,
         nidm_coordinateVector: = "[-16,-58,-38]" %% xsd:string])
-    wasDerivedFrom(niiri:8345510a279773a85dbd456831121d91, niiri:5cf9ae44dc03a8c6493baf09bed014d4, -, -, -)
-    entity(niiri:4bff1d01552bc126cd2623ad4ebf3b9a,
+    wasDerivedFrom(niiri:31767e616570435641f143cae011f953, niiri:76f32299041fc5f4d0b950c566a0624b, -, -, -)
+    entity(niiri:18dcf52d105ae341a24bc8dcf187bd7d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0053" %% xsd:string,
-        prov:location = 'niiri:a9399ad6017a33693100cb9d9a9888f2',
+        prov:location = 'niiri:8d26f8dc7b292242e6151b98e0f835db',
         prov:value = "5.87665224075317" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57512554105657" %% xsd:float,
         nidm_pValueUncorrected: = "0.000175029940004845" %% xsd:float,
         nidm_pValueFWER: = "0.999992622705061" %% xsd:float,
         nidm_qValueFDR: = "0.0214921236782135" %% xsd:float])
-    entity(niiri:a9399ad6017a33693100cb9d9a9888f2,
+    entity(niiri:8d26f8dc7b292242e6151b98e0f835db,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0053" %% xsd:string,
         nidm_coordinateVector: = "[-10,-82,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:4bff1d01552bc126cd2623ad4ebf3b9a, niiri:dfe1466699f719841d6d98d1188da0c8, -, -, -)
-    entity(niiri:061bf720e78be5f38a4d203be70999ba,
+    wasDerivedFrom(niiri:18dcf52d105ae341a24bc8dcf187bd7d, niiri:9e864aa27a55745175707c98d46a334c, -, -, -)
+    entity(niiri:29d29448ea553b9836a11b3f3932ffc9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0054" %% xsd:string,
-        prov:location = 'niiri:029afc2516914e2a77271d16e01d5717',
+        prov:location = 'niiri:0a1bdaff66645f8b1b42fb1660070405',
         prov:value = "5.86712741851807" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57102607807387" %% xsd:float,
         nidm_pValueUncorrected: = "0.000177792742607208" %% xsd:float,
         nidm_pValueFWER: = "0.999993649803941" %% xsd:float,
         nidm_qValueFDR: = "0.0216816267105749" %% xsd:float])
-    entity(niiri:029afc2516914e2a77271d16e01d5717,
+    entity(niiri:0a1bdaff66645f8b1b42fb1660070405,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0054" %% xsd:string,
         nidm_coordinateVector: = "[50,50,8]" %% xsd:string])
-    wasDerivedFrom(niiri:061bf720e78be5f38a4d203be70999ba, niiri:e69a5e282ae0346ca803f55371164aa7, -, -, -)
-    entity(niiri:b356784762f635ac6a6625d03f3fd1d5,
+    wasDerivedFrom(niiri:29d29448ea553b9836a11b3f3932ffc9, niiri:628a97ee4df64877d84868107814f955, -, -, -)
+    entity(niiri:136b0dae4c0cc7c691f5df819a046a16,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0055" %% xsd:string,
-        prov:location = 'niiri:6879e2b7fd420a16198270a7fda0c0ec',
+        prov:location = 'niiri:47c22b00af020d507b9cfcdebf96840b',
         prov:value = "5.85824680328369" %% xsd:float,
         nidm_equivalentZStatistic: = "3.56719995255891" %% xsd:float,
         nidm_pValueUncorrected: = "0.000180408078987448" %% xsd:float,
         nidm_pValueFWER: = "0.999994487319543" %% xsd:float,
         nidm_qValueFDR: = "0.0217930814133279" %% xsd:float])
-    entity(niiri:6879e2b7fd420a16198270a7fda0c0ec,
+    entity(niiri:47c22b00af020d507b9cfcdebf96840b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0055" %% xsd:string,
         nidm_coordinateVector: = "[-6,-78,56]" %% xsd:string])
-    wasDerivedFrom(niiri:b356784762f635ac6a6625d03f3fd1d5, niiri:d168d4b61807fc13619ad56c31dad174, -, -, -)
-    entity(niiri:52474a24c82a42c438dfac7f6b6ebe74,
+    wasDerivedFrom(niiri:136b0dae4c0cc7c691f5df819a046a16, niiri:52a2c6444b10fca5e154fba0b3e62d50, -, -, -)
+    entity(niiri:7d6ac5abaee75da771fcc4ee9ae756b9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0056" %% xsd:string,
-        prov:location = 'niiri:b536ab3bffaed62ccb1ca6267c85947b',
+        prov:location = 'niiri:eaa049bc0deda3f95639705970fa8823',
         prov:value = "5.81644201278687" %% xsd:float,
         nidm_equivalentZStatistic: = "3.54913757298709" %% xsd:float,
         nidm_pValueUncorrected: = "0.000193247549691744" %% xsd:float,
         nidm_pValueFWER: = "0.99999722874557" %% xsd:float,
         nidm_qValueFDR: = "0.022905022613713" %% xsd:float])
-    entity(niiri:b536ab3bffaed62ccb1ca6267c85947b,
+    entity(niiri:eaa049bc0deda3f95639705970fa8823,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0056" %% xsd:string,
         nidm_coordinateVector: = "[44,50,20]" %% xsd:string])
-    wasDerivedFrom(niiri:52474a24c82a42c438dfac7f6b6ebe74, niiri:522e011a3a54e833c99dc9315f577dfe, -, -, -)
-    entity(niiri:63d794c7a20b8c3844c02909a430c400,
+    wasDerivedFrom(niiri:7d6ac5abaee75da771fcc4ee9ae756b9, niiri:a9bc5d8a6d734a19d1ee638ddfa9e34f, -, -, -)
+    entity(niiri:92f780b833bf32893f3b88e89980d8d8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0057" %% xsd:string,
-        prov:location = 'niiri:c04e40e59d081babf861f27fff0bc656',
+        prov:location = 'niiri:453445eb90a279054934aeb350144243',
         prov:value = "5.75350570678711" %% xsd:float,
         nidm_equivalentZStatistic: = "3.52178406559812" %% xsd:float,
         nidm_pValueUncorrected: = "0.000214326572548162" %% xsd:float,
         nidm_pValueFWER: = "0.999999083879168" %% xsd:float,
         nidm_qValueFDR: = "0.0245474913207941" %% xsd:float])
-    entity(niiri:c04e40e59d081babf861f27fff0bc656,
+    entity(niiri:453445eb90a279054934aeb350144243,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0057" %% xsd:string,
         nidm_coordinateVector: = "[-30,-58,-52]" %% xsd:string])
-    wasDerivedFrom(niiri:63d794c7a20b8c3844c02909a430c400, niiri:bcc290b739057f6cb5c02dcc79c4b5bc, -, -, -)
-    entity(niiri:341c565fefe9949adb1369f3da7a2a11,
+    wasDerivedFrom(niiri:92f780b833bf32893f3b88e89980d8d8, niiri:cf869ef162fc61878c8c7fbac7157264, -, -, -)
+    entity(niiri:253b21a384f1f3314298745cb5d1668d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0058" %% xsd:string,
-        prov:location = 'niiri:6f522d3d3123b608cd947c46fdc012a6',
+        prov:location = 'niiri:03ad8275dad57815babc684e230f29da',
         prov:value = "5.74829816818237" %% xsd:float,
         nidm_equivalentZStatistic: = "3.51951200270118" %% xsd:float,
         nidm_pValueUncorrected: = "0.000216170736607735" %% xsd:float,
         nidm_pValueFWER: = "0.999999167412893" %% xsd:float,
         nidm_qValueFDR: = "0.0246525319493899" %% xsd:float])
-    entity(niiri:6f522d3d3123b608cd947c46fdc012a6,
+    entity(niiri:03ad8275dad57815babc684e230f29da,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0058" %% xsd:string,
         nidm_coordinateVector: = "[-38,36,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:341c565fefe9949adb1369f3da7a2a11, niiri:6f3de48dca5b4c3a6aca0be63ddd27cd, -, -, -)
-    entity(niiri:511b02a8bf4a6e0270aa9e4d8188cf98,
+    wasDerivedFrom(niiri:253b21a384f1f3314298745cb5d1668d, niiri:404edd754b52ba04b35f56d4e502f8ce, -, -, -)
+    entity(niiri:de597d8b3789310d0a77b771a6a6e111,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0059" %% xsd:string,
-        prov:location = 'niiri:08733586f578952e07d3ef0bedd783e7',
+        prov:location = 'niiri:44711cdf019c5b4f5b970ff900611073',
         prov:value = "5.7312970161438" %% xsd:float,
         nidm_equivalentZStatistic: = "3.51208496979963" %% xsd:float,
         nidm_pValueUncorrected: = "0.000222302913436612" %% xsd:float,
         nidm_pValueFWER: = "0.99999939333845" %% xsd:float,
         nidm_qValueFDR: = "0.0250806761204491" %% xsd:float])
-    entity(niiri:08733586f578952e07d3ef0bedd783e7,
+    entity(niiri:44711cdf019c5b4f5b970ff900611073,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0059" %% xsd:string,
         nidm_coordinateVector: = "[-50,12,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:511b02a8bf4a6e0270aa9e4d8188cf98, niiri:f77f344a47f917de9a802b78319c354f, -, -, -)
-    entity(niiri:2f69fd65193eb1b02e7f447cca5b3d63,
+    wasDerivedFrom(niiri:de597d8b3789310d0a77b771a6a6e111, niiri:646c9634927ecdb2332ab5dfe7a28006, -, -, -)
+    entity(niiri:8e7f20532879d495c5a42e5d03642d77,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0060" %% xsd:string,
-        prov:location = 'niiri:ca4ad108c221d6463345f5410c20d1b6',
+        prov:location = 'niiri:93b03e2e5d1ab918fd6387ca80923df5',
         prov:value = "5.61407613754272" %% xsd:float,
         nidm_equivalentZStatistic: = "3.46048027314539" %% xsd:float,
         nidm_pValueUncorrected: = "0.000269606369816766" %% xsd:float,
         nidm_pValueFWER: = "0.999999943721802" %% xsd:float,
         nidm_qValueFDR: = "0.0285650985701987" %% xsd:float])
-    entity(niiri:ca4ad108c221d6463345f5410c20d1b6,
+    entity(niiri:93b03e2e5d1ab918fd6387ca80923df5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0060" %% xsd:string,
         nidm_coordinateVector: = "[-52,38,14]" %% xsd:string])
-    wasDerivedFrom(niiri:2f69fd65193eb1b02e7f447cca5b3d63, niiri:9df645a4ce3520ee828e35a6dac32f9f, -, -, -)
-    entity(niiri:6fb432a65a1864ebc7f79bd73139967a,
+    wasDerivedFrom(niiri:8e7f20532879d495c5a42e5d03642d77, niiri:c0fd049d894fca767270c43b39b70df9, -, -, -)
+    entity(niiri:5c140482468e320e3d5211e55d1b2399,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0061" %% xsd:string,
-        prov:location = 'niiri:05b2d9da6ce7b779041ee7d321cee8e3',
+        prov:location = 'niiri:f3b8807229024d21b3f54c200a577a82',
         prov:value = "5.53163862228394" %% xsd:float,
         nidm_equivalentZStatistic: = "3.42376539987989" %% xsd:float,
         nidm_pValueUncorrected: = "0.000308799561745898" %% xsd:float,
         nidm_pValueFWER: = "0.999999991534363" %% xsd:float,
         nidm_qValueFDR: = "0.0312013208214028" %% xsd:float])
-    entity(niiri:05b2d9da6ce7b779041ee7d321cee8e3,
+    entity(niiri:f3b8807229024d21b3f54c200a577a82,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0061" %% xsd:string,
         nidm_coordinateVector: = "[-14,-80,10]" %% xsd:string])
-    wasDerivedFrom(niiri:6fb432a65a1864ebc7f79bd73139967a, niiri:1dea88b1f0062ddb01809c2f336aff3f, -, -, -)
-    entity(niiri:ef1964afa02d57f263805ebae4d754c5,
+    wasDerivedFrom(niiri:5c140482468e320e3d5211e55d1b2399, niiri:9552b4dbfe0833d9f21d39cf5a3f531c, -, -, -)
+    entity(niiri:0456eeedb5dc828ec86c0c36377fb91f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0062" %% xsd:string,
-        prov:location = 'niiri:0d2cac5a83e96f9282820e4e4438c966',
+        prov:location = 'niiri:01308065c94d19b3fc7a19a6d160ef56',
         prov:value = "5.52454996109009" %% xsd:float,
         nidm_equivalentZStatistic: = "3.42059171809414" %% xsd:float,
         nidm_pValueUncorrected: = "0.000312425309546338" %% xsd:float,
         nidm_pValueFWER: = "0.999999992873262" %% xsd:float,
         nidm_qValueFDR: = "0.0313644959462665" %% xsd:float])
-    entity(niiri:0d2cac5a83e96f9282820e4e4438c966,
+    entity(niiri:01308065c94d19b3fc7a19a6d160ef56,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0062" %% xsd:string,
         nidm_coordinateVector: = "[-66,-40,18]" %% xsd:string])
-    wasDerivedFrom(niiri:ef1964afa02d57f263805ebae4d754c5, niiri:f424b0ee093c7ca1771bb8144718087b, -, -, -)
-    entity(niiri:bd558d7e2f31e68ed9630cf47a3dc77f,
+    wasDerivedFrom(niiri:0456eeedb5dc828ec86c0c36377fb91f, niiri:4cb0bf65605055716432884893e5e9c2, -, -, -)
+    entity(niiri:c60b521a8155d25ab1d81a437359bcd0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0063" %% xsd:string,
-        prov:location = 'niiri:d292d5aee905fd862dc0c678e3fe9df2',
+        prov:location = 'niiri:7c7faa3f4c77dc526122e2f47f62aece',
         prov:value = "5.51989889144897" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41850793238069" %% xsd:float,
         nidm_pValueUncorrected: = "0.000314827412227103" %% xsd:float,
         nidm_pValueFWER: = "0.99999999363976" %% xsd:float,
         nidm_qValueFDR: = "0.0315295603356192" %% xsd:float])
-    entity(niiri:d292d5aee905fd862dc0c678e3fe9df2,
+    entity(niiri:7c7faa3f4c77dc526122e2f47f62aece,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0063" %% xsd:string,
         nidm_coordinateVector: = "[-2,-90,16]" %% xsd:string])
-    wasDerivedFrom(niiri:bd558d7e2f31e68ed9630cf47a3dc77f, niiri:258ff3de07e51a57d0b27d6699fb2508, -, -, -)
-    entity(niiri:cbcc21fd20778a31e84881bfab50ee09,
+    wasDerivedFrom(niiri:c60b521a8155d25ab1d81a437359bcd0, niiri:d6b37cc773edb870bb55c2d6372f256b, -, -, -)
+    entity(niiri:228fb7b44d90fa76d0a2bd634ed30bad,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0064" %% xsd:string,
-        prov:location = 'niiri:4abf0e8985243764b8b4d826d3ff3cac',
+        prov:location = 'niiri:344815ee260bb617fd9b0d32cadfc871',
         prov:value = "5.50013113021851" %% xsd:float,
         nidm_equivalentZStatistic: = "3.40963871850162" %% xsd:float,
         nidm_pValueUncorrected: = "0.000325244937404157" %% xsd:float,
         nidm_pValueFWER: = "0.99999999610751" %% xsd:float,
         nidm_qValueFDR: = "0.0320937892728011" %% xsd:float])
-    entity(niiri:4abf0e8985243764b8b4d826d3ff3cac,
+    entity(niiri:344815ee260bb617fd9b0d32cadfc871,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0064" %% xsd:string,
         nidm_coordinateVector: = "[48,-68,24]" %% xsd:string])
-    wasDerivedFrom(niiri:cbcc21fd20778a31e84881bfab50ee09, niiri:fd669f02bbb8da3eff612dc0d4b807f6, -, -, -)
-    entity(niiri:76de7fa6ab94ab4a76284547a4e3f1aa,
+    wasDerivedFrom(niiri:228fb7b44d90fa76d0a2bd634ed30bad, niiri:27724b6869441a042387c9d5c13942d2, -, -, -)
+    entity(niiri:3eb9240a880fd3014089aee2ec60e9ee,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0065" %% xsd:string,
-        prov:location = 'niiri:91f9c5e62fe3707f1980b1138c4853ca',
+        prov:location = 'niiri:f8140c6cb955395595441fdd0ac9060f',
         prov:value = "5.47258329391479" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39724406479958" %% xsd:float,
         nidm_pValueUncorrected: = "0.000340341137511579" %% xsd:float,
         nidm_pValueFWER: = "0.999999998076035" %% xsd:float,
         nidm_qValueFDR: = "0.0330219418190176" %% xsd:float])
-    entity(niiri:91f9c5e62fe3707f1980b1138c4853ca,
+    entity(niiri:f8140c6cb955395595441fdd0ac9060f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0065" %% xsd:string,
         nidm_coordinateVector: = "[-66,-52,14]" %% xsd:string])
-    wasDerivedFrom(niiri:76de7fa6ab94ab4a76284547a4e3f1aa, niiri:2560564a14e0250f709b385639d02fb9, -, -, -)
-    entity(niiri:9e085633b6f20c82d2de1068c8944127,
+    wasDerivedFrom(niiri:3eb9240a880fd3014089aee2ec60e9ee, niiri:6c4baced41f2f8c3fb0cb36e9ec2f421, -, -, -)
+    entity(niiri:894e7b5f3c0f1694051eaa36e3339902,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0066" %% xsd:string,
-        prov:location = 'niiri:8940c35372a329a691f251d5f01211da',
+        prov:location = 'niiri:71f8c30346b0401144bb9a6aafce5d89',
         prov:value = "5.47253847122192" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39722386451209" %% xsd:float,
         nidm_pValueUncorrected: = "0.000340366263790748" %% xsd:float,
         nidm_pValueFWER: = "0.999999998078278" %% xsd:float,
         nidm_qValueFDR: = "0.0330219418190176" %% xsd:float])
-    entity(niiri:8940c35372a329a691f251d5f01211da,
+    entity(niiri:71f8c30346b0401144bb9a6aafce5d89,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0066" %% xsd:string,
         nidm_coordinateVector: = "[-24,-70,-40]" %% xsd:string])
-    wasDerivedFrom(niiri:9e085633b6f20c82d2de1068c8944127, niiri:589d688bdb65a26f0e5afdd4ff33865b, -, -, -)
-    entity(niiri:584625db35fd1e69dc1aeb8466d8899b,
+    wasDerivedFrom(niiri:894e7b5f3c0f1694051eaa36e3339902, niiri:8b632dcc185547a7f8ad04edead2291a, -, -, -)
+    entity(niiri:26000f9c87b50b1ed4cbfc0c38d36776,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0067" %% xsd:string,
-        prov:location = 'niiri:56067390bd867fbe6b52bf178e0f2d8f',
+        prov:location = 'niiri:e1962c719c187e312f46dbb443ea0ba6',
         prov:value = "5.40879058837891" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36838466104027" %% xsd:float,
         nidm_pValueUncorrected: = "0.00037805012668235" %% xsd:float,
         nidm_pValueFWER: = "0.999999999657857" %% xsd:float,
         nidm_qValueFDR: = "0.0351846046980527" %% xsd:float])
-    entity(niiri:56067390bd867fbe6b52bf178e0f2d8f,
+    entity(niiri:e1962c719c187e312f46dbb443ea0ba6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0067" %% xsd:string,
         nidm_coordinateVector: = "[-52,28,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:584625db35fd1e69dc1aeb8466d8899b, niiri:b1e45a95e3b162cbfbb274efa0609a1a, -, -, -)
-    entity(niiri:923ab0d2b10cd0fb1178741e5f7e4d80,
+    wasDerivedFrom(niiri:26000f9c87b50b1ed4cbfc0c38d36776, niiri:0b81b51c15877094ca33c61a79325340, -, -, -)
+    entity(niiri:66f05ba7ece66064d5053eeba2010534,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0068" %% xsd:string,
-        prov:location = 'niiri:297f004b78125a381f4cc1a5fa03cfa7',
+        prov:location = 'niiri:a97959a880c8ff0a4d1b087cca95a7ba',
         prov:value = "5.40180397033691" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36521050637541" %% xsd:float,
         nidm_pValueUncorrected: = "0.000382426408436776" %% xsd:float,
         nidm_pValueFWER: = "0.999999999719179" %% xsd:float,
         nidm_qValueFDR: = "0.0353860600288775" %% xsd:float])
-    entity(niiri:297f004b78125a381f4cc1a5fa03cfa7,
+    entity(niiri:a97959a880c8ff0a4d1b087cca95a7ba,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0068" %% xsd:string,
         nidm_coordinateVector: = "[46,40,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:923ab0d2b10cd0fb1178741e5f7e4d80, niiri:5ac022b3dd1da9d78456eb9feccbe272, -, -, -)
-    entity(niiri:d2e0beea05ad13eb0757a2f7874a5c30,
+    wasDerivedFrom(niiri:66f05ba7ece66064d5053eeba2010534, niiri:39734aff0e8ba70db0c48ce245fe4c87, -, -, -)
+    entity(niiri:aad41db07b26e0fc135033c3c54c6265,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0069" %% xsd:string,
-        prov:location = 'niiri:f086d252f5f4c91e62368d78b62ac58b',
+        prov:location = 'niiri:880971a35f2cb80ebdb3cce39907ade3',
         prov:value = "5.37467432022095" %% xsd:float,
         nidm_equivalentZStatistic: = "3.35285956111335" %% xsd:float,
         nidm_pValueUncorrected: = "0.000399906393667493" %% xsd:float,
         nidm_pValueFWER: = "0.999999999871685" %% xsd:float,
         nidm_qValueFDR: = "0.0362799194266732" %% xsd:float])
-    entity(niiri:f086d252f5f4c91e62368d78b62ac58b,
+    entity(niiri:880971a35f2cb80ebdb3cce39907ade3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0069" %% xsd:string,
         nidm_coordinateVector: = "[-24,-64,-26]" %% xsd:string])
-    wasDerivedFrom(niiri:d2e0beea05ad13eb0757a2f7874a5c30, niiri:0aa8942e14fb246e8d24f1826bdd073f, -, -, -)
-    entity(niiri:71949ac8bb1d34c0f6a227d787830b42,
+    wasDerivedFrom(niiri:aad41db07b26e0fc135033c3c54c6265, niiri:715173a69633af936b825645f63d4b6e, -, -, -)
+    entity(niiri:5d2e7b231ceaa16ac77fce6999cbee79,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0070" %% xsd:string,
-        prov:location = 'niiri:4faa09a4da27e254773d00b12e8ce476',
+        prov:location = 'niiri:7fee676079f21de5ddb648922d6cfc96',
         prov:value = "5.37411737442017" %% xsd:float,
         nidm_equivalentZStatistic: = "3.35260558298398" %% xsd:float,
         nidm_pValueUncorrected: = "0.00040027350203431" %% xsd:float,
         nidm_pValueFWER: = "0.999999999873767" %% xsd:float,
         nidm_qValueFDR: = "0.0362799194266732" %% xsd:float])
-    entity(niiri:4faa09a4da27e254773d00b12e8ce476,
+    entity(niiri:7fee676079f21de5ddb648922d6cfc96,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0070" %% xsd:string,
         nidm_coordinateVector: = "[6,-78,4]" %% xsd:string])
-    wasDerivedFrom(niiri:71949ac8bb1d34c0f6a227d787830b42, niiri:47175a90c2a865c8e7cb888b760d6bf8, -, -, -)
-    entity(niiri:102e3f4f656d62e79230957d3c5b9d14,
+    wasDerivedFrom(niiri:5d2e7b231ceaa16ac77fce6999cbee79, niiri:1c44f60f8e5351b0a92c492ed60e2137, -, -, -)
+    entity(niiri:293523500452c1280cc36cd2bec7c9d6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0071" %% xsd:string,
-        prov:location = 'niiri:a9650048b29ccca030a5ee54b9940e46',
+        prov:location = 'niiri:39d51facd795550d74df67b084209afb',
         prov:value = "5.30396842956543" %% xsd:float,
         nidm_equivalentZStatistic: = "3.32047825714677" %% xsd:float,
         nidm_pValueUncorrected: = "0.000449316793136201" %% xsd:float,
         nidm_pValueFWER: = "0.999999999985317" %% xsd:float,
         nidm_qValueFDR: = "0.038893908226916" %% xsd:float])
-    entity(niiri:a9650048b29ccca030a5ee54b9940e46,
+    entity(niiri:39d51facd795550d74df67b084209afb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0071" %% xsd:string,
         nidm_coordinateVector: = "[-18,6,-16]" %% xsd:string])
-    wasDerivedFrom(niiri:102e3f4f656d62e79230957d3c5b9d14, niiri:d3f621d08874a1c4b62c86623e9e9780, -, -, -)
-    entity(niiri:1c9771ed932e3bdfafbe567879a399d9,
+    wasDerivedFrom(niiri:293523500452c1280cc36cd2bec7c9d6, niiri:f2443d4e5be8deae8260b1f1dedfc174, -, -, -)
+    entity(niiri:dd17912e2a4135820561e7201f7942dc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0072" %% xsd:string,
-        prov:location = 'niiri:df34c6eabebd48e7dc695cf8cd35940f',
+        prov:location = 'niiri:1d8c77d2e14a912b0d6091aa51a528ec',
         prov:value = "5.3003044128418" %% xsd:float,
         nidm_equivalentZStatistic: = "3.31879260124815" %% xsd:float,
         nidm_pValueUncorrected: = "0.000452037748311596" %% xsd:float,
         nidm_pValueFWER: = "0.999999999986945" %% xsd:float,
         nidm_qValueFDR: = "0.0390806835204476" %% xsd:float])
-    entity(niiri:df34c6eabebd48e7dc695cf8cd35940f,
+    entity(niiri:1d8c77d2e14a912b0d6091aa51a528ec,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0072" %% xsd:string,
         nidm_coordinateVector: = "[44,34,22]" %% xsd:string])
-    wasDerivedFrom(niiri:1c9771ed932e3bdfafbe567879a399d9, niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56, -, -, -)
-    entity(niiri:6e63ab7247516f8dc04092e22e2759ec,
+    wasDerivedFrom(niiri:dd17912e2a4135820561e7201f7942dc, niiri:de6358617bfe8f7769d05d29a4316925, -, -, -)
+    entity(niiri:3daf6b4701e8ccb2e1874fd38153c225,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0073" %% xsd:string,
-        prov:location = 'niiri:51436c3b224aac45c74640b1163904f9',
+        prov:location = 'niiri:305677c749428098b4af066f04082753',
         prov:value = "5.2790060043335" %% xsd:float,
         nidm_equivalentZStatistic: = "3.30897907487843" %% xsd:float,
         nidm_pValueUncorrected: = "0.000468184175549835" %% xsd:float,
         nidm_pValueFWER: = "0.999999999993475" %% xsd:float,
         nidm_qValueFDR: = "0.0399946769218688" %% xsd:float])
-    entity(niiri:51436c3b224aac45c74640b1163904f9,
+    entity(niiri:305677c749428098b4af066f04082753,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0073" %% xsd:string,
         nidm_coordinateVector: = "[-16,-70,62]" %% xsd:string])
-    wasDerivedFrom(niiri:6e63ab7247516f8dc04092e22e2759ec, niiri:730bd100bdb468af0d3821d0d42d24a3, -, -, -)
-    entity(niiri:86c90a2f51f1ad8289191c43b5d97061,
+    wasDerivedFrom(niiri:3daf6b4701e8ccb2e1874fd38153c225, niiri:28b00390010cb45d9a423be0d041e4eb, -, -, -)
+    entity(niiri:56ea6a1820785a481a616a83d7912917,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0074" %% xsd:string,
-        prov:location = 'niiri:e46fca08428611170031546e4ef81393',
+        prov:location = 'niiri:76e25882363bf74544ee45db516ada9f',
         prov:value = "5.22220420837402" %% xsd:float,
         nidm_equivalentZStatistic: = "3.28268028866984" %% xsd:float,
         nidm_pValueUncorrected: = "0.000514126053509312" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999062" %% xsd:float,
         nidm_qValueFDR: = "0.0424551034128408" %% xsd:float])
-    entity(niiri:e46fca08428611170031546e4ef81393,
+    entity(niiri:76e25882363bf74544ee45db516ada9f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0074" %% xsd:string,
         nidm_coordinateVector: = "[-18,-90,34]" %% xsd:string])
-    wasDerivedFrom(niiri:86c90a2f51f1ad8289191c43b5d97061, niiri:c30c1334c3597905fbc441edbc3d5ada, -, -, -)
-    entity(niiri:545e517cd64f442db87872d4a27b47f7,
+    wasDerivedFrom(niiri:56ea6a1820785a481a616a83d7912917, niiri:6f2458f857e5301314e4c49c53ddab5c, -, -, -)
+    entity(niiri:94336fe7b97ca1dbe7f4c74a8e1f26c1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0075" %% xsd:string,
-        prov:location = 'niiri:1042007b111f87e5138bb438f2ae2bc0',
+        prov:location = 'niiri:e6fd08976db92d3550930b0866ffd452',
         prov:value = "5.1730318069458" %% xsd:float,
         nidm_equivalentZStatistic: = "3.25976321879304" %% xsd:float,
         nidm_pValueUncorrected: = "0.000557526302441769" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999843" %% xsd:float,
         nidm_qValueFDR: = "0.0447389446131481" %% xsd:float])
-    entity(niiri:1042007b111f87e5138bb438f2ae2bc0,
+    entity(niiri:e6fd08976db92d3550930b0866ffd452,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0075" %% xsd:string,
         nidm_coordinateVector: = "[36,62,8]" %% xsd:string])
-    wasDerivedFrom(niiri:545e517cd64f442db87872d4a27b47f7, niiri:f3476be8b24ab5bb218fe71d0b0daed0, -, -, -)
-    entity(niiri:f3f05a481523891d44824beadda448ee,
+    wasDerivedFrom(niiri:94336fe7b97ca1dbe7f4c74a8e1f26c1, niiri:a5ccd12af883dc80ecb285cbc7d90996, -, -, -)
+    entity(niiri:c7aca18db0a1f6a5280f9703bc935efc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0076" %% xsd:string,
-        prov:location = 'niiri:194bdcb422ae39cd8096994d6fce64ac',
+        prov:location = 'niiri:e78bdc31a6807cf01d6eaa462befa9d9',
         prov:value = "5.17224788665771" %% xsd:float,
         nidm_equivalentZStatistic: = "3.25939672404754" %% xsd:float,
         nidm_pValueUncorrected: = "0.000558247108556009" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999848" %% xsd:float,
         nidm_qValueFDR: = "0.0447389446131481" %% xsd:float])
-    entity(niiri:194bdcb422ae39cd8096994d6fce64ac,
+    entity(niiri:e78bdc31a6807cf01d6eaa462befa9d9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0076" %% xsd:string,
         nidm_coordinateVector: = "[44,46,-18]" %% xsd:string])
-    wasDerivedFrom(niiri:f3f05a481523891d44824beadda448ee, niiri:e129e49f77be02735062a975f639c82e, -, -, -)
-    entity(niiri:62b1a35b9b004426fc8baefb3985fe01,
+    wasDerivedFrom(niiri:c7aca18db0a1f6a5280f9703bc935efc, niiri:075cefbcdab0306f76e523f39577afc9, -, -, -)
+    entity(niiri:b810043fb497b4b30e67d61f1ef6d95d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0077" %% xsd:string,
-        prov:location = 'niiri:bbea39448c6107a5d4ad5ddee203d4d2',
+        prov:location = 'niiri:ac9a89a3bf9c8e03f7d0abfd07ea181a',
         prov:value = "5.13746070861816" %% xsd:float,
         nidm_equivalentZStatistic: = "3.24309671226403" %% xsd:float,
         nidm_pValueUncorrected: = "0.000591190343014691" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999996" %% xsd:float,
         nidm_qValueFDR: = "0.0465822754926653" %% xsd:float])
-    entity(niiri:bbea39448c6107a5d4ad5ddee203d4d2,
+    entity(niiri:ac9a89a3bf9c8e03f7d0abfd07ea181a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0077" %% xsd:string,
         nidm_coordinateVector: = "[22,-18,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:62b1a35b9b004426fc8baefb3985fe01, niiri:f445b49b9174ce8611d41a7cc11e1717, -, -, -)
-    entity(niiri:7e86c6411e52fa0a7b9b20dcbb6e36b0,
+    wasDerivedFrom(niiri:b810043fb497b4b30e67d61f1ef6d95d, niiri:67b2de2f1c8c8f1c6308f97901012c85, -, -, -)
+    entity(niiri:7b232038d9487e4356e8dfb4323accd3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0078" %% xsd:string,
-        prov:location = 'niiri:5f9f0cd6ac7c81914637716591108924',
+        prov:location = 'niiri:b4963c38f81a01898be7895643388317',
         prov:value = "5.11799764633179" %% xsd:float,
         nidm_equivalentZStatistic: = "3.23394572778211" %% xsd:float,
         nidm_pValueUncorrected: = "0.000610463272072148" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999981" %% xsd:float,
         nidm_qValueFDR: = "0.0474717326152994" %% xsd:float])
-    entity(niiri:5f9f0cd6ac7c81914637716591108924,
+    entity(niiri:b4963c38f81a01898be7895643388317,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0078" %% xsd:string,
         nidm_coordinateVector: = "[-54,34,4]" %% xsd:string])
-    wasDerivedFrom(niiri:7e86c6411e52fa0a7b9b20dcbb6e36b0, niiri:5ca600306779ba8f48c5d087d9fac9a9, -, -, -)
-    entity(niiri:97c62dc69d6cfc9480ed5f2d7063dc28,
+    wasDerivedFrom(niiri:7b232038d9487e4356e8dfb4323accd3, niiri:3e4aab372e14b498f67d8f3af7fe64d4, -, -, -)
+    entity(niiri:11ed40cf7c6d1e1b76914519ad648298,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0079" %% xsd:string,
-        prov:location = 'niiri:34c95820a8a121e8a225fd9376361242',
+        prov:location = 'niiri:b2c2c2474e5e6fee6e66d413930cd815',
         prov:value = "5.10930299758911" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22985044435181" %% xsd:float,
         nidm_pValueUncorrected: = "0.000619274939217984" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999987" %% xsd:float,
         nidm_qValueFDR: = "0.047852944668371" %% xsd:float])
-    entity(niiri:34c95820a8a121e8a225fd9376361242,
+    entity(niiri:b2c2c2474e5e6fee6e66d413930cd815,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0079" %% xsd:string,
         nidm_coordinateVector: = "[-30,-64,-52]" %% xsd:string])
-    wasDerivedFrom(niiri:97c62dc69d6cfc9480ed5f2d7063dc28, niiri:40bbe1b7b060c1d54f113fd9fcf154aa, -, -, -)
-    entity(niiri:fd255fdebba34e1d3d741757f42127cb,
+    wasDerivedFrom(niiri:11ed40cf7c6d1e1b76914519ad648298, niiri:4e46f866f0c4c884a98d67ad4f286185, -, -, -)
+    entity(niiri:4d10f48cdd2d3f00f61d037f49b32b4f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0080" %% xsd:string,
-        prov:location = 'niiri:e2093ea5a4830bc016df153a1447adb3',
+        prov:location = 'niiri:7016a6fd792cf01d7c320f58e80217f0',
         prov:value = "5.10401487350464" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22735746106492" %% xsd:float,
         nidm_pValueUncorrected: = "0.000624696357977461" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999989" %% xsd:float,
         nidm_qValueFDR: = "0.0480043833565767" %% xsd:float])
-    entity(niiri:e2093ea5a4830bc016df153a1447adb3,
+    entity(niiri:7016a6fd792cf01d7c320f58e80217f0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0080" %% xsd:string,
         nidm_coordinateVector: = "[-48,-78,18]" %% xsd:string])
-    wasDerivedFrom(niiri:fd255fdebba34e1d3d741757f42127cb, niiri:5d9d1b3e1bbc6746185f53561c74bace, -, -, -)
-    entity(niiri:d03d3f46620d80d545af7b487f982e5b,
+    wasDerivedFrom(niiri:4d10f48cdd2d3f00f61d037f49b32b4f, niiri:0c4f8238e0d8817ab291795ad931058d, -, -, -)
+    entity(niiri:9a335bf5867319042aef935fdd61a2ca,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0081" %% xsd:string,
-        prov:location = 'niiri:8beacede341a47f3167389d2db31c511',
+        prov:location = 'niiri:bdd410f3992b80366097ff8da55c6572',
         prov:value = "5.09518003463745" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22318870378714" %% xsd:float,
         nidm_pValueUncorrected: = "0.000633860042171808" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999993" %% xsd:float,
         nidm_qValueFDR: = "0.0483657513246105" %% xsd:float])
-    entity(niiri:8beacede341a47f3167389d2db31c511,
+    entity(niiri:bdd410f3992b80366097ff8da55c6572,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0081" %% xsd:string,
         nidm_coordinateVector: = "[4,-86,38]" %% xsd:string])
-    wasDerivedFrom(niiri:d03d3f46620d80d545af7b487f982e5b, niiri:4c53636a1293cd4482cb63ff70691d79, -, -, -)
-    entity(niiri:26a9a6f6ecb327e047fbdaf46b98bd6e,
+    wasDerivedFrom(niiri:9a335bf5867319042aef935fdd61a2ca, niiri:45b239a4d9c3d2d8505e69c949d3d8e8, -, -, -)
+    entity(niiri:71e3044821bf1685ebc1d1ccc482996c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0082" %% xsd:string,
-        prov:location = 'niiri:1be4f6ad62254ca44faf09f21e98b4ef',
+        prov:location = 'niiri:cbce0e0cb8230da058e27ef6498e9822',
         prov:value = "5.08291101455688" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21739172198432" %% xsd:float,
         nidm_pValueUncorrected: = "0.000646809225746448" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999996" %% xsd:float,
         nidm_qValueFDR: = "0.0489980390158314" %% xsd:float])
-    entity(niiri:1be4f6ad62254ca44faf09f21e98b4ef,
+    entity(niiri:cbce0e0cb8230da058e27ef6498e9822,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0082" %% xsd:string,
         nidm_coordinateVector: = "[-14,-50,-36]" %% xsd:string])
-    wasDerivedFrom(niiri:26a9a6f6ecb327e047fbdaf46b98bd6e, niiri:2b3b2f5817481e92102b214f3bf33995, -, -, -)
-    entity(niiri:eed8b6f60fa2ab238d44784bc24f49fc,
+    wasDerivedFrom(niiri:71e3044821bf1685ebc1d1ccc482996c, niiri:d81ab34b3d15a5e83dcac601860e2c67, -, -, -)
+    entity(niiri:64739c4167dc0d3498f8e2a1c8595f71,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0083" %% xsd:string,
-        prov:location = 'niiri:f840d99aa197bd8d4fa2aca6525dd6b6',
+        prov:location = 'niiri:f40d5d8206a7e8bfeb960db99a347c49',
         prov:value = "5.0689902305603" %% xsd:float,
         nidm_equivalentZStatistic: = "3.21080328886987" %% xsd:float,
         nidm_pValueUncorrected: = "0.000661822545445001" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
         nidm_qValueFDR: = "0.0496832380294054" %% xsd:float])
-    entity(niiri:f840d99aa197bd8d4fa2aca6525dd6b6,
+    entity(niiri:f40d5d8206a7e8bfeb960db99a347c49,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0083" %% xsd:string,
         nidm_coordinateVector: = "[30,68,10]" %% xsd:string])
-    wasDerivedFrom(niiri:eed8b6f60fa2ab238d44784bc24f49fc, niiri:86437031e803eee8517a97d2e8420009, -, -, -)
-    entity(niiri:5e7cb532886034b9c21ce9230724cf4e,
+    wasDerivedFrom(niiri:64739c4167dc0d3498f8e2a1c8595f71, niiri:17915a4b4045396b3dc9e808d4f43fff, -, -, -)
+    entity(niiri:a433274bd13730beb4dfc0d55357557e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0084" %% xsd:string,
-        prov:location = 'niiri:fa765c1dff998dba8cec43964f9fd0ac',
+        prov:location = 'niiri:7c271a5a16a2eba0109c81f0cefb625f',
         prov:value = "5.05907249450684" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20610225272296" %% xsd:float,
         nidm_pValueUncorrected: = "0.000672730842027125" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
         nidm_qValueFDR: = "0.0501943510982274" %% xsd:float])
-    entity(niiri:fa765c1dff998dba8cec43964f9fd0ac,
+    entity(niiri:7c271a5a16a2eba0109c81f0cefb625f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0084" %% xsd:string,
         nidm_coordinateVector: = "[10,-30,80]" %% xsd:string])
-    wasDerivedFrom(niiri:5e7cb532886034b9c21ce9230724cf4e, niiri:927385c4b1c66020878360a5006a3e3b, -, -, -)
-    entity(niiri:3b0256e0257667bc847e43ec82712c6a,
+    wasDerivedFrom(niiri:a433274bd13730beb4dfc0d55357557e, niiri:fb337b3deac825168c6547e71cdf45e4, -, -, -)
+    entity(niiri:fe448e07f10dd77ad7048bec2935288a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0085" %% xsd:string,
-        prov:location = 'niiri:0513413f42049f48fad742e27fa4823c',
+        prov:location = 'niiri:2146da53497ad34f011f172dddd97f90',
         prov:value = "5.05790328979492" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20554765226523" %% xsd:float,
         nidm_pValueUncorrected: = "0.000674028618936839" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999998" %% xsd:float,
         nidm_qValueFDR: = "0.0502551505802037" %% xsd:float])
-    entity(niiri:0513413f42049f48fad742e27fa4823c,
+    entity(niiri:2146da53497ad34f011f172dddd97f90,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0085" %% xsd:string,
         nidm_coordinateVector: = "[44,-76,8]" %% xsd:string])
-    wasDerivedFrom(niiri:3b0256e0257667bc847e43ec82712c6a, niiri:0087c0fa9854a20b9b26757b4c0e9a68, -, -, -)
-    entity(niiri:546a3ae2919066aba8b04feb7eaf222b,
+    wasDerivedFrom(niiri:fe448e07f10dd77ad7048bec2935288a, niiri:d1e644390766d6283debb5ff26e27399, -, -, -)
+    entity(niiri:e39a0ed9969f84905bcc14001d8bf13f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0086" %% xsd:string,
-        prov:location = 'niiri:711f068fef9833519c8dc8540cb0ba53',
+        prov:location = 'niiri:2bc5786adf5e16150692c21f687fd1e7',
         prov:value = "5.04969549179077" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20165202224461" %% xsd:float,
         nidm_pValueUncorrected: = "0.000683209765197312" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999999" %% xsd:float,
         nidm_qValueFDR: = "0.050613270744433" %% xsd:float])
-    entity(niiri:711f068fef9833519c8dc8540cb0ba53,
+    entity(niiri:2bc5786adf5e16150692c21f687fd1e7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0086" %% xsd:string,
         nidm_coordinateVector: = "[-52,-36,44]" %% xsd:string])
-    wasDerivedFrom(niiri:546a3ae2919066aba8b04feb7eaf222b, niiri:679d2ced08c3de3ec63ab76190f2d86d, -, -, -)
-    entity(niiri:3c565a898ce1cb8d1a32498833886420,
+    wasDerivedFrom(niiri:e39a0ed9969f84905bcc14001d8bf13f, niiri:f2c41aa526c7ecfe683fb5b1f2a7588a, -, -, -)
+    entity(niiri:5f5dd191ac43989e197e1dc7f76d17b2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0087" %% xsd:string,
-        prov:location = 'niiri:d1361e7764f4b544072c31608b9db437',
+        prov:location = 'niiri:fd5647f38306e48b87e44239ec80d981',
         prov:value = "5.02838468551636" %% xsd:float,
         nidm_equivalentZStatistic: = "3.19151815181806" %% xsd:float,
         nidm_pValueUncorrected: = "0.000707636089146368" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.051650625154872" %% xsd:float])
-    entity(niiri:d1361e7764f4b544072c31608b9db437,
+    entity(niiri:fd5647f38306e48b87e44239ec80d981,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0087" %% xsd:string,
         nidm_coordinateVector: = "[-44,-40,42]" %% xsd:string])
-    wasDerivedFrom(niiri:3c565a898ce1cb8d1a32498833886420, niiri:302d0ae98bffba69292672583d115e8c, -, -, -)
-    entity(niiri:895ab0cb66ad5fe2b8f0ccfda413020f,
+    wasDerivedFrom(niiri:5f5dd191ac43989e197e1dc7f76d17b2, niiri:b6e3adf39b177b2fe3b6833a47713718, -, -, -)
+    entity(niiri:f71c1e2e5f91a95c5712a4d4ba89c40f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0088" %% xsd:string,
-        prov:location = 'niiri:f2b167b359b019d6526e5256b4b2a4e7',
+        prov:location = 'niiri:8acbde476f7d16ebe1080128d978f2a5',
         prov:value = "5.02759695053101" %% xsd:float,
         nidm_equivalentZStatistic: = "3.19114302879552" %% xsd:float,
         nidm_pValueUncorrected: = "0.00070855553886906" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0516996133446043" %% xsd:float])
-    entity(niiri:f2b167b359b019d6526e5256b4b2a4e7,
+    entity(niiri:8acbde476f7d16ebe1080128d978f2a5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0088" %% xsd:string,
         nidm_coordinateVector: = "[-44,54,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:895ab0cb66ad5fe2b8f0ccfda413020f, niiri:f443e4b03660a8ad618e307479bf8a95, -, -, -)
-    entity(niiri:38744d312469d30ea2aad6e112efd815,
+    wasDerivedFrom(niiri:f71c1e2e5f91a95c5712a4d4ba89c40f, niiri:ac9ee3188f787257a289a9904e28a0df, -, -, -)
+    entity(niiri:af1ef614c297cb2b0e8df9da0f88d85f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0089" %% xsd:string,
-        prov:location = 'niiri:4e8ff56debee785959e0deb820ab4223',
+        prov:location = 'niiri:5e694eb878b5af9458d3d142d8858bc7',
         prov:value = "5.00743103027344" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18152691683286" %% xsd:float,
         nidm_pValueUncorrected: = "0.000732504543232371" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0526896959368281" %% xsd:float])
-    entity(niiri:4e8ff56debee785959e0deb820ab4223,
+    entity(niiri:5e694eb878b5af9458d3d142d8858bc7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0089" %% xsd:string,
         nidm_coordinateVector: = "[36,58,18]" %% xsd:string])
-    wasDerivedFrom(niiri:38744d312469d30ea2aad6e112efd815, niiri:80e9d7b2bd34593272f3fb19fc9254e9, -, -, -)
-    entity(niiri:6d61e7dcb92b6e6b6f64536ea335f5e2,
+    wasDerivedFrom(niiri:af1ef614c297cb2b0e8df9da0f88d85f, niiri:499c553f4f05bed3bf262435de53d3b1, -, -, -)
+    entity(niiri:2bc5fdc6aa9851c6ac2a13fe3cadb39d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0090" %% xsd:string,
-        prov:location = 'niiri:19af79f4d565155ceba8d4b51e598b73',
+        prov:location = 'niiri:855f018b32553b4caf4fc1bf009968d2',
         prov:value = "4.99766159057617" %% xsd:float,
         nidm_equivalentZStatistic: = "3.17685933085535" %% xsd:float,
         nidm_pValueUncorrected: = "0.000744396146822202" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0532506765476335" %% xsd:float])
-    entity(niiri:19af79f4d565155ceba8d4b51e598b73,
+    entity(niiri:855f018b32553b4caf4fc1bf009968d2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0090" %% xsd:string,
         nidm_coordinateVector: = "[-44,22,40]" %% xsd:string])
-    wasDerivedFrom(niiri:6d61e7dcb92b6e6b6f64536ea335f5e2, niiri:91bc3a2972b2938504904a8d68057f2e, -, -, -)
-    entity(niiri:9a1ce2e69e3dbc416c997bb0ba8cf8fa,
+    wasDerivedFrom(niiri:2bc5fdc6aa9851c6ac2a13fe3cadb39d, niiri:425b3b59bb1a3d7b86c2c5264b8a6627, -, -, -)
+    entity(niiri:5fc1f607a58e2e1e41ba524f5b5569bf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0091" %% xsd:string,
-        prov:location = 'niiri:ddbc2b5e1f26927e114e09c84b260fdd',
+        prov:location = 'niiri:5af36ea4b1408261746969b90904aa72',
         prov:value = "4.98628282546997" %% xsd:float,
         nidm_equivalentZStatistic: = "3.1714153864203" %% xsd:float,
         nidm_pValueUncorrected: = "0.00075849026901309" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0537320048825192" %% xsd:float])
-    entity(niiri:ddbc2b5e1f26927e114e09c84b260fdd,
+    entity(niiri:5af36ea4b1408261746969b90904aa72,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0091" %% xsd:string,
         nidm_coordinateVector: = "[32,-24,72]" %% xsd:string])
-    wasDerivedFrom(niiri:9a1ce2e69e3dbc416c997bb0ba8cf8fa, niiri:681cc93cdfd04b41012417cfd725953f, -, -, -)
-    entity(niiri:1e37e838816ab673f5b1a0e528a618fb,
+    wasDerivedFrom(niiri:5fc1f607a58e2e1e41ba524f5b5569bf, niiri:9c92e09c369b8211d4e65fbfbb9c9aa4, -, -, -)
+    entity(niiri:d574b1737bae301e87767c0ba911977b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0092" %% xsd:string,
-        prov:location = 'niiri:b33af54063165da162cc0a06d18506f6',
+        prov:location = 'niiri:70168be09147ff18f1b4d58e45414ac5',
         prov:value = "4.97769069671631" %% xsd:float,
         nidm_equivalentZStatistic: = "3.16729931357798" %% xsd:float,
         nidm_pValueUncorrected: = "0.000769309331678514" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0542313534025412" %% xsd:float])
-    entity(niiri:b33af54063165da162cc0a06d18506f6,
+    entity(niiri:70168be09147ff18f1b4d58e45414ac5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0092" %% xsd:string,
         nidm_coordinateVector: = "[50,-30,60]" %% xsd:string])
-    wasDerivedFrom(niiri:1e37e838816ab673f5b1a0e528a618fb, niiri:1288217d5c8b70c54915067a87402187, -, -, -)
-    entity(niiri:af091ddb51f232e6c9bd315c31128cde,
+    wasDerivedFrom(niiri:d574b1737bae301e87767c0ba911977b, niiri:d76384fac79adab2f8bcdd74e38b05e5, -, -, -)
+    entity(niiri:c8377608c568eaa0cdfbf4c747621fa9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0093" %% xsd:string,
-        prov:location = 'niiri:a3d5999988833de22efee90511c9be29',
+        prov:location = 'niiri:acdaf7ebdad9ef3b2e6853b153b2cecc',
         prov:value = "4.95973443984985" %% xsd:float,
         nidm_equivalentZStatistic: = "3.15868244743865" %% xsd:float,
         nidm_pValueUncorrected: = "0.000792420371319991" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.05524320395595" %% xsd:float])
-    entity(niiri:a3d5999988833de22efee90511c9be29,
+    entity(niiri:acdaf7ebdad9ef3b2e6853b153b2cecc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0093" %% xsd:string,
         nidm_coordinateVector: = "[-32,-74,-28]" %% xsd:string])
-    wasDerivedFrom(niiri:af091ddb51f232e6c9bd315c31128cde, niiri:9a33ec7dcbaf4c333c9be7973d3674ae, -, -, -)
-    entity(niiri:040db063243906b03c972dbf813f1e8f,
+    wasDerivedFrom(niiri:c8377608c568eaa0cdfbf4c747621fa9, niiri:66b4285fcdb2a68d01ddbdfea09445d1, -, -, -)
+    entity(niiri:e21e14898e4a6342702db7821daa0b6f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0094" %% xsd:string,
-        prov:location = 'niiri:c2ea305012d99e2652d0a3896a349455',
+        prov:location = 'niiri:e4ee48571566d6ae17936ca8119e4c6e',
         prov:value = "4.95515823364258" %% xsd:float,
         nidm_equivalentZStatistic: = "3.15648318111342" %% xsd:float,
         nidm_pValueUncorrected: = "0.000798420481037398" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0553418612137989" %% xsd:float])
-    entity(niiri:c2ea305012d99e2652d0a3896a349455,
+    entity(niiri:e4ee48571566d6ae17936ca8119e4c6e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0094" %% xsd:string,
         nidm_coordinateVector: = "[-26,-86,40]" %% xsd:string])
-    wasDerivedFrom(niiri:040db063243906b03c972dbf813f1e8f, niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73, -, -, -)
-    entity(niiri:5eaeb3f75f7650cb74f379ed173f7e58,
+    wasDerivedFrom(niiri:e21e14898e4a6342702db7821daa0b6f, niiri:ce2fd9609bbaf4260567fecf8334f73a, -, -, -)
+    entity(niiri:ec800b1561a8e211d893b9129cbd17ff,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0095" %% xsd:string,
-        prov:location = 'niiri:c72bbf109b350d78e64ee37ee86ef87a',
+        prov:location = 'niiri:a5b7712f3a3c7ea5cce3b7f25d7840d9',
         prov:value = "4.93855857849121" %% xsd:float,
         nidm_equivalentZStatistic: = "3.14849453487417" %% xsd:float,
         nidm_pValueUncorrected: = "0.000820568960055779" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0562262327439451" %% xsd:float])
-    entity(niiri:c72bbf109b350d78e64ee37ee86ef87a,
+    entity(niiri:a5b7712f3a3c7ea5cce3b7f25d7840d9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0095" %% xsd:string,
         nidm_coordinateVector: = "[-10,8,6]" %% xsd:string])
-    wasDerivedFrom(niiri:5eaeb3f75f7650cb74f379ed173f7e58, niiri:99af69862e054a4c62b8e6066ff12cfd, -, -, -)
-    entity(niiri:3716c38360149956c53c557239c91fd7,
+    wasDerivedFrom(niiri:ec800b1561a8e211d893b9129cbd17ff, niiri:a482e942f85057c7e6150a9211c470d5, -, -, -)
+    entity(niiri:2acd52cd4d8b0806cc76e3f29c4eff53,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0096" %% xsd:string,
-        prov:location = 'niiri:8947ac3de97fe88382a65c163f842436',
+        prov:location = 'niiri:d5d56e7417d11be82b076cdec47aa14c',
         prov:value = "4.90264129638672" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13114947632107" %% xsd:float,
         nidm_pValueUncorrected: = "0.000870617549853403" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.058320641241518" %% xsd:float])
-    entity(niiri:8947ac3de97fe88382a65c163f842436,
+    entity(niiri:d5d56e7417d11be82b076cdec47aa14c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0096" %% xsd:string,
         nidm_coordinateVector: = "[14,8,10]" %% xsd:string])
-    wasDerivedFrom(niiri:3716c38360149956c53c557239c91fd7, niiri:20fc427845c2a14183959299a0d233ce, -, -, -)
-    entity(niiri:17f311b4781af2c645292f1b0c08e56c,
+    wasDerivedFrom(niiri:2acd52cd4d8b0806cc76e3f29c4eff53, niiri:72e4e5b0d793f6bdd394586ab7b319ae, -, -, -)
+    entity(niiri:c96ee0b4ee3228aa7692569b05c9d521,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0097" %% xsd:string,
-        prov:location = 'niiri:90f614e5e280a7d031215612221686fb',
+        prov:location = 'niiri:5a6d01da2d934174919cb15f04e572d4',
         prov:value = "4.90243864059448" %% xsd:float,
         nidm_equivalentZStatistic: = "3.1310513773308" %% xsd:float,
         nidm_pValueUncorrected: = "0.000870908426383377" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.058320641241518" %% xsd:float])
-    entity(niiri:90f614e5e280a7d031215612221686fb,
+    entity(niiri:5a6d01da2d934174919cb15f04e572d4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0097" %% xsd:string,
         nidm_coordinateVector: = "[-20,-54,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:17f311b4781af2c645292f1b0c08e56c, niiri:0294b8b1f3c4b525a18397bf17d17d63, -, -, -)
-    entity(niiri:261827ec7c4ac6d56b850bf7be1a0995,
+    wasDerivedFrom(niiri:c96ee0b4ee3228aa7692569b05c9d521, niiri:698f920512e0bc86196ac5bdf9403706, -, -, -)
+    entity(niiri:1d08526aab6a9a90c5952a579bfe70f9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0098" %% xsd:string,
-        prov:location = 'niiri:0dc46ac23cbc0284b413f46af5e9b5bf',
+        prov:location = 'niiri:4305ea19e546e9f3e09c4e96ecb80222',
         prov:value = "4.88119602203369" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12075392909771" %% xsd:float,
         nidm_pValueUncorrected: = "0.000901943498395119" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0594947205600118" %% xsd:float])
-    entity(niiri:0dc46ac23cbc0284b413f46af5e9b5bf,
+    entity(niiri:4305ea19e546e9f3e09c4e96ecb80222,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0098" %% xsd:string,
         nidm_coordinateVector: = "[-26,-84,44]" %% xsd:string])
-    wasDerivedFrom(niiri:261827ec7c4ac6d56b850bf7be1a0995, niiri:3dc796cbf0403561b0e6ea42b96ea1a9, -, -, -)
-    entity(niiri:2ae246317f788cd3eeea499f36da2784,
+    wasDerivedFrom(niiri:1d08526aab6a9a90c5952a579bfe70f9, niiri:ad1cd56f7d143bd776b5691683c59add, -, -, -)
+    entity(niiri:e293b60c32a79f675471d9249f7c74e9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0099" %% xsd:string,
-        prov:location = 'niiri:ba8c00af87b3e78bc9d96bf0d493697c',
+        prov:location = 'niiri:f76d40c83ee44efc114b2f7748b07ab0',
         prov:value = "4.86706686019897" %% xsd:float,
         nidm_equivalentZStatistic: = "3.11388868389685" %% xsd:float,
         nidm_pValueUncorrected: = "0.000923195680083033" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0603762016821821" %% xsd:float])
-    entity(niiri:ba8c00af87b3e78bc9d96bf0d493697c,
+    entity(niiri:f76d40c83ee44efc114b2f7748b07ab0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0099" %% xsd:string,
         nidm_coordinateVector: = "[-54,22,10]" %% xsd:string])
-    wasDerivedFrom(niiri:2ae246317f788cd3eeea499f36da2784, niiri:14518885ee853fba951013cf73f66bed, -, -, -)
-    entity(niiri:e7bbc2a18733379b4ba6e4c9b9da44fa,
+    wasDerivedFrom(niiri:e293b60c32a79f675471d9249f7c74e9, niiri:eaa184888e18a33c4f8a743428f908be, -, -, -)
+    entity(niiri:a2e6eded6d5f1f58391a348ff3e8a663,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0100" %% xsd:string,
-        prov:location = 'niiri:8726957d4cdde9d04e29bbe51a70e336',
+        prov:location = 'niiri:6c3e52ed132f2f99aa602219a7ebe413',
         prov:value = "4.84812355041504" %% xsd:float,
         nidm_equivalentZStatistic: = "3.10466401400555" %% xsd:float,
         nidm_pValueUncorrected: = "0.000952476397051205" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0616422795595169" %% xsd:float])
-    entity(niiri:8726957d4cdde9d04e29bbe51a70e336,
+    entity(niiri:6c3e52ed132f2f99aa602219a7ebe413,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0100" %% xsd:string,
         nidm_coordinateVector: = "[32,-80,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:e7bbc2a18733379b4ba6e4c9b9da44fa, niiri:7666b1a689a3839cdadb86af5e5c7c39, -, -, -)
-    entity(niiri:38f3fc0e0c53bc3fde20e9f5bbf1c52d,
+    wasDerivedFrom(niiri:a2e6eded6d5f1f58391a348ff3e8a663, niiri:7a8727b45ba0d1d9809d83d6afaba387, -, -, -)
+    entity(niiri:97ef4abdcfd8473e154e7543d15c3849,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0101" %% xsd:string,
-        prov:location = 'niiri:97cc916bbf9c73be7bceb77865458446',
+        prov:location = 'niiri:c0861ab711f9c4ee99cc4d65f2359ec6',
         prov:value = "4.82597017288208" %% xsd:float,
         nidm_equivalentZStatistic: = "3.09384653195936" %% xsd:float,
         nidm_pValueUncorrected: = "0.00098789830908641" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0629671631402158" %% xsd:float])
-    entity(niiri:97cc916bbf9c73be7bceb77865458446,
+    entity(niiri:c0861ab711f9c4ee99cc4d65f2359ec6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0101" %% xsd:string,
         nidm_coordinateVector: = "[10,-80,4]" %% xsd:string])
-    wasDerivedFrom(niiri:38f3fc0e0c53bc3fde20e9f5bbf1c52d, niiri:2cac2c4baab8136a53bdf03e74fdc1c5, -, -, -)
-    entity(niiri:c9916a684f8ab6fd7ebe1ce3907a9b34,
+    wasDerivedFrom(niiri:97ef4abdcfd8473e154e7543d15c3849, niiri:e37d9920261de8039f51fb95dfc921a4, -, -, -)
+    entity(niiri:6d05594f0412161046c44eacac40a42a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0102" %% xsd:string,
-        prov:location = 'niiri:302777c17a3ab317d1e6b6ffd24666ff',
+        prov:location = 'niiri:c299d10452cbc4dd22179d17b089b932',
         prov:value = "4.82537364959717" %% xsd:float,
         nidm_equivalentZStatistic: = "3.09355480628341" %% xsd:float,
         nidm_pValueUncorrected: = "0.000988870098138084" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0629727239584754" %% xsd:float])
-    entity(niiri:302777c17a3ab317d1e6b6ffd24666ff,
+    entity(niiri:c299d10452cbc4dd22179d17b089b932,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0102" %% xsd:string,
         nidm_coordinateVector: = "[16,-50,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:c9916a684f8ab6fd7ebe1ce3907a9b34, niiri:8768acb96e7e44e4cd45548f0d52dd3f, -, -, -)
-    entity(niiri:380422cca8da791d72bac3c9bd4f903f,
+    wasDerivedFrom(niiri:6d05594f0412161046c44eacac40a42a, niiri:69d9b433456370b7c1a9673758c8fe93, -, -, -)
+    entity(niiri:e51a96651be45131bb9f48a47747e9ef,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0103" %% xsd:string,
-        prov:location = 'niiri:6f88b65eb9c9991d816265aa7f3ca79a',
+        prov:location = 'niiri:11a804aecddacdb1c417a8972e693084',
         prov:value = "4.82024002075195" %% xsd:float,
         nidm_equivalentZStatistic: = "3.09104327517968" %% xsd:float,
         nidm_pValueUncorrected: = "0.000997272813291428" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.0632678542871923" %% xsd:float])
-    entity(niiri:6f88b65eb9c9991d816265aa7f3ca79a,
+    entity(niiri:11a804aecddacdb1c417a8972e693084,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0103" %% xsd:string,
         nidm_coordinateVector: = "[-12,-20,12]" %% xsd:string])
-    wasDerivedFrom(niiri:380422cca8da791d72bac3c9bd4f903f, niiri:816f19a8ef8789235a9bd7bfe4396a14, -, -, -)
+    wasDerivedFrom(niiri:e51a96651be45131bb9f48a47747e9ef, niiri:f8f9f105adf5f8aecb1ef2a7b71b7a33, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_f_test/nidm.ttl
+++ b/spmexport/ex_spm_f_test/nidm.ttl
@@ -1,0 +1,3368 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:21b3c4311946920c7bb866cb7241f06a
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:26e4ed7e4ca9f8d6f69ba2608dc2bb2b
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:cfc5d5cf6de0f5ccfe313e6d43587323
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:cfc5d5cf6de0f5ccfe313e6d43587323 prov:wasAssociatedWith niiri:26e4ed7e4ca9f8d6f69ba2608dc2bb2b .
+
+_:blank5 a prov:Generation .
+
+niiri:21b3c4311946920c7bb866cb7241f06a prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:11:24"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_FStatistic: <http://purl.obolibrary.org/obo/STATO_0000282> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastExplainedMeanSquareMap: <http://purl.org/nidash/nidm#NIDM_0000163> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070> .
+@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
+@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .
+@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .
+@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082> .
+@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .
+@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092> .
+@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
+@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
+
+niiri:43a3ee53f98ee35a82fd6af9eebbd163
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:6cbc3e147cf7f32be569d44f46d94c1f
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:e3676e8eec4990ea33ab365f41819e4c
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:a4aacd65a7c45519a9f2f3175def869f
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:3769ef4c5efe49a97295e3959f9dc7ad
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:e95fdfe90dea233f4527fc2ab0df8f98 ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:a4aacd65a7c45519a9f2f3175def869f ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:e95fdfe90dea233f4527fc2ab0df8f98
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:b2fe7439c407fcd2dde1efc329a7b0f3
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:403063ca7469ea436c4ddd80ac3e76cd
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:403063ca7469ea436c4ddd80ac3e76cd prov:wasAssociatedWith niiri:43a3ee53f98ee35a82fd6af9eebbd163 .
+
+niiri:403063ca7469ea436c4ddd80ac3e76cd prov:used niiri:3769ef4c5efe49a97295e3959f9dc7ad .
+
+niiri:403063ca7469ea436c4ddd80ac3e76cd prov:used niiri:e3676e8eec4990ea33ab365f41819e4c .
+
+niiri:403063ca7469ea436c4ddd80ac3e76cd prov:used niiri:b2fe7439c407fcd2dde1efc329a7b0f3 .
+
+niiri:2dfea426e8928d3252adb676004ffb9d
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
+
+niiri:9791d34c6aacce2cfbb27ce2f9075562
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
+
+niiri:2dfea426e8928d3252adb676004ffb9d prov:wasDerivedFrom niiri:9791d34c6aacce2cfbb27ce2f9075562 .
+
+niiri:2dfea426e8928d3252adb676004ffb9d prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:fe1de7f78c02a415bd4ad2098cae4f59
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "108.038318634033"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
+
+niiri:fe1de7f78c02a415bd4ad2098cae4f59 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+
+niiri:335e2de27a1a351eae295b2d6aba0ccc
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "11c208792e1874b4837ea90ec03320c8eeb702ad3966ee5912aa2e33b5bdb17b0e88caa31ed546f7f601160ced8eceebdf5db6449df6ec3ffbd17e27917ec328"^^xsd:string .
+
+niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7 prov:wasDerivedFrom niiri:335e2de27a1a351eae295b2d6aba0ccc .
+
+niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:40508269ce9f0c03d9af35c886882e23
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+
+niiri:493248b59478ddca0df41a77bc6f1482
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
+
+niiri:40508269ce9f0c03d9af35c886882e23 prov:wasDerivedFrom niiri:493248b59478ddca0df41a77bc6f1482 .
+
+niiri:40508269ce9f0c03d9af35c886882e23 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:336fa6f65e23fda5fa34e118d1c9a0e1
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+
+niiri:7fd42856ebc39326ecf3d9c7336203ad
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "833a477bd4e758bdde7fcc9e6682186e9e38c1eeaa2a66de7d67e5f3c57cbaed7bddd45a7f7c86db713a8aa708790eaa31e0d8f0d0af9db9e87b545990b9e91e"^^xsd:string .
+
+niiri:336fa6f65e23fda5fa34e118d1c9a0e1 prov:wasDerivedFrom niiri:7fd42856ebc39326ecf3d9c7336203ad .
+
+niiri:336fa6f65e23fda5fa34e118d1c9a0e1 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:16e0178c267997ead20f777bffe45894
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 4" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+
+niiri:ffb56ac43e312f7d862bd04227ca2771
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0004.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "8044c2e517efad185114b1d5478983a5073547d99f6b5778bcefe9caa7d243b89824b69841e3e5aa05e1da5393c9d1a34fec9a050b6a1e8a87da31cad99bfe69"^^xsd:string .
+
+niiri:16e0178c267997ead20f777bffe45894 prov:wasDerivedFrom niiri:ffb56ac43e312f7d862bd04227ca2771 .
+
+niiri:16e0178c267997ead20f777bffe45894 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:717d24f6fc8fcd6daeec2603e49ed740
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 5" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+
+niiri:67d86f251b1b458908a8aee56a029301
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0005.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "15551a7f3970720338fd0643bd017ba2f7f5db09c16b38909560b0479aa69eb74cd746fa98b2adc796153af88fba9b2ddd4eb5713b6f6011e62b7efb6531426d"^^xsd:string .
+
+niiri:717d24f6fc8fcd6daeec2603e49ed740 prov:wasDerivedFrom niiri:67d86f251b1b458908a8aee56a029301 .
+
+niiri:717d24f6fc8fcd6daeec2603e49ed740 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:b8e1b2bd6e02f1d74415b3190da5e6ce
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 6" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+
+niiri:0f227926cc2656b6333cd6e70b59bef0
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0006.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
+
+niiri:b8e1b2bd6e02f1d74415b3190da5e6ce prov:wasDerivedFrom niiri:0f227926cc2656b6333cd6e70b59bef0 .
+
+niiri:b8e1b2bd6e02f1d74415b3190da5e6ce prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:f446aad676c7f507c6dfdb3e65bd6cb3
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    crypto:sha512 "9f1acf4f335317f388cc8adcc04086aa4e6bc6d19d5633a6a8d8dd85716386748c7ed700ef8031c7a3733228557d5ecf96eb6a889e2d36ad065e7bc852ae0b8c"^^xsd:string .
+
+niiri:7dc7be1e08841016c50f481df400db45
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "641184631587ff0ed74f92302d94dd40f2802efab358753eade14667fb6ee74fe64f3090b02fdf20e4a99d444610a61a1ae8a684628c9b2037535fbed9d53a12"^^xsd:string .
+
+niiri:f446aad676c7f507c6dfdb3e65bd6cb3 prov:wasDerivedFrom niiri:7dc7be1e08841016c50f481df400db45 .
+
+niiri:f446aad676c7f507c6dfdb3e65bd6cb3 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:952c39e2aa9fff43b62bbe9b77405227
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    crypto:sha512 "a093dd7a9dd81e95f3696221e49cbb3ad8080b1f316ece53c9aafcb5cc9b767e55c594b7131d933e31231744c65db07483e64245480afd95075b76ccd2432789"^^xsd:string .
+
+niiri:48a4ebca3d7eaf837f3c511ad76b8b82
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "6ccf9e1895f8a26549f392b1d1a3676888cd729a207c6a93bcda6d549de2d4f133c0b2847bd2e839a462f3ba74cb9d9525eddb9f8499b99fb452b93cd713a158"^^xsd:string .
+
+niiri:952c39e2aa9fff43b62bbe9b77405227 prov:wasDerivedFrom niiri:48a4ebca3d7eaf837f3c511ad76b8b82 .
+
+niiri:952c39e2aa9fff43b62bbe9b77405227 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+
+niiri:eaf42d3560a64658c65dfc990556d651
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_FStatistic: ;
+    nidm_contrastName: "F Contrast Test"^^xsd:string ;
+    rdfs:label "Contrast: F Contrast Test" ;
+    prov:value "[[1, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0],[0, 0, 0, 1, 0, 0]]"^^xsd:string .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:wasAssociatedWith niiri:43a3ee53f98ee35a82fd6af9eebbd163 .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:2dfea426e8928d3252adb676004ffb9d .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:f446aad676c7f507c6dfdb3e65bd6cb3 .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:3769ef4c5efe49a97295e3959f9dc7ad .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:eaf42d3560a64658c65dfc990556d651 .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7 .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:40508269ce9f0c03d9af35c886882e23 .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:336fa6f65e23fda5fa34e118d1c9a0e1 .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:16e0178c267997ead20f777bffe45894 .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:717d24f6fc8fcd6daeec2603e49ed740 .
+
+niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:b8e1b2bd6e02f1d74415b3190da5e6ce .
+
+niiri:b61012119e0a476f635df26d721e8c30
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: F Contrast Test" ;
+    nidm_statisticType: stato_FStatistic: ;
+    nidm_contrastName: "F Contrast Test"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "192.999999999651"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "3.99999999999962"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    crypto:sha512 "ca31a667d26797ee68a3709a8fa04f799ad113f17e6eff75ad6e88f53c44aa9e158a0d007354d454ad01df82d6b0f25f07b324cc3baa32f7623096a92ee6f304"^^xsd:string .
+
+niiri:7a977781f43baadb29a7109b66db5c80
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmF_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "db6d4200b2e060c1fbd3e5c71011ac95ce60024087239685545954651a68733ec2d949c56520d2637add9e91c8e7883742c7d307667ad83c4ebe2a8531a1cc53"^^xsd:string .
+
+niiri:b61012119e0a476f635df26d721e8c30 prov:wasDerivedFrom niiri:7a977781f43baadb29a7109b66db5c80 .
+
+niiri:b61012119e0a476f635df26d721e8c30 prov:wasGeneratedBy niiri:b6fffa4c3247dbca41c70d6abf376201 .
+
+niiri:5da9115bb9224fc27deb59c4db51293d
+    a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
+    prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Explained Mean Square Map" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    crypto:sha512 "a4b2ff6f792524a027a625aba962b798c3ea321cdd6636193ab521acf5dafa8ceb7fd4cb99a450ab7872359d0e6dac97f82b7523d609747780623b5077e02588"^^xsd:string .
+
+niiri:5da9115bb9224fc27deb59c4db51293d prov:wasGeneratedBy niiri:b6fffa4c3247dbca41c70d6abf376201 .
+
+niiri:790a0bb2d27b9d88e6869e877e73216b
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    prov:value "0.000999500086842908"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:cdc27d5485a25b98dc806d64eab06294 ;
+    nidm_equivalentThreshold: niiri:3a45a7e93b85e390a50cf7b33998e058 .
+
+niiri:cdc27d5485a25b98dc806d64eab06294
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "4.81888651656205"^^xsd:float .
+
+niiri:3a45a7e93b85e390a50cf7b33998e058
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:311c74b903cbe301d2ea1ed406ef3819
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:d03c098b559b5d8b940ae0e6f4e45ac2 ;
+    nidm_equivalentThreshold: niiri:1256253b1ec8513cc907a598b85b5d25 .
+
+niiri:d03c098b559b5d8b940ae0e6f4e45ac2
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:1256253b1ec8513cc907a598b85b5d25
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:0499a436458abc172a88ee306d18a605
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:83fc9ee7c0ea36a7bd88d4420b89b29c
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:wasAssociatedWith niiri:43a3ee53f98ee35a82fd6af9eebbd163 .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:790a0bb2d27b9d88e6869e877e73216b .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:311c74b903cbe301d2ea1ed406ef3819 .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:b61012119e0a476f635df26d721e8c30 .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:952c39e2aa9fff43b62bbe9b77405227 .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:2dfea426e8928d3252adb676004ffb9d .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:0499a436458abc172a88ee306d18a605 .
+
+niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:83fc9ee7c0ea36a7bd88d4420b89b29c .
+
+niiri:0bd153c871e44425ad2d0d70154ff868
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
+    nidm_reselSizeInVoxels: "68.4409986586639"^^xsd:float ;
+    nidm_searchVolumeInResels: "2811.45809925498"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[5, 96.6116867805811, 900.100332657459, 2811.45809925498]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.16320607513029, 4.05765428344923, 4.05147708968716]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.32641215026059, 8.11530856689846, 8.10295417937431]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "4.8177623848126"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "45.9650640219086"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "9.80643263054093"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "8.38272571563721"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "68"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "51"^^xsd:int ;
+    crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
+
+niiri:0bd153c871e44425ad2d0d70154ff868 prov:wasGeneratedBy niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c .
+
+niiri:1f1a3d63428e4d2bf1696942c7dcd71e
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "89"^^xsd:int ;
+    nidm_pValue: "1.20671430625663e-08"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:ea2c3c814c10994917dd56bc9fe21873 ;
+    nidm_hasMaximumIntensityProjection: niiri:dd34657f27860de0933d54ae20a5bde9 ;
+    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    crypto:sha512 "7655b200bdcbba72ab5ab79029728a420df3f3368bcb553410540390e1372e99531cb91885edbdd03945d7e2391516a3d8dc537da81527730e866035d4af7894"^^xsd:string .
+
+niiri:ea2c3c814c10994917dd56bc9fe21873
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:dd34657f27860de0933d54ae20a5bde9
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:1f1a3d63428e4d2bf1696942c7dcd71e prov:wasGeneratedBy niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c .
+
+niiri:0af3c1dadf9b022bafb92d73c4057be6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0001" ;
+    nidm_clusterSizeInVoxels: "1078"^^xsd:int ;
+    nidm_clusterSizeInResels: "15.7507929622172"^^xsd:float ;
+    nidm_pValueUncorrected: "4.44714364460473e-20"^^xsd:float ;
+    nidm_pValueFWER: "0"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "1"^^xsd:int .
+
+niiri:0af3c1dadf9b022bafb92d73c4057be6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:1f6332db35b31af3ee6ca935dfaeba0c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0002" ;
+    nidm_clusterSizeInVoxels: "930"^^xsd:int ;
+    nidm_clusterSizeInResels: "13.5883464330816"^^xsd:float ;
+    nidm_pValueUncorrected: "2.90091267643839e-18"^^xsd:float ;
+    nidm_pValueFWER: "1.11022302462516e-16"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "2"^^xsd:int .
+
+niiri:1f6332db35b31af3ee6ca935dfaeba0c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:0d4bf8c640cd15c305d2e49ef14b9ac6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0003" ;
+    nidm_clusterSizeInVoxels: "61"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.891278637008579"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00140501536931943"^^xsd:float ;
+    nidm_pValueFWER: "0.0625404056276491"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "3"^^xsd:int .
+
+niiri:0d4bf8c640cd15c305d2e49ef14b9ac6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:32439b88059be589d0e2a8586ea799ec
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0004" ;
+    nidm_clusterSizeInVoxels: "51"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.74516738503996"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00294180828906497"^^xsd:float ;
+    nidm_pValueFWER: "0.126476639623878"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "4"^^xsd:int .
+
+niiri:32439b88059be589d0e2a8586ea799ec prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:d8b9846e25000609adbc385c634a1be0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0005" ;
+    nidm_clusterSizeInVoxels: "102"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.49033477007992"^^xsd:float ;
+    nidm_pValueUncorrected: "9.58684672197711e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.00439690541625271"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "5"^^xsd:int .
+
+niiri:d8b9846e25000609adbc385c634a1be0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:f8e22d4c567142a3ab813140dd91551e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0006" ;
+    nidm_clusterSizeInVoxels: "69"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.00816763858347"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000800670143082103"^^xsd:float ;
+    nidm_pValueFWER: "0.0361338614001637"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "6"^^xsd:int .
+
+niiri:f8e22d4c567142a3ab813140dd91551e prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:96a2e290f72fc28530510650c52e2805
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0007" ;
+    nidm_clusterSizeInVoxels: "81"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.18350114094582"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000358186300522155"^^xsd:float ;
+    nidm_pValueFWER: "0.0163292644152585"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "7"^^xsd:int .
+
+niiri:96a2e290f72fc28530510650c52e2805 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:1062efea331d3022773f16c049f8543d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0008" ;
+    nidm_clusterSizeInVoxels: "62"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.905889762205441"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00130795483514697"^^xsd:float ;
+    nidm_pValueFWER: "0.0583486858266125"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "8"^^xsd:int .
+
+niiri:1062efea331d3022773f16c049f8543d prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:5577dc13c7013d8bb90b8dd111792d46
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0009" ;
+    nidm_clusterSizeInVoxels: "27"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.394500380315273"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0220489738091681"^^xsd:float ;
+    nidm_pValueFWER: "0.637047204368496"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "9"^^xsd:int .
+
+niiri:5577dc13c7013d8bb90b8dd111792d46 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:64ae5737521bbc7fe14f0c862379e927
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0010" ;
+    nidm_clusterSizeInVoxels: "69"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.00816763858347"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000800670143082103"^^xsd:float ;
+    nidm_pValueFWER: "0.0361338614001637"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "10"^^xsd:int .
+
+niiri:64ae5737521bbc7fe14f0c862379e927 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:900846b4c16bba4a9b8a34762cba2da0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0011" ;
+    nidm_clusterSizeInVoxels: "34"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.496778256693306"^^xsd:float ;
+    nidm_pValueUncorrected: "0.011700144046285"^^xsd:float ;
+    nidm_pValueFWER: "0.41596704628578"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "11"^^xsd:int .
+
+niiri:900846b4c16bba4a9b8a34762cba2da0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:7ede1db6987922a4806abc265aecda62
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0012" ;
+    nidm_clusterSizeInVoxels: "16"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.233778003149791"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0678018153345425"^^xsd:float ;
+    nidm_pValueFWER: "0.955688665756324"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "12"^^xsd:int .
+
+niiri:7ede1db6987922a4806abc265aecda62 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:9287b2a8106c3ffe3abf93837cfbd61c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0013" ;
+    nidm_clusterSizeInVoxels: "33"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.482167131496445"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0127719721079915"^^xsd:float ;
+    nidm_pValueFWER: "0.444043105508432"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "13"^^xsd:int .
+
+niiri:9287b2a8106c3ffe3abf93837cfbd61c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:c515278968596a92906ae29ffad63511
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0014" ;
+    nidm_clusterSizeInVoxels: "29"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.423722630708997"^^xsd:float ;
+    nidm_pValueUncorrected: "0.01830452631499"^^xsd:float ;
+    nidm_pValueFWER: "0.568879964907834"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "14"^^xsd:int .
+
+niiri:c515278968596a92906ae29ffad63511 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:0493a379c4735cda662e56229168b8a9
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0015" ;
+    nidm_clusterSizeInVoxels: "52"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.759778510236822"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00272666362579781"^^xsd:float ;
+    nidm_pValueFWER: "0.117795392093901"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "15"^^xsd:int .
+
+niiri:0493a379c4735cda662e56229168b8a9 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:6f915c93d573d9f832d05fb003dcbfb0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0016" ;
+    nidm_clusterSizeInVoxels: "19"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.277611378740377"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0489067183857246"^^xsd:float ;
+    nidm_pValueFWER: "0.894389812698126"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "16"^^xsd:int .
+
+niiri:6f915c93d573d9f832d05fb003dcbfb0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:2344710a34a75f050910ebd48e1159af
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0017" ;
+    nidm_clusterSizeInVoxels: "15"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.219166877952929"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0759384102313504"^^xsd:float ;
+    nidm_pValueFWER: "0.969514797834504"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "17"^^xsd:int .
+
+niiri:2344710a34a75f050910ebd48e1159af prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:a904380f9b13e67a2253c5f952a57f9f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0018" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346653"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0606787631410972"^^xsd:float ;
+    nidm_pValueFWER: "0.938523680835064"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "18"^^xsd:int .
+
+niiri:a904380f9b13e67a2253c5f952a57f9f prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:8348fc8e7248e46840dad7df7f8763bf
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0019" ;
+    nidm_clusterSizeInVoxels: "37"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.540611632283892"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00903991120867935"^^xsd:float ;
+    nidm_pValueFWER: "0.340003071301302"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "19"^^xsd:int .
+
+niiri:8348fc8e7248e46840dad7df7f8763bf prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:db6eb647802a5fc531c369aa668af574
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0020" ;
+    nidm_clusterSizeInVoxels: "9"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.131500126771758"^^xsd:float ;
+    nidm_pValueUncorrected: "0.15980273271822"^^xsd:float ;
+    nidm_pValueFWER: "0.999354408004913"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "20"^^xsd:int .
+
+niiri:db6eb647802a5fc531c369aa668af574 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:efddc25357ec7a4b9a063a62f5a2c864
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0021" ;
+    nidm_clusterSizeInVoxels: "27"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.394500380315273"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0220489738091681"^^xsd:float ;
+    nidm_pValueFWER: "0.637047204368496"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "21"^^xsd:int .
+
+niiri:efddc25357ec7a4b9a063a62f5a2c864 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:92832eb3b91834fca357233c33e92d47
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0022" ;
+    nidm_clusterSizeInVoxels: "24"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.350667004724687"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0294098545193599"^^xsd:float ;
+    nidm_pValueFWER: "0.741232640256625"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "22"^^xsd:int .
+
+niiri:92832eb3b91834fca357233c33e92d47 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:27a928cca18b5d563bf58797f306d0e0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0023" ;
+    nidm_clusterSizeInVoxels: "30"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.438333755905859"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0167048818724221"^^xsd:float ;
+    nidm_pValueFWER: "0.535986190221124"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "23"^^xsd:int .
+
+niiri:27a928cca18b5d563bf58797f306d0e0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:9197197694f96c553e0e78334284b0c7
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0024" ;
+    nidm_clusterSizeInVoxels: "19"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.277611378740377"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0489067183857246"^^xsd:float ;
+    nidm_pValueFWER: "0.894389812698126"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "24"^^xsd:int .
+
+niiri:9197197694f96c553e0e78334284b0c7 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:4babeddab7c30570f5f7bca47ad8e349
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0025" ;
+    nidm_clusterSizeInVoxels: "68"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.993556513386613"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000857915851634946"^^xsd:float ;
+    nidm_pValueFWER: "0.0386667510721175"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "25"^^xsd:int .
+
+niiri:4babeddab7c30570f5f7bca47ad8e349 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:abcdfa125cb9a6705001908f8633bf90
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0026" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160722377165481"^^xsd:float ;
+    nidm_pValueUncorrected: "0.122909028578024"^^xsd:float ;
+    nidm_pValueFWER: "0.996480799224121"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "26"^^xsd:int .
+
+niiri:abcdfa125cb9a6705001908f8633bf90 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:2583f6b74e4ca256d5338bb9b9f07a29
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0027" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.14611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.139840260197002"^^xsd:float ;
+    nidm_pValueFWER: "0.998383943752383"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "27"^^xsd:int .
+
+niiri:2583f6b74e4ca256d5338bb9b9f07a29 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:9656cbf27ba556542b025f2f8e45acfd
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0028" ;
+    nidm_clusterSizeInVoxels: "15"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.219166877952929"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0759384102313504"^^xsd:float ;
+    nidm_pValueFWER: "0.969514797834504"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "28"^^xsd:int .
+
+niiri:9656cbf27ba556542b025f2f8e45acfd prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:52cafab6790abfb27ec51f00e747fe9a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0029" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346653"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0606787631410972"^^xsd:float ;
+    nidm_pValueFWER: "0.938523680835064"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "29"^^xsd:int .
+
+niiri:52cafab6790abfb27ec51f00e747fe9a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:4c64b57b636863b3e947522d1311c0f1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0030" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.175333502362343"^^xsd:float ;
+    nidm_pValueUncorrected: "0.108445358385968"^^xsd:float ;
+    nidm_pValueFWER: "0.993158154960398"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "30"^^xsd:int .
+
+niiri:4c64b57b636863b3e947522d1311c0f1 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:a8236e3bfdb590d4516edd326dbac95d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0031" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.343698638066254"^^xsd:float ;
+    nidm_pValueFWER: "0.99999986229194"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "31"^^xsd:int .
+
+niiri:a8236e3bfdb590d4516edd326dbac95d prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:90dce13e46266944c40d12f4f1a86219
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0032" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160722377165481"^^xsd:float ;
+    nidm_pValueUncorrected: "0.122909028578024"^^xsd:float ;
+    nidm_pValueFWER: "0.996480799224121"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "32"^^xsd:int .
+
+niiri:90dce13e46266944c40d12f4f1a86219 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:4b569159d1ddc968752a57917503c6f4
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0033" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.14611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.139840260197002"^^xsd:float ;
+    nidm_pValueFWER: "0.998383943752383"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "33"^^xsd:int .
+
+niiri:4b569159d1ddc968752a57917503c6f4 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:674c9062dc421a541e91be283cce8f16
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0034" ;
+    nidm_clusterSizeInVoxels: "9"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.131500126771758"^^xsd:float ;
+    nidm_pValueUncorrected: "0.15980273271822"^^xsd:float ;
+    nidm_pValueFWER: "0.999354408004913"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "34"^^xsd:int .
+
+niiri:674c9062dc421a541e91be283cce8f16 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:d3a1762138c1b259db52c75933757662
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0035" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.116889001574896"^^xsd:float ;
+    nidm_pValueUncorrected: "0.183538919045686"^^xsd:float ;
+    nidm_pValueFWER: "0.999783165932851"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "35"^^xsd:int .
+
+niiri:d3a1762138c1b259db52c75933757662 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:9dc472e5df63cfbf55f8afa2ad7233f1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0036" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.343698638066254"^^xsd:float ;
+    nidm_pValueFWER: "0.99999986229194"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "36"^^xsd:int .
+
+niiri:9dc472e5df63cfbf55f8afa2ad7233f1 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:3fd667ca8587427124fe4b4ff80af21a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0037" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.175333502362343"^^xsd:float ;
+    nidm_pValueUncorrected: "0.108445358385968"^^xsd:float ;
+    nidm_pValueFWER: "0.993158154960398"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "37"^^xsd:int .
+
+niiri:3fd667ca8587427124fe4b4ff80af21a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:c60cf8d223f50376ab05520bb51598af
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0038" ;
+    nidm_clusterSizeInVoxels: "13"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.189944627559205"^^xsd:float ;
+    nidm_pValueUncorrected: "0.096012927539169"^^xsd:float ;
+    nidm_pValueFWER: "0.987884145093703"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "38"^^xsd:int .
+
+niiri:c60cf8d223f50376ab05520bb51598af prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:f551110d12542058bdc59cae03013010
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0039" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811717"^^xsd:float ;
+    nidm_pValueUncorrected: "0.246729452566726"^^xsd:float ;
+    nidm_pValueFWER: "0.999988123335902"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "39"^^xsd:int .
+
+niiri:f551110d12542058bdc59cae03013010 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:fb9120500eef24a89fb5e84238991362
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0040" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.343698638066254"^^xsd:float ;
+    nidm_pValueFWER: "0.99999986229194"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "40"^^xsd:int .
+
+niiri:fb9120500eef24a89fb5e84238991362 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:dde8bc734b1e70c777683f3419f9b22a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0041" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811717"^^xsd:float ;
+    nidm_pValueUncorrected: "0.246729452566726"^^xsd:float ;
+    nidm_pValueFWER: "0.999988123335902"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "41"^^xsd:int .
+
+niiri:dde8bc734b1e70c777683f3419f9b22a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:89223f01a7e676c300c22c8da4a82ef8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0042" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160722377165481"^^xsd:float ;
+    nidm_pValueUncorrected: "0.122909028578024"^^xsd:float ;
+    nidm_pValueFWER: "0.996480799224121"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "42"^^xsd:int .
+
+niiri:89223f01a7e676c300c22c8da4a82ef8 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:7ac6ced5ac5b95c88fbe93f4ad51726c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0043" ;
+    nidm_clusterSizeInVoxels: "14"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.204555752756067"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0852685099572997"^^xsd:float ;
+    nidm_pValueFWER: "0.980146451443566"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "43"^^xsd:int .
+
+niiri:7ac6ced5ac5b95c88fbe93f4ad51726c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:5d05848ec2715382392265640fc9d57e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0044" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.14611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.139840260197002"^^xsd:float ;
+    nidm_pValueFWER: "0.998383943752383"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "44"^^xsd:int .
+
+niiri:5d05848ec2715382392265640fc9d57e prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:ca24bdc833f185dc48a439c9bd8cfea6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0045" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102277876378034"^^xsd:float ;
+    nidm_pValueUncorrected: "0.212050388130978"^^xsd:float ;
+    nidm_pValueFWER: "0.999941524907657"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "45"^^xsd:int .
+
+niiri:ca24bdc833f185dc48a439c9bd8cfea6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:302ad243c21e156bc35f157e2595460d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0046" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "46"^^xsd:int .
+
+niiri:302ad243c21e156bc35f157e2595460d prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:b0e84ab2cd541b237634e56ebf391609
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0047" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.116889001574896"^^xsd:float ;
+    nidm_pValueUncorrected: "0.183538919045686"^^xsd:float ;
+    nidm_pValueFWER: "0.999783165932851"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "47"^^xsd:int .
+
+niiri:b0e84ab2cd541b237634e56ebf391609 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:27969eb0dc2d34026b32c881a0f07667
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0048" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "48"^^xsd:int .
+
+niiri:27969eb0dc2d34026b32c881a0f07667 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:488053a695a16e1621e578a90cd45d96
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0049" ;
+    nidm_clusterSizeInVoxels: "9"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.131500126771758"^^xsd:float ;
+    nidm_pValueUncorrected: "0.15980273271822"^^xsd:float ;
+    nidm_pValueFWER: "0.999354408004913"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "49"^^xsd:int .
+
+niiri:488053a695a16e1621e578a90cd45d96 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:ed908db943ba3e97ea5826f9b78e251e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0050" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.343698638066254"^^xsd:float ;
+    nidm_pValueFWER: "0.99999986229194"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "50"^^xsd:int .
+
+niiri:ed908db943ba3e97ea5826f9b78e251e prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:f5e02329544635d1b1ebf65b366251dc
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0051" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102277876378034"^^xsd:float ;
+    nidm_pValueUncorrected: "0.212050388130978"^^xsd:float ;
+    nidm_pValueFWER: "0.999941524907657"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "51"^^xsd:int .
+
+niiri:f5e02329544635d1b1ebf65b366251dc prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:48785ebe53244b67446462ca165511f6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0052" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0730556259843098"^^xsd:float ;
+    nidm_pValueUncorrected: "0.289588977139942"^^xsd:float ;
+    nidm_pValueFWER: "0.999998343785323"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "52"^^xsd:int .
+
+niiri:48785ebe53244b67446462ca165511f6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:dd83d9e917f614f418e9401cdb99e43c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0053" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.343698638066254"^^xsd:float ;
+    nidm_pValueFWER: "0.99999986229194"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "53"^^xsd:int .
+
+niiri:dd83d9e917f614f418e9401cdb99e43c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:f9dfccb5b804ef9741131141e3190a4b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0054" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102277876378034"^^xsd:float ;
+    nidm_pValueUncorrected: "0.212050388130978"^^xsd:float ;
+    nidm_pValueFWER: "0.999941524907657"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "54"^^xsd:int .
+
+niiri:f9dfccb5b804ef9741131141e3190a4b prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0055" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160722377165481"^^xsd:float ;
+    nidm_pValueUncorrected: "0.122909028578024"^^xsd:float ;
+    nidm_pValueFWER: "0.996480799224121"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "55"^^xsd:int .
+
+niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:024c443604af80b2271c971bd66fc9a0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0056" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "56"^^xsd:int .
+
+niiri:024c443604af80b2271c971bd66fc9a0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:bd7d210916ff0d725f61db0ca48f5d05
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0057" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "57"^^xsd:int .
+
+niiri:bd7d210916ff0d725f61db0ca48f5d05 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:7925cec36e37f32d88f7027ba176a2e1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0058" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "58"^^xsd:int .
+
+niiri:7925cec36e37f32d88f7027ba176a2e1 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:11d4226a2f26d5d215e759b0b4e1b65c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0059" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102277876378034"^^xsd:float ;
+    nidm_pValueUncorrected: "0.212050388130978"^^xsd:float ;
+    nidm_pValueFWER: "0.999941524907657"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "59"^^xsd:int .
+
+niiri:11d4226a2f26d5d215e759b0b4e1b65c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:cd265e81b525edcdebe748129d48fb9f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0060" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.343698638066254"^^xsd:float ;
+    nidm_pValueFWER: "0.99999986229194"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "60"^^xsd:int .
+
+niiri:cd265e81b525edcdebe748129d48fb9f prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:aa2c86e9352626823ca6bb3bbda5947a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0061" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "61"^^xsd:int .
+
+niiri:aa2c86e9352626823ca6bb3bbda5947a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:8d3a03589611da3ed8127a06d493acd6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0062" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905859"^^xsd:float ;
+    nidm_pValueUncorrected: "0.41411715244508"^^xsd:float ;
+    nidm_pValueFWER: "0.999999994589484"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "62"^^xsd:int .
+
+niiri:8d3a03589611da3ed8127a06d493acd6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:3f311421a632e712f70cc6839f7e9489
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0063" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "63"^^xsd:int .
+
+niiri:3f311421a632e712f70cc6839f7e9489 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:bcc132262f6d7297d1d28a6f0a171093
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0064" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.343698638066254"^^xsd:float ;
+    nidm_pValueFWER: "0.99999986229194"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "64"^^xsd:int .
+
+niiri:bcc132262f6d7297d1d28a6f0a171093 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:3bdec6eb0b5535174fa631dd70795a7e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0065" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "65"^^xsd:int .
+
+niiri:3bdec6eb0b5535174fa631dd70795a7e prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:f1946d8aa4c75dc6c7b6e735e96e1847
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0066" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "66"^^xsd:int .
+
+niiri:f1946d8aa4c75dc6c7b6e735e96e1847 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:3592a75cac312314b4a818b743916efd
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0067" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "67"^^xsd:int .
+
+niiri:3592a75cac312314b4a818b743916efd prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:a457cd8f3b3381f0a12661e0907b556a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0068" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.343698638066254"^^xsd:float ;
+    nidm_pValueFWER: "0.99999986229194"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "68"^^xsd:int .
+
+niiri:a457cd8f3b3381f0a12661e0907b556a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:698306b72f010c2b2851ac92120e72d6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0069" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0730556259843098"^^xsd:float ;
+    nidm_pValueUncorrected: "0.289588977139942"^^xsd:float ;
+    nidm_pValueFWER: "0.999998343785323"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "69"^^xsd:int .
+
+niiri:698306b72f010c2b2851ac92120e72d6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:5d9c59bbe6ff835dfd7a715340e2d8b7
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0070" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "70"^^xsd:int .
+
+niiri:5d9c59bbe6ff835dfd7a715340e2d8b7 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:8cb05ce5ff1f36539390753e60f586ff
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0071" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905859"^^xsd:float ;
+    nidm_pValueUncorrected: "0.41411715244508"^^xsd:float ;
+    nidm_pValueFWER: "0.999999994589484"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "71"^^xsd:int .
+
+niiri:8cb05ce5ff1f36539390753e60f586ff prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0072" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "72"^^xsd:int .
+
+niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:08144c2f2914ca0e8f2d5090a382dd9c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0073" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "73"^^xsd:int .
+
+niiri:08144c2f2914ca0e8f2d5090a382dd9c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:20fdb21c4b6e1b56aba03dc17e6e0cad
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0074" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "74"^^xsd:int .
+
+niiri:20fdb21c4b6e1b56aba03dc17e6e0cad prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:b16302312e147e9c8ce1bdd421f19045
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0075" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "75"^^xsd:int .
+
+niiri:b16302312e147e9c8ce1bdd421f19045 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:9e57216b41802f20cbaf2104bd85f6ec
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0076" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "76"^^xsd:int .
+
+niiri:9e57216b41802f20cbaf2104bd85f6ec prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:002e00007a510fe7b30fd39adc263872
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0077" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "77"^^xsd:int .
+
+niiri:002e00007a510fe7b30fd39adc263872 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:2b00f1f0bcfadf17e4e74a633d9cbe02
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0078" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "78"^^xsd:int .
+
+niiri:2b00f1f0bcfadf17e4e74a633d9cbe02 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:0a99da6db6ffdb6abd70dfec062dacc6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0079" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0730556259843098"^^xsd:float ;
+    nidm_pValueUncorrected: "0.289588977139942"^^xsd:float ;
+    nidm_pValueFWER: "0.999998343785323"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "79"^^xsd:int .
+
+niiri:0a99da6db6ffdb6abd70dfec062dacc6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:ee9edf2a051832c657f8417f27f95a8f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0080" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "80"^^xsd:int .
+
+niiri:ee9edf2a051832c657f8417f27f95a8f prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:db1e7cd2ec53abce67f4898eb3c88730
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0081" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "81"^^xsd:int .
+
+niiri:db1e7cd2ec53abce67f4898eb3c88730 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:1066c8d3aa41693bfd354d1824cc7afe
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0082" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.510282095685957"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999934903"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "82"^^xsd:int .
+
+niiri:1066c8d3aa41693bfd354d1824cc7afe prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:176e7ef375f6f1d2e26f1a064f8f6d39
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0083" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "83"^^xsd:int .
+
+niiri:176e7ef375f6f1d2e26f1a064f8f6d39 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:08a3f7b7f6c942ab91160dfccbb968f2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0084" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "84"^^xsd:int .
+
+niiri:08a3f7b7f6c942ab91160dfccbb968f2 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:bddc2499a043f720b9c5a3c2a309f42c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0085" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "85"^^xsd:int .
+
+niiri:bddc2499a043f720b9c5a3c2a309f42c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:189d9d696ac51ec44003eb5f973b6c64
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0086" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "86"^^xsd:int .
+
+niiri:189d9d696ac51ec44003eb5f973b6c64 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:5d37a307684854af5c2a17ddbdb8f17f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0087" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "87"^^xsd:int .
+
+niiri:5d37a307684854af5c2a17ddbdb8f17f prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:df310d7fb2c5397364d68a8d3fa65bc0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0088" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "88"^^xsd:int .
+
+niiri:df310d7fb2c5397364d68a8d3fa65bc0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:d0abba065cadfdf673c1ba317a4155ef
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0089" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.014611125196862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654533745817325"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999914"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "89"^^xsd:int .
+
+niiri:d0abba065cadfdf673c1ba317a4155ef prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+
+niiri:cd9309db3e1c88a98ba96314ae5579f0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0001" ;
+    prov:atLocation niiri:4bc98dbacc7bcd13b355272508d662cd ;
+    prov:value "16.0820484161377"^^xsd:float ;
+    nidm_equivalentZStatistic: "6.58928757769047"^^xsd:float ;
+    nidm_pValueUncorrected: "2.20971019260219e-11"^^xsd:float ;
+    nidm_pValueFWER: "4.59341100222943e-06"^^xsd:float ;
+    nidm_qValueFDR: "2.11792501803032e-06"^^xsd:float .
+
+niiri:4bc98dbacc7bcd13b355272508d662cd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0001" ;
+    nidm_coordinateVector: "[-14,-84,-14]"^^xsd:string .
+
+niiri:cd9309db3e1c88a98ba96314ae5579f0 prov:wasDerivedFrom niiri:0af3c1dadf9b022bafb92d73c4057be6 .
+
+niiri:89156d76de8aafb9c0d7504b45de19a1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0002" ;
+    prov:atLocation niiri:0692b895967968b5ad50805b77073b6f ;
+    prov:value "13.9779033660889"^^xsd:float ;
+    nidm_equivalentZStatistic: "6.11142244434854"^^xsd:float ;
+    nidm_pValueUncorrected: "4.93734941819923e-10"^^xsd:float ;
+    nidm_pValueFWER: "0.000102635598608014"^^xsd:float ;
+    nidm_qValueFDR: "5.60210458059015e-06"^^xsd:float .
+
+niiri:0692b895967968b5ad50805b77073b6f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0002" ;
+    nidm_coordinateVector: "[-42,-76,-12]"^^xsd:string .
+
+niiri:89156d76de8aafb9c0d7504b45de19a1 prov:wasDerivedFrom niiri:0af3c1dadf9b022bafb92d73c4057be6 .
+
+niiri:3cc1aa7c32068139da6b5f92edd82cb6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0003" ;
+    prov:atLocation niiri:5dfe29da2cb5f0c3c504895aeba5f33f ;
+    prov:value "10.3123865127563"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.1402197604635"^^xsd:float ;
+    nidm_pValueUncorrected: "1.3720866187672e-07"^^xsd:float ;
+    nidm_pValueFWER: "0.0248386091747108"^^xsd:float ;
+    nidm_qValueFDR: "0.000165827847161811"^^xsd:float .
+
+niiri:5dfe29da2cb5f0c3c504895aeba5f33f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0003" ;
+    nidm_coordinateVector: "[-20,-90,8]"^^xsd:string .
+
+niiri:3cc1aa7c32068139da6b5f92edd82cb6 prov:wasDerivedFrom niiri:0af3c1dadf9b022bafb92d73c4057be6 .
+
+niiri:92bb19c86792f383f51524cf04efcf6f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0004" ;
+    prov:atLocation niiri:9872f9d3dc8e27014ef5a3559e09b981 ;
+    prov:value "13.7427864074707"^^xsd:float ;
+    nidm_equivalentZStatistic: "6.05489626279796"^^xsd:float ;
+    nidm_pValueUncorrected: "7.02540914332417e-10"^^xsd:float ;
+    nidm_pValueFWER: "0.000146041348950021"^^xsd:float ;
+    nidm_qValueFDR: "5.84165395800085e-06"^^xsd:float .
+
+niiri:9872f9d3dc8e27014ef5a3559e09b981
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0004" ;
+    nidm_coordinateVector: "[22,-98,10]"^^xsd:string .
+
+niiri:92bb19c86792f383f51524cf04efcf6f prov:wasDerivedFrom niiri:1f6332db35b31af3ee6ca935dfaeba0c .
+
+niiri:20e1e7c992a4871fb508554d0585da06
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0005" ;
+    prov:atLocation niiri:db23149ad95a1fe9c4c1cd4d7de870aa ;
+    prov:value "12.7449989318848"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.80709618365418"^^xsd:float ;
+    nidm_pValueUncorrected: "3.17828119378305e-09"^^xsd:float ;
+    nidm_pValueFWER: "0.000660688335281101"^^xsd:float ;
+    nidm_qValueFDR: "1.54333527599919e-05"^^xsd:float .
+
+niiri:db23149ad95a1fe9c4c1cd4d7de870aa
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0005" ;
+    nidm_coordinateVector: "[40,-76,-4]"^^xsd:string .
+
+niiri:20e1e7c992a4871fb508554d0585da06 prov:wasDerivedFrom niiri:1f6332db35b31af3ee6ca935dfaeba0c .
+
+niiri:9b0669d94cf1e0b09df66fa7a674c7e3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0006" ;
+    prov:atLocation niiri:241eddcd45421fb2df8644ec543399de ;
+    prov:value "11.9460592269897"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.59865646408728"^^xsd:float ;
+    nidm_pValueUncorrected: "1.08009692301181e-08"^^xsd:float ;
+    nidm_pValueFWER: "0.00224526225660115"^^xsd:float ;
+    nidm_qValueFDR: "3.11841980083494e-05"^^xsd:float .
+
+niiri:241eddcd45421fb2df8644ec543399de
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0006" ;
+    nidm_coordinateVector: "[36,-86,8]"^^xsd:string .
+
+niiri:9b0669d94cf1e0b09df66fa7a674c7e3 prov:wasDerivedFrom niiri:1f6332db35b31af3ee6ca935dfaeba0c .
+
+niiri:fd3df422ba6b5a2312c81b7470fa4ce8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0007" ;
+    prov:atLocation niiri:785ed6e870cebde278aee39c7b6befdd ;
+    prov:value "10.8997001647949"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.31044487629651"^^xsd:float ;
+    nidm_pValueUncorrected: "5.46789791222579e-08"^^xsd:float ;
+    nidm_pValueFWER: "0.0109446324802115"^^xsd:float ;
+    nidm_qValueFDR: "8.7562484520721e-05"^^xsd:float .
+
+niiri:785ed6e870cebde278aee39c7b6befdd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0007" ;
+    nidm_coordinateVector: "[32,-66,32]"^^xsd:string .
+
+niiri:fd3df422ba6b5a2312c81b7470fa4ce8 prov:wasDerivedFrom niiri:0d4bf8c640cd15c305d2e49ef14b9ac6 .
+
+niiri:53ee6d1cb132259d2b6100b015ee9dce
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0008" ;
+    prov:atLocation niiri:72b3ecc6501f7b746bb979c1808000d5 ;
+    prov:value "5.45807838439941"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.39070148271528"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000348569950826771"^^xsd:float ;
+    nidm_pValueFWER: "0.999999998685327"^^xsd:float ;
+    nidm_qValueFDR: "0.0335543570769498"^^xsd:float .
+
+niiri:72b3ecc6501f7b746bb979c1808000d5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0008" ;
+    nidm_coordinateVector: "[32,-74,38]"^^xsd:string .
+
+niiri:53ee6d1cb132259d2b6100b015ee9dce prov:wasDerivedFrom niiri:0d4bf8c640cd15c305d2e49ef14b9ac6 .
+
+niiri:c8c92c4cb3dd742ebdf460a03d8ef227
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0009" ;
+    prov:atLocation niiri:b66031c85008481c6c52a889639df78f ;
+    prov:value "10.0041055679321"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.04819646859005"^^xsd:float ;
+    nidm_pValueUncorrected: "2.23000182986155e-07"^^xsd:float ;
+    nidm_pValueFWER: "0.0380835451252286"^^xsd:float ;
+    nidm_qValueFDR: "0.000232018725953295"^^xsd:float .
+
+niiri:b66031c85008481c6c52a889639df78f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0009" ;
+    nidm_coordinateVector: "[-30,-74,26]"^^xsd:string .
+
+niiri:c8c92c4cb3dd742ebdf460a03d8ef227 prov:wasDerivedFrom niiri:32439b88059be589d0e2a8586ea799ec .
+
+niiri:915c8684b1426b41a850e906a6cb7e51
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0010" ;
+    prov:atLocation niiri:fc9bb7ec98d0292b3cf09ece5735cbf7 ;
+    prov:value "9.62718677520752"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.933015925023"^^xsd:float ;
+    nidm_pValueUncorrected: "4.04847753543436e-07"^^xsd:float ;
+    nidm_pValueFWER: "0.063890884133409"^^xsd:float ;
+    nidm_qValueFDR: "0.000364320989617512"^^xsd:float .
+
+niiri:fc9bb7ec98d0292b3cf09ece5735cbf7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0010" ;
+    nidm_coordinateVector: "[-42,24,20]"^^xsd:string .
+
+niiri:915c8684b1426b41a850e906a6cb7e51 prov:wasDerivedFrom niiri:d8b9846e25000609adbc385c634a1be0 .
+
+niiri:50922e240192f8efd5ba7edc5395921e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0011" ;
+    prov:atLocation niiri:0090ece1129de1a64a6093a76eead257 ;
+    prov:value "8.07208061218262"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.42255808855286"^^xsd:float ;
+    nidm_pValueUncorrected: "4.87695566220303e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.443484796305441"^^xsd:float ;
+    nidm_qValueFDR: "0.00197238230997959"^^xsd:float .
+
+niiri:0090ece1129de1a64a6093a76eead257
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0011" ;
+    nidm_coordinateVector: "[-50,28,22]"^^xsd:string .
+
+niiri:50922e240192f8efd5ba7edc5395921e prov:wasDerivedFrom niiri:d8b9846e25000609adbc385c634a1be0 .
+
+niiri:7d5e6a7fd65e7845a2f6021bbbfe1474
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0012" ;
+    prov:atLocation niiri:a94285933cf50e277523e5b72912eebe ;
+    prov:value "9.20645141601562"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.80076510146651"^^xsd:float ;
+    nidm_pValueUncorrected: "7.90302914999153e-07"^^xsd:float ;
+    nidm_pValueFWER: "0.112525268059434"^^xsd:float ;
+    nidm_qValueFDR: "0.000576835659463966"^^xsd:float .
+
+niiri:a94285933cf50e277523e5b72912eebe
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0012" ;
+    nidm_coordinateVector: "[-50,8,42]"^^xsd:string .
+
+niiri:7d5e6a7fd65e7845a2f6021bbbfe1474 prov:wasDerivedFrom niiri:f8e22d4c567142a3ab813140dd91551e .
+
+niiri:48d52b482ad32267090b771eef9d8a13
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0013" ;
+    prov:atLocation niiri:3f8983479e0d587591c1816f757bfb40 ;
+    prov:value "7.18871355056763"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.10255932739581"^^xsd:float ;
+    nidm_pValueUncorrected: "2.04302517635702e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.864381142749573"^^xsd:float ;
+    nidm_qValueFDR: "0.00518559511521378"^^xsd:float .
+
+niiri:3f8983479e0d587591c1816f757bfb40
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0013" ;
+    nidm_coordinateVector: "[-52,2,48]"^^xsd:string .
+
+niiri:48d52b482ad32267090b771eef9d8a13 prov:wasDerivedFrom niiri:f8e22d4c567142a3ab813140dd91551e .
+
+niiri:6bc27ded8e7208b5260f9cfa18a8c8c7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0014" ;
+    prov:atLocation niiri:a58791ee2a73dbe92a31d79f5a887db7 ;
+    prov:value "8.94470500946045"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.71641138081763"^^xsd:float ;
+    nidm_pValueUncorrected: "1.20020424165812e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.158435738485403"^^xsd:float ;
+    nidm_qValueFDR: "0.000760651849406736"^^xsd:float .
+
+niiri:a58791ee2a73dbe92a31d79f5a887db7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0014" ;
+    nidm_coordinateVector: "[-24,-64,66]"^^xsd:string .
+
+niiri:6bc27ded8e7208b5260f9cfa18a8c8c7 prov:wasDerivedFrom niiri:96a2e290f72fc28530510650c52e2805 .
+
+niiri:3f894ae7abee049abdc170030b86694a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0015" ;
+    prov:atLocation niiri:5ee690d78930edfd59a3872c7c5bbdaf ;
+    prov:value "7.5668888092041"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.24258939908316"^^xsd:float ;
+    nidm_pValueUncorrected: "1.10477738578529e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.693995702855766"^^xsd:float ;
+    nidm_qValueFDR: "0.0033973072847523"^^xsd:float .
+
+niiri:5ee690d78930edfd59a3872c7c5bbdaf
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0015" ;
+    nidm_coordinateVector: "[-32,-56,62]"^^xsd:string .
+
+niiri:3f894ae7abee049abdc170030b86694a prov:wasDerivedFrom niiri:96a2e290f72fc28530510650c52e2805 .
+
+niiri:8aed68850a4238bd9003356dee5c1046
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0016" ;
+    prov:atLocation niiri:fa9d9d6751bc279dd4c31bcc4b3c5b6f ;
+    prov:value "8.42212200164795"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.54288070436711"^^xsd:float ;
+    nidm_pValueUncorrected: "2.77453287811369e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.301737952159247"^^xsd:float ;
+    nidm_qValueFDR: "0.00135672565933354"^^xsd:float .
+
+niiri:fa9d9d6751bc279dd4c31bcc4b3c5b6f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0016" ;
+    nidm_coordinateVector: "[22,-52,4]"^^xsd:string .
+
+niiri:8aed68850a4238bd9003356dee5c1046 prov:wasDerivedFrom niiri:1062efea331d3022773f16c049f8543d .
+
+niiri:17a00ab62ce14cefa4ccb65ef36cb0a3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0017" ;
+    prov:atLocation niiri:2e878a68f59b4166e7af126a1d092dd7 ;
+    prov:value "8.14441299438477"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.44770400954001"^^xsd:float ;
+    nidm_pValueUncorrected: "4.33965069324138e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.411238149698711"^^xsd:float ;
+    nidm_qValueFDR: "0.00180683059312593"^^xsd:float .
+
+niiri:2e878a68f59b4166e7af126a1d092dd7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0017" ;
+    nidm_coordinateVector: "[-36,-54,-22]"^^xsd:string .
+
+niiri:17a00ab62ce14cefa4ccb65ef36cb0a3 prov:wasDerivedFrom niiri:5577dc13c7013d8bb90b8dd111792d46 .
+
+niiri:df246b9f6ad9be0fa1598d6017c22c17
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0018" ;
+    prov:atLocation niiri:dbfef4bdf74855624e49b48413b48527 ;
+    prov:value "7.75212860107422"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.30948435197428"^^xsd:float ;
+    nidm_pValueUncorrected: "8.18178178840778e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.599664226758408"^^xsd:float ;
+    nidm_qValueFDR: "0.00278317762946249"^^xsd:float .
+
+niiri:dbfef4bdf74855624e49b48413b48527
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0018" ;
+    nidm_coordinateVector: "[10,-66,-50]"^^xsd:string .
+
+niiri:df246b9f6ad9be0fa1598d6017c22c17 prov:wasDerivedFrom niiri:64ae5737521bbc7fe14f0c862379e927 .
+
+niiri:0f733836ed39e3d5c7c881ba1d4b0f3c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0019" ;
+    prov:atLocation niiri:2d648076c6516fc9f5b180d7e46bd38d ;
+    prov:value "6.59869337081909"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.87398612970452"^^xsd:float ;
+    nidm_pValueUncorrected: "5.35347545974618e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.988687386127249"^^xsd:float ;
+    nidm_qValueFDR: "0.0099990013840748"^^xsd:float .
+
+niiri:2d648076c6516fc9f5b180d7e46bd38d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0019" ;
+    nidm_coordinateVector: "[26,-72,-50]"^^xsd:string .
+
+niiri:0f733836ed39e3d5c7c881ba1d4b0f3c prov:wasDerivedFrom niiri:64ae5737521bbc7fe14f0c862379e927 .
+
+niiri:fccb01f20ca9740796a77be1dc284607
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0020" ;
+    prov:atLocation niiri:de5ae9445107927a2f321f5cb43d375a ;
+    prov:value "6.09796094894409"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.6691747416434"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000121667358184974"^^xsd:float ;
+    nidm_pValueFWER: "0.999849800966092"^^xsd:float ;
+    nidm_qValueFDR: "0.0170443244379802"^^xsd:float .
+
+niiri:de5ae9445107927a2f321f5cb43d375a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0020" ;
+    nidm_coordinateVector: "[16,-72,-50]"^^xsd:string .
+
+niiri:fccb01f20ca9740796a77be1dc284607 prov:wasDerivedFrom niiri:64ae5737521bbc7fe14f0c862379e927 .
+
+niiri:73c78b95c93f862d2d03440138b1b31d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0021" ;
+    prov:atLocation niiri:f70e1a4652c056f2ce720d0c047e4050 ;
+    prov:value "7.67598438262939"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.28211703257948"^^xsd:float ;
+    nidm_pValueUncorrected: "9.25617831770698e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.638571937641115"^^xsd:float ;
+    nidm_qValueFDR: "0.00302106969058158"^^xsd:float .
+
+niiri:f70e1a4652c056f2ce720d0c047e4050
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0021" ;
+    nidm_coordinateVector: "[42,-22,66]"^^xsd:string .
+
+niiri:73c78b95c93f862d2d03440138b1b31d prov:wasDerivedFrom niiri:900846b4c16bba4a9b8a34762cba2da0 .
+
+niiri:b6efabc36e950249575e4d4ac70621f0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0022" ;
+    prov:atLocation niiri:4dbfbaac273513d9f226876fdf8b306f ;
+    prov:value "6.16005897521973"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.6951610937944"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000109873708078023"^^xsd:float ;
+    nidm_pValueFWER: "0.999696971784475"^^xsd:float ;
+    nidm_qValueFDR: "0.0160177852706299"^^xsd:float .
+
+niiri:4dbfbaac273513d9f226876fdf8b306f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0022" ;
+    nidm_coordinateVector: "[48,-18,62]"^^xsd:string .
+
+niiri:b6efabc36e950249575e4d4ac70621f0 prov:wasDerivedFrom niiri:900846b4c16bba4a9b8a34762cba2da0 .
+
+niiri:ce78c1d328ebf373304efd0ad0d63b55
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0023" ;
+    prov:atLocation niiri:b48d465b5d910dd4c05a26a988a8418b ;
+    prov:value "7.57218790054321"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.24451811148991"^^xsd:float ;
+    nidm_pValueUncorrected: "1.09531837353405e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.691329596120285"^^xsd:float ;
+    nidm_qValueFDR: "0.00338801480937036"^^xsd:float .
+
+niiri:b48d465b5d910dd4c05a26a988a8418b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0023" ;
+    nidm_coordinateVector: "[30,-36,-22]"^^xsd:string .
+
+niiri:ce78c1d328ebf373304efd0ad0d63b55 prov:wasDerivedFrom niiri:7ede1db6987922a4806abc265aecda62 .
+
+niiri:1cd13c2942d906be09937adb3135674a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0024" ;
+    prov:atLocation niiri:4c8fbc4e92f73c6bb61d3f66d9c3c99e ;
+    prov:value "7.4740514755249"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.20865253327564"^^xsd:float ;
+    nidm_pValueUncorrected: "1.28449040975864e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.739935004547452"^^xsd:float ;
+    nidm_qValueFDR: "0.00374497115452541"^^xsd:float .
+
+niiri:4c8fbc4e92f73c6bb61d3f66d9c3c99e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0024" ;
+    nidm_coordinateVector: "[22,-70,60]"^^xsd:string .
+
+niiri:1cd13c2942d906be09937adb3135674a prov:wasDerivedFrom niiri:9287b2a8106c3ffe3abf93837cfbd61c .
+
+niiri:3121dd1ff9adac7ae75e440df583fb9d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0025" ;
+    prov:atLocation niiri:939c1c6e7eee0ff04a1bae0f1e2b3a44 ;
+    prov:value "7.42476272583008"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.19052086074216"^^xsd:float ;
+    nidm_pValueUncorrected: "1.39157412012425e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.76353829505901"^^xsd:float ;
+    nidm_qValueFDR: "0.00397904916843096"^^xsd:float .
+
+niiri:939c1c6e7eee0ff04a1bae0f1e2b3a44
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0025" ;
+    nidm_coordinateVector: "[14,-44,-2]"^^xsd:string .
+
+niiri:3121dd1ff9adac7ae75e440df583fb9d prov:wasDerivedFrom niiri:c515278968596a92906ae29ffad63511 .
+
+niiri:2cde520c847515e95346b9608b4b29b1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0026" ;
+    prov:atLocation niiri:fec739a9148832b2f9f9f6df4c90ef60 ;
+    prov:value "7.41156482696533"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.1856522195161"^^xsd:float ;
+    nidm_pValueUncorrected: "1.42174217934166e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.76974170216107"^^xsd:float ;
+    nidm_qValueFDR: "0.00404779744790916"^^xsd:float .
+
+niiri:fec739a9148832b2f9f9f6df4c90ef60
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0026" ;
+    nidm_coordinateVector: "[0,-22,66]"^^xsd:string .
+
+niiri:2cde520c847515e95346b9608b4b29b1 prov:wasDerivedFrom niiri:0493a379c4735cda662e56229168b8a9 .
+
+niiri:435b54b1b98826b7c51b454f604d72e2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0027" ;
+    prov:atLocation niiri:f5083c9588b5eb1d38e2b68f14c48ec5 ;
+    prov:value "7.3316125869751"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.15603434431885"^^xsd:float ;
+    nidm_pValueUncorrected: "1.61909583913378e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.806071531912271"^^xsd:float ;
+    nidm_qValueFDR: "0.00442558415624652"^^xsd:float .
+
+niiri:f5083c9588b5eb1d38e2b68f14c48ec5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0027" ;
+    nidm_coordinateVector: "[-40,-26,-22]"^^xsd:string .
+
+niiri:435b54b1b98826b7c51b454f604d72e2 prov:wasDerivedFrom niiri:6f915c93d573d9f832d05fb003dcbfb0 .
+
+niiri:ff2cc94456764baf2e5e407f30f996e8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0028" ;
+    prov:atLocation niiri:bfdee7cfc8fffe98250a78af5abdc715 ;
+    prov:value "7.15871143341064"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.09124266610495"^^xsd:float ;
+    nidm_pValueUncorrected: "2.14533936502281e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.875348981068006"^^xsd:float ;
+    nidm_qValueFDR: "0.00534735431216318"^^xsd:float .
+
+niiri:bfdee7cfc8fffe98250a78af5abdc715
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0028" ;
+    nidm_coordinateVector: "[-48,-42,58]"^^xsd:string .
+
+niiri:ff2cc94456764baf2e5e407f30f996e8 prov:wasDerivedFrom niiri:2344710a34a75f050910ebd48e1159af .
+
+niiri:1d8688390cefe3ad6af53ca62e203d1f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0029" ;
+    prov:atLocation niiri:05d5987ec004e7f8a055c0e0f8991383 ;
+    prov:value "7.11809158325195"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.075870818357"^^xsd:float ;
+    nidm_pValueUncorrected: "2.29212322924166e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.889420975253515"^^xsd:float ;
+    nidm_qValueFDR: "0.00557942469794563"^^xsd:float .
+
+niiri:05d5987ec004e7f8a055c0e0f8991383
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0029" ;
+    nidm_coordinateVector: "[-40,-34,66]"^^xsd:string .
+
+niiri:1d8688390cefe3ad6af53ca62e203d1f prov:wasDerivedFrom niiri:a904380f9b13e67a2253c5f952a57f9f .
+
+niiri:458ec12f9ad36a91b5eaa2f1aae4c164
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0030" ;
+    prov:atLocation niiri:7021fdf0169b26db50952433ad70adc0 ;
+    prov:value "7.07621002197266"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.05996049269805"^^xsd:float ;
+    nidm_pValueUncorrected: "2.45405099345009e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.902960652497904"^^xsd:float ;
+    nidm_qValueFDR: "0.00587047829619361"^^xsd:float .
+
+niiri:7021fdf0169b26db50952433ad70adc0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0030" ;
+    nidm_coordinateVector: "[-28,-64,36]"^^xsd:string .
+
+niiri:458ec12f9ad36a91b5eaa2f1aae4c164 prov:wasDerivedFrom niiri:8348fc8e7248e46840dad7df7f8763bf .
+
+niiri:d4cd299a7933f93390ebcea529b036b0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0031" ;
+    prov:atLocation niiri:000b610104b25fcabfd24c7ac9c414e9 ;
+    prov:value "6.77566051483154"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.94391444392688"^^xsd:float ;
+    nidm_pValueUncorrected: "4.0081133562353e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.970449378854534"^^xsd:float ;
+    nidm_qValueFDR: "0.0083237489519884"^^xsd:float .
+
+niiri:000b610104b25fcabfd24c7ac9c414e9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0031" ;
+    nidm_coordinateVector: "[56,-14,52]"^^xsd:string .
+
+niiri:d4cd299a7933f93390ebcea529b036b0 prov:wasDerivedFrom niiri:db6eb647802a5fc531c369aa668af574 .
+
+niiri:c18aee0f08a51ffb9a71f22087ef50c5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0032" ;
+    prov:atLocation niiri:58fc0101181c3b004a7dd3b51e2ceb83 ;
+    prov:value "6.75197219848633"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.9346244929229"^^xsd:float ;
+    nidm_pValueUncorrected: "4.16634347842892e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.973679338420771"^^xsd:float ;
+    nidm_qValueFDR: "0.00848286835858746"^^xsd:float .
+
+niiri:58fc0101181c3b004a7dd3b51e2ceb83
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0032" ;
+    nidm_coordinateVector: "[-40,56,6]"^^xsd:string .
+
+niiri:c18aee0f08a51ffb9a71f22087ef50c5 prov:wasDerivedFrom niiri:efddc25357ec7a4b9a063a62f5a2c864 .
+
+niiri:94d6c08508093e713ac4415d0a932884
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0033" ;
+    prov:atLocation niiri:bf7aac775c73f4c943e7eaf5e718d980 ;
+    prov:value "5.62889766693115"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.4670438729023"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000263107996845591"^^xsd:float ;
+    nidm_pValueFWER: "0.999999922471127"^^xsd:float ;
+    nidm_qValueFDR: "0.0280636167791234"^^xsd:float .
+
+niiri:bf7aac775c73f4c943e7eaf5e718d980
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0033" ;
+    nidm_coordinateVector: "[-34,62,8]"^^xsd:string .
+
+niiri:94d6c08508093e713ac4415d0a932884 prov:wasDerivedFrom niiri:efddc25357ec7a4b9a063a62f5a2c864 .
+
+niiri:68ee8476808402fcd35123f92e1fe86d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0034" ;
+    prov:atLocation niiri:97631cb919ed750fce6fd5369d603724 ;
+    prov:value "6.72361373901367"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.92347467532863"^^xsd:float ;
+    nidm_pValueUncorrected: "4.3640471964479e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.977197537328254"^^xsd:float ;
+    nidm_qValueFDR: "0.00877369894078824"^^xsd:float .
+
+niiri:97631cb919ed750fce6fd5369d603724
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0034" ;
+    nidm_coordinateVector: "[-4,-52,6]"^^xsd:string .
+
+niiri:68ee8476808402fcd35123f92e1fe86d prov:wasDerivedFrom niiri:92832eb3b91834fca357233c33e92d47 .
+
+niiri:97c0b234b24d4cfa8426c9b127f1426a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0035" ;
+    prov:atLocation niiri:07a69af261f8c7ce9c1e9223b91c2b3f ;
+    prov:value "5.89449167251587"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.58279190167641"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000169970706923372"^^xsd:float ;
+    nidm_pValueFWER: "0.999990278549049"^^xsd:float ;
+    nidm_qValueFDR: "0.0210834330463974"^^xsd:float .
+
+niiri:07a69af261f8c7ce9c1e9223b91c2b3f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0035" ;
+    nidm_coordinateVector: "[-8,-56,0]"^^xsd:string .
+
+niiri:97c0b234b24d4cfa8426c9b127f1426a prov:wasDerivedFrom niiri:92832eb3b91834fca357233c33e92d47 .
+
+niiri:208bd0fa9e65bd7ecda2f9025fbf5026
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0036" ;
+    prov:atLocation niiri:8a98506f0a361325cf3279d2ee5df080 ;
+    prov:value "6.7043924331665"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.91589968256295"^^xsd:float ;
+    nidm_pValueUncorrected: "4.5033848123488e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.979375630051391"^^xsd:float ;
+    nidm_qValueFDR: "0.00887748685076858"^^xsd:float .
+
+niiri:8a98506f0a361325cf3279d2ee5df080
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0036" ;
+    nidm_coordinateVector: "[50,-64,-6]"^^xsd:string .
+
+niiri:208bd0fa9e65bd7ecda2f9025fbf5026 prov:wasDerivedFrom niiri:27a928cca18b5d563bf58797f306d0e0 .
+
+niiri:b0078cef21c117e25080fc7b68a2e9f6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0037" ;
+    prov:atLocation niiri:4b3286c3a11f909de28869ea7523656c ;
+    prov:value "6.67913484573364"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.90592399967592"^^xsd:float ;
+    nidm_pValueUncorrected: "4.6933006303207e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.981996459937482"^^xsd:float ;
+    nidm_qValueFDR: "0.00914383746051283"^^xsd:float .
+
+niiri:4b3286c3a11f909de28869ea7523656c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0037" ;
+    nidm_coordinateVector: "[-34,-40,36]"^^xsd:string .
+
+niiri:b0078cef21c117e25080fc7b68a2e9f6 prov:wasDerivedFrom niiri:9197197694f96c553e0e78334284b0c7 .
+
+niiri:51561d272cfbd20b578e0d0cb999769c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0038" ;
+    prov:atLocation niiri:7391c47b3ce0a5295cfbe1d0b7dfa35c ;
+    prov:value "6.64170026779175"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.89109301638303"^^xsd:float ;
+    nidm_pValueUncorrected: "4.98968323957572e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.985407255166263"^^xsd:float ;
+    nidm_qValueFDR: "0.00949872959107623"^^xsd:float .
+
+niiri:7391c47b3ce0a5295cfbe1d0b7dfa35c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0038" ;
+    nidm_coordinateVector: "[22,10,-12]"^^xsd:string .
+
+niiri:51561d272cfbd20b578e0d0cb999769c prov:wasDerivedFrom niiri:4babeddab7c30570f5f7bca47ad8e349 .
+
+niiri:462393ac68491f3db8a262b5078fc9a9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0039" ;
+    prov:atLocation niiri:86657e11e856b1fdbc9692e7270e9f36 ;
+    prov:value "5.66292333602905"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.48206928174656"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000248777471726358"^^xsd:float ;
+    nidm_pValueFWER: "0.999999841793879"^^xsd:float ;
+    nidm_qValueFDR: "0.0270792144117247"^^xsd:float .
+
+niiri:86657e11e856b1fdbc9692e7270e9f36
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0039" ;
+    nidm_coordinateVector: "[22,10,2]"^^xsd:string .
+
+niiri:462393ac68491f3db8a262b5078fc9a9 prov:wasDerivedFrom niiri:4babeddab7c30570f5f7bca47ad8e349 .
+
+niiri:662a754e5ebb07a4f3658f0ab369277c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0040" ;
+    prov:atLocation niiri:dce98efb340c18452b3198b7a9d43ec6 ;
+    prov:value "6.58932304382324"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.87024913662237"^^xsd:float ;
+    nidm_pValueUncorrected: "5.43620931486855e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.9893188063809"^^xsd:float ;
+    nidm_qValueFDR: "0.0101197978315716"^^xsd:float .
+
+niiri:dce98efb340c18452b3198b7a9d43ec6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0040" ;
+    nidm_coordinateVector: "[16,-8,20]"^^xsd:string .
+
+niiri:662a754e5ebb07a4f3658f0ab369277c prov:wasDerivedFrom niiri:abcdfa125cb9a6705001908f8633bf90 .
+
+niiri:21f4ad1561991121f81c93c4a406ef8b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0041" ;
+    prov:atLocation niiri:ea0358caee1ca0292b7b7a8d309dd06c ;
+    prov:value "6.53873300552368"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.8500124840786"^^xsd:float ;
+    nidm_pValueUncorrected: "5.90559022480841e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.992265133018752"^^xsd:float ;
+    nidm_qValueFDR: "0.0107045232421608"^^xsd:float .
+
+niiri:ea0358caee1ca0292b7b7a8d309dd06c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0041" ;
+    nidm_coordinateVector: "[28,-48,72]"^^xsd:string .
+
+niiri:21f4ad1561991121f81c93c4a406ef8b prov:wasDerivedFrom niiri:2583f6b74e4ca256d5338bb9b9f07a29 .
+
+niiri:1babf001e3351aeb7fac6dc5454363cc
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0042" ;
+    prov:atLocation niiri:a42f9f1e579000b2dc77292a8cf2acb7 ;
+    prov:value "6.41633129119873"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.80061969992356"^^xsd:float ;
+    nidm_pValueUncorrected: "7.2167337301976e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.996780557608903"^^xsd:float ;
+    nidm_qValueFDR: "0.0122368668491247"^^xsd:float .
+
+niiri:a42f9f1e579000b2dc77292a8cf2acb7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0042" ;
+    nidm_coordinateVector: "[30,-48,-18]"^^xsd:string .
+
+niiri:1babf001e3351aeb7fac6dc5454363cc prov:wasDerivedFrom niiri:9656cbf27ba556542b025f2f8e45acfd .
+
+niiri:b338a4dd4022769457498158e6091888
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0043" ;
+    prov:atLocation niiri:3e89e3f7a8baa5ac4d836dcdac1c0bda ;
+    prov:value "6.32824850082397"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.764690456476"^^xsd:float ;
+    nidm_pValueUncorrected: "8.33777634952071e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.998439799137585"^^xsd:float ;
+    nidm_qValueFDR: "0.0133433091347082"^^xsd:float .
+
+niiri:3e89e3f7a8baa5ac4d836dcdac1c0bda
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0043" ;
+    nidm_coordinateVector: "[34,64,-2]"^^xsd:string .
+
+niiri:b338a4dd4022769457498158e6091888 prov:wasDerivedFrom niiri:52cafab6790abfb27ec51f00e747fe9a .
+
+niiri:e6169278f433610ff37f3974658c92df
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0044" ;
+    prov:atLocation niiri:c70c80c37a08562550518b4cd4541c41 ;
+    prov:value "6.23233604431152"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.72519134385979"^^xsd:float ;
+    nidm_pValueUncorrected: "9.75835625125487e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.999359408722565"^^xsd:float ;
+    nidm_qValueFDR: "0.0147821614629234"^^xsd:float .
+
+niiri:c70c80c37a08562550518b4cd4541c41
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0044" ;
+    nidm_coordinateVector: "[-42,44,26]"^^xsd:string .
+
+niiri:e6169278f433610ff37f3974658c92df prov:wasDerivedFrom niiri:4c64b57b636863b3e947522d1311c0f1 .
+
+niiri:07af75e3341c3d93da4de231688d5549
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0045" ;
+    prov:atLocation niiri:b7f3f00892f46b6b0ce77c4037087b40 ;
+    prov:value "6.06225728988647"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.6541549978965"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000129015181687619"^^xsd:float ;
+    nidm_pValueFWER: "0.999902284410057"^^xsd:float ;
+    nidm_qValueFDR: "0.0177419633224147"^^xsd:float .
+
+niiri:b7f3f00892f46b6b0ce77c4037087b40
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0045" ;
+    nidm_coordinateVector: "[0,-10,76]"^^xsd:string .
+
+niiri:07af75e3341c3d93da4de231688d5549 prov:wasDerivedFrom niiri:a8236e3bfdb590d4516edd326dbac95d .
+
+niiri:41260b633b6a2691ee72574f2598723a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0046" ;
+    prov:atLocation niiri:e5d27e5d68b5b3c32ee4902f86477d7a ;
+    prov:value "6.03189373016357"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.64133598155782"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000135613449379846"^^xsd:float ;
+    nidm_pValueFWER: "0.999933280387137"^^xsd:float ;
+    nidm_qValueFDR: "0.0183426760576609"^^xsd:float .
+
+niiri:e5d27e5d68b5b3c32ee4902f86477d7a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0046" ;
+    nidm_coordinateVector: "[34,-16,-12]"^^xsd:string .
+
+niiri:41260b633b6a2691ee72574f2598723a prov:wasDerivedFrom niiri:90dce13e46266944c40d12f4f1a86219 .
+
+niiri:2ec9227f9219716d869254e96c9d0037
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0047" ;
+    prov:atLocation niiri:b099faca4ffbe79b539a9a37c0fecc5b ;
+    prov:value "6.02538537979126"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.63858275251093"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000137071270502886"^^xsd:float ;
+    nidm_pValueFWER: "0.999938640797957"^^xsd:float ;
+    nidm_qValueFDR: "0.0183962430264957"^^xsd:float .
+
+niiri:b099faca4ffbe79b539a9a37c0fecc5b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0047" ;
+    nidm_coordinateVector: "[6,-80,-22]"^^xsd:string .
+
+niiri:2ec9227f9219716d869254e96c9d0037 prov:wasDerivedFrom niiri:4b569159d1ddc968752a57917503c6f4 .
+
+niiri:0c5f2ba8ccadcaf3990cf555adbad737
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0048" ;
+    prov:atLocation niiri:aa874dbac7a9c1e02e0a4e28bd39dfb7 ;
+    prov:value "5.95283126831055"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.60775727167743"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000154427613028529"^^xsd:float ;
+    nidm_pValueFWER: "0.999977036852347"^^xsd:float ;
+    nidm_qValueFDR: "0.0199653441808624"^^xsd:float .
+
+niiri:aa874dbac7a9c1e02e0a4e28bd39dfb7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0048" ;
+    nidm_coordinateVector: "[-26,-38,-52]"^^xsd:string .
+
+niiri:0c5f2ba8ccadcaf3990cf555adbad737 prov:wasDerivedFrom niiri:674c9062dc421a541e91be283cce8f16 .
+
+niiri:3d268b9ac3f787ed4e0702d7f1ec3eb8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0049" ;
+    prov:atLocation niiri:d0604d3ccc8739eebfb0264b562dd48c ;
+    prov:value "5.9493842124939"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.60628663469786"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000155305014835405"^^xsd:float ;
+    nidm_pValueFWER: "0.999978135328144"^^xsd:float ;
+    nidm_qValueFDR: "0.0200343508975978"^^xsd:float .
+
+niiri:d0604d3ccc8739eebfb0264b562dd48c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0049" ;
+    nidm_coordinateVector: "[32,-52,46]"^^xsd:string .
+
+niiri:3d268b9ac3f787ed4e0702d7f1ec3eb8 prov:wasDerivedFrom niiri:d3a1762138c1b259db52c75933757662 .
+
+niiri:110d36e0f43c3b73543fd2a54c15fcef
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0050" ;
+    prov:atLocation niiri:6f51bb746dc99583cc8e3bccd8b52a17 ;
+    prov:value "5.90739822387695"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.58832892416593"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00016640212943575"^^xsd:float ;
+    nidm_pValueFWER: "0.999988176695278"^^xsd:float ;
+    nidm_qValueFDR: "0.0208396911967648"^^xsd:float .
+
+niiri:6f51bb746dc99583cc8e3bccd8b52a17
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0050" ;
+    nidm_coordinateVector: "[20,58,6]"^^xsd:string .
+
+niiri:110d36e0f43c3b73543fd2a54c15fcef prov:wasDerivedFrom niiri:9dc472e5df63cfbf55f8afa2ad7233f1 .
+
+niiri:5c65ee8dd873a043b1b0ce011fed4f35
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0051" ;
+    prov:atLocation niiri:89b9ae5151cd9b1561aaf8ff96b4b6ec ;
+    prov:value "5.88568687438965"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.57901000852841"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000172449130450447"^^xsd:float ;
+    nidm_pValueFWER: "0.999991509605729"^^xsd:float ;
+    nidm_qValueFDR: "0.0213019172775607"^^xsd:float .
+
+niiri:89b9ae5151cd9b1561aaf8ff96b4b6ec
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0051" ;
+    nidm_coordinateVector: "[-28,-70,-52]"^^xsd:string .
+
+niiri:5c65ee8dd873a043b1b0ce011fed4f35 prov:wasDerivedFrom niiri:3fd667ca8587427124fe4b4ff80af21a .
+
+niiri:57c990b6ba31385d10715d6c40e7aa55
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0052" ;
+    prov:atLocation niiri:9ebb93a3d4e207e403dbaa5999a1be35 ;
+    prov:value "5.88288545608521"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.57780594841694"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000173245266573252"^^xsd:float ;
+    nidm_pValueFWER: "0.999991870214044"^^xsd:float ;
+    nidm_qValueFDR: "0.0213621903805226"^^xsd:float .
+
+niiri:9ebb93a3d4e207e403dbaa5999a1be35
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0052" ;
+    nidm_coordinateVector: "[-16,-58,-38]"^^xsd:string .
+
+niiri:57c990b6ba31385d10715d6c40e7aa55 prov:wasDerivedFrom niiri:c60cf8d223f50376ab05520bb51598af .
+
+niiri:2098d30ab385854e90d3cb8115b3a9b2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0053" ;
+    prov:atLocation niiri:c3eb4272d1ec05c8e84a0681eea459bd ;
+    prov:value "5.87665224075317"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.57512554105657"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000175029940004845"^^xsd:float ;
+    nidm_pValueFWER: "0.999992622705061"^^xsd:float ;
+    nidm_qValueFDR: "0.0214921236782135"^^xsd:float .
+
+niiri:c3eb4272d1ec05c8e84a0681eea459bd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0053" ;
+    nidm_coordinateVector: "[-10,-82,-30]"^^xsd:string .
+
+niiri:2098d30ab385854e90d3cb8115b3a9b2 prov:wasDerivedFrom niiri:f551110d12542058bdc59cae03013010 .
+
+niiri:3e504483f4e511a366bffb06b50ca097
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0054" ;
+    prov:atLocation niiri:7c66d78243fad1b742ee22ad32e56f1b ;
+    prov:value "5.86712741851807"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.57102607807387"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000177792742607208"^^xsd:float ;
+    nidm_pValueFWER: "0.999993649803941"^^xsd:float ;
+    nidm_qValueFDR: "0.0216816267105749"^^xsd:float .
+
+niiri:7c66d78243fad1b742ee22ad32e56f1b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0054" ;
+    nidm_coordinateVector: "[50,50,8]"^^xsd:string .
+
+niiri:3e504483f4e511a366bffb06b50ca097 prov:wasDerivedFrom niiri:fb9120500eef24a89fb5e84238991362 .
+
+niiri:38cfaeebf97d0d2b0b71a5f0ba640e98
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0055" ;
+    prov:atLocation niiri:83fb05512223e38d67cb83a805cd00b3 ;
+    prov:value "5.85824680328369"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.56719995255891"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000180408078987448"^^xsd:float ;
+    nidm_pValueFWER: "0.999994487319543"^^xsd:float ;
+    nidm_qValueFDR: "0.0217930814133279"^^xsd:float .
+
+niiri:83fb05512223e38d67cb83a805cd00b3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0055" ;
+    nidm_coordinateVector: "[-6,-78,56]"^^xsd:string .
+
+niiri:38cfaeebf97d0d2b0b71a5f0ba640e98 prov:wasDerivedFrom niiri:dde8bc734b1e70c777683f3419f9b22a .
+
+niiri:6bed9eb8c16b5bfc1b7f13853ba3719d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0056" ;
+    prov:atLocation niiri:07d1fc16b4011bf11b157bc94038717f ;
+    prov:value "5.81644201278687"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.54913757298709"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000193247549691744"^^xsd:float ;
+    nidm_pValueFWER: "0.99999722874557"^^xsd:float ;
+    nidm_qValueFDR: "0.022905022613713"^^xsd:float .
+
+niiri:07d1fc16b4011bf11b157bc94038717f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0056" ;
+    nidm_coordinateVector: "[44,50,20]"^^xsd:string .
+
+niiri:6bed9eb8c16b5bfc1b7f13853ba3719d prov:wasDerivedFrom niiri:89223f01a7e676c300c22c8da4a82ef8 .
+
+niiri:13789ff64ea178d4dd930d5649ad0efa
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0057" ;
+    prov:atLocation niiri:09872dc9def2ebbedbd2d8b56d8ccec8 ;
+    prov:value "5.75350570678711"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.52178406559812"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000214326572548162"^^xsd:float ;
+    nidm_pValueFWER: "0.999999083879168"^^xsd:float ;
+    nidm_qValueFDR: "0.0245474913207941"^^xsd:float .
+
+niiri:09872dc9def2ebbedbd2d8b56d8ccec8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0057" ;
+    nidm_coordinateVector: "[-30,-58,-52]"^^xsd:string .
+
+niiri:13789ff64ea178d4dd930d5649ad0efa prov:wasDerivedFrom niiri:7ac6ced5ac5b95c88fbe93f4ad51726c .
+
+niiri:9d748709970f09ad37966b4ebd88970d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0058" ;
+    prov:atLocation niiri:a8566c5632b9f7d195407d5bbeb8d694 ;
+    prov:value "5.74829816818237"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.51951200270118"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000216170736607735"^^xsd:float ;
+    nidm_pValueFWER: "0.999999167412893"^^xsd:float ;
+    nidm_qValueFDR: "0.0246525319493899"^^xsd:float .
+
+niiri:a8566c5632b9f7d195407d5bbeb8d694
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0058" ;
+    nidm_coordinateVector: "[-38,36,-14]"^^xsd:string .
+
+niiri:9d748709970f09ad37966b4ebd88970d prov:wasDerivedFrom niiri:5d05848ec2715382392265640fc9d57e .
+
+niiri:8f1086c487206beee6166192435ccbb7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0059" ;
+    prov:atLocation niiri:7bd2497735bee9acdd922777fd6b5af3 ;
+    prov:value "5.7312970161438"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.51208496979963"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000222302913436612"^^xsd:float ;
+    nidm_pValueFWER: "0.99999939333845"^^xsd:float ;
+    nidm_qValueFDR: "0.0250806761204491"^^xsd:float .
+
+niiri:7bd2497735bee9acdd922777fd6b5af3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0059" ;
+    nidm_coordinateVector: "[-50,12,-2]"^^xsd:string .
+
+niiri:8f1086c487206beee6166192435ccbb7 prov:wasDerivedFrom niiri:ca24bdc833f185dc48a439c9bd8cfea6 .
+
+niiri:9622cbdc321584d153d90164a7e3a512
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0060" ;
+    prov:atLocation niiri:ab618775ab67eaf9567d2f85e813dc0d ;
+    prov:value "5.61407613754272"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.46048027314539"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000269606369816766"^^xsd:float ;
+    nidm_pValueFWER: "0.999999943721802"^^xsd:float ;
+    nidm_qValueFDR: "0.0285650985701987"^^xsd:float .
+
+niiri:ab618775ab67eaf9567d2f85e813dc0d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0060" ;
+    nidm_coordinateVector: "[-52,38,14]"^^xsd:string .
+
+niiri:9622cbdc321584d153d90164a7e3a512 prov:wasDerivedFrom niiri:302ad243c21e156bc35f157e2595460d .
+
+niiri:dafa541111dbf27389241fc1622583e6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0061" ;
+    prov:atLocation niiri:8a2dcced4bbeb2d604abdc206edbd812 ;
+    prov:value "5.53163862228394"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.42376539987989"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000308799561745898"^^xsd:float ;
+    nidm_pValueFWER: "0.999999991534363"^^xsd:float ;
+    nidm_qValueFDR: "0.0312013208214028"^^xsd:float .
+
+niiri:8a2dcced4bbeb2d604abdc206edbd812
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0061" ;
+    nidm_coordinateVector: "[-14,-80,10]"^^xsd:string .
+
+niiri:dafa541111dbf27389241fc1622583e6 prov:wasDerivedFrom niiri:b0e84ab2cd541b237634e56ebf391609 .
+
+niiri:a1b7280bae7cb27c5d032057b5e5ee6a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0062" ;
+    prov:atLocation niiri:c15f83bf0af7227fccfcc19a8ff53a78 ;
+    prov:value "5.52454996109009"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.42059171809414"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000312425309546338"^^xsd:float ;
+    nidm_pValueFWER: "0.999999992873262"^^xsd:float ;
+    nidm_qValueFDR: "0.0313644959462665"^^xsd:float .
+
+niiri:c15f83bf0af7227fccfcc19a8ff53a78
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0062" ;
+    nidm_coordinateVector: "[-66,-40,18]"^^xsd:string .
+
+niiri:a1b7280bae7cb27c5d032057b5e5ee6a prov:wasDerivedFrom niiri:27969eb0dc2d34026b32c881a0f07667 .
+
+niiri:3240ad2c7b4c375b2ffb7def8241fc33
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0063" ;
+    prov:atLocation niiri:8977a52fd8fb3c0c00a547480b793cb2 ;
+    prov:value "5.51989889144897"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.41850793238069"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000314827412227103"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999363976"^^xsd:float ;
+    nidm_qValueFDR: "0.0315295603356192"^^xsd:float .
+
+niiri:8977a52fd8fb3c0c00a547480b793cb2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0063" ;
+    nidm_coordinateVector: "[-2,-90,16]"^^xsd:string .
+
+niiri:3240ad2c7b4c375b2ffb7def8241fc33 prov:wasDerivedFrom niiri:488053a695a16e1621e578a90cd45d96 .
+
+niiri:e98e410c62ad05bb4759e8520048a9be
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0064" ;
+    prov:atLocation niiri:c244d6cda3ac6e6dc81d3a691f072524 ;
+    prov:value "5.50013113021851"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.40963871850162"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000325244937404157"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999610751"^^xsd:float ;
+    nidm_qValueFDR: "0.0320937892728011"^^xsd:float .
+
+niiri:c244d6cda3ac6e6dc81d3a691f072524
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0064" ;
+    nidm_coordinateVector: "[48,-68,24]"^^xsd:string .
+
+niiri:e98e410c62ad05bb4759e8520048a9be prov:wasDerivedFrom niiri:ed908db943ba3e97ea5826f9b78e251e .
+
+niiri:028200a0f3330e69e713e62343e4c118
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0065" ;
+    prov:atLocation niiri:6672ab9c3b56f3def7af8a2d31e7bf6b ;
+    prov:value "5.47258329391479"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.39724406479958"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000340341137511579"^^xsd:float ;
+    nidm_pValueFWER: "0.999999998076035"^^xsd:float ;
+    nidm_qValueFDR: "0.0330219418190176"^^xsd:float .
+
+niiri:6672ab9c3b56f3def7af8a2d31e7bf6b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0065" ;
+    nidm_coordinateVector: "[-66,-52,14]"^^xsd:string .
+
+niiri:028200a0f3330e69e713e62343e4c118 prov:wasDerivedFrom niiri:f5e02329544635d1b1ebf65b366251dc .
+
+niiri:83b5e42ee4a22a019efa3ad1b7c43432
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0066" ;
+    prov:atLocation niiri:1365efa4ae8395b0cf5121fab0888e16 ;
+    prov:value "5.47253847122192"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.39722386451209"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000340366263790748"^^xsd:float ;
+    nidm_pValueFWER: "0.999999998078278"^^xsd:float ;
+    nidm_qValueFDR: "0.0330219418190176"^^xsd:float .
+
+niiri:1365efa4ae8395b0cf5121fab0888e16
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0066" ;
+    nidm_coordinateVector: "[-24,-70,-40]"^^xsd:string .
+
+niiri:83b5e42ee4a22a019efa3ad1b7c43432 prov:wasDerivedFrom niiri:48785ebe53244b67446462ca165511f6 .
+
+niiri:4d855c9b2c870365cbdf9a1cf976b2f7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0067" ;
+    prov:atLocation niiri:bc66a863068c99d04a911bb1348a178e ;
+    prov:value "5.40879058837891"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.36838466104027"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00037805012668235"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999657857"^^xsd:float ;
+    nidm_qValueFDR: "0.0351846046980527"^^xsd:float .
+
+niiri:bc66a863068c99d04a911bb1348a178e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0067" ;
+    nidm_coordinateVector: "[-52,28,-4]"^^xsd:string .
+
+niiri:4d855c9b2c870365cbdf9a1cf976b2f7 prov:wasDerivedFrom niiri:dd83d9e917f614f418e9401cdb99e43c .
+
+niiri:086b014ac09ab4e4ea973ffddfa71a22
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0068" ;
+    prov:atLocation niiri:06cfc8651ab4c54efee830c631e39857 ;
+    prov:value "5.40180397033691"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.36521050637541"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000382426408436776"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999719179"^^xsd:float ;
+    nidm_qValueFDR: "0.0353860600288775"^^xsd:float .
+
+niiri:06cfc8651ab4c54efee830c631e39857
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0068" ;
+    nidm_coordinateVector: "[46,40,-20]"^^xsd:string .
+
+niiri:086b014ac09ab4e4ea973ffddfa71a22 prov:wasDerivedFrom niiri:f9dfccb5b804ef9741131141e3190a4b .
+
+niiri:53c569adbfc5ab366e0314685b165853
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0069" ;
+    prov:atLocation niiri:13c44e2155af4ee2e20a16ec29b76a47 ;
+    prov:value "5.37467432022095"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.35285956111335"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000399906393667493"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999871685"^^xsd:float ;
+    nidm_qValueFDR: "0.0362799194266732"^^xsd:float .
+
+niiri:13c44e2155af4ee2e20a16ec29b76a47
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0069" ;
+    nidm_coordinateVector: "[-24,-64,-26]"^^xsd:string .
+
+niiri:53c569adbfc5ab366e0314685b165853 prov:wasDerivedFrom niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5 .
+
+niiri:be4788197353dff3599d99682ec3031b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0070" ;
+    prov:atLocation niiri:917e6352e6ae3e3613ae739c3f135a19 ;
+    prov:value "5.37411737442017"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.35260558298398"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00040027350203431"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999873767"^^xsd:float ;
+    nidm_qValueFDR: "0.0362799194266732"^^xsd:float .
+
+niiri:917e6352e6ae3e3613ae739c3f135a19
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0070" ;
+    nidm_coordinateVector: "[6,-78,4]"^^xsd:string .
+
+niiri:be4788197353dff3599d99682ec3031b prov:wasDerivedFrom niiri:024c443604af80b2271c971bd66fc9a0 .
+
+niiri:3f93410e4f041c83e4b8d8a0e0adbfff
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0071" ;
+    prov:atLocation niiri:0b950426b4901232779f3393314e29d9 ;
+    prov:value "5.30396842956543"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.32047825714677"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000449316793136201"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999985317"^^xsd:float ;
+    nidm_qValueFDR: "0.038893908226916"^^xsd:float .
+
+niiri:0b950426b4901232779f3393314e29d9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0071" ;
+    nidm_coordinateVector: "[-18,6,-16]"^^xsd:string .
+
+niiri:3f93410e4f041c83e4b8d8a0e0adbfff prov:wasDerivedFrom niiri:bd7d210916ff0d725f61db0ca48f5d05 .
+
+niiri:5f9a78d502e9bb9f0b83b39b814fcb68
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0072" ;
+    prov:atLocation niiri:b466f652f73aa477a6d1a60f80c8435c ;
+    prov:value "5.3003044128418"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.31879260124815"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000452037748311596"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999986945"^^xsd:float ;
+    nidm_qValueFDR: "0.0390806835204476"^^xsd:float .
+
+niiri:b466f652f73aa477a6d1a60f80c8435c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0072" ;
+    nidm_coordinateVector: "[44,34,22]"^^xsd:string .
+
+niiri:5f9a78d502e9bb9f0b83b39b814fcb68 prov:wasDerivedFrom niiri:7925cec36e37f32d88f7027ba176a2e1 .
+
+niiri:d0e4dbe4e90bfbe444d4822b9a651afc
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0073" ;
+    prov:atLocation niiri:be4116def5b2ec22ad63aa256b25428e ;
+    prov:value "5.2790060043335"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.30897907487843"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000468184175549835"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999993475"^^xsd:float ;
+    nidm_qValueFDR: "0.0399946769218688"^^xsd:float .
+
+niiri:be4116def5b2ec22ad63aa256b25428e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0073" ;
+    nidm_coordinateVector: "[-16,-70,62]"^^xsd:string .
+
+niiri:d0e4dbe4e90bfbe444d4822b9a651afc prov:wasDerivedFrom niiri:11d4226a2f26d5d215e759b0b4e1b65c .
+
+niiri:7ab232ff50649870750ccc2d7f5c4da3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0074" ;
+    prov:atLocation niiri:6f88478d05d4710af9b94706fcfdcacb ;
+    prov:value "5.22220420837402"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.28268028866984"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000514126053509312"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999062"^^xsd:float ;
+    nidm_qValueFDR: "0.0424551034128408"^^xsd:float .
+
+niiri:6f88478d05d4710af9b94706fcfdcacb
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0074" ;
+    nidm_coordinateVector: "[-18,-90,34]"^^xsd:string .
+
+niiri:7ab232ff50649870750ccc2d7f5c4da3 prov:wasDerivedFrom niiri:cd265e81b525edcdebe748129d48fb9f .
+
+niiri:dbaf7dcfae21971052a8c4d8630590a6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0075" ;
+    prov:atLocation niiri:803c967b5027caa5ecf5d2a6fc5e8db2 ;
+    prov:value "5.1730318069458"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.25976321879304"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000557526302441769"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999843"^^xsd:float ;
+    nidm_qValueFDR: "0.0447389446131481"^^xsd:float .
+
+niiri:803c967b5027caa5ecf5d2a6fc5e8db2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0075" ;
+    nidm_coordinateVector: "[36,62,8]"^^xsd:string .
+
+niiri:dbaf7dcfae21971052a8c4d8630590a6 prov:wasDerivedFrom niiri:aa2c86e9352626823ca6bb3bbda5947a .
+
+niiri:4cc71160f45e34b952ca323ad055c180
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0076" ;
+    prov:atLocation niiri:c7f8ed36a2e92d11b23926f9debb338a ;
+    prov:value "5.17224788665771"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.25939672404754"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000558247108556009"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999848"^^xsd:float ;
+    nidm_qValueFDR: "0.0447389446131481"^^xsd:float .
+
+niiri:c7f8ed36a2e92d11b23926f9debb338a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0076" ;
+    nidm_coordinateVector: "[44,46,-18]"^^xsd:string .
+
+niiri:4cc71160f45e34b952ca323ad055c180 prov:wasDerivedFrom niiri:8d3a03589611da3ed8127a06d493acd6 .
+
+niiri:fbddf0f56adf238723f50586d9383121
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0077" ;
+    prov:atLocation niiri:827b144eb0409183e6f5e65935ea8fac ;
+    prov:value "5.13746070861816"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.24309671226403"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000591190343014691"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999999996"^^xsd:float ;
+    nidm_qValueFDR: "0.0465822754926653"^^xsd:float .
+
+niiri:827b144eb0409183e6f5e65935ea8fac
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0077" ;
+    nidm_coordinateVector: "[22,-18,-10]"^^xsd:string .
+
+niiri:fbddf0f56adf238723f50586d9383121 prov:wasDerivedFrom niiri:3f311421a632e712f70cc6839f7e9489 .
+
+niiri:f7fbd57305037f549d9fa2567e5b8559
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0078" ;
+    prov:atLocation niiri:82ccce4a7354b15f17bc0943ef2b529c ;
+    prov:value "5.11799764633179"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.23394572778211"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000610463272072148"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999981"^^xsd:float ;
+    nidm_qValueFDR: "0.0474717326152994"^^xsd:float .
+
+niiri:82ccce4a7354b15f17bc0943ef2b529c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0078" ;
+    nidm_coordinateVector: "[-54,34,4]"^^xsd:string .
+
+niiri:f7fbd57305037f549d9fa2567e5b8559 prov:wasDerivedFrom niiri:bcc132262f6d7297d1d28a6f0a171093 .
+
+niiri:dbb595cffa04de52d8f33921efbecc84
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0079" ;
+    prov:atLocation niiri:27b2020b2732af62cc07a03a8002f7be ;
+    prov:value "5.10930299758911"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.22985044435181"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000619274939217984"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999987"^^xsd:float ;
+    nidm_qValueFDR: "0.047852944668371"^^xsd:float .
+
+niiri:27b2020b2732af62cc07a03a8002f7be
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0079" ;
+    nidm_coordinateVector: "[-30,-64,-52]"^^xsd:string .
+
+niiri:dbb595cffa04de52d8f33921efbecc84 prov:wasDerivedFrom niiri:3bdec6eb0b5535174fa631dd70795a7e .
+
+niiri:49c1e9ef96178d1e9db83a47b1907de9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0080" ;
+    prov:atLocation niiri:dc95edb06b3ad737ba9ce90d974a8f91 ;
+    prov:value "5.10401487350464"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.22735746106492"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000624696357977461"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999989"^^xsd:float ;
+    nidm_qValueFDR: "0.0480043833565767"^^xsd:float .
+
+niiri:dc95edb06b3ad737ba9ce90d974a8f91
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0080" ;
+    nidm_coordinateVector: "[-48,-78,18]"^^xsd:string .
+
+niiri:49c1e9ef96178d1e9db83a47b1907de9 prov:wasDerivedFrom niiri:f1946d8aa4c75dc6c7b6e735e96e1847 .
+
+niiri:c4b0c9d7d5bf10ed940aa36f9a2898fc
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0081" ;
+    prov:atLocation niiri:690f349d00c402f64f9afef69a04d47d ;
+    prov:value "5.09518003463745"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.22318870378714"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000633860042171808"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
+    nidm_qValueFDR: "0.0483657513246105"^^xsd:float .
+
+niiri:690f349d00c402f64f9afef69a04d47d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0081" ;
+    nidm_coordinateVector: "[4,-86,38]"^^xsd:string .
+
+niiri:c4b0c9d7d5bf10ed940aa36f9a2898fc prov:wasDerivedFrom niiri:3592a75cac312314b4a818b743916efd .
+
+niiri:6f1dcaa9702ce8b1e56004f2e154bcc7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0082" ;
+    prov:atLocation niiri:6579bb9b7980bc6caf30f72d161dccb3 ;
+    prov:value "5.08291101455688"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.21739172198432"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000646809225746448"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999996"^^xsd:float ;
+    nidm_qValueFDR: "0.0489980390158314"^^xsd:float .
+
+niiri:6579bb9b7980bc6caf30f72d161dccb3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0082" ;
+    nidm_coordinateVector: "[-14,-50,-36]"^^xsd:string .
+
+niiri:6f1dcaa9702ce8b1e56004f2e154bcc7 prov:wasDerivedFrom niiri:a457cd8f3b3381f0a12661e0907b556a .
+
+niiri:bb4e0dcfa0ad034c05e92f6d076501cb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0083" ;
+    prov:atLocation niiri:1a121ade9e841ce8da6580e606ec3b7b ;
+    prov:value "5.0689902305603"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.21080328886987"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000661822545445001"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
+    nidm_qValueFDR: "0.0496832380294054"^^xsd:float .
+
+niiri:1a121ade9e841ce8da6580e606ec3b7b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0083" ;
+    nidm_coordinateVector: "[30,68,10]"^^xsd:string .
+
+niiri:bb4e0dcfa0ad034c05e92f6d076501cb prov:wasDerivedFrom niiri:698306b72f010c2b2851ac92120e72d6 .
+
+niiri:77969ad2ea1b902a3de4c5dfa8bce613
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0084" ;
+    prov:atLocation niiri:ee032b83f3abbbdb30b2a62197d9e399 ;
+    prov:value "5.05907249450684"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.20610225272296"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000672730842027125"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
+    nidm_qValueFDR: "0.0501943510982274"^^xsd:float .
+
+niiri:ee032b83f3abbbdb30b2a62197d9e399
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0084" ;
+    nidm_coordinateVector: "[10,-30,80]"^^xsd:string .
+
+niiri:77969ad2ea1b902a3de4c5dfa8bce613 prov:wasDerivedFrom niiri:5d9c59bbe6ff835dfd7a715340e2d8b7 .
+
+niiri:0bc108a04fa102d651c09d417f06163e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0085" ;
+    prov:atLocation niiri:85320af157905fd663b941a235d3c218 ;
+    prov:value "5.05790328979492"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.20554765226523"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000674028618936839"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
+    nidm_qValueFDR: "0.0502551505802037"^^xsd:float .
+
+niiri:85320af157905fd663b941a235d3c218
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0085" ;
+    nidm_coordinateVector: "[44,-76,8]"^^xsd:string .
+
+niiri:0bc108a04fa102d651c09d417f06163e prov:wasDerivedFrom niiri:8cb05ce5ff1f36539390753e60f586ff .
+
+niiri:9ad0a5fb1e4870a3f1763d5f1630bf32
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0086" ;
+    prov:atLocation niiri:3906fb2e94c751bdf7ed2d37f73381e1 ;
+    prov:value "5.04969549179077"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.20165202224461"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000683209765197312"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
+    nidm_qValueFDR: "0.050613270744433"^^xsd:float .
+
+niiri:3906fb2e94c751bdf7ed2d37f73381e1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0086" ;
+    nidm_coordinateVector: "[-52,-36,44]"^^xsd:string .
+
+niiri:9ad0a5fb1e4870a3f1763d5f1630bf32 prov:wasDerivedFrom niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5 .
+
+niiri:f5ef66098a9f9c1e70f89f697490eeaf
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0087" ;
+    prov:atLocation niiri:e86bfb71232ecd6e43bcb633d2431b88 ;
+    prov:value "5.02838468551636"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.19151815181806"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000707636089146368"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.051650625154872"^^xsd:float .
+
+niiri:e86bfb71232ecd6e43bcb633d2431b88
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0087" ;
+    nidm_coordinateVector: "[-44,-40,42]"^^xsd:string .
+
+niiri:f5ef66098a9f9c1e70f89f697490eeaf prov:wasDerivedFrom niiri:08144c2f2914ca0e8f2d5090a382dd9c .
+
+niiri:f701ebe269b6e286af398dc8db3aa776
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0088" ;
+    prov:atLocation niiri:5e45ebc90297b83e805af2fa5c27599d ;
+    prov:value "5.02759695053101"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.19114302879552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00070855553886906"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0516996133446043"^^xsd:float .
+
+niiri:5e45ebc90297b83e805af2fa5c27599d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0088" ;
+    nidm_coordinateVector: "[-44,54,-6]"^^xsd:string .
+
+niiri:f701ebe269b6e286af398dc8db3aa776 prov:wasDerivedFrom niiri:20fdb21c4b6e1b56aba03dc17e6e0cad .
+
+niiri:ea882a65b0dfd559a13cfe9234c2c24d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0089" ;
+    prov:atLocation niiri:ea22c84ed8e7c73c83ed6c329b8aa7db ;
+    prov:value "5.00743103027344"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.18152691683286"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000732504543232371"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0526896959368281"^^xsd:float .
+
+niiri:ea22c84ed8e7c73c83ed6c329b8aa7db
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0089" ;
+    nidm_coordinateVector: "[36,58,18]"^^xsd:string .
+
+niiri:ea882a65b0dfd559a13cfe9234c2c24d prov:wasDerivedFrom niiri:b16302312e147e9c8ce1bdd421f19045 .
+
+niiri:a610e963c32e5f537ce4379d79a33677
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0090" ;
+    prov:atLocation niiri:e137a7aa81cf8b25e12262b0d38b2162 ;
+    prov:value "4.99766159057617"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.17685933085535"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000744396146822202"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0532506765476335"^^xsd:float .
+
+niiri:e137a7aa81cf8b25e12262b0d38b2162
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0090" ;
+    nidm_coordinateVector: "[-44,22,40]"^^xsd:string .
+
+niiri:a610e963c32e5f537ce4379d79a33677 prov:wasDerivedFrom niiri:9e57216b41802f20cbaf2104bd85f6ec .
+
+niiri:8a5fcc105ffc1799aa129242dff957a1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0091" ;
+    prov:atLocation niiri:9189a192e96af6b4e8a8d551eda8ce86 ;
+    prov:value "4.98628282546997"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.1714153864203"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00075849026901309"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0537320048825192"^^xsd:float .
+
+niiri:9189a192e96af6b4e8a8d551eda8ce86
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0091" ;
+    nidm_coordinateVector: "[32,-24,72]"^^xsd:string .
+
+niiri:8a5fcc105ffc1799aa129242dff957a1 prov:wasDerivedFrom niiri:002e00007a510fe7b30fd39adc263872 .
+
+niiri:048dfb27e0ec2f8c989f283aa5001023
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0092" ;
+    prov:atLocation niiri:730207a65b3cc9b8b3494340623e3fad ;
+    prov:value "4.97769069671631"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.16729931357798"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000769309331678514"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0542313534025412"^^xsd:float .
+
+niiri:730207a65b3cc9b8b3494340623e3fad
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0092" ;
+    nidm_coordinateVector: "[50,-30,60]"^^xsd:string .
+
+niiri:048dfb27e0ec2f8c989f283aa5001023 prov:wasDerivedFrom niiri:2b00f1f0bcfadf17e4e74a633d9cbe02 .
+
+niiri:4a609db5a795868ef47abe1fb286fd19
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0093" ;
+    prov:atLocation niiri:dfeb92f46265f28e2d20e5b1a396299e ;
+    prov:value "4.95973443984985"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.15868244743865"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000792420371319991"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.05524320395595"^^xsd:float .
+
+niiri:dfeb92f46265f28e2d20e5b1a396299e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0093" ;
+    nidm_coordinateVector: "[-32,-74,-28]"^^xsd:string .
+
+niiri:4a609db5a795868ef47abe1fb286fd19 prov:wasDerivedFrom niiri:0a99da6db6ffdb6abd70dfec062dacc6 .
+
+niiri:72e747c045e6ce18c7ea2d8872ec01bd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0094" ;
+    prov:atLocation niiri:3d10b3a98099f6ac7bd61e8504591520 ;
+    prov:value "4.95515823364258"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.15648318111342"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000798420481037398"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0553418612137989"^^xsd:float .
+
+niiri:3d10b3a98099f6ac7bd61e8504591520
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0094" ;
+    nidm_coordinateVector: "[-26,-86,40]"^^xsd:string .
+
+niiri:72e747c045e6ce18c7ea2d8872ec01bd prov:wasDerivedFrom niiri:ee9edf2a051832c657f8417f27f95a8f .
+
+niiri:26738ed1bfc7ad05331c2ac978006528
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0095" ;
+    prov:atLocation niiri:80998b0375b4ec6cd6d7875df2f956d9 ;
+    prov:value "4.93855857849121"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.14849453487417"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000820568960055779"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0562262327439451"^^xsd:float .
+
+niiri:80998b0375b4ec6cd6d7875df2f956d9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0095" ;
+    nidm_coordinateVector: "[-10,8,6]"^^xsd:string .
+
+niiri:26738ed1bfc7ad05331c2ac978006528 prov:wasDerivedFrom niiri:db1e7cd2ec53abce67f4898eb3c88730 .
+
+niiri:4b0a6177d3028a1d196d8e8644c68f46
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0096" ;
+    prov:atLocation niiri:e2315b6373bae1a1a264e9e11bacd9c2 ;
+    prov:value "4.90264129638672"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.13114947632107"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000870617549853403"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.058320641241518"^^xsd:float .
+
+niiri:e2315b6373bae1a1a264e9e11bacd9c2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0096" ;
+    nidm_coordinateVector: "[14,8,10]"^^xsd:string .
+
+niiri:4b0a6177d3028a1d196d8e8644c68f46 prov:wasDerivedFrom niiri:1066c8d3aa41693bfd354d1824cc7afe .
+
+niiri:6c657d496e9b2f580793789f0903637f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0097" ;
+    prov:atLocation niiri:92223eda5bee2fa6366d50cdb0ad17ae ;
+    prov:value "4.90243864059448"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.1310513773308"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000870908426383377"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.058320641241518"^^xsd:float .
+
+niiri:92223eda5bee2fa6366d50cdb0ad17ae
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0097" ;
+    nidm_coordinateVector: "[-20,-54,-2]"^^xsd:string .
+
+niiri:6c657d496e9b2f580793789f0903637f prov:wasDerivedFrom niiri:176e7ef375f6f1d2e26f1a064f8f6d39 .
+
+niiri:a9f12b36f390508d489680fa6cd977ef
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0098" ;
+    prov:atLocation niiri:400d143354fecfac34d7ed6f2f74e6d2 ;
+    prov:value "4.88119602203369"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.12075392909771"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000901943498395119"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0594947205600118"^^xsd:float .
+
+niiri:400d143354fecfac34d7ed6f2f74e6d2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0098" ;
+    nidm_coordinateVector: "[-26,-84,44]"^^xsd:string .
+
+niiri:a9f12b36f390508d489680fa6cd977ef prov:wasDerivedFrom niiri:08a3f7b7f6c942ab91160dfccbb968f2 .
+
+niiri:41ef706109f70aebe1bd69047789d6e8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0099" ;
+    prov:atLocation niiri:832aed24b7e9f89f7aac213df0041827 ;
+    prov:value "4.86706686019897"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.11388868389685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000923195680083033"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0603762016821821"^^xsd:float .
+
+niiri:832aed24b7e9f89f7aac213df0041827
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0099" ;
+    nidm_coordinateVector: "[-54,22,10]"^^xsd:string .
+
+niiri:41ef706109f70aebe1bd69047789d6e8 prov:wasDerivedFrom niiri:bddc2499a043f720b9c5a3c2a309f42c .
+
+niiri:b47830006cf1b3f215bc9fd3e64ca371
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0100" ;
+    prov:atLocation niiri:d9dbb81cee63c9d429edaac681bad88e ;
+    prov:value "4.84812355041504"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.10466401400555"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000952476397051205"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0616422795595169"^^xsd:float .
+
+niiri:d9dbb81cee63c9d429edaac681bad88e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0100" ;
+    nidm_coordinateVector: "[32,-80,-24]"^^xsd:string .
+
+niiri:b47830006cf1b3f215bc9fd3e64ca371 prov:wasDerivedFrom niiri:189d9d696ac51ec44003eb5f973b6c64 .
+
+niiri:e92e382c720879269b6002714e4a16ac
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0101" ;
+    prov:atLocation niiri:dde3f75099fb3b6b61a79003461a2d21 ;
+    prov:value "4.82597017288208"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.09384653195936"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00098789830908641"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0629671631402158"^^xsd:float .
+
+niiri:dde3f75099fb3b6b61a79003461a2d21
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0101" ;
+    nidm_coordinateVector: "[10,-80,4]"^^xsd:string .
+
+niiri:e92e382c720879269b6002714e4a16ac prov:wasDerivedFrom niiri:5d37a307684854af5c2a17ddbdb8f17f .
+
+niiri:b3a2d1e439fbf61d76d02cbdc713f8d9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0102" ;
+    prov:atLocation niiri:434dda457215299529b6e3b3f80e543c ;
+    prov:value "4.82537364959717"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.09355480628341"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000988870098138084"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0629727239584754"^^xsd:float .
+
+niiri:434dda457215299529b6e3b3f80e543c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0102" ;
+    nidm_coordinateVector: "[16,-50,-50]"^^xsd:string .
+
+niiri:b3a2d1e439fbf61d76d02cbdc713f8d9 prov:wasDerivedFrom niiri:df310d7fb2c5397364d68a8d3fa65bc0 .
+
+niiri:5c2c228fe7c73da50c74454b38d9ce4f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0103" ;
+    prov:atLocation niiri:83a52daf4eb7997573701f3945da1301 ;
+    prov:value "4.82024002075195"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.09104327517968"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000997272813291428"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.0632678542871923"^^xsd:float .
+
+niiri:83a52daf4eb7997573701f3945da1301
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0103" ;
+    nidm_coordinateVector: "[-12,-20,12]"^^xsd:string .
+
+niiri:5c2c228fe7c73da50c74454b38d9ce4f prov:wasDerivedFrom niiri:d0abba065cadfdf673c1ba317a4155ef .
+

--- a/spmexport/ex_spm_f_test/nidm.ttl
+++ b/spmexport/ex_spm_f_test/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:21b3c4311946920c7bb866cb7241f06a
+niiri:e7c622c060f6ce4999c83cd4e7d504a2
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:26e4ed7e4ca9f8d6f69ba2608dc2bb2b
+niiri:64a0a1e03c4e2566a0c7d5a14157ea25
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:cfc5d5cf6de0f5ccfe313e6d43587323
+niiri:4547ccdcb0181d8f245befc50dcc96be
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:cfc5d5cf6de0f5ccfe313e6d43587323 prov:wasAssociatedWith niiri:26e4ed7e4ca9f8d6f69ba2608dc2bb2b .
+niiri:4547ccdcb0181d8f245befc50dcc96be prov:wasAssociatedWith niiri:64a0a1e03c4e2566a0c7d5a14157ea25 .
 
 _:blank5 a prov:Generation .
 
-niiri:21b3c4311946920c7bb866cb7241f06a prov:qualifiedGeneration _:blank5 .
+niiri:e7c622c060f6ce4999c83cd4e7d504a2 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:11:24"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:33:38"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -137,12 +137,12 @@ _:blank5 prov:atTime "2016-01-11T10:11:24"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:43a3ee53f98ee35a82fd6af9eebbd163
+niiri:a9aa267d850571686083e814acacec85
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:6cbc3e147cf7f32be569d44f46d94c1f
+niiri:8631110ecbf1ae2c61c651d3c345e53a
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -152,35 +152,35 @@ niiri:6cbc3e147cf7f32be569d44f46d94c1f
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:e3676e8eec4990ea33ab365f41819e4c
+niiri:4065e9c0832a79eea2d7f48f6837481b
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:a4aacd65a7c45519a9f2f3175def869f
+niiri:6aef7089ce827a6b71f19c009ab15a95
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:3769ef4c5efe49a97295e3959f9dc7ad
+niiri:ea225237d5825ad08d76e698758e674b
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:e95fdfe90dea233f4527fc2ab0df8f98 ;
+    dc:description niiri:1a0a5cc4df2739bc50811b7823bb401e ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:a4aacd65a7c45519a9f2f3175def869f ;
+    nidm_hasDriftModel: niiri:6aef7089ce827a6b71f19c009ab15a95 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:e95fdfe90dea233f4527fc2ab0df8f98
+niiri:1a0a5cc4df2739bc50811b7823bb401e
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:b2fe7439c407fcd2dde1efc329a7b0f3
+niiri:b5697884a43743feb7d20368b80f55a9
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -188,213 +188,213 @@ niiri:b2fe7439c407fcd2dde1efc329a7b0f3
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:403063ca7469ea436c4ddd80ac3e76cd
+niiri:3c0b88356def21e2b7fe83f740cf597b
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:403063ca7469ea436c4ddd80ac3e76cd prov:wasAssociatedWith niiri:43a3ee53f98ee35a82fd6af9eebbd163 .
+niiri:3c0b88356def21e2b7fe83f740cf597b prov:wasAssociatedWith niiri:a9aa267d850571686083e814acacec85 .
 
-niiri:403063ca7469ea436c4ddd80ac3e76cd prov:used niiri:3769ef4c5efe49a97295e3959f9dc7ad .
+niiri:3c0b88356def21e2b7fe83f740cf597b prov:used niiri:ea225237d5825ad08d76e698758e674b .
 
-niiri:403063ca7469ea436c4ddd80ac3e76cd prov:used niiri:e3676e8eec4990ea33ab365f41819e4c .
+niiri:3c0b88356def21e2b7fe83f740cf597b prov:used niiri:4065e9c0832a79eea2d7f48f6837481b .
 
-niiri:403063ca7469ea436c4ddd80ac3e76cd prov:used niiri:b2fe7439c407fcd2dde1efc329a7b0f3 .
+niiri:3c0b88356def21e2b7fe83f740cf597b prov:used niiri:b5697884a43743feb7d20368b80f55a9 .
 
-niiri:2dfea426e8928d3252adb676004ffb9d
+niiri:dd3a1b34bce9178ca5eb9e0c6f64572b
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:9791d34c6aacce2cfbb27ce2f9075562
+niiri:f081077fa790becea31f832bed0ad762
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
 
-niiri:2dfea426e8928d3252adb676004ffb9d prov:wasDerivedFrom niiri:9791d34c6aacce2cfbb27ce2f9075562 .
+niiri:dd3a1b34bce9178ca5eb9e0c6f64572b prov:wasDerivedFrom niiri:f081077fa790becea31f832bed0ad762 .
 
-niiri:2dfea426e8928d3252adb676004ffb9d prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:dd3a1b34bce9178ca5eb9e0c6f64572b prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:fe1de7f78c02a415bd4ad2098cae4f59
+niiri:a45718cdddcc1f52a7095a49c028bc7b
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "108.038318634033"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
     crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
 
-niiri:fe1de7f78c02a415bd4ad2098cae4f59 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:a45718cdddcc1f52a7095a49c028bc7b prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7
+niiri:855ff1743625270dda4931a04ecd1031
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
 
-niiri:335e2de27a1a351eae295b2d6aba0ccc
+niiri:97dfe474f83a8bb5d149d855133a64bc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "11c208792e1874b4837ea90ec03320c8eeb702ad3966ee5912aa2e33b5bdb17b0e88caa31ed546f7f601160ced8eceebdf5db6449df6ec3ffbd17e27917ec328"^^xsd:string .
 
-niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7 prov:wasDerivedFrom niiri:335e2de27a1a351eae295b2d6aba0ccc .
+niiri:855ff1743625270dda4931a04ecd1031 prov:wasDerivedFrom niiri:97dfe474f83a8bb5d149d855133a64bc .
 
-niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:855ff1743625270dda4931a04ecd1031 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:40508269ce9f0c03d9af35c886882e23
+niiri:4fbc59d57cc5244670a944301b75c49e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
 
-niiri:493248b59478ddca0df41a77bc6f1482
+niiri:552b132ff1cb3c6356eed45cfba091e2
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
 
-niiri:40508269ce9f0c03d9af35c886882e23 prov:wasDerivedFrom niiri:493248b59478ddca0df41a77bc6f1482 .
+niiri:4fbc59d57cc5244670a944301b75c49e prov:wasDerivedFrom niiri:552b132ff1cb3c6356eed45cfba091e2 .
 
-niiri:40508269ce9f0c03d9af35c886882e23 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:4fbc59d57cc5244670a944301b75c49e prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:336fa6f65e23fda5fa34e118d1c9a0e1
+niiri:4fcd0feb226f491d94d19ede647cf6df
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
 
-niiri:7fd42856ebc39326ecf3d9c7336203ad
+niiri:47beaf2666652e2dfc40b9d59975b754
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "833a477bd4e758bdde7fcc9e6682186e9e38c1eeaa2a66de7d67e5f3c57cbaed7bddd45a7f7c86db713a8aa708790eaa31e0d8f0d0af9db9e87b545990b9e91e"^^xsd:string .
 
-niiri:336fa6f65e23fda5fa34e118d1c9a0e1 prov:wasDerivedFrom niiri:7fd42856ebc39326ecf3d9c7336203ad .
+niiri:4fcd0feb226f491d94d19ede647cf6df prov:wasDerivedFrom niiri:47beaf2666652e2dfc40b9d59975b754 .
 
-niiri:336fa6f65e23fda5fa34e118d1c9a0e1 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:4fcd0feb226f491d94d19ede647cf6df prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:16e0178c267997ead20f777bffe45894
+niiri:b1423cdb1726cd9674ebf1bcab3bcf56
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
 
-niiri:ffb56ac43e312f7d862bd04227ca2771
+niiri:8e1176bdcc74a45839a55e6b1d4afb84
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "8044c2e517efad185114b1d5478983a5073547d99f6b5778bcefe9caa7d243b89824b69841e3e5aa05e1da5393c9d1a34fec9a050b6a1e8a87da31cad99bfe69"^^xsd:string .
 
-niiri:16e0178c267997ead20f777bffe45894 prov:wasDerivedFrom niiri:ffb56ac43e312f7d862bd04227ca2771 .
+niiri:b1423cdb1726cd9674ebf1bcab3bcf56 prov:wasDerivedFrom niiri:8e1176bdcc74a45839a55e6b1d4afb84 .
 
-niiri:16e0178c267997ead20f777bffe45894 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:b1423cdb1726cd9674ebf1bcab3bcf56 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:717d24f6fc8fcd6daeec2603e49ed740
+niiri:15b31a17ded6db8183340b7bf088bf97
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
 
-niiri:67d86f251b1b458908a8aee56a029301
+niiri:345e3096159163131e4b2fc7f1ed4857
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "15551a7f3970720338fd0643bd017ba2f7f5db09c16b38909560b0479aa69eb74cd746fa98b2adc796153af88fba9b2ddd4eb5713b6f6011e62b7efb6531426d"^^xsd:string .
 
-niiri:717d24f6fc8fcd6daeec2603e49ed740 prov:wasDerivedFrom niiri:67d86f251b1b458908a8aee56a029301 .
+niiri:15b31a17ded6db8183340b7bf088bf97 prov:wasDerivedFrom niiri:345e3096159163131e4b2fc7f1ed4857 .
 
-niiri:717d24f6fc8fcd6daeec2603e49ed740 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:15b31a17ded6db8183340b7bf088bf97 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:b8e1b2bd6e02f1d74415b3190da5e6ce
+niiri:08de3e9dd167da4e0236e06f6ffa9f7a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 6" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f .
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
 
-niiri:0f227926cc2656b6333cd6e70b59bef0
+niiri:77879d25adca01d9f67bf80353db2ca6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
 
-niiri:b8e1b2bd6e02f1d74415b3190da5e6ce prov:wasDerivedFrom niiri:0f227926cc2656b6333cd6e70b59bef0 .
+niiri:08de3e9dd167da4e0236e06f6ffa9f7a prov:wasDerivedFrom niiri:77879d25adca01d9f67bf80353db2ca6 .
 
-niiri:b8e1b2bd6e02f1d74415b3190da5e6ce prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:08de3e9dd167da4e0236e06f6ffa9f7a prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:f446aad676c7f507c6dfdb3e65bd6cb3
+niiri:3406078060d97913cb8d424d34703ab9
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
     crypto:sha512 "9f1acf4f335317f388cc8adcc04086aa4e6bc6d19d5633a6a8d8dd85716386748c7ed700ef8031c7a3733228557d5ecf96eb6a889e2d36ad065e7bc852ae0b8c"^^xsd:string .
 
-niiri:7dc7be1e08841016c50f481df400db45
+niiri:c636630fb563318d5b35ab4a8b0a34c0
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "641184631587ff0ed74f92302d94dd40f2802efab358753eade14667fb6ee74fe64f3090b02fdf20e4a99d444610a61a1ae8a684628c9b2037535fbed9d53a12"^^xsd:string .
 
-niiri:f446aad676c7f507c6dfdb3e65bd6cb3 prov:wasDerivedFrom niiri:7dc7be1e08841016c50f481df400db45 .
+niiri:3406078060d97913cb8d424d34703ab9 prov:wasDerivedFrom niiri:c636630fb563318d5b35ab4a8b0a34c0 .
 
-niiri:f446aad676c7f507c6dfdb3e65bd6cb3 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:3406078060d97913cb8d424d34703ab9 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:952c39e2aa9fff43b62bbe9b77405227
+niiri:345400b745ebe143b4f453e4c217c209
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
     crypto:sha512 "a093dd7a9dd81e95f3696221e49cbb3ad8080b1f316ece53c9aafcb5cc9b767e55c594b7131d933e31231744c65db07483e64245480afd95075b76ccd2432789"^^xsd:string .
 
-niiri:48a4ebca3d7eaf837f3c511ad76b8b82
+niiri:774ad877e270db9e46dc564231f1b2e3
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "6ccf9e1895f8a26549f392b1d1a3676888cd729a207c6a93bcda6d549de2d4f133c0b2847bd2e839a462f3ba74cb9d9525eddb9f8499b99fb452b93cd713a158"^^xsd:string .
 
-niiri:952c39e2aa9fff43b62bbe9b77405227 prov:wasDerivedFrom niiri:48a4ebca3d7eaf837f3c511ad76b8b82 .
+niiri:345400b745ebe143b4f453e4c217c209 prov:wasDerivedFrom niiri:774ad877e270db9e46dc564231f1b2e3 .
 
-niiri:952c39e2aa9fff43b62bbe9b77405227 prov:wasGeneratedBy niiri:403063ca7469ea436c4ddd80ac3e76cd .
+niiri:345400b745ebe143b4f453e4c217c209 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
 
-niiri:eaf42d3560a64658c65dfc990556d651
+niiri:c9f72062391a92f26280783481f9d41e
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_FStatistic: ;
     nidm_contrastName: "F Contrast Test"^^xsd:string ;
     rdfs:label "Contrast: F Contrast Test" ;
     prov:value "[[1, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0],[0, 0, 0, 1, 0, 0]]"^^xsd:string .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201
+niiri:aedde2b1a02ad24ed234029b5dc86c0e
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:wasAssociatedWith niiri:43a3ee53f98ee35a82fd6af9eebbd163 .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:wasAssociatedWith niiri:a9aa267d850571686083e814acacec85 .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:2dfea426e8928d3252adb676004ffb9d .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:dd3a1b34bce9178ca5eb9e0c6f64572b .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:f446aad676c7f507c6dfdb3e65bd6cb3 .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:3406078060d97913cb8d424d34703ab9 .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:3769ef4c5efe49a97295e3959f9dc7ad .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:ea225237d5825ad08d76e698758e674b .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:eaf42d3560a64658c65dfc990556d651 .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:c9f72062391a92f26280783481f9d41e .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:5bee8bdf3c8a7ff6bf8aa1850f5064d7 .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:855ff1743625270dda4931a04ecd1031 .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:40508269ce9f0c03d9af35c886882e23 .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:4fbc59d57cc5244670a944301b75c49e .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:336fa6f65e23fda5fa34e118d1c9a0e1 .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:4fcd0feb226f491d94d19ede647cf6df .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:16e0178c267997ead20f777bffe45894 .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:b1423cdb1726cd9674ebf1bcab3bcf56 .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:717d24f6fc8fcd6daeec2603e49ed740 .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:15b31a17ded6db8183340b7bf088bf97 .
 
-niiri:b6fffa4c3247dbca41c70d6abf376201 prov:used niiri:b8e1b2bd6e02f1d74415b3190da5e6ce .
+niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:08de3e9dd167da4e0236e06f6ffa9f7a .
 
-niiri:b61012119e0a476f635df26d721e8c30
+niiri:b0e7b8f9e020e8724283e6191e2da703
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
@@ -404,104 +404,104 @@ niiri:b61012119e0a476f635df26d721e8c30
     nidm_contrastName: "F Contrast Test"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.999999999651"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "3.99999999999962"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
     crypto:sha512 "ca31a667d26797ee68a3709a8fa04f799ad113f17e6eff75ad6e88f53c44aa9e158a0d007354d454ad01df82d6b0f25f07b324cc3baa32f7623096a92ee6f304"^^xsd:string .
 
-niiri:7a977781f43baadb29a7109b66db5c80
+niiri:27281b97c78d257b22887871c6a68112
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmF_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "db6d4200b2e060c1fbd3e5c71011ac95ce60024087239685545954651a68733ec2d949c56520d2637add9e91c8e7883742c7d307667ad83c4ebe2a8531a1cc53"^^xsd:string .
 
-niiri:b61012119e0a476f635df26d721e8c30 prov:wasDerivedFrom niiri:7a977781f43baadb29a7109b66db5c80 .
+niiri:b0e7b8f9e020e8724283e6191e2da703 prov:wasDerivedFrom niiri:27281b97c78d257b22887871c6a68112 .
 
-niiri:b61012119e0a476f635df26d721e8c30 prov:wasGeneratedBy niiri:b6fffa4c3247dbca41c70d6abf376201 .
+niiri:b0e7b8f9e020e8724283e6191e2da703 prov:wasGeneratedBy niiri:aedde2b1a02ad24ed234029b5dc86c0e .
 
-niiri:5da9115bb9224fc27deb59c4db51293d
+niiri:0c51bc0fe4411e7dcd2abb844e9d9483
     a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
     prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Explained Mean Square Map" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
     crypto:sha512 "a4b2ff6f792524a027a625aba962b798c3ea321cdd6636193ab521acf5dafa8ceb7fd4cb99a450ab7872359d0e6dac97f82b7523d609747780623b5077e02588"^^xsd:string .
 
-niiri:5da9115bb9224fc27deb59c4db51293d prov:wasGeneratedBy niiri:b6fffa4c3247dbca41c70d6abf376201 .
+niiri:0c51bc0fe4411e7dcd2abb844e9d9483 prov:wasGeneratedBy niiri:aedde2b1a02ad24ed234029b5dc86c0e .
 
-niiri:790a0bb2d27b9d88e6869e877e73216b
+niiri:7f46ae22cdc5ee6822a2f2f5b2ca2f2b
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500086842908"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:cdc27d5485a25b98dc806d64eab06294 ;
-    nidm_equivalentThreshold: niiri:3a45a7e93b85e390a50cf7b33998e058 .
+    nidm_equivalentThreshold: niiri:0b8b0ea120e66e277cc906e8c638f4a1 ;
+    nidm_equivalentThreshold: niiri:01b61d5a54d124c25b0dfe4842452479 .
 
-niiri:cdc27d5485a25b98dc806d64eab06294
+niiri:0b8b0ea120e66e277cc906e8c638f4a1
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.81888651656205"^^xsd:float .
 
-niiri:3a45a7e93b85e390a50cf7b33998e058
+niiri:01b61d5a54d124c25b0dfe4842452479
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:311c74b903cbe301d2ea1ed406ef3819
+niiri:5c63a2de98701908b773b73724aa2e6c
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:d03c098b559b5d8b940ae0e6f4e45ac2 ;
-    nidm_equivalentThreshold: niiri:1256253b1ec8513cc907a598b85b5d25 .
+    nidm_equivalentThreshold: niiri:eb923f6975373720518450d07547dba1 ;
+    nidm_equivalentThreshold: niiri:c6c498af368977c112799bfa72671339 .
 
-niiri:d03c098b559b5d8b940ae0e6f4e45ac2
+niiri:eb923f6975373720518450d07547dba1
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:1256253b1ec8513cc907a598b85b5d25
+niiri:c6c498af368977c112799bfa72671339
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:0499a436458abc172a88ee306d18a605
+niiri:0b2c9ff1807f3f9bd6728cc73ddb271a
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:83fc9ee7c0ea36a7bd88d4420b89b29c
+niiri:ee02bfd0ffe03ca3e43583cd21adab51
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c
+niiri:87b5e03e41975da7e1db9bc068fc452a
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:wasAssociatedWith niiri:43a3ee53f98ee35a82fd6af9eebbd163 .
+niiri:87b5e03e41975da7e1db9bc068fc452a prov:wasAssociatedWith niiri:a9aa267d850571686083e814acacec85 .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:790a0bb2d27b9d88e6869e877e73216b .
+niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:7f46ae22cdc5ee6822a2f2f5b2ca2f2b .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:311c74b903cbe301d2ea1ed406ef3819 .
+niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:5c63a2de98701908b773b73724aa2e6c .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:b61012119e0a476f635df26d721e8c30 .
+niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:b0e7b8f9e020e8724283e6191e2da703 .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:952c39e2aa9fff43b62bbe9b77405227 .
+niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:345400b745ebe143b4f453e4c217c209 .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:2dfea426e8928d3252adb676004ffb9d .
+niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:dd3a1b34bce9178ca5eb9e0c6f64572b .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:0499a436458abc172a88ee306d18a605 .
+niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:0b2c9ff1807f3f9bd6728cc73ddb271a .
 
-niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c prov:used niiri:83fc9ee7c0ea36a7bd88d4420b89b29c .
+niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:ee02bfd0ffe03ca3e43583cd21adab51 .
 
-niiri:0bd153c871e44425ad2d0d70154ff868
+niiri:6fa69d1e83da07700b4a4ed4fdff8fa4
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
     nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
     nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.4409986586639"^^xsd:float ;
@@ -518,9 +518,9 @@ niiri:0bd153c871e44425ad2d0d70154ff868
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "51"^^xsd:int ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:0bd153c871e44425ad2d0d70154ff868 prov:wasGeneratedBy niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c .
+niiri:6fa69d1e83da07700b4a4ed4fdff8fa4 prov:wasGeneratedBy niiri:87b5e03e41975da7e1db9bc068fc452a .
 
-niiri:1f1a3d63428e4d2bf1696942c7dcd71e
+niiri:bfc22c098dc267a88d326bbf0e6793e3
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -528,26 +528,26 @@ niiri:1f1a3d63428e4d2bf1696942c7dcd71e
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "89"^^xsd:int ;
     nidm_pValue: "1.20671430625663e-08"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:ea2c3c814c10994917dd56bc9fe21873 ;
-    nidm_hasMaximumIntensityProjection: niiri:dd34657f27860de0933d54ae20a5bde9 ;
-    nidm_inCoordinateSpace: niiri:6cbc3e147cf7f32be569d44f46d94c1f ;
+    nidm_hasClusterLabelsMap: niiri:c872c243f35f93570da8e3e8bb2b7ead ;
+    nidm_hasMaximumIntensityProjection: niiri:9fea03d98e6320e3400bb3c188004db8 ;
+    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
     crypto:sha512 "7655b200bdcbba72ab5ab79029728a420df3f3368bcb553410540390e1372e99531cb91885edbdd03945d7e2391516a3d8dc537da81527730e866035d4af7894"^^xsd:string .
 
-niiri:ea2c3c814c10994917dd56bc9fe21873
+niiri:c872c243f35f93570da8e3e8bb2b7ead
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:dd34657f27860de0933d54ae20a5bde9
+niiri:9fea03d98e6320e3400bb3c188004db8
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:1f1a3d63428e4d2bf1696942c7dcd71e prov:wasGeneratedBy niiri:4c952f4f3a7b2d2cd2006efbd9bfe96c .
+niiri:bfc22c098dc267a88d326bbf0e6793e3 prov:wasGeneratedBy niiri:87b5e03e41975da7e1db9bc068fc452a .
 
-niiri:0af3c1dadf9b022bafb92d73c4057be6
+niiri:8337790d11808f2fb788ee8093e46afe
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1078"^^xsd:int ;
@@ -557,9 +557,9 @@ niiri:0af3c1dadf9b022bafb92d73c4057be6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:0af3c1dadf9b022bafb92d73c4057be6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:8337790d11808f2fb788ee8093e46afe prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:1f6332db35b31af3ee6ca935dfaeba0c
+niiri:2e44272daecb8718b2883f84f352fc62
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "930"^^xsd:int ;
@@ -569,9 +569,9 @@ niiri:1f6332db35b31af3ee6ca935dfaeba0c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:1f6332db35b31af3ee6ca935dfaeba0c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:2e44272daecb8718b2883f84f352fc62 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:0d4bf8c640cd15c305d2e49ef14b9ac6
+niiri:c893d69da88fea01efe542f9787608c5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "61"^^xsd:int ;
@@ -581,9 +581,9 @@ niiri:0d4bf8c640cd15c305d2e49ef14b9ac6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:0d4bf8c640cd15c305d2e49ef14b9ac6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:c893d69da88fea01efe542f9787608c5 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:32439b88059be589d0e2a8586ea799ec
+niiri:fafaf22f396d11e8355f5d1e7a7367ea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "51"^^xsd:int ;
@@ -593,9 +593,9 @@ niiri:32439b88059be589d0e2a8586ea799ec
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:32439b88059be589d0e2a8586ea799ec prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:fafaf22f396d11e8355f5d1e7a7367ea prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:d8b9846e25000609adbc385c634a1be0
+niiri:0820636de884fe0d783c5385916ab101
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "102"^^xsd:int ;
@@ -605,9 +605,9 @@ niiri:d8b9846e25000609adbc385c634a1be0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:d8b9846e25000609adbc385c634a1be0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:0820636de884fe0d783c5385916ab101 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:f8e22d4c567142a3ab813140dd91551e
+niiri:1e3c8c027b813bda7df5358a8ab4f63a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "69"^^xsd:int ;
@@ -617,9 +617,9 @@ niiri:f8e22d4c567142a3ab813140dd91551e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:f8e22d4c567142a3ab813140dd91551e prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:1e3c8c027b813bda7df5358a8ab4f63a prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:96a2e290f72fc28530510650c52e2805
+niiri:e24e457b7371fd1bac7d4cb391bb9432
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "81"^^xsd:int ;
@@ -629,9 +629,9 @@ niiri:96a2e290f72fc28530510650c52e2805
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:96a2e290f72fc28530510650c52e2805 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:e24e457b7371fd1bac7d4cb391bb9432 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:1062efea331d3022773f16c049f8543d
+niiri:2f5fcfc4453f648ede4260a16cff5960
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "62"^^xsd:int ;
@@ -641,9 +641,9 @@ niiri:1062efea331d3022773f16c049f8543d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:1062efea331d3022773f16c049f8543d prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:2f5fcfc4453f648ede4260a16cff5960 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:5577dc13c7013d8bb90b8dd111792d46
+niiri:dbbddbece734ef2c5ed154985b15ffe8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -653,9 +653,9 @@ niiri:5577dc13c7013d8bb90b8dd111792d46
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:5577dc13c7013d8bb90b8dd111792d46 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:dbbddbece734ef2c5ed154985b15ffe8 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:64ae5737521bbc7fe14f0c862379e927
+niiri:6aecc2d95fe5ba4cd2d39d16afe85407
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "69"^^xsd:int ;
@@ -665,9 +665,9 @@ niiri:64ae5737521bbc7fe14f0c862379e927
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:64ae5737521bbc7fe14f0c862379e927 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:6aecc2d95fe5ba4cd2d39d16afe85407 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:900846b4c16bba4a9b8a34762cba2da0
+niiri:a9c284c82bc4ef4eba48570f53c9c9c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "34"^^xsd:int ;
@@ -677,9 +677,9 @@ niiri:900846b4c16bba4a9b8a34762cba2da0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:900846b4c16bba4a9b8a34762cba2da0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:a9c284c82bc4ef4eba48570f53c9c9c4 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:7ede1db6987922a4806abc265aecda62
+niiri:0637af2e34d8b1c842ae7d1386357498
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -689,9 +689,9 @@ niiri:7ede1db6987922a4806abc265aecda62
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:7ede1db6987922a4806abc265aecda62 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:0637af2e34d8b1c842ae7d1386357498 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:9287b2a8106c3ffe3abf93837cfbd61c
+niiri:1cd4117828f514ec0fff4b67f780d6b9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -701,9 +701,9 @@ niiri:9287b2a8106c3ffe3abf93837cfbd61c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:9287b2a8106c3ffe3abf93837cfbd61c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:1cd4117828f514ec0fff4b67f780d6b9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:c515278968596a92906ae29ffad63511
+niiri:d85063f48080f770ca548748f7419e12
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -713,9 +713,9 @@ niiri:c515278968596a92906ae29ffad63511
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:c515278968596a92906ae29ffad63511 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:d85063f48080f770ca548748f7419e12 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:0493a379c4735cda662e56229168b8a9
+niiri:ec3fc3cfa0c303c00f68f5986e44044e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "52"^^xsd:int ;
@@ -725,9 +725,9 @@ niiri:0493a379c4735cda662e56229168b8a9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:0493a379c4735cda662e56229168b8a9 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:ec3fc3cfa0c303c00f68f5986e44044e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:6f915c93d573d9f832d05fb003dcbfb0
+niiri:23c6e94e6643122dcb458402a972758e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -737,9 +737,9 @@ niiri:6f915c93d573d9f832d05fb003dcbfb0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:6f915c93d573d9f832d05fb003dcbfb0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:23c6e94e6643122dcb458402a972758e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:2344710a34a75f050910ebd48e1159af
+niiri:68f9a66ca71f514199366c398a2831ab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -749,9 +749,9 @@ niiri:2344710a34a75f050910ebd48e1159af
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:2344710a34a75f050910ebd48e1159af prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:68f9a66ca71f514199366c398a2831ab prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:a904380f9b13e67a2253c5f952a57f9f
+niiri:6f303953fe538a2a99d9b754b92e311e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -761,9 +761,9 @@ niiri:a904380f9b13e67a2253c5f952a57f9f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:a904380f9b13e67a2253c5f952a57f9f prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:6f303953fe538a2a99d9b754b92e311e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:8348fc8e7248e46840dad7df7f8763bf
+niiri:b32513dc3cebea135a4227a2ff2989c6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -773,9 +773,9 @@ niiri:8348fc8e7248e46840dad7df7f8763bf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:8348fc8e7248e46840dad7df7f8763bf prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:b32513dc3cebea135a4227a2ff2989c6 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:db6eb647802a5fc531c369aa668af574
+niiri:b7301eccecd4c049bbeed4467b530024
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -785,9 +785,9 @@ niiri:db6eb647802a5fc531c369aa668af574
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:db6eb647802a5fc531c369aa668af574 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:b7301eccecd4c049bbeed4467b530024 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:efddc25357ec7a4b9a063a62f5a2c864
+niiri:765e5201ffb06ca1f162ea8d7d3f0abd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -797,9 +797,9 @@ niiri:efddc25357ec7a4b9a063a62f5a2c864
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:efddc25357ec7a4b9a063a62f5a2c864 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:765e5201ffb06ca1f162ea8d7d3f0abd prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:92832eb3b91834fca357233c33e92d47
+niiri:aeb5ca84ea986c7559b385b24d2806c0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -809,9 +809,9 @@ niiri:92832eb3b91834fca357233c33e92d47
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:92832eb3b91834fca357233c33e92d47 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:aeb5ca84ea986c7559b385b24d2806c0 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:27a928cca18b5d563bf58797f306d0e0
+niiri:d36b472817f6888ac2860c8f78cda4e9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -821,9 +821,9 @@ niiri:27a928cca18b5d563bf58797f306d0e0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:27a928cca18b5d563bf58797f306d0e0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:d36b472817f6888ac2860c8f78cda4e9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:9197197694f96c553e0e78334284b0c7
+niiri:e1375ee26540e9328da498ca97a69cb4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -833,9 +833,9 @@ niiri:9197197694f96c553e0e78334284b0c7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:9197197694f96c553e0e78334284b0c7 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:e1375ee26540e9328da498ca97a69cb4 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:4babeddab7c30570f5f7bca47ad8e349
+niiri:d5f1c18934146a18337779acd9486123
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "68"^^xsd:int ;
@@ -845,9 +845,9 @@ niiri:4babeddab7c30570f5f7bca47ad8e349
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:4babeddab7c30570f5f7bca47ad8e349 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:d5f1c18934146a18337779acd9486123 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:abcdfa125cb9a6705001908f8633bf90
+niiri:275de6b748d7ad0f11eed3004edbf892
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -857,9 +857,9 @@ niiri:abcdfa125cb9a6705001908f8633bf90
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:abcdfa125cb9a6705001908f8633bf90 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:275de6b748d7ad0f11eed3004edbf892 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:2583f6b74e4ca256d5338bb9b9f07a29
+niiri:2dd4cb8812c93538b5902225b29e0471
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -869,9 +869,9 @@ niiri:2583f6b74e4ca256d5338bb9b9f07a29
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:2583f6b74e4ca256d5338bb9b9f07a29 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:2dd4cb8812c93538b5902225b29e0471 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:9656cbf27ba556542b025f2f8e45acfd
+niiri:67ae07e7ee0396386eefce6ed5341a79
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -881,9 +881,9 @@ niiri:9656cbf27ba556542b025f2f8e45acfd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:9656cbf27ba556542b025f2f8e45acfd prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:67ae07e7ee0396386eefce6ed5341a79 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:52cafab6790abfb27ec51f00e747fe9a
+niiri:c589ee96ca2b908bdd9d337ca523d5af
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -893,9 +893,9 @@ niiri:52cafab6790abfb27ec51f00e747fe9a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:52cafab6790abfb27ec51f00e747fe9a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:c589ee96ca2b908bdd9d337ca523d5af prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:4c64b57b636863b3e947522d1311c0f1
+niiri:e43455a02504b9d87a4939904a0ca976
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -905,9 +905,9 @@ niiri:4c64b57b636863b3e947522d1311c0f1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:4c64b57b636863b3e947522d1311c0f1 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:e43455a02504b9d87a4939904a0ca976 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:a8236e3bfdb590d4516edd326dbac95d
+niiri:5dc937975dc687d7eb55e11a685cdd94
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -917,9 +917,9 @@ niiri:a8236e3bfdb590d4516edd326dbac95d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:a8236e3bfdb590d4516edd326dbac95d prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:5dc937975dc687d7eb55e11a685cdd94 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:90dce13e46266944c40d12f4f1a86219
+niiri:30c5174c5d495474060913c40bab0961
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -929,9 +929,9 @@ niiri:90dce13e46266944c40d12f4f1a86219
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:90dce13e46266944c40d12f4f1a86219 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:30c5174c5d495474060913c40bab0961 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:4b569159d1ddc968752a57917503c6f4
+niiri:ea999779ae02d5714142530d4b2e638b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -941,9 +941,9 @@ niiri:4b569159d1ddc968752a57917503c6f4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:4b569159d1ddc968752a57917503c6f4 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:ea999779ae02d5714142530d4b2e638b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:674c9062dc421a541e91be283cce8f16
+niiri:15b2530019f1c4c6d5e910962b35274b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -953,9 +953,9 @@ niiri:674c9062dc421a541e91be283cce8f16
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:674c9062dc421a541e91be283cce8f16 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:15b2530019f1c4c6d5e910962b35274b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:d3a1762138c1b259db52c75933757662
+niiri:5782e52657a04683a9d9acc635ffc74a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -965,9 +965,9 @@ niiri:d3a1762138c1b259db52c75933757662
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:d3a1762138c1b259db52c75933757662 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:5782e52657a04683a9d9acc635ffc74a prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:9dc472e5df63cfbf55f8afa2ad7233f1
+niiri:e26340fcd624896679dd2542ec2348be
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -977,9 +977,9 @@ niiri:9dc472e5df63cfbf55f8afa2ad7233f1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:9dc472e5df63cfbf55f8afa2ad7233f1 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:e26340fcd624896679dd2542ec2348be prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:3fd667ca8587427124fe4b4ff80af21a
+niiri:e4e5f6e0de1fb1456effbec6ec82e736
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -989,9 +989,9 @@ niiri:3fd667ca8587427124fe4b4ff80af21a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:3fd667ca8587427124fe4b4ff80af21a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:e4e5f6e0de1fb1456effbec6ec82e736 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:c60cf8d223f50376ab05520bb51598af
+niiri:5cf9ae44dc03a8c6493baf09bed014d4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1001,9 +1001,9 @@ niiri:c60cf8d223f50376ab05520bb51598af
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:c60cf8d223f50376ab05520bb51598af prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:5cf9ae44dc03a8c6493baf09bed014d4 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:f551110d12542058bdc59cae03013010
+niiri:dfe1466699f719841d6d98d1188da0c8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1013,9 +1013,9 @@ niiri:f551110d12542058bdc59cae03013010
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:f551110d12542058bdc59cae03013010 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:dfe1466699f719841d6d98d1188da0c8 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:fb9120500eef24a89fb5e84238991362
+niiri:e69a5e282ae0346ca803f55371164aa7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1025,9 +1025,9 @@ niiri:fb9120500eef24a89fb5e84238991362
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:fb9120500eef24a89fb5e84238991362 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:e69a5e282ae0346ca803f55371164aa7 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:dde8bc734b1e70c777683f3419f9b22a
+niiri:d168d4b61807fc13619ad56c31dad174
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1037,9 +1037,9 @@ niiri:dde8bc734b1e70c777683f3419f9b22a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:dde8bc734b1e70c777683f3419f9b22a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:d168d4b61807fc13619ad56c31dad174 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:89223f01a7e676c300c22c8da4a82ef8
+niiri:522e011a3a54e833c99dc9315f577dfe
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1049,9 +1049,9 @@ niiri:89223f01a7e676c300c22c8da4a82ef8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:89223f01a7e676c300c22c8da4a82ef8 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:522e011a3a54e833c99dc9315f577dfe prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:7ac6ced5ac5b95c88fbe93f4ad51726c
+niiri:bcc290b739057f6cb5c02dcc79c4b5bc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1061,9 +1061,9 @@ niiri:7ac6ced5ac5b95c88fbe93f4ad51726c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:7ac6ced5ac5b95c88fbe93f4ad51726c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:bcc290b739057f6cb5c02dcc79c4b5bc prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:5d05848ec2715382392265640fc9d57e
+niiri:6f3de48dca5b4c3a6aca0be63ddd27cd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1073,9 +1073,9 @@ niiri:5d05848ec2715382392265640fc9d57e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:5d05848ec2715382392265640fc9d57e prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:6f3de48dca5b4c3a6aca0be63ddd27cd prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:ca24bdc833f185dc48a439c9bd8cfea6
+niiri:f77f344a47f917de9a802b78319c354f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1085,9 +1085,9 @@ niiri:ca24bdc833f185dc48a439c9bd8cfea6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:ca24bdc833f185dc48a439c9bd8cfea6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:f77f344a47f917de9a802b78319c354f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:302ad243c21e156bc35f157e2595460d
+niiri:9df645a4ce3520ee828e35a6dac32f9f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1097,9 +1097,9 @@ niiri:302ad243c21e156bc35f157e2595460d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:302ad243c21e156bc35f157e2595460d prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:9df645a4ce3520ee828e35a6dac32f9f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:b0e84ab2cd541b237634e56ebf391609
+niiri:1dea88b1f0062ddb01809c2f336aff3f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1109,9 +1109,9 @@ niiri:b0e84ab2cd541b237634e56ebf391609
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:b0e84ab2cd541b237634e56ebf391609 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:1dea88b1f0062ddb01809c2f336aff3f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:27969eb0dc2d34026b32c881a0f07667
+niiri:f424b0ee093c7ca1771bb8144718087b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1121,9 +1121,9 @@ niiri:27969eb0dc2d34026b32c881a0f07667
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:27969eb0dc2d34026b32c881a0f07667 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:f424b0ee093c7ca1771bb8144718087b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:488053a695a16e1621e578a90cd45d96
+niiri:258ff3de07e51a57d0b27d6699fb2508
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1133,9 +1133,9 @@ niiri:488053a695a16e1621e578a90cd45d96
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:488053a695a16e1621e578a90cd45d96 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:258ff3de07e51a57d0b27d6699fb2508 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:ed908db943ba3e97ea5826f9b78e251e
+niiri:fd669f02bbb8da3eff612dc0d4b807f6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1145,9 +1145,9 @@ niiri:ed908db943ba3e97ea5826f9b78e251e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:ed908db943ba3e97ea5826f9b78e251e prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:fd669f02bbb8da3eff612dc0d4b807f6 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:f5e02329544635d1b1ebf65b366251dc
+niiri:2560564a14e0250f709b385639d02fb9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1157,9 +1157,9 @@ niiri:f5e02329544635d1b1ebf65b366251dc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:f5e02329544635d1b1ebf65b366251dc prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:2560564a14e0250f709b385639d02fb9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:48785ebe53244b67446462ca165511f6
+niiri:589d688bdb65a26f0e5afdd4ff33865b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1169,9 +1169,9 @@ niiri:48785ebe53244b67446462ca165511f6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:48785ebe53244b67446462ca165511f6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:589d688bdb65a26f0e5afdd4ff33865b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:dd83d9e917f614f418e9401cdb99e43c
+niiri:b1e45a95e3b162cbfbb274efa0609a1a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1181,9 +1181,9 @@ niiri:dd83d9e917f614f418e9401cdb99e43c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:dd83d9e917f614f418e9401cdb99e43c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:b1e45a95e3b162cbfbb274efa0609a1a prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:f9dfccb5b804ef9741131141e3190a4b
+niiri:5ac022b3dd1da9d78456eb9feccbe272
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1193,9 +1193,9 @@ niiri:f9dfccb5b804ef9741131141e3190a4b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:f9dfccb5b804ef9741131141e3190a4b prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:5ac022b3dd1da9d78456eb9feccbe272 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5
+niiri:0aa8942e14fb246e8d24f1826bdd073f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1205,9 +1205,9 @@ niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:0aa8942e14fb246e8d24f1826bdd073f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:024c443604af80b2271c971bd66fc9a0
+niiri:47175a90c2a865c8e7cb888b760d6bf8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1217,9 +1217,9 @@ niiri:024c443604af80b2271c971bd66fc9a0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:024c443604af80b2271c971bd66fc9a0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:47175a90c2a865c8e7cb888b760d6bf8 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:bd7d210916ff0d725f61db0ca48f5d05
+niiri:d3f621d08874a1c4b62c86623e9e9780
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1229,9 +1229,9 @@ niiri:bd7d210916ff0d725f61db0ca48f5d05
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:bd7d210916ff0d725f61db0ca48f5d05 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:d3f621d08874a1c4b62c86623e9e9780 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:7925cec36e37f32d88f7027ba176a2e1
+niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1241,9 +1241,9 @@ niiri:7925cec36e37f32d88f7027ba176a2e1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:7925cec36e37f32d88f7027ba176a2e1 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:11d4226a2f26d5d215e759b0b4e1b65c
+niiri:730bd100bdb468af0d3821d0d42d24a3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1253,9 +1253,9 @@ niiri:11d4226a2f26d5d215e759b0b4e1b65c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:11d4226a2f26d5d215e759b0b4e1b65c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:730bd100bdb468af0d3821d0d42d24a3 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:cd265e81b525edcdebe748129d48fb9f
+niiri:c30c1334c3597905fbc441edbc3d5ada
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1265,9 +1265,9 @@ niiri:cd265e81b525edcdebe748129d48fb9f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:cd265e81b525edcdebe748129d48fb9f prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:c30c1334c3597905fbc441edbc3d5ada prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:aa2c86e9352626823ca6bb3bbda5947a
+niiri:f3476be8b24ab5bb218fe71d0b0daed0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1277,9 +1277,9 @@ niiri:aa2c86e9352626823ca6bb3bbda5947a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:aa2c86e9352626823ca6bb3bbda5947a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:f3476be8b24ab5bb218fe71d0b0daed0 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:8d3a03589611da3ed8127a06d493acd6
+niiri:e129e49f77be02735062a975f639c82e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1289,9 +1289,9 @@ niiri:8d3a03589611da3ed8127a06d493acd6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:8d3a03589611da3ed8127a06d493acd6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:e129e49f77be02735062a975f639c82e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:3f311421a632e712f70cc6839f7e9489
+niiri:f445b49b9174ce8611d41a7cc11e1717
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1301,9 +1301,9 @@ niiri:3f311421a632e712f70cc6839f7e9489
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:3f311421a632e712f70cc6839f7e9489 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:f445b49b9174ce8611d41a7cc11e1717 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:bcc132262f6d7297d1d28a6f0a171093
+niiri:5ca600306779ba8f48c5d087d9fac9a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1313,9 +1313,9 @@ niiri:bcc132262f6d7297d1d28a6f0a171093
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:bcc132262f6d7297d1d28a6f0a171093 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:5ca600306779ba8f48c5d087d9fac9a9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:3bdec6eb0b5535174fa631dd70795a7e
+niiri:40bbe1b7b060c1d54f113fd9fcf154aa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1325,9 +1325,9 @@ niiri:3bdec6eb0b5535174fa631dd70795a7e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:3bdec6eb0b5535174fa631dd70795a7e prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:40bbe1b7b060c1d54f113fd9fcf154aa prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:f1946d8aa4c75dc6c7b6e735e96e1847
+niiri:5d9d1b3e1bbc6746185f53561c74bace
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1337,9 +1337,9 @@ niiri:f1946d8aa4c75dc6c7b6e735e96e1847
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:f1946d8aa4c75dc6c7b6e735e96e1847 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:5d9d1b3e1bbc6746185f53561c74bace prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:3592a75cac312314b4a818b743916efd
+niiri:4c53636a1293cd4482cb63ff70691d79
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1349,9 +1349,9 @@ niiri:3592a75cac312314b4a818b743916efd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:3592a75cac312314b4a818b743916efd prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:4c53636a1293cd4482cb63ff70691d79 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:a457cd8f3b3381f0a12661e0907b556a
+niiri:2b3b2f5817481e92102b214f3bf33995
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1361,9 +1361,9 @@ niiri:a457cd8f3b3381f0a12661e0907b556a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:a457cd8f3b3381f0a12661e0907b556a prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:2b3b2f5817481e92102b214f3bf33995 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:698306b72f010c2b2851ac92120e72d6
+niiri:86437031e803eee8517a97d2e8420009
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1373,9 +1373,9 @@ niiri:698306b72f010c2b2851ac92120e72d6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:698306b72f010c2b2851ac92120e72d6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:86437031e803eee8517a97d2e8420009 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:5d9c59bbe6ff835dfd7a715340e2d8b7
+niiri:927385c4b1c66020878360a5006a3e3b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1385,9 +1385,9 @@ niiri:5d9c59bbe6ff835dfd7a715340e2d8b7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:5d9c59bbe6ff835dfd7a715340e2d8b7 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:927385c4b1c66020878360a5006a3e3b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:8cb05ce5ff1f36539390753e60f586ff
+niiri:0087c0fa9854a20b9b26757b4c0e9a68
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1397,9 +1397,9 @@ niiri:8cb05ce5ff1f36539390753e60f586ff
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:8cb05ce5ff1f36539390753e60f586ff prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:0087c0fa9854a20b9b26757b4c0e9a68 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5
+niiri:679d2ced08c3de3ec63ab76190f2d86d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1409,9 +1409,9 @@ niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:679d2ced08c3de3ec63ab76190f2d86d prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:08144c2f2914ca0e8f2d5090a382dd9c
+niiri:302d0ae98bffba69292672583d115e8c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1421,9 +1421,9 @@ niiri:08144c2f2914ca0e8f2d5090a382dd9c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:08144c2f2914ca0e8f2d5090a382dd9c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:302d0ae98bffba69292672583d115e8c prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:20fdb21c4b6e1b56aba03dc17e6e0cad
+niiri:f443e4b03660a8ad618e307479bf8a95
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1433,9 +1433,9 @@ niiri:20fdb21c4b6e1b56aba03dc17e6e0cad
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:20fdb21c4b6e1b56aba03dc17e6e0cad prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:f443e4b03660a8ad618e307479bf8a95 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:b16302312e147e9c8ce1bdd421f19045
+niiri:80e9d7b2bd34593272f3fb19fc9254e9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1445,9 +1445,9 @@ niiri:b16302312e147e9c8ce1bdd421f19045
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:b16302312e147e9c8ce1bdd421f19045 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:80e9d7b2bd34593272f3fb19fc9254e9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:9e57216b41802f20cbaf2104bd85f6ec
+niiri:91bc3a2972b2938504904a8d68057f2e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1457,9 +1457,9 @@ niiri:9e57216b41802f20cbaf2104bd85f6ec
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:9e57216b41802f20cbaf2104bd85f6ec prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:91bc3a2972b2938504904a8d68057f2e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:002e00007a510fe7b30fd39adc263872
+niiri:681cc93cdfd04b41012417cfd725953f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1469,9 +1469,9 @@ niiri:002e00007a510fe7b30fd39adc263872
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:002e00007a510fe7b30fd39adc263872 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:681cc93cdfd04b41012417cfd725953f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:2b00f1f0bcfadf17e4e74a633d9cbe02
+niiri:1288217d5c8b70c54915067a87402187
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1481,9 +1481,9 @@ niiri:2b00f1f0bcfadf17e4e74a633d9cbe02
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:2b00f1f0bcfadf17e4e74a633d9cbe02 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:1288217d5c8b70c54915067a87402187 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:0a99da6db6ffdb6abd70dfec062dacc6
+niiri:9a33ec7dcbaf4c333c9be7973d3674ae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1493,9 +1493,9 @@ niiri:0a99da6db6ffdb6abd70dfec062dacc6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:0a99da6db6ffdb6abd70dfec062dacc6 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:9a33ec7dcbaf4c333c9be7973d3674ae prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:ee9edf2a051832c657f8417f27f95a8f
+niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1505,9 +1505,9 @@ niiri:ee9edf2a051832c657f8417f27f95a8f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:ee9edf2a051832c657f8417f27f95a8f prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:db1e7cd2ec53abce67f4898eb3c88730
+niiri:99af69862e054a4c62b8e6066ff12cfd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1517,9 +1517,9 @@ niiri:db1e7cd2ec53abce67f4898eb3c88730
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:db1e7cd2ec53abce67f4898eb3c88730 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:99af69862e054a4c62b8e6066ff12cfd prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:1066c8d3aa41693bfd354d1824cc7afe
+niiri:20fc427845c2a14183959299a0d233ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1529,9 +1529,9 @@ niiri:1066c8d3aa41693bfd354d1824cc7afe
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:1066c8d3aa41693bfd354d1824cc7afe prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:20fc427845c2a14183959299a0d233ce prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:176e7ef375f6f1d2e26f1a064f8f6d39
+niiri:0294b8b1f3c4b525a18397bf17d17d63
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1541,9 +1541,9 @@ niiri:176e7ef375f6f1d2e26f1a064f8f6d39
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:176e7ef375f6f1d2e26f1a064f8f6d39 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:0294b8b1f3c4b525a18397bf17d17d63 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:08a3f7b7f6c942ab91160dfccbb968f2
+niiri:3dc796cbf0403561b0e6ea42b96ea1a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1553,9 +1553,9 @@ niiri:08a3f7b7f6c942ab91160dfccbb968f2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:08a3f7b7f6c942ab91160dfccbb968f2 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:3dc796cbf0403561b0e6ea42b96ea1a9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:bddc2499a043f720b9c5a3c2a309f42c
+niiri:14518885ee853fba951013cf73f66bed
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0085" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1565,9 +1565,9 @@ niiri:bddc2499a043f720b9c5a3c2a309f42c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "85"^^xsd:int .
 
-niiri:bddc2499a043f720b9c5a3c2a309f42c prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:14518885ee853fba951013cf73f66bed prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:189d9d696ac51ec44003eb5f973b6c64
+niiri:7666b1a689a3839cdadb86af5e5c7c39
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0086" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1577,9 +1577,9 @@ niiri:189d9d696ac51ec44003eb5f973b6c64
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "86"^^xsd:int .
 
-niiri:189d9d696ac51ec44003eb5f973b6c64 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:7666b1a689a3839cdadb86af5e5c7c39 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:5d37a307684854af5c2a17ddbdb8f17f
+niiri:2cac2c4baab8136a53bdf03e74fdc1c5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0087" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1589,9 +1589,9 @@ niiri:5d37a307684854af5c2a17ddbdb8f17f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "87"^^xsd:int .
 
-niiri:5d37a307684854af5c2a17ddbdb8f17f prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:2cac2c4baab8136a53bdf03e74fdc1c5 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:df310d7fb2c5397364d68a8d3fa65bc0
+niiri:8768acb96e7e44e4cd45548f0d52dd3f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0088" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1601,9 +1601,9 @@ niiri:df310d7fb2c5397364d68a8d3fa65bc0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "88"^^xsd:int .
 
-niiri:df310d7fb2c5397364d68a8d3fa65bc0 prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:8768acb96e7e44e4cd45548f0d52dd3f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:d0abba065cadfdf673c1ba317a4155ef
+niiri:816f19a8ef8789235a9bd7bfe4396a14
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0089" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1613,1756 +1613,1756 @@ niiri:d0abba065cadfdf673c1ba317a4155ef
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "89"^^xsd:int .
 
-niiri:d0abba065cadfdf673c1ba317a4155ef prov:wasDerivedFrom niiri:1f1a3d63428e4d2bf1696942c7dcd71e .
+niiri:816f19a8ef8789235a9bd7bfe4396a14 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
 
-niiri:cd9309db3e1c88a98ba96314ae5579f0
+niiri:06a391660f148983b073bfec11e5afdd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:4bc98dbacc7bcd13b355272508d662cd ;
+    prov:atLocation niiri:aeb3f38bf9d2106bcfc97930c448be4f ;
     prov:value "16.0820484161377"^^xsd:float ;
     nidm_equivalentZStatistic: "6.58928757769047"^^xsd:float ;
     nidm_pValueUncorrected: "2.20971019260219e-11"^^xsd:float ;
     nidm_pValueFWER: "4.59341100222943e-06"^^xsd:float ;
     nidm_qValueFDR: "2.11792501803032e-06"^^xsd:float .
 
-niiri:4bc98dbacc7bcd13b355272508d662cd
+niiri:aeb3f38bf9d2106bcfc97930c448be4f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-14,-84,-14]"^^xsd:string .
 
-niiri:cd9309db3e1c88a98ba96314ae5579f0 prov:wasDerivedFrom niiri:0af3c1dadf9b022bafb92d73c4057be6 .
+niiri:06a391660f148983b073bfec11e5afdd prov:wasDerivedFrom niiri:8337790d11808f2fb788ee8093e46afe .
 
-niiri:89156d76de8aafb9c0d7504b45de19a1
+niiri:a1abcbfeadef1ab9d090cb0dfd0c65f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:0692b895967968b5ad50805b77073b6f ;
+    prov:atLocation niiri:6040359f287941d8765b5d153e53b7e8 ;
     prov:value "13.9779033660889"^^xsd:float ;
     nidm_equivalentZStatistic: "6.11142244434854"^^xsd:float ;
     nidm_pValueUncorrected: "4.93734941819923e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000102635598608014"^^xsd:float ;
     nidm_qValueFDR: "5.60210458059015e-06"^^xsd:float .
 
-niiri:0692b895967968b5ad50805b77073b6f
+niiri:6040359f287941d8765b5d153e53b7e8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-42,-76,-12]"^^xsd:string .
 
-niiri:89156d76de8aafb9c0d7504b45de19a1 prov:wasDerivedFrom niiri:0af3c1dadf9b022bafb92d73c4057be6 .
+niiri:a1abcbfeadef1ab9d090cb0dfd0c65f9 prov:wasDerivedFrom niiri:8337790d11808f2fb788ee8093e46afe .
 
-niiri:3cc1aa7c32068139da6b5f92edd82cb6
+niiri:f209e76751ccdefc0e9bde5e236ee184
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:5dfe29da2cb5f0c3c504895aeba5f33f ;
+    prov:atLocation niiri:feb1ef85bf7a38f519d22d70f35dd611 ;
     prov:value "10.3123865127563"^^xsd:float ;
     nidm_equivalentZStatistic: "5.1402197604635"^^xsd:float ;
     nidm_pValueUncorrected: "1.3720866187672e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0248386091747108"^^xsd:float ;
     nidm_qValueFDR: "0.000165827847161811"^^xsd:float .
 
-niiri:5dfe29da2cb5f0c3c504895aeba5f33f
+niiri:feb1ef85bf7a38f519d22d70f35dd611
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-20,-90,8]"^^xsd:string .
 
-niiri:3cc1aa7c32068139da6b5f92edd82cb6 prov:wasDerivedFrom niiri:0af3c1dadf9b022bafb92d73c4057be6 .
+niiri:f209e76751ccdefc0e9bde5e236ee184 prov:wasDerivedFrom niiri:8337790d11808f2fb788ee8093e46afe .
 
-niiri:92bb19c86792f383f51524cf04efcf6f
+niiri:f066c96dd3c7c0996c0629c5c10cdb17
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:9872f9d3dc8e27014ef5a3559e09b981 ;
+    prov:atLocation niiri:3183606049158bc6420e12358dd06fd9 ;
     prov:value "13.7427864074707"^^xsd:float ;
     nidm_equivalentZStatistic: "6.05489626279796"^^xsd:float ;
     nidm_pValueUncorrected: "7.02540914332417e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000146041348950021"^^xsd:float ;
     nidm_qValueFDR: "5.84165395800085e-06"^^xsd:float .
 
-niiri:9872f9d3dc8e27014ef5a3559e09b981
+niiri:3183606049158bc6420e12358dd06fd9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[22,-98,10]"^^xsd:string .
 
-niiri:92bb19c86792f383f51524cf04efcf6f prov:wasDerivedFrom niiri:1f6332db35b31af3ee6ca935dfaeba0c .
+niiri:f066c96dd3c7c0996c0629c5c10cdb17 prov:wasDerivedFrom niiri:2e44272daecb8718b2883f84f352fc62 .
 
-niiri:20e1e7c992a4871fb508554d0585da06
+niiri:69750f3f4beb1c6336b85f6351e576c5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:db23149ad95a1fe9c4c1cd4d7de870aa ;
+    prov:atLocation niiri:b63737d1991f399dbba4dd7ae8a8acec ;
     prov:value "12.7449989318848"^^xsd:float ;
     nidm_equivalentZStatistic: "5.80709618365418"^^xsd:float ;
     nidm_pValueUncorrected: "3.17828119378305e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000660688335281101"^^xsd:float ;
     nidm_qValueFDR: "1.54333527599919e-05"^^xsd:float .
 
-niiri:db23149ad95a1fe9c4c1cd4d7de870aa
+niiri:b63737d1991f399dbba4dd7ae8a8acec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[40,-76,-4]"^^xsd:string .
 
-niiri:20e1e7c992a4871fb508554d0585da06 prov:wasDerivedFrom niiri:1f6332db35b31af3ee6ca935dfaeba0c .
+niiri:69750f3f4beb1c6336b85f6351e576c5 prov:wasDerivedFrom niiri:2e44272daecb8718b2883f84f352fc62 .
 
-niiri:9b0669d94cf1e0b09df66fa7a674c7e3
+niiri:e91a1a3ae11967bf367aa53b9ee31c18
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:241eddcd45421fb2df8644ec543399de ;
+    prov:atLocation niiri:98e8748b9e902155aaca94b50263bba1 ;
     prov:value "11.9460592269897"^^xsd:float ;
     nidm_equivalentZStatistic: "5.59865646408728"^^xsd:float ;
     nidm_pValueUncorrected: "1.08009692301181e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00224526225660115"^^xsd:float ;
     nidm_qValueFDR: "3.11841980083494e-05"^^xsd:float .
 
-niiri:241eddcd45421fb2df8644ec543399de
+niiri:98e8748b9e902155aaca94b50263bba1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[36,-86,8]"^^xsd:string .
 
-niiri:9b0669d94cf1e0b09df66fa7a674c7e3 prov:wasDerivedFrom niiri:1f6332db35b31af3ee6ca935dfaeba0c .
+niiri:e91a1a3ae11967bf367aa53b9ee31c18 prov:wasDerivedFrom niiri:2e44272daecb8718b2883f84f352fc62 .
 
-niiri:fd3df422ba6b5a2312c81b7470fa4ce8
+niiri:e5c7f01e47c1fbb085b416d97ceddbba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:785ed6e870cebde278aee39c7b6befdd ;
+    prov:atLocation niiri:7f0badb64e663c1f3676cffc717236fa ;
     prov:value "10.8997001647949"^^xsd:float ;
     nidm_equivalentZStatistic: "5.31044487629651"^^xsd:float ;
     nidm_pValueUncorrected: "5.46789791222579e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0109446324802115"^^xsd:float ;
     nidm_qValueFDR: "8.7562484520721e-05"^^xsd:float .
 
-niiri:785ed6e870cebde278aee39c7b6befdd
+niiri:7f0badb64e663c1f3676cffc717236fa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[32,-66,32]"^^xsd:string .
 
-niiri:fd3df422ba6b5a2312c81b7470fa4ce8 prov:wasDerivedFrom niiri:0d4bf8c640cd15c305d2e49ef14b9ac6 .
+niiri:e5c7f01e47c1fbb085b416d97ceddbba prov:wasDerivedFrom niiri:c893d69da88fea01efe542f9787608c5 .
 
-niiri:53ee6d1cb132259d2b6100b015ee9dce
+niiri:2f7f807c988a3521e2049074aa842731
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:72b3ecc6501f7b746bb979c1808000d5 ;
+    prov:atLocation niiri:396e2c008744ecbc64a33278a34fcdbe ;
     prov:value "5.45807838439941"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39070148271528"^^xsd:float ;
     nidm_pValueUncorrected: "0.000348569950826771"^^xsd:float ;
     nidm_pValueFWER: "0.999999998685327"^^xsd:float ;
     nidm_qValueFDR: "0.0335543570769498"^^xsd:float .
 
-niiri:72b3ecc6501f7b746bb979c1808000d5
+niiri:396e2c008744ecbc64a33278a34fcdbe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[32,-74,38]"^^xsd:string .
 
-niiri:53ee6d1cb132259d2b6100b015ee9dce prov:wasDerivedFrom niiri:0d4bf8c640cd15c305d2e49ef14b9ac6 .
+niiri:2f7f807c988a3521e2049074aa842731 prov:wasDerivedFrom niiri:c893d69da88fea01efe542f9787608c5 .
 
-niiri:c8c92c4cb3dd742ebdf460a03d8ef227
+niiri:2726200f9b0dcba5079dca1eb1a27ebd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:b66031c85008481c6c52a889639df78f ;
+    prov:atLocation niiri:575563e9436156ad59d10591a352d56d ;
     prov:value "10.0041055679321"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04819646859005"^^xsd:float ;
     nidm_pValueUncorrected: "2.23000182986155e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0380835451252286"^^xsd:float ;
     nidm_qValueFDR: "0.000232018725953295"^^xsd:float .
 
-niiri:b66031c85008481c6c52a889639df78f
+niiri:575563e9436156ad59d10591a352d56d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-30,-74,26]"^^xsd:string .
 
-niiri:c8c92c4cb3dd742ebdf460a03d8ef227 prov:wasDerivedFrom niiri:32439b88059be589d0e2a8586ea799ec .
+niiri:2726200f9b0dcba5079dca1eb1a27ebd prov:wasDerivedFrom niiri:fafaf22f396d11e8355f5d1e7a7367ea .
 
-niiri:915c8684b1426b41a850e906a6cb7e51
+niiri:432182ae1dd08fbc638748dae384100d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:fc9bb7ec98d0292b3cf09ece5735cbf7 ;
+    prov:atLocation niiri:49cfb4906f7511441f7faddc5a5b8413 ;
     prov:value "9.62718677520752"^^xsd:float ;
     nidm_equivalentZStatistic: "4.933015925023"^^xsd:float ;
     nidm_pValueUncorrected: "4.04847753543436e-07"^^xsd:float ;
     nidm_pValueFWER: "0.063890884133409"^^xsd:float ;
     nidm_qValueFDR: "0.000364320989617512"^^xsd:float .
 
-niiri:fc9bb7ec98d0292b3cf09ece5735cbf7
+niiri:49cfb4906f7511441f7faddc5a5b8413
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-42,24,20]"^^xsd:string .
 
-niiri:915c8684b1426b41a850e906a6cb7e51 prov:wasDerivedFrom niiri:d8b9846e25000609adbc385c634a1be0 .
+niiri:432182ae1dd08fbc638748dae384100d prov:wasDerivedFrom niiri:0820636de884fe0d783c5385916ab101 .
 
-niiri:50922e240192f8efd5ba7edc5395921e
+niiri:85988a2f55e19fb0932bdaac88d56310
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:0090ece1129de1a64a6093a76eead257 ;
+    prov:atLocation niiri:53ed64c5e6de9d8d444e92f8219ed73e ;
     prov:value "8.07208061218262"^^xsd:float ;
     nidm_equivalentZStatistic: "4.42255808855286"^^xsd:float ;
     nidm_pValueUncorrected: "4.87695566220303e-06"^^xsd:float ;
     nidm_pValueFWER: "0.443484796305441"^^xsd:float ;
     nidm_qValueFDR: "0.00197238230997959"^^xsd:float .
 
-niiri:0090ece1129de1a64a6093a76eead257
+niiri:53ed64c5e6de9d8d444e92f8219ed73e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-50,28,22]"^^xsd:string .
 
-niiri:50922e240192f8efd5ba7edc5395921e prov:wasDerivedFrom niiri:d8b9846e25000609adbc385c634a1be0 .
+niiri:85988a2f55e19fb0932bdaac88d56310 prov:wasDerivedFrom niiri:0820636de884fe0d783c5385916ab101 .
 
-niiri:7d5e6a7fd65e7845a2f6021bbbfe1474
+niiri:b4e90605b1ad8e708a5878d78afbd5df
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:a94285933cf50e277523e5b72912eebe ;
+    prov:atLocation niiri:7191009d584b787e22408325fb584516 ;
     prov:value "9.20645141601562"^^xsd:float ;
     nidm_equivalentZStatistic: "4.80076510146651"^^xsd:float ;
     nidm_pValueUncorrected: "7.90302914999153e-07"^^xsd:float ;
     nidm_pValueFWER: "0.112525268059434"^^xsd:float ;
     nidm_qValueFDR: "0.000576835659463966"^^xsd:float .
 
-niiri:a94285933cf50e277523e5b72912eebe
+niiri:7191009d584b787e22408325fb584516
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[-50,8,42]"^^xsd:string .
 
-niiri:7d5e6a7fd65e7845a2f6021bbbfe1474 prov:wasDerivedFrom niiri:f8e22d4c567142a3ab813140dd91551e .
+niiri:b4e90605b1ad8e708a5878d78afbd5df prov:wasDerivedFrom niiri:1e3c8c027b813bda7df5358a8ab4f63a .
 
-niiri:48d52b482ad32267090b771eef9d8a13
+niiri:18479155c0b9f7007a2606ee355335a9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:3f8983479e0d587591c1816f757bfb40 ;
+    prov:atLocation niiri:8563cb38a4e5f284711af2f862727bd9 ;
     prov:value "7.18871355056763"^^xsd:float ;
     nidm_equivalentZStatistic: "4.10255932739581"^^xsd:float ;
     nidm_pValueUncorrected: "2.04302517635702e-05"^^xsd:float ;
     nidm_pValueFWER: "0.864381142749573"^^xsd:float ;
     nidm_qValueFDR: "0.00518559511521378"^^xsd:float .
 
-niiri:3f8983479e0d587591c1816f757bfb40
+niiri:8563cb38a4e5f284711af2f862727bd9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-52,2,48]"^^xsd:string .
 
-niiri:48d52b482ad32267090b771eef9d8a13 prov:wasDerivedFrom niiri:f8e22d4c567142a3ab813140dd91551e .
+niiri:18479155c0b9f7007a2606ee355335a9 prov:wasDerivedFrom niiri:1e3c8c027b813bda7df5358a8ab4f63a .
 
-niiri:6bc27ded8e7208b5260f9cfa18a8c8c7
+niiri:d3c08577d483b22d049b7eb0c6572b7f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:a58791ee2a73dbe92a31d79f5a887db7 ;
+    prov:atLocation niiri:cbf1b8ec0d607ae0da2d1270f1e5401a ;
     prov:value "8.94470500946045"^^xsd:float ;
     nidm_equivalentZStatistic: "4.71641138081763"^^xsd:float ;
     nidm_pValueUncorrected: "1.20020424165812e-06"^^xsd:float ;
     nidm_pValueFWER: "0.158435738485403"^^xsd:float ;
     nidm_qValueFDR: "0.000760651849406736"^^xsd:float .
 
-niiri:a58791ee2a73dbe92a31d79f5a887db7
+niiri:cbf1b8ec0d607ae0da2d1270f1e5401a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-24,-64,66]"^^xsd:string .
 
-niiri:6bc27ded8e7208b5260f9cfa18a8c8c7 prov:wasDerivedFrom niiri:96a2e290f72fc28530510650c52e2805 .
+niiri:d3c08577d483b22d049b7eb0c6572b7f prov:wasDerivedFrom niiri:e24e457b7371fd1bac7d4cb391bb9432 .
 
-niiri:3f894ae7abee049abdc170030b86694a
+niiri:b22647ec49d2b0b297e2ac1f30758018
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:5ee690d78930edfd59a3872c7c5bbdaf ;
+    prov:atLocation niiri:26c07862039b52fa08db4cc5880af9e4 ;
     prov:value "7.5668888092041"^^xsd:float ;
     nidm_equivalentZStatistic: "4.24258939908316"^^xsd:float ;
     nidm_pValueUncorrected: "1.10477738578529e-05"^^xsd:float ;
     nidm_pValueFWER: "0.693995702855766"^^xsd:float ;
     nidm_qValueFDR: "0.0033973072847523"^^xsd:float .
 
-niiri:5ee690d78930edfd59a3872c7c5bbdaf
+niiri:26c07862039b52fa08db4cc5880af9e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-32,-56,62]"^^xsd:string .
 
-niiri:3f894ae7abee049abdc170030b86694a prov:wasDerivedFrom niiri:96a2e290f72fc28530510650c52e2805 .
+niiri:b22647ec49d2b0b297e2ac1f30758018 prov:wasDerivedFrom niiri:e24e457b7371fd1bac7d4cb391bb9432 .
 
-niiri:8aed68850a4238bd9003356dee5c1046
+niiri:17cf8165ad43953b2998aec1ca9ddd0f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:fa9d9d6751bc279dd4c31bcc4b3c5b6f ;
+    prov:atLocation niiri:2945a0dad8e64bb13fdb60092f3a3334 ;
     prov:value "8.42212200164795"^^xsd:float ;
     nidm_equivalentZStatistic: "4.54288070436711"^^xsd:float ;
     nidm_pValueUncorrected: "2.77453287811369e-06"^^xsd:float ;
     nidm_pValueFWER: "0.301737952159247"^^xsd:float ;
     nidm_qValueFDR: "0.00135672565933354"^^xsd:float .
 
-niiri:fa9d9d6751bc279dd4c31bcc4b3c5b6f
+niiri:2945a0dad8e64bb13fdb60092f3a3334
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[22,-52,4]"^^xsd:string .
 
-niiri:8aed68850a4238bd9003356dee5c1046 prov:wasDerivedFrom niiri:1062efea331d3022773f16c049f8543d .
+niiri:17cf8165ad43953b2998aec1ca9ddd0f prov:wasDerivedFrom niiri:2f5fcfc4453f648ede4260a16cff5960 .
 
-niiri:17a00ab62ce14cefa4ccb65ef36cb0a3
+niiri:8a3dd8fbf2b47192a3e6b6d6690a00b5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:2e878a68f59b4166e7af126a1d092dd7 ;
+    prov:atLocation niiri:f4392121feaef697f908988f9d45a7b3 ;
     prov:value "8.14441299438477"^^xsd:float ;
     nidm_equivalentZStatistic: "4.44770400954001"^^xsd:float ;
     nidm_pValueUncorrected: "4.33965069324138e-06"^^xsd:float ;
     nidm_pValueFWER: "0.411238149698711"^^xsd:float ;
     nidm_qValueFDR: "0.00180683059312593"^^xsd:float .
 
-niiri:2e878a68f59b4166e7af126a1d092dd7
+niiri:f4392121feaef697f908988f9d45a7b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-36,-54,-22]"^^xsd:string .
 
-niiri:17a00ab62ce14cefa4ccb65ef36cb0a3 prov:wasDerivedFrom niiri:5577dc13c7013d8bb90b8dd111792d46 .
+niiri:8a3dd8fbf2b47192a3e6b6d6690a00b5 prov:wasDerivedFrom niiri:dbbddbece734ef2c5ed154985b15ffe8 .
 
-niiri:df246b9f6ad9be0fa1598d6017c22c17
+niiri:b173db6dde57bc22f0de6bac75f47a5e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:dbfef4bdf74855624e49b48413b48527 ;
+    prov:atLocation niiri:9f0f16d82e93cbe816f1c8f4ac5e2aa9 ;
     prov:value "7.75212860107422"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30948435197428"^^xsd:float ;
     nidm_pValueUncorrected: "8.18178178840778e-06"^^xsd:float ;
     nidm_pValueFWER: "0.599664226758408"^^xsd:float ;
     nidm_qValueFDR: "0.00278317762946249"^^xsd:float .
 
-niiri:dbfef4bdf74855624e49b48413b48527
+niiri:9f0f16d82e93cbe816f1c8f4ac5e2aa9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[10,-66,-50]"^^xsd:string .
 
-niiri:df246b9f6ad9be0fa1598d6017c22c17 prov:wasDerivedFrom niiri:64ae5737521bbc7fe14f0c862379e927 .
+niiri:b173db6dde57bc22f0de6bac75f47a5e prov:wasDerivedFrom niiri:6aecc2d95fe5ba4cd2d39d16afe85407 .
 
-niiri:0f733836ed39e3d5c7c881ba1d4b0f3c
+niiri:956544123ed8213df5fbc7f8d6973e3c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:2d648076c6516fc9f5b180d7e46bd38d ;
+    prov:atLocation niiri:c5abac533b273ee4b7bab22f1b00ed76 ;
     prov:value "6.59869337081909"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87398612970452"^^xsd:float ;
     nidm_pValueUncorrected: "5.35347545974618e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988687386127249"^^xsd:float ;
     nidm_qValueFDR: "0.0099990013840748"^^xsd:float .
 
-niiri:2d648076c6516fc9f5b180d7e46bd38d
+niiri:c5abac533b273ee4b7bab22f1b00ed76
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[26,-72,-50]"^^xsd:string .
 
-niiri:0f733836ed39e3d5c7c881ba1d4b0f3c prov:wasDerivedFrom niiri:64ae5737521bbc7fe14f0c862379e927 .
+niiri:956544123ed8213df5fbc7f8d6973e3c prov:wasDerivedFrom niiri:6aecc2d95fe5ba4cd2d39d16afe85407 .
 
-niiri:fccb01f20ca9740796a77be1dc284607
+niiri:f4dea2e696793591088d280fed0f0584
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:de5ae9445107927a2f321f5cb43d375a ;
+    prov:atLocation niiri:e2a291ea227f61911be316ee6108a55f ;
     prov:value "6.09796094894409"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6691747416434"^^xsd:float ;
     nidm_pValueUncorrected: "0.000121667358184974"^^xsd:float ;
     nidm_pValueFWER: "0.999849800966092"^^xsd:float ;
     nidm_qValueFDR: "0.0170443244379802"^^xsd:float .
 
-niiri:de5ae9445107927a2f321f5cb43d375a
+niiri:e2a291ea227f61911be316ee6108a55f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[16,-72,-50]"^^xsd:string .
 
-niiri:fccb01f20ca9740796a77be1dc284607 prov:wasDerivedFrom niiri:64ae5737521bbc7fe14f0c862379e927 .
+niiri:f4dea2e696793591088d280fed0f0584 prov:wasDerivedFrom niiri:6aecc2d95fe5ba4cd2d39d16afe85407 .
 
-niiri:73c78b95c93f862d2d03440138b1b31d
+niiri:d88a4b6a1eb63bac84a9f87e0794ba20
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:f70e1a4652c056f2ce720d0c047e4050 ;
+    prov:atLocation niiri:2281a2b45d8f90027211445c926232e2 ;
     prov:value "7.67598438262939"^^xsd:float ;
     nidm_equivalentZStatistic: "4.28211703257948"^^xsd:float ;
     nidm_pValueUncorrected: "9.25617831770698e-06"^^xsd:float ;
     nidm_pValueFWER: "0.638571937641115"^^xsd:float ;
     nidm_qValueFDR: "0.00302106969058158"^^xsd:float .
 
-niiri:f70e1a4652c056f2ce720d0c047e4050
+niiri:2281a2b45d8f90027211445c926232e2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[42,-22,66]"^^xsd:string .
 
-niiri:73c78b95c93f862d2d03440138b1b31d prov:wasDerivedFrom niiri:900846b4c16bba4a9b8a34762cba2da0 .
+niiri:d88a4b6a1eb63bac84a9f87e0794ba20 prov:wasDerivedFrom niiri:a9c284c82bc4ef4eba48570f53c9c9c4 .
 
-niiri:b6efabc36e950249575e4d4ac70621f0
+niiri:bfba970dca807cd42c369bc26d27f3eb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:4dbfbaac273513d9f226876fdf8b306f ;
+    prov:atLocation niiri:3253ad166d45aa411a00a879e94115b6 ;
     prov:value "6.16005897521973"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6951610937944"^^xsd:float ;
     nidm_pValueUncorrected: "0.000109873708078023"^^xsd:float ;
     nidm_pValueFWER: "0.999696971784475"^^xsd:float ;
     nidm_qValueFDR: "0.0160177852706299"^^xsd:float .
 
-niiri:4dbfbaac273513d9f226876fdf8b306f
+niiri:3253ad166d45aa411a00a879e94115b6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[48,-18,62]"^^xsd:string .
 
-niiri:b6efabc36e950249575e4d4ac70621f0 prov:wasDerivedFrom niiri:900846b4c16bba4a9b8a34762cba2da0 .
+niiri:bfba970dca807cd42c369bc26d27f3eb prov:wasDerivedFrom niiri:a9c284c82bc4ef4eba48570f53c9c9c4 .
 
-niiri:ce78c1d328ebf373304efd0ad0d63b55
+niiri:70cf11cb9bc7570fce0e5ed7c0993493
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:b48d465b5d910dd4c05a26a988a8418b ;
+    prov:atLocation niiri:73acbe399f2ef5551e28416ff0886e25 ;
     prov:value "7.57218790054321"^^xsd:float ;
     nidm_equivalentZStatistic: "4.24451811148991"^^xsd:float ;
     nidm_pValueUncorrected: "1.09531837353405e-05"^^xsd:float ;
     nidm_pValueFWER: "0.691329596120285"^^xsd:float ;
     nidm_qValueFDR: "0.00338801480937036"^^xsd:float .
 
-niiri:b48d465b5d910dd4c05a26a988a8418b
+niiri:73acbe399f2ef5551e28416ff0886e25
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[30,-36,-22]"^^xsd:string .
 
-niiri:ce78c1d328ebf373304efd0ad0d63b55 prov:wasDerivedFrom niiri:7ede1db6987922a4806abc265aecda62 .
+niiri:70cf11cb9bc7570fce0e5ed7c0993493 prov:wasDerivedFrom niiri:0637af2e34d8b1c842ae7d1386357498 .
 
-niiri:1cd13c2942d906be09937adb3135674a
+niiri:a37c7f3e671f54bf1aeb9e2159fc0ead
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:4c8fbc4e92f73c6bb61d3f66d9c3c99e ;
+    prov:atLocation niiri:44277e00fc4cc3cf8ea164e5d184e84d ;
     prov:value "7.4740514755249"^^xsd:float ;
     nidm_equivalentZStatistic: "4.20865253327564"^^xsd:float ;
     nidm_pValueUncorrected: "1.28449040975864e-05"^^xsd:float ;
     nidm_pValueFWER: "0.739935004547452"^^xsd:float ;
     nidm_qValueFDR: "0.00374497115452541"^^xsd:float .
 
-niiri:4c8fbc4e92f73c6bb61d3f66d9c3c99e
+niiri:44277e00fc4cc3cf8ea164e5d184e84d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[22,-70,60]"^^xsd:string .
 
-niiri:1cd13c2942d906be09937adb3135674a prov:wasDerivedFrom niiri:9287b2a8106c3ffe3abf93837cfbd61c .
+niiri:a37c7f3e671f54bf1aeb9e2159fc0ead prov:wasDerivedFrom niiri:1cd4117828f514ec0fff4b67f780d6b9 .
 
-niiri:3121dd1ff9adac7ae75e440df583fb9d
+niiri:95b5e8d1b0a6b737f8baac185d017d03
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:939c1c6e7eee0ff04a1bae0f1e2b3a44 ;
+    prov:atLocation niiri:bcdd17c062f969757a86cbe2d236afea ;
     prov:value "7.42476272583008"^^xsd:float ;
     nidm_equivalentZStatistic: "4.19052086074216"^^xsd:float ;
     nidm_pValueUncorrected: "1.39157412012425e-05"^^xsd:float ;
     nidm_pValueFWER: "0.76353829505901"^^xsd:float ;
     nidm_qValueFDR: "0.00397904916843096"^^xsd:float .
 
-niiri:939c1c6e7eee0ff04a1bae0f1e2b3a44
+niiri:bcdd17c062f969757a86cbe2d236afea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[14,-44,-2]"^^xsd:string .
 
-niiri:3121dd1ff9adac7ae75e440df583fb9d prov:wasDerivedFrom niiri:c515278968596a92906ae29ffad63511 .
+niiri:95b5e8d1b0a6b737f8baac185d017d03 prov:wasDerivedFrom niiri:d85063f48080f770ca548748f7419e12 .
 
-niiri:2cde520c847515e95346b9608b4b29b1
+niiri:376402188bdf566830cafa900c2e2777
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:fec739a9148832b2f9f9f6df4c90ef60 ;
+    prov:atLocation niiri:40631caf86fdb1eb06dd8fb89e5e0cdf ;
     prov:value "7.41156482696533"^^xsd:float ;
     nidm_equivalentZStatistic: "4.1856522195161"^^xsd:float ;
     nidm_pValueUncorrected: "1.42174217934166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.76974170216107"^^xsd:float ;
     nidm_qValueFDR: "0.00404779744790916"^^xsd:float .
 
-niiri:fec739a9148832b2f9f9f6df4c90ef60
+niiri:40631caf86fdb1eb06dd8fb89e5e0cdf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[0,-22,66]"^^xsd:string .
 
-niiri:2cde520c847515e95346b9608b4b29b1 prov:wasDerivedFrom niiri:0493a379c4735cda662e56229168b8a9 .
+niiri:376402188bdf566830cafa900c2e2777 prov:wasDerivedFrom niiri:ec3fc3cfa0c303c00f68f5986e44044e .
 
-niiri:435b54b1b98826b7c51b454f604d72e2
+niiri:e7535b3f1b2924d6cc2cc7dd1021e6ff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:f5083c9588b5eb1d38e2b68f14c48ec5 ;
+    prov:atLocation niiri:1009ccfd64bd14bdf04f231ec38d83db ;
     prov:value "7.3316125869751"^^xsd:float ;
     nidm_equivalentZStatistic: "4.15603434431885"^^xsd:float ;
     nidm_pValueUncorrected: "1.61909583913378e-05"^^xsd:float ;
     nidm_pValueFWER: "0.806071531912271"^^xsd:float ;
     nidm_qValueFDR: "0.00442558415624652"^^xsd:float .
 
-niiri:f5083c9588b5eb1d38e2b68f14c48ec5
+niiri:1009ccfd64bd14bdf04f231ec38d83db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-40,-26,-22]"^^xsd:string .
 
-niiri:435b54b1b98826b7c51b454f604d72e2 prov:wasDerivedFrom niiri:6f915c93d573d9f832d05fb003dcbfb0 .
+niiri:e7535b3f1b2924d6cc2cc7dd1021e6ff prov:wasDerivedFrom niiri:23c6e94e6643122dcb458402a972758e .
 
-niiri:ff2cc94456764baf2e5e407f30f996e8
+niiri:e8318652b9767749a7b94884a6faf52e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:bfdee7cfc8fffe98250a78af5abdc715 ;
+    prov:atLocation niiri:62333962f96d79e4ca7c4f1585c5e395 ;
     prov:value "7.15871143341064"^^xsd:float ;
     nidm_equivalentZStatistic: "4.09124266610495"^^xsd:float ;
     nidm_pValueUncorrected: "2.14533936502281e-05"^^xsd:float ;
     nidm_pValueFWER: "0.875348981068006"^^xsd:float ;
     nidm_qValueFDR: "0.00534735431216318"^^xsd:float .
 
-niiri:bfdee7cfc8fffe98250a78af5abdc715
+niiri:62333962f96d79e4ca7c4f1585c5e395
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[-48,-42,58]"^^xsd:string .
 
-niiri:ff2cc94456764baf2e5e407f30f996e8 prov:wasDerivedFrom niiri:2344710a34a75f050910ebd48e1159af .
+niiri:e8318652b9767749a7b94884a6faf52e prov:wasDerivedFrom niiri:68f9a66ca71f514199366c398a2831ab .
 
-niiri:1d8688390cefe3ad6af53ca62e203d1f
+niiri:79db57175bcf213e5f77bd451afdb6fe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:05d5987ec004e7f8a055c0e0f8991383 ;
+    prov:atLocation niiri:4601ef775986b40077d71682573b43a7 ;
     prov:value "7.11809158325195"^^xsd:float ;
     nidm_equivalentZStatistic: "4.075870818357"^^xsd:float ;
     nidm_pValueUncorrected: "2.29212322924166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.889420975253515"^^xsd:float ;
     nidm_qValueFDR: "0.00557942469794563"^^xsd:float .
 
-niiri:05d5987ec004e7f8a055c0e0f8991383
+niiri:4601ef775986b40077d71682573b43a7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-40,-34,66]"^^xsd:string .
 
-niiri:1d8688390cefe3ad6af53ca62e203d1f prov:wasDerivedFrom niiri:a904380f9b13e67a2253c5f952a57f9f .
+niiri:79db57175bcf213e5f77bd451afdb6fe prov:wasDerivedFrom niiri:6f303953fe538a2a99d9b754b92e311e .
 
-niiri:458ec12f9ad36a91b5eaa2f1aae4c164
+niiri:36ca195508a8e637007acd8f768fa1c9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:7021fdf0169b26db50952433ad70adc0 ;
+    prov:atLocation niiri:9ca689f733bdaa0f890c8fe7e51b6224 ;
     prov:value "7.07621002197266"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05996049269805"^^xsd:float ;
     nidm_pValueUncorrected: "2.45405099345009e-05"^^xsd:float ;
     nidm_pValueFWER: "0.902960652497904"^^xsd:float ;
     nidm_qValueFDR: "0.00587047829619361"^^xsd:float .
 
-niiri:7021fdf0169b26db50952433ad70adc0
+niiri:9ca689f733bdaa0f890c8fe7e51b6224
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-28,-64,36]"^^xsd:string .
 
-niiri:458ec12f9ad36a91b5eaa2f1aae4c164 prov:wasDerivedFrom niiri:8348fc8e7248e46840dad7df7f8763bf .
+niiri:36ca195508a8e637007acd8f768fa1c9 prov:wasDerivedFrom niiri:b32513dc3cebea135a4227a2ff2989c6 .
 
-niiri:d4cd299a7933f93390ebcea529b036b0
+niiri:93964149cf1de70007b3d65bb04b9cd8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:000b610104b25fcabfd24c7ac9c414e9 ;
+    prov:atLocation niiri:bfbd55e8f2473bad1c11d7526e7f8cbb ;
     prov:value "6.77566051483154"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94391444392688"^^xsd:float ;
     nidm_pValueUncorrected: "4.0081133562353e-05"^^xsd:float ;
     nidm_pValueFWER: "0.970449378854534"^^xsd:float ;
     nidm_qValueFDR: "0.0083237489519884"^^xsd:float .
 
-niiri:000b610104b25fcabfd24c7ac9c414e9
+niiri:bfbd55e8f2473bad1c11d7526e7f8cbb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[56,-14,52]"^^xsd:string .
 
-niiri:d4cd299a7933f93390ebcea529b036b0 prov:wasDerivedFrom niiri:db6eb647802a5fc531c369aa668af574 .
+niiri:93964149cf1de70007b3d65bb04b9cd8 prov:wasDerivedFrom niiri:b7301eccecd4c049bbeed4467b530024 .
 
-niiri:c18aee0f08a51ffb9a71f22087ef50c5
+niiri:3e906297c3e2890ce6abb1f2cb9be561
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:58fc0101181c3b004a7dd3b51e2ceb83 ;
+    prov:atLocation niiri:c0d2a2f16c1d44209d3e0ceba1cc405d ;
     prov:value "6.75197219848633"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9346244929229"^^xsd:float ;
     nidm_pValueUncorrected: "4.16634347842892e-05"^^xsd:float ;
     nidm_pValueFWER: "0.973679338420771"^^xsd:float ;
     nidm_qValueFDR: "0.00848286835858746"^^xsd:float .
 
-niiri:58fc0101181c3b004a7dd3b51e2ceb83
+niiri:c0d2a2f16c1d44209d3e0ceba1cc405d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-40,56,6]"^^xsd:string .
 
-niiri:c18aee0f08a51ffb9a71f22087ef50c5 prov:wasDerivedFrom niiri:efddc25357ec7a4b9a063a62f5a2c864 .
+niiri:3e906297c3e2890ce6abb1f2cb9be561 prov:wasDerivedFrom niiri:765e5201ffb06ca1f162ea8d7d3f0abd .
 
-niiri:94d6c08508093e713ac4415d0a932884
+niiri:e0515f336cbd787507ad3edf70116d4e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:bf7aac775c73f4c943e7eaf5e718d980 ;
+    prov:atLocation niiri:9c7564398039623209ebb464e1410345 ;
     prov:value "5.62889766693115"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4670438729023"^^xsd:float ;
     nidm_pValueUncorrected: "0.000263107996845591"^^xsd:float ;
     nidm_pValueFWER: "0.999999922471127"^^xsd:float ;
     nidm_qValueFDR: "0.0280636167791234"^^xsd:float .
 
-niiri:bf7aac775c73f4c943e7eaf5e718d980
+niiri:9c7564398039623209ebb464e1410345
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-34,62,8]"^^xsd:string .
 
-niiri:94d6c08508093e713ac4415d0a932884 prov:wasDerivedFrom niiri:efddc25357ec7a4b9a063a62f5a2c864 .
+niiri:e0515f336cbd787507ad3edf70116d4e prov:wasDerivedFrom niiri:765e5201ffb06ca1f162ea8d7d3f0abd .
 
-niiri:68ee8476808402fcd35123f92e1fe86d
+niiri:68d840be62a1d1171faf588a66b45a69
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:97631cb919ed750fce6fd5369d603724 ;
+    prov:atLocation niiri:9020819036c441bf53457a8d05805fd2 ;
     prov:value "6.72361373901367"^^xsd:float ;
     nidm_equivalentZStatistic: "3.92347467532863"^^xsd:float ;
     nidm_pValueUncorrected: "4.3640471964479e-05"^^xsd:float ;
     nidm_pValueFWER: "0.977197537328254"^^xsd:float ;
     nidm_qValueFDR: "0.00877369894078824"^^xsd:float .
 
-niiri:97631cb919ed750fce6fd5369d603724
+niiri:9020819036c441bf53457a8d05805fd2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-4,-52,6]"^^xsd:string .
 
-niiri:68ee8476808402fcd35123f92e1fe86d prov:wasDerivedFrom niiri:92832eb3b91834fca357233c33e92d47 .
+niiri:68d840be62a1d1171faf588a66b45a69 prov:wasDerivedFrom niiri:aeb5ca84ea986c7559b385b24d2806c0 .
 
-niiri:97c0b234b24d4cfa8426c9b127f1426a
+niiri:fa083ea775134c459dc1bb371ed1dded
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:07a69af261f8c7ce9c1e9223b91c2b3f ;
+    prov:atLocation niiri:4ead7fcdda63c83da247a2a82f447618 ;
     prov:value "5.89449167251587"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58279190167641"^^xsd:float ;
     nidm_pValueUncorrected: "0.000169970706923372"^^xsd:float ;
     nidm_pValueFWER: "0.999990278549049"^^xsd:float ;
     nidm_qValueFDR: "0.0210834330463974"^^xsd:float .
 
-niiri:07a69af261f8c7ce9c1e9223b91c2b3f
+niiri:4ead7fcdda63c83da247a2a82f447618
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-8,-56,0]"^^xsd:string .
 
-niiri:97c0b234b24d4cfa8426c9b127f1426a prov:wasDerivedFrom niiri:92832eb3b91834fca357233c33e92d47 .
+niiri:fa083ea775134c459dc1bb371ed1dded prov:wasDerivedFrom niiri:aeb5ca84ea986c7559b385b24d2806c0 .
 
-niiri:208bd0fa9e65bd7ecda2f9025fbf5026
+niiri:bc11584c2cc9c15970a76804b11b842b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:8a98506f0a361325cf3279d2ee5df080 ;
+    prov:atLocation niiri:6f14c51367b87703537f776c0c0dbdf5 ;
     prov:value "6.7043924331665"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91589968256295"^^xsd:float ;
     nidm_pValueUncorrected: "4.5033848123488e-05"^^xsd:float ;
     nidm_pValueFWER: "0.979375630051391"^^xsd:float ;
     nidm_qValueFDR: "0.00887748685076858"^^xsd:float .
 
-niiri:8a98506f0a361325cf3279d2ee5df080
+niiri:6f14c51367b87703537f776c0c0dbdf5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[50,-64,-6]"^^xsd:string .
 
-niiri:208bd0fa9e65bd7ecda2f9025fbf5026 prov:wasDerivedFrom niiri:27a928cca18b5d563bf58797f306d0e0 .
+niiri:bc11584c2cc9c15970a76804b11b842b prov:wasDerivedFrom niiri:d36b472817f6888ac2860c8f78cda4e9 .
 
-niiri:b0078cef21c117e25080fc7b68a2e9f6
+niiri:8975ccf5a69b1e5ce196d5d0e24ee229
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:4b3286c3a11f909de28869ea7523656c ;
+    prov:atLocation niiri:c035e1c674ce2f5002c7510f276ba0d9 ;
     prov:value "6.67913484573364"^^xsd:float ;
     nidm_equivalentZStatistic: "3.90592399967592"^^xsd:float ;
     nidm_pValueUncorrected: "4.6933006303207e-05"^^xsd:float ;
     nidm_pValueFWER: "0.981996459937482"^^xsd:float ;
     nidm_qValueFDR: "0.00914383746051283"^^xsd:float .
 
-niiri:4b3286c3a11f909de28869ea7523656c
+niiri:c035e1c674ce2f5002c7510f276ba0d9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-34,-40,36]"^^xsd:string .
 
-niiri:b0078cef21c117e25080fc7b68a2e9f6 prov:wasDerivedFrom niiri:9197197694f96c553e0e78334284b0c7 .
+niiri:8975ccf5a69b1e5ce196d5d0e24ee229 prov:wasDerivedFrom niiri:e1375ee26540e9328da498ca97a69cb4 .
 
-niiri:51561d272cfbd20b578e0d0cb999769c
+niiri:e667e51e095b6fa110b25e9400332357
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:7391c47b3ce0a5295cfbe1d0b7dfa35c ;
+    prov:atLocation niiri:d10ee59dc87f8fe64f5ed1f2ea11a4cd ;
     prov:value "6.64170026779175"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89109301638303"^^xsd:float ;
     nidm_pValueUncorrected: "4.98968323957572e-05"^^xsd:float ;
     nidm_pValueFWER: "0.985407255166263"^^xsd:float ;
     nidm_qValueFDR: "0.00949872959107623"^^xsd:float .
 
-niiri:7391c47b3ce0a5295cfbe1d0b7dfa35c
+niiri:d10ee59dc87f8fe64f5ed1f2ea11a4cd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[22,10,-12]"^^xsd:string .
 
-niiri:51561d272cfbd20b578e0d0cb999769c prov:wasDerivedFrom niiri:4babeddab7c30570f5f7bca47ad8e349 .
+niiri:e667e51e095b6fa110b25e9400332357 prov:wasDerivedFrom niiri:d5f1c18934146a18337779acd9486123 .
 
-niiri:462393ac68491f3db8a262b5078fc9a9
+niiri:1221262de1e5620b40e4bdfbdeb36776
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:86657e11e856b1fdbc9692e7270e9f36 ;
+    prov:atLocation niiri:843685ded7e6608a0699d60b38b277bd ;
     prov:value "5.66292333602905"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48206928174656"^^xsd:float ;
     nidm_pValueUncorrected: "0.000248777471726358"^^xsd:float ;
     nidm_pValueFWER: "0.999999841793879"^^xsd:float ;
     nidm_qValueFDR: "0.0270792144117247"^^xsd:float .
 
-niiri:86657e11e856b1fdbc9692e7270e9f36
+niiri:843685ded7e6608a0699d60b38b277bd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[22,10,2]"^^xsd:string .
 
-niiri:462393ac68491f3db8a262b5078fc9a9 prov:wasDerivedFrom niiri:4babeddab7c30570f5f7bca47ad8e349 .
+niiri:1221262de1e5620b40e4bdfbdeb36776 prov:wasDerivedFrom niiri:d5f1c18934146a18337779acd9486123 .
 
-niiri:662a754e5ebb07a4f3658f0ab369277c
+niiri:b35552ce359f982307861566bbcc356c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:dce98efb340c18452b3198b7a9d43ec6 ;
+    prov:atLocation niiri:769e88496004ebf67fff73d31693db58 ;
     prov:value "6.58932304382324"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87024913662237"^^xsd:float ;
     nidm_pValueUncorrected: "5.43620931486855e-05"^^xsd:float ;
     nidm_pValueFWER: "0.9893188063809"^^xsd:float ;
     nidm_qValueFDR: "0.0101197978315716"^^xsd:float .
 
-niiri:dce98efb340c18452b3198b7a9d43ec6
+niiri:769e88496004ebf67fff73d31693db58
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[16,-8,20]"^^xsd:string .
 
-niiri:662a754e5ebb07a4f3658f0ab369277c prov:wasDerivedFrom niiri:abcdfa125cb9a6705001908f8633bf90 .
+niiri:b35552ce359f982307861566bbcc356c prov:wasDerivedFrom niiri:275de6b748d7ad0f11eed3004edbf892 .
 
-niiri:21f4ad1561991121f81c93c4a406ef8b
+niiri:0d369bc39b99736fd4f8e779bf6ac134
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:ea0358caee1ca0292b7b7a8d309dd06c ;
+    prov:atLocation niiri:f6c77de876bf3849b6cec31bea5642c4 ;
     prov:value "6.53873300552368"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8500124840786"^^xsd:float ;
     nidm_pValueUncorrected: "5.90559022480841e-05"^^xsd:float ;
     nidm_pValueFWER: "0.992265133018752"^^xsd:float ;
     nidm_qValueFDR: "0.0107045232421608"^^xsd:float .
 
-niiri:ea0358caee1ca0292b7b7a8d309dd06c
+niiri:f6c77de876bf3849b6cec31bea5642c4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[28,-48,72]"^^xsd:string .
 
-niiri:21f4ad1561991121f81c93c4a406ef8b prov:wasDerivedFrom niiri:2583f6b74e4ca256d5338bb9b9f07a29 .
+niiri:0d369bc39b99736fd4f8e779bf6ac134 prov:wasDerivedFrom niiri:2dd4cb8812c93538b5902225b29e0471 .
 
-niiri:1babf001e3351aeb7fac6dc5454363cc
+niiri:203aed58b8f81dce0ecac8be5e863bda
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:a42f9f1e579000b2dc77292a8cf2acb7 ;
+    prov:atLocation niiri:219472c226c1003f926096d10ddea706 ;
     prov:value "6.41633129119873"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80061969992356"^^xsd:float ;
     nidm_pValueUncorrected: "7.2167337301976e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996780557608903"^^xsd:float ;
     nidm_qValueFDR: "0.0122368668491247"^^xsd:float .
 
-niiri:a42f9f1e579000b2dc77292a8cf2acb7
+niiri:219472c226c1003f926096d10ddea706
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[30,-48,-18]"^^xsd:string .
 
-niiri:1babf001e3351aeb7fac6dc5454363cc prov:wasDerivedFrom niiri:9656cbf27ba556542b025f2f8e45acfd .
+niiri:203aed58b8f81dce0ecac8be5e863bda prov:wasDerivedFrom niiri:67ae07e7ee0396386eefce6ed5341a79 .
 
-niiri:b338a4dd4022769457498158e6091888
+niiri:79605721ecfe71b7f89e29aabbca94a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:3e89e3f7a8baa5ac4d836dcdac1c0bda ;
+    prov:atLocation niiri:8aee97ed0bdda3e3420c52669ffbedb8 ;
     prov:value "6.32824850082397"^^xsd:float ;
     nidm_equivalentZStatistic: "3.764690456476"^^xsd:float ;
     nidm_pValueUncorrected: "8.33777634952071e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998439799137585"^^xsd:float ;
     nidm_qValueFDR: "0.0133433091347082"^^xsd:float .
 
-niiri:3e89e3f7a8baa5ac4d836dcdac1c0bda
+niiri:8aee97ed0bdda3e3420c52669ffbedb8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[34,64,-2]"^^xsd:string .
 
-niiri:b338a4dd4022769457498158e6091888 prov:wasDerivedFrom niiri:52cafab6790abfb27ec51f00e747fe9a .
+niiri:79605721ecfe71b7f89e29aabbca94a0 prov:wasDerivedFrom niiri:c589ee96ca2b908bdd9d337ca523d5af .
 
-niiri:e6169278f433610ff37f3974658c92df
+niiri:7fae1b8bdbfa6d7b6e2b7098b3c6e4d9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:c70c80c37a08562550518b4cd4541c41 ;
+    prov:atLocation niiri:fac73b3e372e29b6987b728b1ee5fbbf ;
     prov:value "6.23233604431152"^^xsd:float ;
     nidm_equivalentZStatistic: "3.72519134385979"^^xsd:float ;
     nidm_pValueUncorrected: "9.75835625125487e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999359408722565"^^xsd:float ;
     nidm_qValueFDR: "0.0147821614629234"^^xsd:float .
 
-niiri:c70c80c37a08562550518b4cd4541c41
+niiri:fac73b3e372e29b6987b728b1ee5fbbf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-42,44,26]"^^xsd:string .
 
-niiri:e6169278f433610ff37f3974658c92df prov:wasDerivedFrom niiri:4c64b57b636863b3e947522d1311c0f1 .
+niiri:7fae1b8bdbfa6d7b6e2b7098b3c6e4d9 prov:wasDerivedFrom niiri:e43455a02504b9d87a4939904a0ca976 .
 
-niiri:07af75e3341c3d93da4de231688d5549
+niiri:c2191d22002dea13759e4534d2a99bb2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:b7f3f00892f46b6b0ce77c4037087b40 ;
+    prov:atLocation niiri:1cd3744caef20860f929658348b743ab ;
     prov:value "6.06225728988647"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6541549978965"^^xsd:float ;
     nidm_pValueUncorrected: "0.000129015181687619"^^xsd:float ;
     nidm_pValueFWER: "0.999902284410057"^^xsd:float ;
     nidm_qValueFDR: "0.0177419633224147"^^xsd:float .
 
-niiri:b7f3f00892f46b6b0ce77c4037087b40
+niiri:1cd3744caef20860f929658348b743ab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[0,-10,76]"^^xsd:string .
 
-niiri:07af75e3341c3d93da4de231688d5549 prov:wasDerivedFrom niiri:a8236e3bfdb590d4516edd326dbac95d .
+niiri:c2191d22002dea13759e4534d2a99bb2 prov:wasDerivedFrom niiri:5dc937975dc687d7eb55e11a685cdd94 .
 
-niiri:41260b633b6a2691ee72574f2598723a
+niiri:8e3e340d146c5b9659376513d4c922c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:e5d27e5d68b5b3c32ee4902f86477d7a ;
+    prov:atLocation niiri:7cf3a56c9ff943e6f0580b9ef6f6505c ;
     prov:value "6.03189373016357"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64133598155782"^^xsd:float ;
     nidm_pValueUncorrected: "0.000135613449379846"^^xsd:float ;
     nidm_pValueFWER: "0.999933280387137"^^xsd:float ;
     nidm_qValueFDR: "0.0183426760576609"^^xsd:float .
 
-niiri:e5d27e5d68b5b3c32ee4902f86477d7a
+niiri:7cf3a56c9ff943e6f0580b9ef6f6505c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[34,-16,-12]"^^xsd:string .
 
-niiri:41260b633b6a2691ee72574f2598723a prov:wasDerivedFrom niiri:90dce13e46266944c40d12f4f1a86219 .
+niiri:8e3e340d146c5b9659376513d4c922c7 prov:wasDerivedFrom niiri:30c5174c5d495474060913c40bab0961 .
 
-niiri:2ec9227f9219716d869254e96c9d0037
+niiri:8766ac26c208ff8612c72111c2100871
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:b099faca4ffbe79b539a9a37c0fecc5b ;
+    prov:atLocation niiri:ac6145a41b42dd4e0f5c9807aaabc438 ;
     prov:value "6.02538537979126"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63858275251093"^^xsd:float ;
     nidm_pValueUncorrected: "0.000137071270502886"^^xsd:float ;
     nidm_pValueFWER: "0.999938640797957"^^xsd:float ;
     nidm_qValueFDR: "0.0183962430264957"^^xsd:float .
 
-niiri:b099faca4ffbe79b539a9a37c0fecc5b
+niiri:ac6145a41b42dd4e0f5c9807aaabc438
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[6,-80,-22]"^^xsd:string .
 
-niiri:2ec9227f9219716d869254e96c9d0037 prov:wasDerivedFrom niiri:4b569159d1ddc968752a57917503c6f4 .
+niiri:8766ac26c208ff8612c72111c2100871 prov:wasDerivedFrom niiri:ea999779ae02d5714142530d4b2e638b .
 
-niiri:0c5f2ba8ccadcaf3990cf555adbad737
+niiri:a6e97fb09e03600e49705c493a878db7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:aa874dbac7a9c1e02e0a4e28bd39dfb7 ;
+    prov:atLocation niiri:e01d6c7223e76ffbae5e844b5dbe79aa ;
     prov:value "5.95283126831055"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60775727167743"^^xsd:float ;
     nidm_pValueUncorrected: "0.000154427613028529"^^xsd:float ;
     nidm_pValueFWER: "0.999977036852347"^^xsd:float ;
     nidm_qValueFDR: "0.0199653441808624"^^xsd:float .
 
-niiri:aa874dbac7a9c1e02e0a4e28bd39dfb7
+niiri:e01d6c7223e76ffbae5e844b5dbe79aa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-26,-38,-52]"^^xsd:string .
 
-niiri:0c5f2ba8ccadcaf3990cf555adbad737 prov:wasDerivedFrom niiri:674c9062dc421a541e91be283cce8f16 .
+niiri:a6e97fb09e03600e49705c493a878db7 prov:wasDerivedFrom niiri:15b2530019f1c4c6d5e910962b35274b .
 
-niiri:3d268b9ac3f787ed4e0702d7f1ec3eb8
+niiri:8bcc743e85db485e4a2986804c97c77b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:d0604d3ccc8739eebfb0264b562dd48c ;
+    prov:atLocation niiri:26a3a76d924a3533d4779f0959a1fbaf ;
     prov:value "5.9493842124939"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60628663469786"^^xsd:float ;
     nidm_pValueUncorrected: "0.000155305014835405"^^xsd:float ;
     nidm_pValueFWER: "0.999978135328144"^^xsd:float ;
     nidm_qValueFDR: "0.0200343508975978"^^xsd:float .
 
-niiri:d0604d3ccc8739eebfb0264b562dd48c
+niiri:26a3a76d924a3533d4779f0959a1fbaf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[32,-52,46]"^^xsd:string .
 
-niiri:3d268b9ac3f787ed4e0702d7f1ec3eb8 prov:wasDerivedFrom niiri:d3a1762138c1b259db52c75933757662 .
+niiri:8bcc743e85db485e4a2986804c97c77b prov:wasDerivedFrom niiri:5782e52657a04683a9d9acc635ffc74a .
 
-niiri:110d36e0f43c3b73543fd2a54c15fcef
+niiri:f70cbe313f78f3bc26491805e90defbf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:6f51bb746dc99583cc8e3bccd8b52a17 ;
+    prov:atLocation niiri:60032f6ce2504b4763622044467988e0 ;
     prov:value "5.90739822387695"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58832892416593"^^xsd:float ;
     nidm_pValueUncorrected: "0.00016640212943575"^^xsd:float ;
     nidm_pValueFWER: "0.999988176695278"^^xsd:float ;
     nidm_qValueFDR: "0.0208396911967648"^^xsd:float .
 
-niiri:6f51bb746dc99583cc8e3bccd8b52a17
+niiri:60032f6ce2504b4763622044467988e0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[20,58,6]"^^xsd:string .
 
-niiri:110d36e0f43c3b73543fd2a54c15fcef prov:wasDerivedFrom niiri:9dc472e5df63cfbf55f8afa2ad7233f1 .
+niiri:f70cbe313f78f3bc26491805e90defbf prov:wasDerivedFrom niiri:e26340fcd624896679dd2542ec2348be .
 
-niiri:5c65ee8dd873a043b1b0ce011fed4f35
+niiri:3349878166a538e7a54b1390c105c88b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:89b9ae5151cd9b1561aaf8ff96b4b6ec ;
+    prov:atLocation niiri:ddefff6ce2c505804cc2f308814149f9 ;
     prov:value "5.88568687438965"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57901000852841"^^xsd:float ;
     nidm_pValueUncorrected: "0.000172449130450447"^^xsd:float ;
     nidm_pValueFWER: "0.999991509605729"^^xsd:float ;
     nidm_qValueFDR: "0.0213019172775607"^^xsd:float .
 
-niiri:89b9ae5151cd9b1561aaf8ff96b4b6ec
+niiri:ddefff6ce2c505804cc2f308814149f9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-28,-70,-52]"^^xsd:string .
 
-niiri:5c65ee8dd873a043b1b0ce011fed4f35 prov:wasDerivedFrom niiri:3fd667ca8587427124fe4b4ff80af21a .
+niiri:3349878166a538e7a54b1390c105c88b prov:wasDerivedFrom niiri:e4e5f6e0de1fb1456effbec6ec82e736 .
 
-niiri:57c990b6ba31385d10715d6c40e7aa55
+niiri:8345510a279773a85dbd456831121d91
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:9ebb93a3d4e207e403dbaa5999a1be35 ;
+    prov:atLocation niiri:3b9c2d356ee88a92c830323a0d5af7c1 ;
     prov:value "5.88288545608521"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57780594841694"^^xsd:float ;
     nidm_pValueUncorrected: "0.000173245266573252"^^xsd:float ;
     nidm_pValueFWER: "0.999991870214044"^^xsd:float ;
     nidm_qValueFDR: "0.0213621903805226"^^xsd:float .
 
-niiri:9ebb93a3d4e207e403dbaa5999a1be35
+niiri:3b9c2d356ee88a92c830323a0d5af7c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-16,-58,-38]"^^xsd:string .
 
-niiri:57c990b6ba31385d10715d6c40e7aa55 prov:wasDerivedFrom niiri:c60cf8d223f50376ab05520bb51598af .
+niiri:8345510a279773a85dbd456831121d91 prov:wasDerivedFrom niiri:5cf9ae44dc03a8c6493baf09bed014d4 .
 
-niiri:2098d30ab385854e90d3cb8115b3a9b2
+niiri:4bff1d01552bc126cd2623ad4ebf3b9a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:c3eb4272d1ec05c8e84a0681eea459bd ;
+    prov:atLocation niiri:a9399ad6017a33693100cb9d9a9888f2 ;
     prov:value "5.87665224075317"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57512554105657"^^xsd:float ;
     nidm_pValueUncorrected: "0.000175029940004845"^^xsd:float ;
     nidm_pValueFWER: "0.999992622705061"^^xsd:float ;
     nidm_qValueFDR: "0.0214921236782135"^^xsd:float .
 
-niiri:c3eb4272d1ec05c8e84a0681eea459bd
+niiri:a9399ad6017a33693100cb9d9a9888f2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[-10,-82,-30]"^^xsd:string .
 
-niiri:2098d30ab385854e90d3cb8115b3a9b2 prov:wasDerivedFrom niiri:f551110d12542058bdc59cae03013010 .
+niiri:4bff1d01552bc126cd2623ad4ebf3b9a prov:wasDerivedFrom niiri:dfe1466699f719841d6d98d1188da0c8 .
 
-niiri:3e504483f4e511a366bffb06b50ca097
+niiri:061bf720e78be5f38a4d203be70999ba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:7c66d78243fad1b742ee22ad32e56f1b ;
+    prov:atLocation niiri:029afc2516914e2a77271d16e01d5717 ;
     prov:value "5.86712741851807"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57102607807387"^^xsd:float ;
     nidm_pValueUncorrected: "0.000177792742607208"^^xsd:float ;
     nidm_pValueFWER: "0.999993649803941"^^xsd:float ;
     nidm_qValueFDR: "0.0216816267105749"^^xsd:float .
 
-niiri:7c66d78243fad1b742ee22ad32e56f1b
+niiri:029afc2516914e2a77271d16e01d5717
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[50,50,8]"^^xsd:string .
 
-niiri:3e504483f4e511a366bffb06b50ca097 prov:wasDerivedFrom niiri:fb9120500eef24a89fb5e84238991362 .
+niiri:061bf720e78be5f38a4d203be70999ba prov:wasDerivedFrom niiri:e69a5e282ae0346ca803f55371164aa7 .
 
-niiri:38cfaeebf97d0d2b0b71a5f0ba640e98
+niiri:b356784762f635ac6a6625d03f3fd1d5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:83fb05512223e38d67cb83a805cd00b3 ;
+    prov:atLocation niiri:6879e2b7fd420a16198270a7fda0c0ec ;
     prov:value "5.85824680328369"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56719995255891"^^xsd:float ;
     nidm_pValueUncorrected: "0.000180408078987448"^^xsd:float ;
     nidm_pValueFWER: "0.999994487319543"^^xsd:float ;
     nidm_qValueFDR: "0.0217930814133279"^^xsd:float .
 
-niiri:83fb05512223e38d67cb83a805cd00b3
+niiri:6879e2b7fd420a16198270a7fda0c0ec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-6,-78,56]"^^xsd:string .
 
-niiri:38cfaeebf97d0d2b0b71a5f0ba640e98 prov:wasDerivedFrom niiri:dde8bc734b1e70c777683f3419f9b22a .
+niiri:b356784762f635ac6a6625d03f3fd1d5 prov:wasDerivedFrom niiri:d168d4b61807fc13619ad56c31dad174 .
 
-niiri:6bed9eb8c16b5bfc1b7f13853ba3719d
+niiri:52474a24c82a42c438dfac7f6b6ebe74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:07d1fc16b4011bf11b157bc94038717f ;
+    prov:atLocation niiri:b536ab3bffaed62ccb1ca6267c85947b ;
     prov:value "5.81644201278687"^^xsd:float ;
     nidm_equivalentZStatistic: "3.54913757298709"^^xsd:float ;
     nidm_pValueUncorrected: "0.000193247549691744"^^xsd:float ;
     nidm_pValueFWER: "0.99999722874557"^^xsd:float ;
     nidm_qValueFDR: "0.022905022613713"^^xsd:float .
 
-niiri:07d1fc16b4011bf11b157bc94038717f
+niiri:b536ab3bffaed62ccb1ca6267c85947b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[44,50,20]"^^xsd:string .
 
-niiri:6bed9eb8c16b5bfc1b7f13853ba3719d prov:wasDerivedFrom niiri:89223f01a7e676c300c22c8da4a82ef8 .
+niiri:52474a24c82a42c438dfac7f6b6ebe74 prov:wasDerivedFrom niiri:522e011a3a54e833c99dc9315f577dfe .
 
-niiri:13789ff64ea178d4dd930d5649ad0efa
+niiri:63d794c7a20b8c3844c02909a430c400
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:09872dc9def2ebbedbd2d8b56d8ccec8 ;
+    prov:atLocation niiri:c04e40e59d081babf861f27fff0bc656 ;
     prov:value "5.75350570678711"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52178406559812"^^xsd:float ;
     nidm_pValueUncorrected: "0.000214326572548162"^^xsd:float ;
     nidm_pValueFWER: "0.999999083879168"^^xsd:float ;
     nidm_qValueFDR: "0.0245474913207941"^^xsd:float .
 
-niiri:09872dc9def2ebbedbd2d8b56d8ccec8
+niiri:c04e40e59d081babf861f27fff0bc656
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[-30,-58,-52]"^^xsd:string .
 
-niiri:13789ff64ea178d4dd930d5649ad0efa prov:wasDerivedFrom niiri:7ac6ced5ac5b95c88fbe93f4ad51726c .
+niiri:63d794c7a20b8c3844c02909a430c400 prov:wasDerivedFrom niiri:bcc290b739057f6cb5c02dcc79c4b5bc .
 
-niiri:9d748709970f09ad37966b4ebd88970d
+niiri:341c565fefe9949adb1369f3da7a2a11
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:a8566c5632b9f7d195407d5bbeb8d694 ;
+    prov:atLocation niiri:6f522d3d3123b608cd947c46fdc012a6 ;
     prov:value "5.74829816818237"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51951200270118"^^xsd:float ;
     nidm_pValueUncorrected: "0.000216170736607735"^^xsd:float ;
     nidm_pValueFWER: "0.999999167412893"^^xsd:float ;
     nidm_qValueFDR: "0.0246525319493899"^^xsd:float .
 
-niiri:a8566c5632b9f7d195407d5bbeb8d694
+niiri:6f522d3d3123b608cd947c46fdc012a6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-38,36,-14]"^^xsd:string .
 
-niiri:9d748709970f09ad37966b4ebd88970d prov:wasDerivedFrom niiri:5d05848ec2715382392265640fc9d57e .
+niiri:341c565fefe9949adb1369f3da7a2a11 prov:wasDerivedFrom niiri:6f3de48dca5b4c3a6aca0be63ddd27cd .
 
-niiri:8f1086c487206beee6166192435ccbb7
+niiri:511b02a8bf4a6e0270aa9e4d8188cf98
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:7bd2497735bee9acdd922777fd6b5af3 ;
+    prov:atLocation niiri:08733586f578952e07d3ef0bedd783e7 ;
     prov:value "5.7312970161438"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51208496979963"^^xsd:float ;
     nidm_pValueUncorrected: "0.000222302913436612"^^xsd:float ;
     nidm_pValueFWER: "0.99999939333845"^^xsd:float ;
     nidm_qValueFDR: "0.0250806761204491"^^xsd:float .
 
-niiri:7bd2497735bee9acdd922777fd6b5af3
+niiri:08733586f578952e07d3ef0bedd783e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-50,12,-2]"^^xsd:string .
 
-niiri:8f1086c487206beee6166192435ccbb7 prov:wasDerivedFrom niiri:ca24bdc833f185dc48a439c9bd8cfea6 .
+niiri:511b02a8bf4a6e0270aa9e4d8188cf98 prov:wasDerivedFrom niiri:f77f344a47f917de9a802b78319c354f .
 
-niiri:9622cbdc321584d153d90164a7e3a512
+niiri:2f69fd65193eb1b02e7f447cca5b3d63
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:ab618775ab67eaf9567d2f85e813dc0d ;
+    prov:atLocation niiri:ca4ad108c221d6463345f5410c20d1b6 ;
     prov:value "5.61407613754272"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46048027314539"^^xsd:float ;
     nidm_pValueUncorrected: "0.000269606369816766"^^xsd:float ;
     nidm_pValueFWER: "0.999999943721802"^^xsd:float ;
     nidm_qValueFDR: "0.0285650985701987"^^xsd:float .
 
-niiri:ab618775ab67eaf9567d2f85e813dc0d
+niiri:ca4ad108c221d6463345f5410c20d1b6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-52,38,14]"^^xsd:string .
 
-niiri:9622cbdc321584d153d90164a7e3a512 prov:wasDerivedFrom niiri:302ad243c21e156bc35f157e2595460d .
+niiri:2f69fd65193eb1b02e7f447cca5b3d63 prov:wasDerivedFrom niiri:9df645a4ce3520ee828e35a6dac32f9f .
 
-niiri:dafa541111dbf27389241fc1622583e6
+niiri:6fb432a65a1864ebc7f79bd73139967a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:8a2dcced4bbeb2d604abdc206edbd812 ;
+    prov:atLocation niiri:05b2d9da6ce7b779041ee7d321cee8e3 ;
     prov:value "5.53163862228394"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42376539987989"^^xsd:float ;
     nidm_pValueUncorrected: "0.000308799561745898"^^xsd:float ;
     nidm_pValueFWER: "0.999999991534363"^^xsd:float ;
     nidm_qValueFDR: "0.0312013208214028"^^xsd:float .
 
-niiri:8a2dcced4bbeb2d604abdc206edbd812
+niiri:05b2d9da6ce7b779041ee7d321cee8e3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[-14,-80,10]"^^xsd:string .
 
-niiri:dafa541111dbf27389241fc1622583e6 prov:wasDerivedFrom niiri:b0e84ab2cd541b237634e56ebf391609 .
+niiri:6fb432a65a1864ebc7f79bd73139967a prov:wasDerivedFrom niiri:1dea88b1f0062ddb01809c2f336aff3f .
 
-niiri:a1b7280bae7cb27c5d032057b5e5ee6a
+niiri:ef1964afa02d57f263805ebae4d754c5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:c15f83bf0af7227fccfcc19a8ff53a78 ;
+    prov:atLocation niiri:0d2cac5a83e96f9282820e4e4438c966 ;
     prov:value "5.52454996109009"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42059171809414"^^xsd:float ;
     nidm_pValueUncorrected: "0.000312425309546338"^^xsd:float ;
     nidm_pValueFWER: "0.999999992873262"^^xsd:float ;
     nidm_qValueFDR: "0.0313644959462665"^^xsd:float .
 
-niiri:c15f83bf0af7227fccfcc19a8ff53a78
+niiri:0d2cac5a83e96f9282820e4e4438c966
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-66,-40,18]"^^xsd:string .
 
-niiri:a1b7280bae7cb27c5d032057b5e5ee6a prov:wasDerivedFrom niiri:27969eb0dc2d34026b32c881a0f07667 .
+niiri:ef1964afa02d57f263805ebae4d754c5 prov:wasDerivedFrom niiri:f424b0ee093c7ca1771bb8144718087b .
 
-niiri:3240ad2c7b4c375b2ffb7def8241fc33
+niiri:bd558d7e2f31e68ed9630cf47a3dc77f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:8977a52fd8fb3c0c00a547480b793cb2 ;
+    prov:atLocation niiri:d292d5aee905fd862dc0c678e3fe9df2 ;
     prov:value "5.51989889144897"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41850793238069"^^xsd:float ;
     nidm_pValueUncorrected: "0.000314827412227103"^^xsd:float ;
     nidm_pValueFWER: "0.99999999363976"^^xsd:float ;
     nidm_qValueFDR: "0.0315295603356192"^^xsd:float .
 
-niiri:8977a52fd8fb3c0c00a547480b793cb2
+niiri:d292d5aee905fd862dc0c678e3fe9df2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-2,-90,16]"^^xsd:string .
 
-niiri:3240ad2c7b4c375b2ffb7def8241fc33 prov:wasDerivedFrom niiri:488053a695a16e1621e578a90cd45d96 .
+niiri:bd558d7e2f31e68ed9630cf47a3dc77f prov:wasDerivedFrom niiri:258ff3de07e51a57d0b27d6699fb2508 .
 
-niiri:e98e410c62ad05bb4759e8520048a9be
+niiri:cbcc21fd20778a31e84881bfab50ee09
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:c244d6cda3ac6e6dc81d3a691f072524 ;
+    prov:atLocation niiri:4abf0e8985243764b8b4d826d3ff3cac ;
     prov:value "5.50013113021851"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40963871850162"^^xsd:float ;
     nidm_pValueUncorrected: "0.000325244937404157"^^xsd:float ;
     nidm_pValueFWER: "0.99999999610751"^^xsd:float ;
     nidm_qValueFDR: "0.0320937892728011"^^xsd:float .
 
-niiri:c244d6cda3ac6e6dc81d3a691f072524
+niiri:4abf0e8985243764b8b4d826d3ff3cac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[48,-68,24]"^^xsd:string .
 
-niiri:e98e410c62ad05bb4759e8520048a9be prov:wasDerivedFrom niiri:ed908db943ba3e97ea5826f9b78e251e .
+niiri:cbcc21fd20778a31e84881bfab50ee09 prov:wasDerivedFrom niiri:fd669f02bbb8da3eff612dc0d4b807f6 .
 
-niiri:028200a0f3330e69e713e62343e4c118
+niiri:76de7fa6ab94ab4a76284547a4e3f1aa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:6672ab9c3b56f3def7af8a2d31e7bf6b ;
+    prov:atLocation niiri:91f9c5e62fe3707f1980b1138c4853ca ;
     prov:value "5.47258329391479"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39724406479958"^^xsd:float ;
     nidm_pValueUncorrected: "0.000340341137511579"^^xsd:float ;
     nidm_pValueFWER: "0.999999998076035"^^xsd:float ;
     nidm_qValueFDR: "0.0330219418190176"^^xsd:float .
 
-niiri:6672ab9c3b56f3def7af8a2d31e7bf6b
+niiri:91f9c5e62fe3707f1980b1138c4853ca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[-66,-52,14]"^^xsd:string .
 
-niiri:028200a0f3330e69e713e62343e4c118 prov:wasDerivedFrom niiri:f5e02329544635d1b1ebf65b366251dc .
+niiri:76de7fa6ab94ab4a76284547a4e3f1aa prov:wasDerivedFrom niiri:2560564a14e0250f709b385639d02fb9 .
 
-niiri:83b5e42ee4a22a019efa3ad1b7c43432
+niiri:9e085633b6f20c82d2de1068c8944127
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:1365efa4ae8395b0cf5121fab0888e16 ;
+    prov:atLocation niiri:8940c35372a329a691f251d5f01211da ;
     prov:value "5.47253847122192"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39722386451209"^^xsd:float ;
     nidm_pValueUncorrected: "0.000340366263790748"^^xsd:float ;
     nidm_pValueFWER: "0.999999998078278"^^xsd:float ;
     nidm_qValueFDR: "0.0330219418190176"^^xsd:float .
 
-niiri:1365efa4ae8395b0cf5121fab0888e16
+niiri:8940c35372a329a691f251d5f01211da
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-24,-70,-40]"^^xsd:string .
 
-niiri:83b5e42ee4a22a019efa3ad1b7c43432 prov:wasDerivedFrom niiri:48785ebe53244b67446462ca165511f6 .
+niiri:9e085633b6f20c82d2de1068c8944127 prov:wasDerivedFrom niiri:589d688bdb65a26f0e5afdd4ff33865b .
 
-niiri:4d855c9b2c870365cbdf9a1cf976b2f7
+niiri:584625db35fd1e69dc1aeb8466d8899b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:bc66a863068c99d04a911bb1348a178e ;
+    prov:atLocation niiri:56067390bd867fbe6b52bf178e0f2d8f ;
     prov:value "5.40879058837891"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36838466104027"^^xsd:float ;
     nidm_pValueUncorrected: "0.00037805012668235"^^xsd:float ;
     nidm_pValueFWER: "0.999999999657857"^^xsd:float ;
     nidm_qValueFDR: "0.0351846046980527"^^xsd:float .
 
-niiri:bc66a863068c99d04a911bb1348a178e
+niiri:56067390bd867fbe6b52bf178e0f2d8f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-52,28,-4]"^^xsd:string .
 
-niiri:4d855c9b2c870365cbdf9a1cf976b2f7 prov:wasDerivedFrom niiri:dd83d9e917f614f418e9401cdb99e43c .
+niiri:584625db35fd1e69dc1aeb8466d8899b prov:wasDerivedFrom niiri:b1e45a95e3b162cbfbb274efa0609a1a .
 
-niiri:086b014ac09ab4e4ea973ffddfa71a22
+niiri:923ab0d2b10cd0fb1178741e5f7e4d80
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:06cfc8651ab4c54efee830c631e39857 ;
+    prov:atLocation niiri:297f004b78125a381f4cc1a5fa03cfa7 ;
     prov:value "5.40180397033691"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36521050637541"^^xsd:float ;
     nidm_pValueUncorrected: "0.000382426408436776"^^xsd:float ;
     nidm_pValueFWER: "0.999999999719179"^^xsd:float ;
     nidm_qValueFDR: "0.0353860600288775"^^xsd:float .
 
-niiri:06cfc8651ab4c54efee830c631e39857
+niiri:297f004b78125a381f4cc1a5fa03cfa7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[46,40,-20]"^^xsd:string .
 
-niiri:086b014ac09ab4e4ea973ffddfa71a22 prov:wasDerivedFrom niiri:f9dfccb5b804ef9741131141e3190a4b .
+niiri:923ab0d2b10cd0fb1178741e5f7e4d80 prov:wasDerivedFrom niiri:5ac022b3dd1da9d78456eb9feccbe272 .
 
-niiri:53c569adbfc5ab366e0314685b165853
+niiri:d2e0beea05ad13eb0757a2f7874a5c30
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:13c44e2155af4ee2e20a16ec29b76a47 ;
+    prov:atLocation niiri:f086d252f5f4c91e62368d78b62ac58b ;
     prov:value "5.37467432022095"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35285956111335"^^xsd:float ;
     nidm_pValueUncorrected: "0.000399906393667493"^^xsd:float ;
     nidm_pValueFWER: "0.999999999871685"^^xsd:float ;
     nidm_qValueFDR: "0.0362799194266732"^^xsd:float .
 
-niiri:13c44e2155af4ee2e20a16ec29b76a47
+niiri:f086d252f5f4c91e62368d78b62ac58b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[-24,-64,-26]"^^xsd:string .
 
-niiri:53c569adbfc5ab366e0314685b165853 prov:wasDerivedFrom niiri:ec4ca0e1cb2f2bcaf19c72281cf210d5 .
+niiri:d2e0beea05ad13eb0757a2f7874a5c30 prov:wasDerivedFrom niiri:0aa8942e14fb246e8d24f1826bdd073f .
 
-niiri:be4788197353dff3599d99682ec3031b
+niiri:71949ac8bb1d34c0f6a227d787830b42
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:917e6352e6ae3e3613ae739c3f135a19 ;
+    prov:atLocation niiri:4faa09a4da27e254773d00b12e8ce476 ;
     prov:value "5.37411737442017"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35260558298398"^^xsd:float ;
     nidm_pValueUncorrected: "0.00040027350203431"^^xsd:float ;
     nidm_pValueFWER: "0.999999999873767"^^xsd:float ;
     nidm_qValueFDR: "0.0362799194266732"^^xsd:float .
 
-niiri:917e6352e6ae3e3613ae739c3f135a19
+niiri:4faa09a4da27e254773d00b12e8ce476
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[6,-78,4]"^^xsd:string .
 
-niiri:be4788197353dff3599d99682ec3031b prov:wasDerivedFrom niiri:024c443604af80b2271c971bd66fc9a0 .
+niiri:71949ac8bb1d34c0f6a227d787830b42 prov:wasDerivedFrom niiri:47175a90c2a865c8e7cb888b760d6bf8 .
 
-niiri:3f93410e4f041c83e4b8d8a0e0adbfff
+niiri:102e3f4f656d62e79230957d3c5b9d14
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:0b950426b4901232779f3393314e29d9 ;
+    prov:atLocation niiri:a9650048b29ccca030a5ee54b9940e46 ;
     prov:value "5.30396842956543"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32047825714677"^^xsd:float ;
     nidm_pValueUncorrected: "0.000449316793136201"^^xsd:float ;
     nidm_pValueFWER: "0.999999999985317"^^xsd:float ;
     nidm_qValueFDR: "0.038893908226916"^^xsd:float .
 
-niiri:0b950426b4901232779f3393314e29d9
+niiri:a9650048b29ccca030a5ee54b9940e46
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-18,6,-16]"^^xsd:string .
 
-niiri:3f93410e4f041c83e4b8d8a0e0adbfff prov:wasDerivedFrom niiri:bd7d210916ff0d725f61db0ca48f5d05 .
+niiri:102e3f4f656d62e79230957d3c5b9d14 prov:wasDerivedFrom niiri:d3f621d08874a1c4b62c86623e9e9780 .
 
-niiri:5f9a78d502e9bb9f0b83b39b814fcb68
+niiri:1c9771ed932e3bdfafbe567879a399d9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:b466f652f73aa477a6d1a60f80c8435c ;
+    prov:atLocation niiri:df34c6eabebd48e7dc695cf8cd35940f ;
     prov:value "5.3003044128418"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31879260124815"^^xsd:float ;
     nidm_pValueUncorrected: "0.000452037748311596"^^xsd:float ;
     nidm_pValueFWER: "0.999999999986945"^^xsd:float ;
     nidm_qValueFDR: "0.0390806835204476"^^xsd:float .
 
-niiri:b466f652f73aa477a6d1a60f80c8435c
+niiri:df34c6eabebd48e7dc695cf8cd35940f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[44,34,22]"^^xsd:string .
 
-niiri:5f9a78d502e9bb9f0b83b39b814fcb68 prov:wasDerivedFrom niiri:7925cec36e37f32d88f7027ba176a2e1 .
+niiri:1c9771ed932e3bdfafbe567879a399d9 prov:wasDerivedFrom niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56 .
 
-niiri:d0e4dbe4e90bfbe444d4822b9a651afc
+niiri:6e63ab7247516f8dc04092e22e2759ec
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:be4116def5b2ec22ad63aa256b25428e ;
+    prov:atLocation niiri:51436c3b224aac45c74640b1163904f9 ;
     prov:value "5.2790060043335"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30897907487843"^^xsd:float ;
     nidm_pValueUncorrected: "0.000468184175549835"^^xsd:float ;
     nidm_pValueFWER: "0.999999999993475"^^xsd:float ;
     nidm_qValueFDR: "0.0399946769218688"^^xsd:float .
 
-niiri:be4116def5b2ec22ad63aa256b25428e
+niiri:51436c3b224aac45c74640b1163904f9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[-16,-70,62]"^^xsd:string .
 
-niiri:d0e4dbe4e90bfbe444d4822b9a651afc prov:wasDerivedFrom niiri:11d4226a2f26d5d215e759b0b4e1b65c .
+niiri:6e63ab7247516f8dc04092e22e2759ec prov:wasDerivedFrom niiri:730bd100bdb468af0d3821d0d42d24a3 .
 
-niiri:7ab232ff50649870750ccc2d7f5c4da3
+niiri:86c90a2f51f1ad8289191c43b5d97061
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:6f88478d05d4710af9b94706fcfdcacb ;
+    prov:atLocation niiri:e46fca08428611170031546e4ef81393 ;
     prov:value "5.22220420837402"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28268028866984"^^xsd:float ;
     nidm_pValueUncorrected: "0.000514126053509312"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999062"^^xsd:float ;
     nidm_qValueFDR: "0.0424551034128408"^^xsd:float .
 
-niiri:6f88478d05d4710af9b94706fcfdcacb
+niiri:e46fca08428611170031546e4ef81393
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-18,-90,34]"^^xsd:string .
 
-niiri:7ab232ff50649870750ccc2d7f5c4da3 prov:wasDerivedFrom niiri:cd265e81b525edcdebe748129d48fb9f .
+niiri:86c90a2f51f1ad8289191c43b5d97061 prov:wasDerivedFrom niiri:c30c1334c3597905fbc441edbc3d5ada .
 
-niiri:dbaf7dcfae21971052a8c4d8630590a6
+niiri:545e517cd64f442db87872d4a27b47f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:803c967b5027caa5ecf5d2a6fc5e8db2 ;
+    prov:atLocation niiri:1042007b111f87e5138bb438f2ae2bc0 ;
     prov:value "5.1730318069458"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25976321879304"^^xsd:float ;
     nidm_pValueUncorrected: "0.000557526302441769"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999843"^^xsd:float ;
     nidm_qValueFDR: "0.0447389446131481"^^xsd:float .
 
-niiri:803c967b5027caa5ecf5d2a6fc5e8db2
+niiri:1042007b111f87e5138bb438f2ae2bc0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[36,62,8]"^^xsd:string .
 
-niiri:dbaf7dcfae21971052a8c4d8630590a6 prov:wasDerivedFrom niiri:aa2c86e9352626823ca6bb3bbda5947a .
+niiri:545e517cd64f442db87872d4a27b47f7 prov:wasDerivedFrom niiri:f3476be8b24ab5bb218fe71d0b0daed0 .
 
-niiri:4cc71160f45e34b952ca323ad055c180
+niiri:f3f05a481523891d44824beadda448ee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:c7f8ed36a2e92d11b23926f9debb338a ;
+    prov:atLocation niiri:194bdcb422ae39cd8096994d6fce64ac ;
     prov:value "5.17224788665771"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25939672404754"^^xsd:float ;
     nidm_pValueUncorrected: "0.000558247108556009"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999848"^^xsd:float ;
     nidm_qValueFDR: "0.0447389446131481"^^xsd:float .
 
-niiri:c7f8ed36a2e92d11b23926f9debb338a
+niiri:194bdcb422ae39cd8096994d6fce64ac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[44,46,-18]"^^xsd:string .
 
-niiri:4cc71160f45e34b952ca323ad055c180 prov:wasDerivedFrom niiri:8d3a03589611da3ed8127a06d493acd6 .
+niiri:f3f05a481523891d44824beadda448ee prov:wasDerivedFrom niiri:e129e49f77be02735062a975f639c82e .
 
-niiri:fbddf0f56adf238723f50586d9383121
+niiri:62b1a35b9b004426fc8baefb3985fe01
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:827b144eb0409183e6f5e65935ea8fac ;
+    prov:atLocation niiri:bbea39448c6107a5d4ad5ddee203d4d2 ;
     prov:value "5.13746070861816"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24309671226403"^^xsd:float ;
     nidm_pValueUncorrected: "0.000591190343014691"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999996"^^xsd:float ;
     nidm_qValueFDR: "0.0465822754926653"^^xsd:float .
 
-niiri:827b144eb0409183e6f5e65935ea8fac
+niiri:bbea39448c6107a5d4ad5ddee203d4d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[22,-18,-10]"^^xsd:string .
 
-niiri:fbddf0f56adf238723f50586d9383121 prov:wasDerivedFrom niiri:3f311421a632e712f70cc6839f7e9489 .
+niiri:62b1a35b9b004426fc8baefb3985fe01 prov:wasDerivedFrom niiri:f445b49b9174ce8611d41a7cc11e1717 .
 
-niiri:f7fbd57305037f549d9fa2567e5b8559
+niiri:7e86c6411e52fa0a7b9b20dcbb6e36b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:82ccce4a7354b15f17bc0943ef2b529c ;
+    prov:atLocation niiri:5f9f0cd6ac7c81914637716591108924 ;
     prov:value "5.11799764633179"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23394572778211"^^xsd:float ;
     nidm_pValueUncorrected: "0.000610463272072148"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999981"^^xsd:float ;
     nidm_qValueFDR: "0.0474717326152994"^^xsd:float .
 
-niiri:82ccce4a7354b15f17bc0943ef2b529c
+niiri:5f9f0cd6ac7c81914637716591108924
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[-54,34,4]"^^xsd:string .
 
-niiri:f7fbd57305037f549d9fa2567e5b8559 prov:wasDerivedFrom niiri:bcc132262f6d7297d1d28a6f0a171093 .
+niiri:7e86c6411e52fa0a7b9b20dcbb6e36b0 prov:wasDerivedFrom niiri:5ca600306779ba8f48c5d087d9fac9a9 .
 
-niiri:dbb595cffa04de52d8f33921efbecc84
+niiri:97c62dc69d6cfc9480ed5f2d7063dc28
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:27b2020b2732af62cc07a03a8002f7be ;
+    prov:atLocation niiri:34c95820a8a121e8a225fd9376361242 ;
     prov:value "5.10930299758911"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22985044435181"^^xsd:float ;
     nidm_pValueUncorrected: "0.000619274939217984"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999987"^^xsd:float ;
     nidm_qValueFDR: "0.047852944668371"^^xsd:float .
 
-niiri:27b2020b2732af62cc07a03a8002f7be
+niiri:34c95820a8a121e8a225fd9376361242
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-30,-64,-52]"^^xsd:string .
 
-niiri:dbb595cffa04de52d8f33921efbecc84 prov:wasDerivedFrom niiri:3bdec6eb0b5535174fa631dd70795a7e .
+niiri:97c62dc69d6cfc9480ed5f2d7063dc28 prov:wasDerivedFrom niiri:40bbe1b7b060c1d54f113fd9fcf154aa .
 
-niiri:49c1e9ef96178d1e9db83a47b1907de9
+niiri:fd255fdebba34e1d3d741757f42127cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:dc95edb06b3ad737ba9ce90d974a8f91 ;
+    prov:atLocation niiri:e2093ea5a4830bc016df153a1447adb3 ;
     prov:value "5.10401487350464"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22735746106492"^^xsd:float ;
     nidm_pValueUncorrected: "0.000624696357977461"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999989"^^xsd:float ;
     nidm_qValueFDR: "0.0480043833565767"^^xsd:float .
 
-niiri:dc95edb06b3ad737ba9ce90d974a8f91
+niiri:e2093ea5a4830bc016df153a1447adb3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[-48,-78,18]"^^xsd:string .
 
-niiri:49c1e9ef96178d1e9db83a47b1907de9 prov:wasDerivedFrom niiri:f1946d8aa4c75dc6c7b6e735e96e1847 .
+niiri:fd255fdebba34e1d3d741757f42127cb prov:wasDerivedFrom niiri:5d9d1b3e1bbc6746185f53561c74bace .
 
-niiri:c4b0c9d7d5bf10ed940aa36f9a2898fc
+niiri:d03d3f46620d80d545af7b487f982e5b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:690f349d00c402f64f9afef69a04d47d ;
+    prov:atLocation niiri:8beacede341a47f3167389d2db31c511 ;
     prov:value "5.09518003463745"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22318870378714"^^xsd:float ;
     nidm_pValueUncorrected: "0.000633860042171808"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.0483657513246105"^^xsd:float .
 
-niiri:690f349d00c402f64f9afef69a04d47d
+niiri:8beacede341a47f3167389d2db31c511
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[4,-86,38]"^^xsd:string .
 
-niiri:c4b0c9d7d5bf10ed940aa36f9a2898fc prov:wasDerivedFrom niiri:3592a75cac312314b4a818b743916efd .
+niiri:d03d3f46620d80d545af7b487f982e5b prov:wasDerivedFrom niiri:4c53636a1293cd4482cb63ff70691d79 .
 
-niiri:6f1dcaa9702ce8b1e56004f2e154bcc7
+niiri:26a9a6f6ecb327e047fbdaf46b98bd6e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:6579bb9b7980bc6caf30f72d161dccb3 ;
+    prov:atLocation niiri:1be4f6ad62254ca44faf09f21e98b4ef ;
     prov:value "5.08291101455688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21739172198432"^^xsd:float ;
     nidm_pValueUncorrected: "0.000646809225746448"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999996"^^xsd:float ;
     nidm_qValueFDR: "0.0489980390158314"^^xsd:float .
 
-niiri:6579bb9b7980bc6caf30f72d161dccb3
+niiri:1be4f6ad62254ca44faf09f21e98b4ef
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[-14,-50,-36]"^^xsd:string .
 
-niiri:6f1dcaa9702ce8b1e56004f2e154bcc7 prov:wasDerivedFrom niiri:a457cd8f3b3381f0a12661e0907b556a .
+niiri:26a9a6f6ecb327e047fbdaf46b98bd6e prov:wasDerivedFrom niiri:2b3b2f5817481e92102b214f3bf33995 .
 
-niiri:bb4e0dcfa0ad034c05e92f6d076501cb
+niiri:eed8b6f60fa2ab238d44784bc24f49fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:1a121ade9e841ce8da6580e606ec3b7b ;
+    prov:atLocation niiri:f840d99aa197bd8d4fa2aca6525dd6b6 ;
     prov:value "5.0689902305603"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21080328886987"^^xsd:float ;
     nidm_pValueUncorrected: "0.000661822545445001"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.0496832380294054"^^xsd:float .
 
-niiri:1a121ade9e841ce8da6580e606ec3b7b
+niiri:f840d99aa197bd8d4fa2aca6525dd6b6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[30,68,10]"^^xsd:string .
 
-niiri:bb4e0dcfa0ad034c05e92f6d076501cb prov:wasDerivedFrom niiri:698306b72f010c2b2851ac92120e72d6 .
+niiri:eed8b6f60fa2ab238d44784bc24f49fc prov:wasDerivedFrom niiri:86437031e803eee8517a97d2e8420009 .
 
-niiri:77969ad2ea1b902a3de4c5dfa8bce613
+niiri:5e7cb532886034b9c21ce9230724cf4e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:ee032b83f3abbbdb30b2a62197d9e399 ;
+    prov:atLocation niiri:fa765c1dff998dba8cec43964f9fd0ac ;
     prov:value "5.05907249450684"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20610225272296"^^xsd:float ;
     nidm_pValueUncorrected: "0.000672730842027125"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.0501943510982274"^^xsd:float .
 
-niiri:ee032b83f3abbbdb30b2a62197d9e399
+niiri:fa765c1dff998dba8cec43964f9fd0ac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[10,-30,80]"^^xsd:string .
 
-niiri:77969ad2ea1b902a3de4c5dfa8bce613 prov:wasDerivedFrom niiri:5d9c59bbe6ff835dfd7a715340e2d8b7 .
+niiri:5e7cb532886034b9c21ce9230724cf4e prov:wasDerivedFrom niiri:927385c4b1c66020878360a5006a3e3b .
 
-niiri:0bc108a04fa102d651c09d417f06163e
+niiri:3b0256e0257667bc847e43ec82712c6a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:85320af157905fd663b941a235d3c218 ;
+    prov:atLocation niiri:0513413f42049f48fad742e27fa4823c ;
     prov:value "5.05790328979492"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20554765226523"^^xsd:float ;
     nidm_pValueUncorrected: "0.000674028618936839"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.0502551505802037"^^xsd:float .
 
-niiri:85320af157905fd663b941a235d3c218
+niiri:0513413f42049f48fad742e27fa4823c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[44,-76,8]"^^xsd:string .
 
-niiri:0bc108a04fa102d651c09d417f06163e prov:wasDerivedFrom niiri:8cb05ce5ff1f36539390753e60f586ff .
+niiri:3b0256e0257667bc847e43ec82712c6a prov:wasDerivedFrom niiri:0087c0fa9854a20b9b26757b4c0e9a68 .
 
-niiri:9ad0a5fb1e4870a3f1763d5f1630bf32
+niiri:546a3ae2919066aba8b04feb7eaf222b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:3906fb2e94c751bdf7ed2d37f73381e1 ;
+    prov:atLocation niiri:711f068fef9833519c8dc8540cb0ba53 ;
     prov:value "5.04969549179077"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20165202224461"^^xsd:float ;
     nidm_pValueUncorrected: "0.000683209765197312"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.050613270744433"^^xsd:float .
 
-niiri:3906fb2e94c751bdf7ed2d37f73381e1
+niiri:711f068fef9833519c8dc8540cb0ba53
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-52,-36,44]"^^xsd:string .
 
-niiri:9ad0a5fb1e4870a3f1763d5f1630bf32 prov:wasDerivedFrom niiri:7ea54f9b32f6dc38cd6db6e7a66e53e5 .
+niiri:546a3ae2919066aba8b04feb7eaf222b prov:wasDerivedFrom niiri:679d2ced08c3de3ec63ab76190f2d86d .
 
-niiri:f5ef66098a9f9c1e70f89f697490eeaf
+niiri:3c565a898ce1cb8d1a32498833886420
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:e86bfb71232ecd6e43bcb633d2431b88 ;
+    prov:atLocation niiri:d1361e7764f4b544072c31608b9db437 ;
     prov:value "5.02838468551636"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19151815181806"^^xsd:float ;
     nidm_pValueUncorrected: "0.000707636089146368"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.051650625154872"^^xsd:float .
 
-niiri:e86bfb71232ecd6e43bcb633d2431b88
+niiri:d1361e7764f4b544072c31608b9db437
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-44,-40,42]"^^xsd:string .
 
-niiri:f5ef66098a9f9c1e70f89f697490eeaf prov:wasDerivedFrom niiri:08144c2f2914ca0e8f2d5090a382dd9c .
+niiri:3c565a898ce1cb8d1a32498833886420 prov:wasDerivedFrom niiri:302d0ae98bffba69292672583d115e8c .
 
-niiri:f701ebe269b6e286af398dc8db3aa776
+niiri:895ab0cb66ad5fe2b8f0ccfda413020f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:5e45ebc90297b83e805af2fa5c27599d ;
+    prov:atLocation niiri:f2b167b359b019d6526e5256b4b2a4e7 ;
     prov:value "5.02759695053101"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19114302879552"^^xsd:float ;
     nidm_pValueUncorrected: "0.00070855553886906"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0516996133446043"^^xsd:float .
 
-niiri:5e45ebc90297b83e805af2fa5c27599d
+niiri:f2b167b359b019d6526e5256b4b2a4e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[-44,54,-6]"^^xsd:string .
 
-niiri:f701ebe269b6e286af398dc8db3aa776 prov:wasDerivedFrom niiri:20fdb21c4b6e1b56aba03dc17e6e0cad .
+niiri:895ab0cb66ad5fe2b8f0ccfda413020f prov:wasDerivedFrom niiri:f443e4b03660a8ad618e307479bf8a95 .
 
-niiri:ea882a65b0dfd559a13cfe9234c2c24d
+niiri:38744d312469d30ea2aad6e112efd815
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:ea22c84ed8e7c73c83ed6c329b8aa7db ;
+    prov:atLocation niiri:4e8ff56debee785959e0deb820ab4223 ;
     prov:value "5.00743103027344"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18152691683286"^^xsd:float ;
     nidm_pValueUncorrected: "0.000732504543232371"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0526896959368281"^^xsd:float .
 
-niiri:ea22c84ed8e7c73c83ed6c329b8aa7db
+niiri:4e8ff56debee785959e0deb820ab4223
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[36,58,18]"^^xsd:string .
 
-niiri:ea882a65b0dfd559a13cfe9234c2c24d prov:wasDerivedFrom niiri:b16302312e147e9c8ce1bdd421f19045 .
+niiri:38744d312469d30ea2aad6e112efd815 prov:wasDerivedFrom niiri:80e9d7b2bd34593272f3fb19fc9254e9 .
 
-niiri:a610e963c32e5f537ce4379d79a33677
+niiri:6d61e7dcb92b6e6b6f64536ea335f5e2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:e137a7aa81cf8b25e12262b0d38b2162 ;
+    prov:atLocation niiri:19af79f4d565155ceba8d4b51e598b73 ;
     prov:value "4.99766159057617"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17685933085535"^^xsd:float ;
     nidm_pValueUncorrected: "0.000744396146822202"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0532506765476335"^^xsd:float .
 
-niiri:e137a7aa81cf8b25e12262b0d38b2162
+niiri:19af79f4d565155ceba8d4b51e598b73
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[-44,22,40]"^^xsd:string .
 
-niiri:a610e963c32e5f537ce4379d79a33677 prov:wasDerivedFrom niiri:9e57216b41802f20cbaf2104bd85f6ec .
+niiri:6d61e7dcb92b6e6b6f64536ea335f5e2 prov:wasDerivedFrom niiri:91bc3a2972b2938504904a8d68057f2e .
 
-niiri:8a5fcc105ffc1799aa129242dff957a1
+niiri:9a1ce2e69e3dbc416c997bb0ba8cf8fa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:9189a192e96af6b4e8a8d551eda8ce86 ;
+    prov:atLocation niiri:ddbc2b5e1f26927e114e09c84b260fdd ;
     prov:value "4.98628282546997"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1714153864203"^^xsd:float ;
     nidm_pValueUncorrected: "0.00075849026901309"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0537320048825192"^^xsd:float .
 
-niiri:9189a192e96af6b4e8a8d551eda8ce86
+niiri:ddbc2b5e1f26927e114e09c84b260fdd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[32,-24,72]"^^xsd:string .
 
-niiri:8a5fcc105ffc1799aa129242dff957a1 prov:wasDerivedFrom niiri:002e00007a510fe7b30fd39adc263872 .
+niiri:9a1ce2e69e3dbc416c997bb0ba8cf8fa prov:wasDerivedFrom niiri:681cc93cdfd04b41012417cfd725953f .
 
-niiri:048dfb27e0ec2f8c989f283aa5001023
+niiri:1e37e838816ab673f5b1a0e528a618fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:730207a65b3cc9b8b3494340623e3fad ;
+    prov:atLocation niiri:b33af54063165da162cc0a06d18506f6 ;
     prov:value "4.97769069671631"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16729931357798"^^xsd:float ;
     nidm_pValueUncorrected: "0.000769309331678514"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0542313534025412"^^xsd:float .
 
-niiri:730207a65b3cc9b8b3494340623e3fad
+niiri:b33af54063165da162cc0a06d18506f6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[50,-30,60]"^^xsd:string .
 
-niiri:048dfb27e0ec2f8c989f283aa5001023 prov:wasDerivedFrom niiri:2b00f1f0bcfadf17e4e74a633d9cbe02 .
+niiri:1e37e838816ab673f5b1a0e528a618fb prov:wasDerivedFrom niiri:1288217d5c8b70c54915067a87402187 .
 
-niiri:4a609db5a795868ef47abe1fb286fd19
+niiri:af091ddb51f232e6c9bd315c31128cde
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:dfeb92f46265f28e2d20e5b1a396299e ;
+    prov:atLocation niiri:a3d5999988833de22efee90511c9be29 ;
     prov:value "4.95973443984985"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15868244743865"^^xsd:float ;
     nidm_pValueUncorrected: "0.000792420371319991"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.05524320395595"^^xsd:float .
 
-niiri:dfeb92f46265f28e2d20e5b1a396299e
+niiri:a3d5999988833de22efee90511c9be29
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[-32,-74,-28]"^^xsd:string .
 
-niiri:4a609db5a795868ef47abe1fb286fd19 prov:wasDerivedFrom niiri:0a99da6db6ffdb6abd70dfec062dacc6 .
+niiri:af091ddb51f232e6c9bd315c31128cde prov:wasDerivedFrom niiri:9a33ec7dcbaf4c333c9be7973d3674ae .
 
-niiri:72e747c045e6ce18c7ea2d8872ec01bd
+niiri:040db063243906b03c972dbf813f1e8f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:3d10b3a98099f6ac7bd61e8504591520 ;
+    prov:atLocation niiri:c2ea305012d99e2652d0a3896a349455 ;
     prov:value "4.95515823364258"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15648318111342"^^xsd:float ;
     nidm_pValueUncorrected: "0.000798420481037398"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0553418612137989"^^xsd:float .
 
-niiri:3d10b3a98099f6ac7bd61e8504591520
+niiri:c2ea305012d99e2652d0a3896a349455
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-26,-86,40]"^^xsd:string .
 
-niiri:72e747c045e6ce18c7ea2d8872ec01bd prov:wasDerivedFrom niiri:ee9edf2a051832c657f8417f27f95a8f .
+niiri:040db063243906b03c972dbf813f1e8f prov:wasDerivedFrom niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73 .
 
-niiri:26738ed1bfc7ad05331c2ac978006528
+niiri:5eaeb3f75f7650cb74f379ed173f7e58
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:80998b0375b4ec6cd6d7875df2f956d9 ;
+    prov:atLocation niiri:c72bbf109b350d78e64ee37ee86ef87a ;
     prov:value "4.93855857849121"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14849453487417"^^xsd:float ;
     nidm_pValueUncorrected: "0.000820568960055779"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0562262327439451"^^xsd:float .
 
-niiri:80998b0375b4ec6cd6d7875df2f956d9
+niiri:c72bbf109b350d78e64ee37ee86ef87a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[-10,8,6]"^^xsd:string .
 
-niiri:26738ed1bfc7ad05331c2ac978006528 prov:wasDerivedFrom niiri:db1e7cd2ec53abce67f4898eb3c88730 .
+niiri:5eaeb3f75f7650cb74f379ed173f7e58 prov:wasDerivedFrom niiri:99af69862e054a4c62b8e6066ff12cfd .
 
-niiri:4b0a6177d3028a1d196d8e8644c68f46
+niiri:3716c38360149956c53c557239c91fd7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:e2315b6373bae1a1a264e9e11bacd9c2 ;
+    prov:atLocation niiri:8947ac3de97fe88382a65c163f842436 ;
     prov:value "4.90264129638672"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13114947632107"^^xsd:float ;
     nidm_pValueUncorrected: "0.000870617549853403"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.058320641241518"^^xsd:float .
 
-niiri:e2315b6373bae1a1a264e9e11bacd9c2
+niiri:8947ac3de97fe88382a65c163f842436
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[14,8,10]"^^xsd:string .
 
-niiri:4b0a6177d3028a1d196d8e8644c68f46 prov:wasDerivedFrom niiri:1066c8d3aa41693bfd354d1824cc7afe .
+niiri:3716c38360149956c53c557239c91fd7 prov:wasDerivedFrom niiri:20fc427845c2a14183959299a0d233ce .
 
-niiri:6c657d496e9b2f580793789f0903637f
+niiri:17f311b4781af2c645292f1b0c08e56c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:92223eda5bee2fa6366d50cdb0ad17ae ;
+    prov:atLocation niiri:90f614e5e280a7d031215612221686fb ;
     prov:value "4.90243864059448"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1310513773308"^^xsd:float ;
     nidm_pValueUncorrected: "0.000870908426383377"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.058320641241518"^^xsd:float .
 
-niiri:92223eda5bee2fa6366d50cdb0ad17ae
+niiri:90f614e5e280a7d031215612221686fb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[-20,-54,-2]"^^xsd:string .
 
-niiri:6c657d496e9b2f580793789f0903637f prov:wasDerivedFrom niiri:176e7ef375f6f1d2e26f1a064f8f6d39 .
+niiri:17f311b4781af2c645292f1b0c08e56c prov:wasDerivedFrom niiri:0294b8b1f3c4b525a18397bf17d17d63 .
 
-niiri:a9f12b36f390508d489680fa6cd977ef
+niiri:261827ec7c4ac6d56b850bf7be1a0995
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:400d143354fecfac34d7ed6f2f74e6d2 ;
+    prov:atLocation niiri:0dc46ac23cbc0284b413f46af5e9b5bf ;
     prov:value "4.88119602203369"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12075392909771"^^xsd:float ;
     nidm_pValueUncorrected: "0.000901943498395119"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0594947205600118"^^xsd:float .
 
-niiri:400d143354fecfac34d7ed6f2f74e6d2
+niiri:0dc46ac23cbc0284b413f46af5e9b5bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[-26,-84,44]"^^xsd:string .
 
-niiri:a9f12b36f390508d489680fa6cd977ef prov:wasDerivedFrom niiri:08a3f7b7f6c942ab91160dfccbb968f2 .
+niiri:261827ec7c4ac6d56b850bf7be1a0995 prov:wasDerivedFrom niiri:3dc796cbf0403561b0e6ea42b96ea1a9 .
 
-niiri:41ef706109f70aebe1bd69047789d6e8
+niiri:2ae246317f788cd3eeea499f36da2784
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:832aed24b7e9f89f7aac213df0041827 ;
+    prov:atLocation niiri:ba8c00af87b3e78bc9d96bf0d493697c ;
     prov:value "4.86706686019897"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11388868389685"^^xsd:float ;
     nidm_pValueUncorrected: "0.000923195680083033"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0603762016821821"^^xsd:float .
 
-niiri:832aed24b7e9f89f7aac213df0041827
+niiri:ba8c00af87b3e78bc9d96bf0d493697c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-54,22,10]"^^xsd:string .
 
-niiri:41ef706109f70aebe1bd69047789d6e8 prov:wasDerivedFrom niiri:bddc2499a043f720b9c5a3c2a309f42c .
+niiri:2ae246317f788cd3eeea499f36da2784 prov:wasDerivedFrom niiri:14518885ee853fba951013cf73f66bed .
 
-niiri:b47830006cf1b3f215bc9fd3e64ca371
+niiri:e7bbc2a18733379b4ba6e4c9b9da44fa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:d9dbb81cee63c9d429edaac681bad88e ;
+    prov:atLocation niiri:8726957d4cdde9d04e29bbe51a70e336 ;
     prov:value "4.84812355041504"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10466401400555"^^xsd:float ;
     nidm_pValueUncorrected: "0.000952476397051205"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0616422795595169"^^xsd:float .
 
-niiri:d9dbb81cee63c9d429edaac681bad88e
+niiri:8726957d4cdde9d04e29bbe51a70e336
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[32,-80,-24]"^^xsd:string .
 
-niiri:b47830006cf1b3f215bc9fd3e64ca371 prov:wasDerivedFrom niiri:189d9d696ac51ec44003eb5f973b6c64 .
+niiri:e7bbc2a18733379b4ba6e4c9b9da44fa prov:wasDerivedFrom niiri:7666b1a689a3839cdadb86af5e5c7c39 .
 
-niiri:e92e382c720879269b6002714e4a16ac
+niiri:38f3fc0e0c53bc3fde20e9f5bbf1c52d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:dde3f75099fb3b6b61a79003461a2d21 ;
+    prov:atLocation niiri:97cc916bbf9c73be7bceb77865458446 ;
     prov:value "4.82597017288208"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09384653195936"^^xsd:float ;
     nidm_pValueUncorrected: "0.00098789830908641"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0629671631402158"^^xsd:float .
 
-niiri:dde3f75099fb3b6b61a79003461a2d21
+niiri:97cc916bbf9c73be7bceb77865458446
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[10,-80,4]"^^xsd:string .
 
-niiri:e92e382c720879269b6002714e4a16ac prov:wasDerivedFrom niiri:5d37a307684854af5c2a17ddbdb8f17f .
+niiri:38f3fc0e0c53bc3fde20e9f5bbf1c52d prov:wasDerivedFrom niiri:2cac2c4baab8136a53bdf03e74fdc1c5 .
 
-niiri:b3a2d1e439fbf61d76d02cbdc713f8d9
+niiri:c9916a684f8ab6fd7ebe1ce3907a9b34
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:434dda457215299529b6e3b3f80e543c ;
+    prov:atLocation niiri:302777c17a3ab317d1e6b6ffd24666ff ;
     prov:value "4.82537364959717"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09355480628341"^^xsd:float ;
     nidm_pValueUncorrected: "0.000988870098138084"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0629727239584754"^^xsd:float .
 
-niiri:434dda457215299529b6e3b3f80e543c
+niiri:302777c17a3ab317d1e6b6ffd24666ff
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[16,-50,-50]"^^xsd:string .
 
-niiri:b3a2d1e439fbf61d76d02cbdc713f8d9 prov:wasDerivedFrom niiri:df310d7fb2c5397364d68a8d3fa65bc0 .
+niiri:c9916a684f8ab6fd7ebe1ce3907a9b34 prov:wasDerivedFrom niiri:8768acb96e7e44e4cd45548f0d52dd3f .
 
-niiri:5c2c228fe7c73da50c74454b38d9ce4f
+niiri:380422cca8da791d72bac3c9bd4f903f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:83a52daf4eb7997573701f3945da1301 ;
+    prov:atLocation niiri:6f88b65eb9c9991d816265aa7f3ca79a ;
     prov:value "4.82024002075195"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09104327517968"^^xsd:float ;
     nidm_pValueUncorrected: "0.000997272813291428"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0632678542871923"^^xsd:float .
 
-niiri:83a52daf4eb7997573701f3945da1301
+niiri:6f88b65eb9c9991d816265aa7f3ca79a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[-12,-20,12]"^^xsd:string .
 
-niiri:5c2c228fe7c73da50c74454b38d9ce4f prov:wasDerivedFrom niiri:d0abba065cadfdf673c1ba317a4155ef .
+niiri:380422cca8da791d72bac3c9bd4f903f prov:wasDerivedFrom niiri:816f19a8ef8789235a9bd7bfe4396a14 .
 

--- a/spmexport/ex_spm_f_test/nidm.ttl
+++ b/spmexport/ex_spm_f_test/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:e7c622c060f6ce4999c83cd4e7d504a2
+niiri:94350a30508710a81c55188bdb54b3a9
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:64a0a1e03c4e2566a0c7d5a14157ea25
+niiri:c3ce6e8455b93d01b003f62798403114
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:4547ccdcb0181d8f245befc50dcc96be
+niiri:b12f70ab92b50ab520c458bd3f6fcd10
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:4547ccdcb0181d8f245befc50dcc96be prov:wasAssociatedWith niiri:64a0a1e03c4e2566a0c7d5a14157ea25 .
+niiri:b12f70ab92b50ab520c458bd3f6fcd10 prov:wasAssociatedWith niiri:c3ce6e8455b93d01b003f62798403114 .
 
 _:blank5 a prov:Generation .
 
-niiri:e7c622c060f6ce4999c83cd4e7d504a2 prov:qualifiedGeneration _:blank5 .
+niiri:94350a30508710a81c55188bdb54b3a9 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:33:38"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:43:58"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -137,12 +137,12 @@ _:blank5 prov:atTime "2016-01-11T10:33:38"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:a9aa267d850571686083e814acacec85
+niiri:ea8d144ccce6489b92b187acdc792bec
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:8631110ecbf1ae2c61c651d3c345e53a
+niiri:3afab7fbc0c106b802099cf168ca0377
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -152,35 +152,35 @@ niiri:8631110ecbf1ae2c61c651d3c345e53a
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:4065e9c0832a79eea2d7f48f6837481b
+niiri:680b19ae5cf36bf681e8dbe95af38dc2
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:6aef7089ce827a6b71f19c009ab15a95
+niiri:3af050cd6585ce5a06f1b07cb80ed0e0
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:ea225237d5825ad08d76e698758e674b
+niiri:a0660d4d7fa510f658959260466e1e3e
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:1a0a5cc4df2739bc50811b7823bb401e ;
+    dc:description niiri:eaa7306a1252a08b865632eb736793e2 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:6aef7089ce827a6b71f19c009ab15a95 ;
+    nidm_hasDriftModel: niiri:3af050cd6585ce5a06f1b07cb80ed0e0 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:1a0a5cc4df2739bc50811b7823bb401e
+niiri:eaa7306a1252a08b865632eb736793e2
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:b5697884a43743feb7d20368b80f55a9
+niiri:0bd8aede66fc8be9ae3875eb95a27342
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -188,213 +188,213 @@ niiri:b5697884a43743feb7d20368b80f55a9
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:3c0b88356def21e2b7fe83f740cf597b
+niiri:9d8cf492466560d50918318864025c61
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:3c0b88356def21e2b7fe83f740cf597b prov:wasAssociatedWith niiri:a9aa267d850571686083e814acacec85 .
+niiri:9d8cf492466560d50918318864025c61 prov:wasAssociatedWith niiri:ea8d144ccce6489b92b187acdc792bec .
 
-niiri:3c0b88356def21e2b7fe83f740cf597b prov:used niiri:ea225237d5825ad08d76e698758e674b .
+niiri:9d8cf492466560d50918318864025c61 prov:used niiri:a0660d4d7fa510f658959260466e1e3e .
 
-niiri:3c0b88356def21e2b7fe83f740cf597b prov:used niiri:4065e9c0832a79eea2d7f48f6837481b .
+niiri:9d8cf492466560d50918318864025c61 prov:used niiri:680b19ae5cf36bf681e8dbe95af38dc2 .
 
-niiri:3c0b88356def21e2b7fe83f740cf597b prov:used niiri:b5697884a43743feb7d20368b80f55a9 .
+niiri:9d8cf492466560d50918318864025c61 prov:used niiri:0bd8aede66fc8be9ae3875eb95a27342 .
 
-niiri:dd3a1b34bce9178ca5eb9e0c6f64572b
+niiri:4a2baf3c1d8fbb1b78319c1483b1b28e
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:f081077fa790becea31f832bed0ad762
+niiri:c6ef8881327f7dbd655c5bd684eddd5f
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
 
-niiri:dd3a1b34bce9178ca5eb9e0c6f64572b prov:wasDerivedFrom niiri:f081077fa790becea31f832bed0ad762 .
+niiri:4a2baf3c1d8fbb1b78319c1483b1b28e prov:wasDerivedFrom niiri:c6ef8881327f7dbd655c5bd684eddd5f .
 
-niiri:dd3a1b34bce9178ca5eb9e0c6f64572b prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:4a2baf3c1d8fbb1b78319c1483b1b28e prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:a45718cdddcc1f52a7095a49c028bc7b
+niiri:e32ad7d6a1d3a7b17810d670e8fd072a
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "108.038318634033"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 ;
     crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
 
-niiri:a45718cdddcc1f52a7095a49c028bc7b prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:e32ad7d6a1d3a7b17810d670e8fd072a prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:855ff1743625270dda4931a04ecd1031
+niiri:fc7a2a7c4dc5f4907189ccf4e254bef8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 .
 
-niiri:97dfe474f83a8bb5d149d855133a64bc
+niiri:0b1ee3d8ddfaddb3225d71c6fa48f10d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "11c208792e1874b4837ea90ec03320c8eeb702ad3966ee5912aa2e33b5bdb17b0e88caa31ed546f7f601160ced8eceebdf5db6449df6ec3ffbd17e27917ec328"^^xsd:string .
 
-niiri:855ff1743625270dda4931a04ecd1031 prov:wasDerivedFrom niiri:97dfe474f83a8bb5d149d855133a64bc .
+niiri:fc7a2a7c4dc5f4907189ccf4e254bef8 prov:wasDerivedFrom niiri:0b1ee3d8ddfaddb3225d71c6fa48f10d .
 
-niiri:855ff1743625270dda4931a04ecd1031 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:fc7a2a7c4dc5f4907189ccf4e254bef8 prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:4fbc59d57cc5244670a944301b75c49e
+niiri:7f0262e97145372a803588a6101fa2ae
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 .
 
-niiri:552b132ff1cb3c6356eed45cfba091e2
+niiri:e157b91be2875d773dbb473a64e2fe41
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
 
-niiri:4fbc59d57cc5244670a944301b75c49e prov:wasDerivedFrom niiri:552b132ff1cb3c6356eed45cfba091e2 .
+niiri:7f0262e97145372a803588a6101fa2ae prov:wasDerivedFrom niiri:e157b91be2875d773dbb473a64e2fe41 .
 
-niiri:4fbc59d57cc5244670a944301b75c49e prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:7f0262e97145372a803588a6101fa2ae prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:4fcd0feb226f491d94d19ede647cf6df
+niiri:52b5f0dfeef5a989ceb73981bb38aea1
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 .
 
-niiri:47beaf2666652e2dfc40b9d59975b754
+niiri:5a6aaf833cfaf0d24c2ee98156b45a17
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "833a477bd4e758bdde7fcc9e6682186e9e38c1eeaa2a66de7d67e5f3c57cbaed7bddd45a7f7c86db713a8aa708790eaa31e0d8f0d0af9db9e87b545990b9e91e"^^xsd:string .
 
-niiri:4fcd0feb226f491d94d19ede647cf6df prov:wasDerivedFrom niiri:47beaf2666652e2dfc40b9d59975b754 .
+niiri:52b5f0dfeef5a989ceb73981bb38aea1 prov:wasDerivedFrom niiri:5a6aaf833cfaf0d24c2ee98156b45a17 .
 
-niiri:4fcd0feb226f491d94d19ede647cf6df prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:52b5f0dfeef5a989ceb73981bb38aea1 prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:b1423cdb1726cd9674ebf1bcab3bcf56
+niiri:54d1aded0ce58fe08df4293d8ceddadf
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 .
 
-niiri:8e1176bdcc74a45839a55e6b1d4afb84
+niiri:917bda9ca5a5cd276b5de3dd367e6ec4
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "8044c2e517efad185114b1d5478983a5073547d99f6b5778bcefe9caa7d243b89824b69841e3e5aa05e1da5393c9d1a34fec9a050b6a1e8a87da31cad99bfe69"^^xsd:string .
 
-niiri:b1423cdb1726cd9674ebf1bcab3bcf56 prov:wasDerivedFrom niiri:8e1176bdcc74a45839a55e6b1d4afb84 .
+niiri:54d1aded0ce58fe08df4293d8ceddadf prov:wasDerivedFrom niiri:917bda9ca5a5cd276b5de3dd367e6ec4 .
 
-niiri:b1423cdb1726cd9674ebf1bcab3bcf56 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:54d1aded0ce58fe08df4293d8ceddadf prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:15b31a17ded6db8183340b7bf088bf97
+niiri:c17ccb3d27e2d45265ebedf07304238f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 .
 
-niiri:345e3096159163131e4b2fc7f1ed4857
+niiri:1de788620c205e069ddf02ffd1a53060
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "15551a7f3970720338fd0643bd017ba2f7f5db09c16b38909560b0479aa69eb74cd746fa98b2adc796153af88fba9b2ddd4eb5713b6f6011e62b7efb6531426d"^^xsd:string .
 
-niiri:15b31a17ded6db8183340b7bf088bf97 prov:wasDerivedFrom niiri:345e3096159163131e4b2fc7f1ed4857 .
+niiri:c17ccb3d27e2d45265ebedf07304238f prov:wasDerivedFrom niiri:1de788620c205e069ddf02ffd1a53060 .
 
-niiri:15b31a17ded6db8183340b7bf088bf97 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:c17ccb3d27e2d45265ebedf07304238f prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:08de3e9dd167da4e0236e06f6ffa9f7a
+niiri:4851c787a436167f4a71edf42259ba00
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 6" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a .
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 .
 
-niiri:77879d25adca01d9f67bf80353db2ca6
+niiri:1d9572dddd28e78581bf46f4943a00b3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
 
-niiri:08de3e9dd167da4e0236e06f6ffa9f7a prov:wasDerivedFrom niiri:77879d25adca01d9f67bf80353db2ca6 .
+niiri:4851c787a436167f4a71edf42259ba00 prov:wasDerivedFrom niiri:1d9572dddd28e78581bf46f4943a00b3 .
 
-niiri:08de3e9dd167da4e0236e06f6ffa9f7a prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:4851c787a436167f4a71edf42259ba00 prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:3406078060d97913cb8d424d34703ab9
+niiri:044de1fe963ba759e42829a1aa90a533
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 ;
     crypto:sha512 "9f1acf4f335317f388cc8adcc04086aa4e6bc6d19d5633a6a8d8dd85716386748c7ed700ef8031c7a3733228557d5ecf96eb6a889e2d36ad065e7bc852ae0b8c"^^xsd:string .
 
-niiri:c636630fb563318d5b35ab4a8b0a34c0
+niiri:e7cb96c8612281b1aa20712f5ab8d78a
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "641184631587ff0ed74f92302d94dd40f2802efab358753eade14667fb6ee74fe64f3090b02fdf20e4a99d444610a61a1ae8a684628c9b2037535fbed9d53a12"^^xsd:string .
 
-niiri:3406078060d97913cb8d424d34703ab9 prov:wasDerivedFrom niiri:c636630fb563318d5b35ab4a8b0a34c0 .
+niiri:044de1fe963ba759e42829a1aa90a533 prov:wasDerivedFrom niiri:e7cb96c8612281b1aa20712f5ab8d78a .
 
-niiri:3406078060d97913cb8d424d34703ab9 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:044de1fe963ba759e42829a1aa90a533 prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:345400b745ebe143b4f453e4c217c209
+niiri:fde6c201825e0d228d8f071226d6df72
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 ;
     crypto:sha512 "a093dd7a9dd81e95f3696221e49cbb3ad8080b1f316ece53c9aafcb5cc9b767e55c594b7131d933e31231744c65db07483e64245480afd95075b76ccd2432789"^^xsd:string .
 
-niiri:774ad877e270db9e46dc564231f1b2e3
+niiri:bb6e9ede0fb10dff1545bbf67b08e145
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "6ccf9e1895f8a26549f392b1d1a3676888cd729a207c6a93bcda6d549de2d4f133c0b2847bd2e839a462f3ba74cb9d9525eddb9f8499b99fb452b93cd713a158"^^xsd:string .
 
-niiri:345400b745ebe143b4f453e4c217c209 prov:wasDerivedFrom niiri:774ad877e270db9e46dc564231f1b2e3 .
+niiri:fde6c201825e0d228d8f071226d6df72 prov:wasDerivedFrom niiri:bb6e9ede0fb10dff1545bbf67b08e145 .
 
-niiri:345400b745ebe143b4f453e4c217c209 prov:wasGeneratedBy niiri:3c0b88356def21e2b7fe83f740cf597b .
+niiri:fde6c201825e0d228d8f071226d6df72 prov:wasGeneratedBy niiri:9d8cf492466560d50918318864025c61 .
 
-niiri:c9f72062391a92f26280783481f9d41e
+niiri:11535783db3c16f234c0a9a9c08eeff7
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_FStatistic: ;
     nidm_contrastName: "F Contrast Test"^^xsd:string ;
     rdfs:label "Contrast: F Contrast Test" ;
     prov:value "[[1, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0],[0, 0, 0, 1, 0, 0]]"^^xsd:string .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e
+niiri:01c79625dd156fe0cc39d295e9a1bc02
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:wasAssociatedWith niiri:a9aa267d850571686083e814acacec85 .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:wasAssociatedWith niiri:ea8d144ccce6489b92b187acdc792bec .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:dd3a1b34bce9178ca5eb9e0c6f64572b .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:4a2baf3c1d8fbb1b78319c1483b1b28e .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:3406078060d97913cb8d424d34703ab9 .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:044de1fe963ba759e42829a1aa90a533 .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:ea225237d5825ad08d76e698758e674b .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:a0660d4d7fa510f658959260466e1e3e .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:c9f72062391a92f26280783481f9d41e .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:11535783db3c16f234c0a9a9c08eeff7 .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:855ff1743625270dda4931a04ecd1031 .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:fc7a2a7c4dc5f4907189ccf4e254bef8 .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:4fbc59d57cc5244670a944301b75c49e .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:7f0262e97145372a803588a6101fa2ae .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:4fcd0feb226f491d94d19ede647cf6df .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:52b5f0dfeef5a989ceb73981bb38aea1 .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:b1423cdb1726cd9674ebf1bcab3bcf56 .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:54d1aded0ce58fe08df4293d8ceddadf .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:15b31a17ded6db8183340b7bf088bf97 .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:c17ccb3d27e2d45265ebedf07304238f .
 
-niiri:aedde2b1a02ad24ed234029b5dc86c0e prov:used niiri:08de3e9dd167da4e0236e06f6ffa9f7a .
+niiri:01c79625dd156fe0cc39d295e9a1bc02 prov:used niiri:4851c787a436167f4a71edf42259ba00 .
 
-niiri:b0e7b8f9e020e8724283e6191e2da703
+niiri:445e63a4c2b814664d88bb41eb6a0e93
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
@@ -404,104 +404,104 @@ niiri:b0e7b8f9e020e8724283e6191e2da703
     nidm_contrastName: "F Contrast Test"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.999999999651"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "3.99999999999962"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 ;
     crypto:sha512 "ca31a667d26797ee68a3709a8fa04f799ad113f17e6eff75ad6e88f53c44aa9e158a0d007354d454ad01df82d6b0f25f07b324cc3baa32f7623096a92ee6f304"^^xsd:string .
 
-niiri:27281b97c78d257b22887871c6a68112
+niiri:b7a13b645ead1cd72ae3434790f2a7c3
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmF_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "db6d4200b2e060c1fbd3e5c71011ac95ce60024087239685545954651a68733ec2d949c56520d2637add9e91c8e7883742c7d307667ad83c4ebe2a8531a1cc53"^^xsd:string .
 
-niiri:b0e7b8f9e020e8724283e6191e2da703 prov:wasDerivedFrom niiri:27281b97c78d257b22887871c6a68112 .
+niiri:445e63a4c2b814664d88bb41eb6a0e93 prov:wasDerivedFrom niiri:b7a13b645ead1cd72ae3434790f2a7c3 .
 
-niiri:b0e7b8f9e020e8724283e6191e2da703 prov:wasGeneratedBy niiri:aedde2b1a02ad24ed234029b5dc86c0e .
+niiri:445e63a4c2b814664d88bb41eb6a0e93 prov:wasGeneratedBy niiri:01c79625dd156fe0cc39d295e9a1bc02 .
 
-niiri:0c51bc0fe4411e7dcd2abb844e9d9483
+niiri:b84b557c73a4800ede8eb4970d8fbd08
     a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
     prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Explained Mean Square Map" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 ;
     crypto:sha512 "a4b2ff6f792524a027a625aba962b798c3ea321cdd6636193ab521acf5dafa8ceb7fd4cb99a450ab7872359d0e6dac97f82b7523d609747780623b5077e02588"^^xsd:string .
 
-niiri:0c51bc0fe4411e7dcd2abb844e9d9483 prov:wasGeneratedBy niiri:aedde2b1a02ad24ed234029b5dc86c0e .
+niiri:b84b557c73a4800ede8eb4970d8fbd08 prov:wasGeneratedBy niiri:01c79625dd156fe0cc39d295e9a1bc02 .
 
-niiri:7f46ae22cdc5ee6822a2f2f5b2ca2f2b
+niiri:9cd223dcc0ec8314815147f964be2fee
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500086842908"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:0b8b0ea120e66e277cc906e8c638f4a1 ;
-    nidm_equivalentThreshold: niiri:01b61d5a54d124c25b0dfe4842452479 .
+    nidm_equivalentThreshold: niiri:a369c40ba876dd1b11662a065f62caba ;
+    nidm_equivalentThreshold: niiri:acc7ca43aa3ae020f2992ce6646c4d82 .
 
-niiri:0b8b0ea120e66e277cc906e8c638f4a1
+niiri:a369c40ba876dd1b11662a065f62caba
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.81888651656205"^^xsd:float .
 
-niiri:01b61d5a54d124c25b0dfe4842452479
+niiri:acc7ca43aa3ae020f2992ce6646c4d82
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:5c63a2de98701908b773b73724aa2e6c
+niiri:1bf6a1379f676d90935a4c9cba3549dd
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:eb923f6975373720518450d07547dba1 ;
-    nidm_equivalentThreshold: niiri:c6c498af368977c112799bfa72671339 .
+    nidm_equivalentThreshold: niiri:8a8890213f87d19045b69e60f0fea2a3 ;
+    nidm_equivalentThreshold: niiri:5bddf3675665070262f012165db26554 .
 
-niiri:eb923f6975373720518450d07547dba1
+niiri:8a8890213f87d19045b69e60f0fea2a3
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:c6c498af368977c112799bfa72671339
+niiri:5bddf3675665070262f012165db26554
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:0b2c9ff1807f3f9bd6728cc73ddb271a
+niiri:5f51c5b8d9b08bb6dfc880cd6a7406f0
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:ee02bfd0ffe03ca3e43583cd21adab51
+niiri:4cd73eb3fe73378073fd798331a4a363
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a
+niiri:b7277b9b56644163330bef68a876971a
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a prov:wasAssociatedWith niiri:a9aa267d850571686083e814acacec85 .
+niiri:b7277b9b56644163330bef68a876971a prov:wasAssociatedWith niiri:ea8d144ccce6489b92b187acdc792bec .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:7f46ae22cdc5ee6822a2f2f5b2ca2f2b .
+niiri:b7277b9b56644163330bef68a876971a prov:used niiri:9cd223dcc0ec8314815147f964be2fee .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:5c63a2de98701908b773b73724aa2e6c .
+niiri:b7277b9b56644163330bef68a876971a prov:used niiri:1bf6a1379f676d90935a4c9cba3549dd .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:b0e7b8f9e020e8724283e6191e2da703 .
+niiri:b7277b9b56644163330bef68a876971a prov:used niiri:445e63a4c2b814664d88bb41eb6a0e93 .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:345400b745ebe143b4f453e4c217c209 .
+niiri:b7277b9b56644163330bef68a876971a prov:used niiri:fde6c201825e0d228d8f071226d6df72 .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:dd3a1b34bce9178ca5eb9e0c6f64572b .
+niiri:b7277b9b56644163330bef68a876971a prov:used niiri:4a2baf3c1d8fbb1b78319c1483b1b28e .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:0b2c9ff1807f3f9bd6728cc73ddb271a .
+niiri:b7277b9b56644163330bef68a876971a prov:used niiri:5f51c5b8d9b08bb6dfc880cd6a7406f0 .
 
-niiri:87b5e03e41975da7e1db9bc068fc452a prov:used niiri:ee02bfd0ffe03ca3e43583cd21adab51 .
+niiri:b7277b9b56644163330bef68a876971a prov:used niiri:4cd73eb3fe73378073fd798331a4a363 .
 
-niiri:6fa69d1e83da07700b4a4ed4fdff8fa4
+niiri:213f699536a3c6b036ed7516495f25af
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 ;
     nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
     nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.4409986586639"^^xsd:float ;
@@ -518,9 +518,9 @@ niiri:6fa69d1e83da07700b4a4ed4fdff8fa4
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "51"^^xsd:int ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:6fa69d1e83da07700b4a4ed4fdff8fa4 prov:wasGeneratedBy niiri:87b5e03e41975da7e1db9bc068fc452a .
+niiri:213f699536a3c6b036ed7516495f25af prov:wasGeneratedBy niiri:b7277b9b56644163330bef68a876971a .
 
-niiri:bfc22c098dc267a88d326bbf0e6793e3
+niiri:693cbd3283b68002fb1375c234a7ba13
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -528,26 +528,26 @@ niiri:bfc22c098dc267a88d326bbf0e6793e3
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "89"^^xsd:int ;
     nidm_pValue: "1.20671430625663e-08"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:c872c243f35f93570da8e3e8bb2b7ead ;
-    nidm_hasMaximumIntensityProjection: niiri:9fea03d98e6320e3400bb3c188004db8 ;
-    nidm_inCoordinateSpace: niiri:8631110ecbf1ae2c61c651d3c345e53a ;
+    nidm_hasClusterLabelsMap: niiri:5f008af65afcb63ce31164ba65ba7611 ;
+    nidm_hasMaximumIntensityProjection: niiri:fa74373bbf11f8977e622e922390906d ;
+    nidm_inCoordinateSpace: niiri:3afab7fbc0c106b802099cf168ca0377 ;
     crypto:sha512 "7655b200bdcbba72ab5ab79029728a420df3f3368bcb553410540390e1372e99531cb91885edbdd03945d7e2391516a3d8dc537da81527730e866035d4af7894"^^xsd:string .
 
-niiri:c872c243f35f93570da8e3e8bb2b7ead
+niiri:5f008af65afcb63ce31164ba65ba7611
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:9fea03d98e6320e3400bb3c188004db8
+niiri:fa74373bbf11f8977e622e922390906d
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:bfc22c098dc267a88d326bbf0e6793e3 prov:wasGeneratedBy niiri:87b5e03e41975da7e1db9bc068fc452a .
+niiri:693cbd3283b68002fb1375c234a7ba13 prov:wasGeneratedBy niiri:b7277b9b56644163330bef68a876971a .
 
-niiri:8337790d11808f2fb788ee8093e46afe
+niiri:70b2003559708458bd92e73d3d3c7bf4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1078"^^xsd:int ;
@@ -557,9 +557,9 @@ niiri:8337790d11808f2fb788ee8093e46afe
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:8337790d11808f2fb788ee8093e46afe prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:70b2003559708458bd92e73d3d3c7bf4 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:2e44272daecb8718b2883f84f352fc62
+niiri:e2b47f512f66716985aee0fe421c3346
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "930"^^xsd:int ;
@@ -569,9 +569,9 @@ niiri:2e44272daecb8718b2883f84f352fc62
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:2e44272daecb8718b2883f84f352fc62 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:e2b47f512f66716985aee0fe421c3346 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:c893d69da88fea01efe542f9787608c5
+niiri:3c6dd5e94db642fc0c6313fade61752c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "61"^^xsd:int ;
@@ -581,9 +581,9 @@ niiri:c893d69da88fea01efe542f9787608c5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:c893d69da88fea01efe542f9787608c5 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:3c6dd5e94db642fc0c6313fade61752c prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:fafaf22f396d11e8355f5d1e7a7367ea
+niiri:13dc91c36d42d9c0075971b7e2e4340a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "51"^^xsd:int ;
@@ -593,9 +593,9 @@ niiri:fafaf22f396d11e8355f5d1e7a7367ea
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:fafaf22f396d11e8355f5d1e7a7367ea prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:13dc91c36d42d9c0075971b7e2e4340a prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:0820636de884fe0d783c5385916ab101
+niiri:63baaa25c1850e25ff8b59437cf378c6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "102"^^xsd:int ;
@@ -605,9 +605,9 @@ niiri:0820636de884fe0d783c5385916ab101
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:0820636de884fe0d783c5385916ab101 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:63baaa25c1850e25ff8b59437cf378c6 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:1e3c8c027b813bda7df5358a8ab4f63a
+niiri:938d8c88ecfbbf04abff04ec2e6740f3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "69"^^xsd:int ;
@@ -617,9 +617,9 @@ niiri:1e3c8c027b813bda7df5358a8ab4f63a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:1e3c8c027b813bda7df5358a8ab4f63a prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:938d8c88ecfbbf04abff04ec2e6740f3 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:e24e457b7371fd1bac7d4cb391bb9432
+niiri:86d427d519cd54a38aa4d9fc15de80c3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "81"^^xsd:int ;
@@ -629,9 +629,9 @@ niiri:e24e457b7371fd1bac7d4cb391bb9432
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:e24e457b7371fd1bac7d4cb391bb9432 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:86d427d519cd54a38aa4d9fc15de80c3 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:2f5fcfc4453f648ede4260a16cff5960
+niiri:d23334e15ca989a88f18103920c37202
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "62"^^xsd:int ;
@@ -641,9 +641,9 @@ niiri:2f5fcfc4453f648ede4260a16cff5960
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:2f5fcfc4453f648ede4260a16cff5960 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:d23334e15ca989a88f18103920c37202 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:dbbddbece734ef2c5ed154985b15ffe8
+niiri:34d7407deceb41bb05814c58f568aa8a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -653,9 +653,9 @@ niiri:dbbddbece734ef2c5ed154985b15ffe8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:dbbddbece734ef2c5ed154985b15ffe8 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:34d7407deceb41bb05814c58f568aa8a prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:6aecc2d95fe5ba4cd2d39d16afe85407
+niiri:f11390729469ff5ad94b49a0bdfa4678
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "69"^^xsd:int ;
@@ -665,9 +665,9 @@ niiri:6aecc2d95fe5ba4cd2d39d16afe85407
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:6aecc2d95fe5ba4cd2d39d16afe85407 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:f11390729469ff5ad94b49a0bdfa4678 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:a9c284c82bc4ef4eba48570f53c9c9c4
+niiri:ccdacac7fbef86b94a12c5dabbf08bc2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "34"^^xsd:int ;
@@ -677,9 +677,9 @@ niiri:a9c284c82bc4ef4eba48570f53c9c9c4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:a9c284c82bc4ef4eba48570f53c9c9c4 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:ccdacac7fbef86b94a12c5dabbf08bc2 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:0637af2e34d8b1c842ae7d1386357498
+niiri:13403d7573cd820266b83ff32d0e9707
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -689,9 +689,9 @@ niiri:0637af2e34d8b1c842ae7d1386357498
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:0637af2e34d8b1c842ae7d1386357498 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:13403d7573cd820266b83ff32d0e9707 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:1cd4117828f514ec0fff4b67f780d6b9
+niiri:d86187d8105730183f4e8c029a41bf61
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -701,9 +701,9 @@ niiri:1cd4117828f514ec0fff4b67f780d6b9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:1cd4117828f514ec0fff4b67f780d6b9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:d86187d8105730183f4e8c029a41bf61 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:d85063f48080f770ca548748f7419e12
+niiri:67556c87393c94a727ee0b764b5d8856
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -713,9 +713,9 @@ niiri:d85063f48080f770ca548748f7419e12
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:d85063f48080f770ca548748f7419e12 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:67556c87393c94a727ee0b764b5d8856 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:ec3fc3cfa0c303c00f68f5986e44044e
+niiri:8832fdb39eea98ef7aabb68883c63c22
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "52"^^xsd:int ;
@@ -725,9 +725,9 @@ niiri:ec3fc3cfa0c303c00f68f5986e44044e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:ec3fc3cfa0c303c00f68f5986e44044e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:8832fdb39eea98ef7aabb68883c63c22 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:23c6e94e6643122dcb458402a972758e
+niiri:0a733ee37ab9d8fc5554d22235fb2ebb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -737,9 +737,9 @@ niiri:23c6e94e6643122dcb458402a972758e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:23c6e94e6643122dcb458402a972758e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:0a733ee37ab9d8fc5554d22235fb2ebb prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:68f9a66ca71f514199366c398a2831ab
+niiri:20f7a6809dd02ee80d08c981d7533384
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -749,9 +749,9 @@ niiri:68f9a66ca71f514199366c398a2831ab
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:68f9a66ca71f514199366c398a2831ab prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:20f7a6809dd02ee80d08c981d7533384 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:6f303953fe538a2a99d9b754b92e311e
+niiri:c1ebe6af3636d8119b6c8c898bc0b9cd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -761,9 +761,9 @@ niiri:6f303953fe538a2a99d9b754b92e311e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:6f303953fe538a2a99d9b754b92e311e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:c1ebe6af3636d8119b6c8c898bc0b9cd prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:b32513dc3cebea135a4227a2ff2989c6
+niiri:f967cba917487022842df44264a09b9a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -773,9 +773,9 @@ niiri:b32513dc3cebea135a4227a2ff2989c6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:b32513dc3cebea135a4227a2ff2989c6 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:f967cba917487022842df44264a09b9a prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:b7301eccecd4c049bbeed4467b530024
+niiri:dead248e9a831f2d39ed43c1307d7a6f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -785,9 +785,9 @@ niiri:b7301eccecd4c049bbeed4467b530024
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:b7301eccecd4c049bbeed4467b530024 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:dead248e9a831f2d39ed43c1307d7a6f prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:765e5201ffb06ca1f162ea8d7d3f0abd
+niiri:63395ba4fe844e99193e44b8b12c407b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -797,9 +797,9 @@ niiri:765e5201ffb06ca1f162ea8d7d3f0abd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:765e5201ffb06ca1f162ea8d7d3f0abd prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:63395ba4fe844e99193e44b8b12c407b prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:aeb5ca84ea986c7559b385b24d2806c0
+niiri:9e473a48bfa3001fcf429b2b016fa5ea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -809,9 +809,9 @@ niiri:aeb5ca84ea986c7559b385b24d2806c0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:aeb5ca84ea986c7559b385b24d2806c0 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:9e473a48bfa3001fcf429b2b016fa5ea prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:d36b472817f6888ac2860c8f78cda4e9
+niiri:66117305de42f7fc8878b963008d257b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -821,9 +821,9 @@ niiri:d36b472817f6888ac2860c8f78cda4e9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:d36b472817f6888ac2860c8f78cda4e9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:66117305de42f7fc8878b963008d257b prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:e1375ee26540e9328da498ca97a69cb4
+niiri:4b2de1d700d8a7f369f0417da0db1e66
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -833,9 +833,9 @@ niiri:e1375ee26540e9328da498ca97a69cb4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:e1375ee26540e9328da498ca97a69cb4 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:4b2de1d700d8a7f369f0417da0db1e66 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:d5f1c18934146a18337779acd9486123
+niiri:f5ac935852ea4b1b9fed377c2aeb3b18
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "68"^^xsd:int ;
@@ -845,9 +845,9 @@ niiri:d5f1c18934146a18337779acd9486123
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:d5f1c18934146a18337779acd9486123 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:f5ac935852ea4b1b9fed377c2aeb3b18 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:275de6b748d7ad0f11eed3004edbf892
+niiri:e0f3dfa1c85357af4b401994ac38769b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -857,9 +857,9 @@ niiri:275de6b748d7ad0f11eed3004edbf892
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:275de6b748d7ad0f11eed3004edbf892 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:e0f3dfa1c85357af4b401994ac38769b prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:2dd4cb8812c93538b5902225b29e0471
+niiri:614c41139aa842cbd80a44616011d080
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -869,9 +869,9 @@ niiri:2dd4cb8812c93538b5902225b29e0471
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:2dd4cb8812c93538b5902225b29e0471 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:614c41139aa842cbd80a44616011d080 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:67ae07e7ee0396386eefce6ed5341a79
+niiri:c8f3c9da99d7be6a54c536483f0ca346
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -881,9 +881,9 @@ niiri:67ae07e7ee0396386eefce6ed5341a79
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:67ae07e7ee0396386eefce6ed5341a79 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:c8f3c9da99d7be6a54c536483f0ca346 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:c589ee96ca2b908bdd9d337ca523d5af
+niiri:cf1f683799f80f149702b64601072e25
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -893,9 +893,9 @@ niiri:c589ee96ca2b908bdd9d337ca523d5af
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:c589ee96ca2b908bdd9d337ca523d5af prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:cf1f683799f80f149702b64601072e25 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:e43455a02504b9d87a4939904a0ca976
+niiri:fcfdc3edc7e7cbb46b2a5e7bd6a60b5a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -905,9 +905,9 @@ niiri:e43455a02504b9d87a4939904a0ca976
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:e43455a02504b9d87a4939904a0ca976 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:fcfdc3edc7e7cbb46b2a5e7bd6a60b5a prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:5dc937975dc687d7eb55e11a685cdd94
+niiri:c6b09785e79116c69c0d566f14508194
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -917,9 +917,9 @@ niiri:5dc937975dc687d7eb55e11a685cdd94
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:5dc937975dc687d7eb55e11a685cdd94 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:c6b09785e79116c69c0d566f14508194 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:30c5174c5d495474060913c40bab0961
+niiri:b62d08e7f48d3b48c3d3470c4864b0f5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -929,9 +929,9 @@ niiri:30c5174c5d495474060913c40bab0961
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:30c5174c5d495474060913c40bab0961 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:b62d08e7f48d3b48c3d3470c4864b0f5 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:ea999779ae02d5714142530d4b2e638b
+niiri:820eae4f2ecfa96c61f16f68989e60f2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -941,9 +941,9 @@ niiri:ea999779ae02d5714142530d4b2e638b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:ea999779ae02d5714142530d4b2e638b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:820eae4f2ecfa96c61f16f68989e60f2 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:15b2530019f1c4c6d5e910962b35274b
+niiri:0c814c8aa73eb23edb6b0bdf05d875b9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -953,9 +953,9 @@ niiri:15b2530019f1c4c6d5e910962b35274b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:15b2530019f1c4c6d5e910962b35274b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:0c814c8aa73eb23edb6b0bdf05d875b9 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:5782e52657a04683a9d9acc635ffc74a
+niiri:3237418b7d965d5533963a3817c7547f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -965,9 +965,9 @@ niiri:5782e52657a04683a9d9acc635ffc74a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:5782e52657a04683a9d9acc635ffc74a prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:3237418b7d965d5533963a3817c7547f prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:e26340fcd624896679dd2542ec2348be
+niiri:479583c290f59d278781273768ba65dc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -977,9 +977,9 @@ niiri:e26340fcd624896679dd2542ec2348be
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:e26340fcd624896679dd2542ec2348be prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:479583c290f59d278781273768ba65dc prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:e4e5f6e0de1fb1456effbec6ec82e736
+niiri:609da3fb63ae9918c3e77a08cdb6cfc2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -989,9 +989,9 @@ niiri:e4e5f6e0de1fb1456effbec6ec82e736
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:e4e5f6e0de1fb1456effbec6ec82e736 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:609da3fb63ae9918c3e77a08cdb6cfc2 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:5cf9ae44dc03a8c6493baf09bed014d4
+niiri:76f32299041fc5f4d0b950c566a0624b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1001,9 +1001,9 @@ niiri:5cf9ae44dc03a8c6493baf09bed014d4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:5cf9ae44dc03a8c6493baf09bed014d4 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:76f32299041fc5f4d0b950c566a0624b prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:dfe1466699f719841d6d98d1188da0c8
+niiri:9e864aa27a55745175707c98d46a334c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1013,9 +1013,9 @@ niiri:dfe1466699f719841d6d98d1188da0c8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:dfe1466699f719841d6d98d1188da0c8 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:9e864aa27a55745175707c98d46a334c prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:e69a5e282ae0346ca803f55371164aa7
+niiri:628a97ee4df64877d84868107814f955
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1025,9 +1025,9 @@ niiri:e69a5e282ae0346ca803f55371164aa7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:e69a5e282ae0346ca803f55371164aa7 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:628a97ee4df64877d84868107814f955 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:d168d4b61807fc13619ad56c31dad174
+niiri:52a2c6444b10fca5e154fba0b3e62d50
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1037,9 +1037,9 @@ niiri:d168d4b61807fc13619ad56c31dad174
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:d168d4b61807fc13619ad56c31dad174 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:52a2c6444b10fca5e154fba0b3e62d50 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:522e011a3a54e833c99dc9315f577dfe
+niiri:a9bc5d8a6d734a19d1ee638ddfa9e34f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1049,9 +1049,9 @@ niiri:522e011a3a54e833c99dc9315f577dfe
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:522e011a3a54e833c99dc9315f577dfe prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:a9bc5d8a6d734a19d1ee638ddfa9e34f prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:bcc290b739057f6cb5c02dcc79c4b5bc
+niiri:cf869ef162fc61878c8c7fbac7157264
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1061,9 +1061,9 @@ niiri:bcc290b739057f6cb5c02dcc79c4b5bc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:bcc290b739057f6cb5c02dcc79c4b5bc prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:cf869ef162fc61878c8c7fbac7157264 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:6f3de48dca5b4c3a6aca0be63ddd27cd
+niiri:404edd754b52ba04b35f56d4e502f8ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1073,9 +1073,9 @@ niiri:6f3de48dca5b4c3a6aca0be63ddd27cd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:6f3de48dca5b4c3a6aca0be63ddd27cd prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:404edd754b52ba04b35f56d4e502f8ce prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:f77f344a47f917de9a802b78319c354f
+niiri:646c9634927ecdb2332ab5dfe7a28006
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1085,9 +1085,9 @@ niiri:f77f344a47f917de9a802b78319c354f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:f77f344a47f917de9a802b78319c354f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:646c9634927ecdb2332ab5dfe7a28006 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:9df645a4ce3520ee828e35a6dac32f9f
+niiri:c0fd049d894fca767270c43b39b70df9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1097,9 +1097,9 @@ niiri:9df645a4ce3520ee828e35a6dac32f9f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:9df645a4ce3520ee828e35a6dac32f9f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:c0fd049d894fca767270c43b39b70df9 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:1dea88b1f0062ddb01809c2f336aff3f
+niiri:9552b4dbfe0833d9f21d39cf5a3f531c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1109,9 +1109,9 @@ niiri:1dea88b1f0062ddb01809c2f336aff3f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:1dea88b1f0062ddb01809c2f336aff3f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:9552b4dbfe0833d9f21d39cf5a3f531c prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:f424b0ee093c7ca1771bb8144718087b
+niiri:4cb0bf65605055716432884893e5e9c2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1121,9 +1121,9 @@ niiri:f424b0ee093c7ca1771bb8144718087b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:f424b0ee093c7ca1771bb8144718087b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:4cb0bf65605055716432884893e5e9c2 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:258ff3de07e51a57d0b27d6699fb2508
+niiri:d6b37cc773edb870bb55c2d6372f256b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1133,9 +1133,9 @@ niiri:258ff3de07e51a57d0b27d6699fb2508
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:258ff3de07e51a57d0b27d6699fb2508 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:d6b37cc773edb870bb55c2d6372f256b prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:fd669f02bbb8da3eff612dc0d4b807f6
+niiri:27724b6869441a042387c9d5c13942d2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1145,9 +1145,9 @@ niiri:fd669f02bbb8da3eff612dc0d4b807f6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:fd669f02bbb8da3eff612dc0d4b807f6 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:27724b6869441a042387c9d5c13942d2 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:2560564a14e0250f709b385639d02fb9
+niiri:6c4baced41f2f8c3fb0cb36e9ec2f421
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1157,9 +1157,9 @@ niiri:2560564a14e0250f709b385639d02fb9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:2560564a14e0250f709b385639d02fb9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:6c4baced41f2f8c3fb0cb36e9ec2f421 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:589d688bdb65a26f0e5afdd4ff33865b
+niiri:8b632dcc185547a7f8ad04edead2291a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1169,9 +1169,9 @@ niiri:589d688bdb65a26f0e5afdd4ff33865b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:589d688bdb65a26f0e5afdd4ff33865b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:8b632dcc185547a7f8ad04edead2291a prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:b1e45a95e3b162cbfbb274efa0609a1a
+niiri:0b81b51c15877094ca33c61a79325340
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1181,9 +1181,9 @@ niiri:b1e45a95e3b162cbfbb274efa0609a1a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:b1e45a95e3b162cbfbb274efa0609a1a prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:0b81b51c15877094ca33c61a79325340 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:5ac022b3dd1da9d78456eb9feccbe272
+niiri:39734aff0e8ba70db0c48ce245fe4c87
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1193,9 +1193,9 @@ niiri:5ac022b3dd1da9d78456eb9feccbe272
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:5ac022b3dd1da9d78456eb9feccbe272 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:39734aff0e8ba70db0c48ce245fe4c87 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:0aa8942e14fb246e8d24f1826bdd073f
+niiri:715173a69633af936b825645f63d4b6e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1205,9 +1205,9 @@ niiri:0aa8942e14fb246e8d24f1826bdd073f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:0aa8942e14fb246e8d24f1826bdd073f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:715173a69633af936b825645f63d4b6e prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:47175a90c2a865c8e7cb888b760d6bf8
+niiri:1c44f60f8e5351b0a92c492ed60e2137
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1217,9 +1217,9 @@ niiri:47175a90c2a865c8e7cb888b760d6bf8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:47175a90c2a865c8e7cb888b760d6bf8 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:1c44f60f8e5351b0a92c492ed60e2137 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:d3f621d08874a1c4b62c86623e9e9780
+niiri:f2443d4e5be8deae8260b1f1dedfc174
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1229,9 +1229,9 @@ niiri:d3f621d08874a1c4b62c86623e9e9780
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:d3f621d08874a1c4b62c86623e9e9780 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:f2443d4e5be8deae8260b1f1dedfc174 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56
+niiri:de6358617bfe8f7769d05d29a4316925
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1241,9 +1241,9 @@ niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:de6358617bfe8f7769d05d29a4316925 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:730bd100bdb468af0d3821d0d42d24a3
+niiri:28b00390010cb45d9a423be0d041e4eb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1253,9 +1253,9 @@ niiri:730bd100bdb468af0d3821d0d42d24a3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:730bd100bdb468af0d3821d0d42d24a3 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:28b00390010cb45d9a423be0d041e4eb prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:c30c1334c3597905fbc441edbc3d5ada
+niiri:6f2458f857e5301314e4c49c53ddab5c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1265,9 +1265,9 @@ niiri:c30c1334c3597905fbc441edbc3d5ada
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:c30c1334c3597905fbc441edbc3d5ada prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:6f2458f857e5301314e4c49c53ddab5c prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:f3476be8b24ab5bb218fe71d0b0daed0
+niiri:a5ccd12af883dc80ecb285cbc7d90996
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1277,9 +1277,9 @@ niiri:f3476be8b24ab5bb218fe71d0b0daed0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:f3476be8b24ab5bb218fe71d0b0daed0 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:a5ccd12af883dc80ecb285cbc7d90996 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:e129e49f77be02735062a975f639c82e
+niiri:075cefbcdab0306f76e523f39577afc9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1289,9 +1289,9 @@ niiri:e129e49f77be02735062a975f639c82e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:e129e49f77be02735062a975f639c82e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:075cefbcdab0306f76e523f39577afc9 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:f445b49b9174ce8611d41a7cc11e1717
+niiri:67b2de2f1c8c8f1c6308f97901012c85
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1301,9 +1301,9 @@ niiri:f445b49b9174ce8611d41a7cc11e1717
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:f445b49b9174ce8611d41a7cc11e1717 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:67b2de2f1c8c8f1c6308f97901012c85 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:5ca600306779ba8f48c5d087d9fac9a9
+niiri:3e4aab372e14b498f67d8f3af7fe64d4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1313,9 +1313,9 @@ niiri:5ca600306779ba8f48c5d087d9fac9a9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:5ca600306779ba8f48c5d087d9fac9a9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:3e4aab372e14b498f67d8f3af7fe64d4 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:40bbe1b7b060c1d54f113fd9fcf154aa
+niiri:4e46f866f0c4c884a98d67ad4f286185
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1325,9 +1325,9 @@ niiri:40bbe1b7b060c1d54f113fd9fcf154aa
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:40bbe1b7b060c1d54f113fd9fcf154aa prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:4e46f866f0c4c884a98d67ad4f286185 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:5d9d1b3e1bbc6746185f53561c74bace
+niiri:0c4f8238e0d8817ab291795ad931058d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1337,9 +1337,9 @@ niiri:5d9d1b3e1bbc6746185f53561c74bace
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:5d9d1b3e1bbc6746185f53561c74bace prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:0c4f8238e0d8817ab291795ad931058d prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:4c53636a1293cd4482cb63ff70691d79
+niiri:45b239a4d9c3d2d8505e69c949d3d8e8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1349,9 +1349,9 @@ niiri:4c53636a1293cd4482cb63ff70691d79
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:4c53636a1293cd4482cb63ff70691d79 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:45b239a4d9c3d2d8505e69c949d3d8e8 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:2b3b2f5817481e92102b214f3bf33995
+niiri:d81ab34b3d15a5e83dcac601860e2c67
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1361,9 +1361,9 @@ niiri:2b3b2f5817481e92102b214f3bf33995
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:2b3b2f5817481e92102b214f3bf33995 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:d81ab34b3d15a5e83dcac601860e2c67 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:86437031e803eee8517a97d2e8420009
+niiri:17915a4b4045396b3dc9e808d4f43fff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1373,9 +1373,9 @@ niiri:86437031e803eee8517a97d2e8420009
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:86437031e803eee8517a97d2e8420009 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:17915a4b4045396b3dc9e808d4f43fff prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:927385c4b1c66020878360a5006a3e3b
+niiri:fb337b3deac825168c6547e71cdf45e4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1385,9 +1385,9 @@ niiri:927385c4b1c66020878360a5006a3e3b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:927385c4b1c66020878360a5006a3e3b prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:fb337b3deac825168c6547e71cdf45e4 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:0087c0fa9854a20b9b26757b4c0e9a68
+niiri:d1e644390766d6283debb5ff26e27399
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1397,9 +1397,9 @@ niiri:0087c0fa9854a20b9b26757b4c0e9a68
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:0087c0fa9854a20b9b26757b4c0e9a68 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:d1e644390766d6283debb5ff26e27399 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:679d2ced08c3de3ec63ab76190f2d86d
+niiri:f2c41aa526c7ecfe683fb5b1f2a7588a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1409,9 +1409,9 @@ niiri:679d2ced08c3de3ec63ab76190f2d86d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:679d2ced08c3de3ec63ab76190f2d86d prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:f2c41aa526c7ecfe683fb5b1f2a7588a prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:302d0ae98bffba69292672583d115e8c
+niiri:b6e3adf39b177b2fe3b6833a47713718
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1421,9 +1421,9 @@ niiri:302d0ae98bffba69292672583d115e8c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:302d0ae98bffba69292672583d115e8c prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:b6e3adf39b177b2fe3b6833a47713718 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:f443e4b03660a8ad618e307479bf8a95
+niiri:ac9ee3188f787257a289a9904e28a0df
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1433,9 +1433,9 @@ niiri:f443e4b03660a8ad618e307479bf8a95
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:f443e4b03660a8ad618e307479bf8a95 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:ac9ee3188f787257a289a9904e28a0df prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:80e9d7b2bd34593272f3fb19fc9254e9
+niiri:499c553f4f05bed3bf262435de53d3b1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1445,9 +1445,9 @@ niiri:80e9d7b2bd34593272f3fb19fc9254e9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:80e9d7b2bd34593272f3fb19fc9254e9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:499c553f4f05bed3bf262435de53d3b1 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:91bc3a2972b2938504904a8d68057f2e
+niiri:425b3b59bb1a3d7b86c2c5264b8a6627
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1457,9 +1457,9 @@ niiri:91bc3a2972b2938504904a8d68057f2e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:91bc3a2972b2938504904a8d68057f2e prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:425b3b59bb1a3d7b86c2c5264b8a6627 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:681cc93cdfd04b41012417cfd725953f
+niiri:9c92e09c369b8211d4e65fbfbb9c9aa4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1469,9 +1469,9 @@ niiri:681cc93cdfd04b41012417cfd725953f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:681cc93cdfd04b41012417cfd725953f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:9c92e09c369b8211d4e65fbfbb9c9aa4 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:1288217d5c8b70c54915067a87402187
+niiri:d76384fac79adab2f8bcdd74e38b05e5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1481,9 +1481,9 @@ niiri:1288217d5c8b70c54915067a87402187
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:1288217d5c8b70c54915067a87402187 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:d76384fac79adab2f8bcdd74e38b05e5 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:9a33ec7dcbaf4c333c9be7973d3674ae
+niiri:66b4285fcdb2a68d01ddbdfea09445d1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1493,9 +1493,9 @@ niiri:9a33ec7dcbaf4c333c9be7973d3674ae
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:9a33ec7dcbaf4c333c9be7973d3674ae prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:66b4285fcdb2a68d01ddbdfea09445d1 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73
+niiri:ce2fd9609bbaf4260567fecf8334f73a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1505,9 +1505,9 @@ niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:ce2fd9609bbaf4260567fecf8334f73a prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:99af69862e054a4c62b8e6066ff12cfd
+niiri:a482e942f85057c7e6150a9211c470d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1517,9 +1517,9 @@ niiri:99af69862e054a4c62b8e6066ff12cfd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:99af69862e054a4c62b8e6066ff12cfd prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:a482e942f85057c7e6150a9211c470d5 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:20fc427845c2a14183959299a0d233ce
+niiri:72e4e5b0d793f6bdd394586ab7b319ae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1529,9 +1529,9 @@ niiri:20fc427845c2a14183959299a0d233ce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:20fc427845c2a14183959299a0d233ce prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:72e4e5b0d793f6bdd394586ab7b319ae prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:0294b8b1f3c4b525a18397bf17d17d63
+niiri:698f920512e0bc86196ac5bdf9403706
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1541,9 +1541,9 @@ niiri:0294b8b1f3c4b525a18397bf17d17d63
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:0294b8b1f3c4b525a18397bf17d17d63 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:698f920512e0bc86196ac5bdf9403706 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:3dc796cbf0403561b0e6ea42b96ea1a9
+niiri:ad1cd56f7d143bd776b5691683c59add
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1553,9 +1553,9 @@ niiri:3dc796cbf0403561b0e6ea42b96ea1a9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:3dc796cbf0403561b0e6ea42b96ea1a9 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:ad1cd56f7d143bd776b5691683c59add prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:14518885ee853fba951013cf73f66bed
+niiri:eaa184888e18a33c4f8a743428f908be
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0085" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1565,9 +1565,9 @@ niiri:14518885ee853fba951013cf73f66bed
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "85"^^xsd:int .
 
-niiri:14518885ee853fba951013cf73f66bed prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:eaa184888e18a33c4f8a743428f908be prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:7666b1a689a3839cdadb86af5e5c7c39
+niiri:7a8727b45ba0d1d9809d83d6afaba387
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0086" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1577,9 +1577,9 @@ niiri:7666b1a689a3839cdadb86af5e5c7c39
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "86"^^xsd:int .
 
-niiri:7666b1a689a3839cdadb86af5e5c7c39 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:7a8727b45ba0d1d9809d83d6afaba387 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:2cac2c4baab8136a53bdf03e74fdc1c5
+niiri:e37d9920261de8039f51fb95dfc921a4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0087" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1589,9 +1589,9 @@ niiri:2cac2c4baab8136a53bdf03e74fdc1c5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "87"^^xsd:int .
 
-niiri:2cac2c4baab8136a53bdf03e74fdc1c5 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:e37d9920261de8039f51fb95dfc921a4 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:8768acb96e7e44e4cd45548f0d52dd3f
+niiri:69d9b433456370b7c1a9673758c8fe93
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0088" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1601,9 +1601,9 @@ niiri:8768acb96e7e44e4cd45548f0d52dd3f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "88"^^xsd:int .
 
-niiri:8768acb96e7e44e4cd45548f0d52dd3f prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:69d9b433456370b7c1a9673758c8fe93 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:816f19a8ef8789235a9bd7bfe4396a14
+niiri:f8f9f105adf5f8aecb1ef2a7b71b7a33
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0089" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1613,1756 +1613,1756 @@ niiri:816f19a8ef8789235a9bd7bfe4396a14
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "89"^^xsd:int .
 
-niiri:816f19a8ef8789235a9bd7bfe4396a14 prov:wasDerivedFrom niiri:bfc22c098dc267a88d326bbf0e6793e3 .
+niiri:f8f9f105adf5f8aecb1ef2a7b71b7a33 prov:wasDerivedFrom niiri:693cbd3283b68002fb1375c234a7ba13 .
 
-niiri:06a391660f148983b073bfec11e5afdd
+niiri:93496da83c58096fe3cadb5c0a487eb8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:aeb3f38bf9d2106bcfc97930c448be4f ;
+    prov:atLocation niiri:42ca6d43b5feb478f133427c1a06d1fa ;
     prov:value "16.0820484161377"^^xsd:float ;
     nidm_equivalentZStatistic: "6.58928757769047"^^xsd:float ;
     nidm_pValueUncorrected: "2.20971019260219e-11"^^xsd:float ;
     nidm_pValueFWER: "4.59341100222943e-06"^^xsd:float ;
     nidm_qValueFDR: "2.11792501803032e-06"^^xsd:float .
 
-niiri:aeb3f38bf9d2106bcfc97930c448be4f
+niiri:42ca6d43b5feb478f133427c1a06d1fa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-14,-84,-14]"^^xsd:string .
 
-niiri:06a391660f148983b073bfec11e5afdd prov:wasDerivedFrom niiri:8337790d11808f2fb788ee8093e46afe .
+niiri:93496da83c58096fe3cadb5c0a487eb8 prov:wasDerivedFrom niiri:70b2003559708458bd92e73d3d3c7bf4 .
 
-niiri:a1abcbfeadef1ab9d090cb0dfd0c65f9
+niiri:9aa03bdba011795f1f4d5ac002e49c6c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:6040359f287941d8765b5d153e53b7e8 ;
+    prov:atLocation niiri:a54d946bc00da59c9cfa1ed1e4c0a194 ;
     prov:value "13.9779033660889"^^xsd:float ;
     nidm_equivalentZStatistic: "6.11142244434854"^^xsd:float ;
     nidm_pValueUncorrected: "4.93734941819923e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000102635598608014"^^xsd:float ;
     nidm_qValueFDR: "5.60210458059015e-06"^^xsd:float .
 
-niiri:6040359f287941d8765b5d153e53b7e8
+niiri:a54d946bc00da59c9cfa1ed1e4c0a194
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-42,-76,-12]"^^xsd:string .
 
-niiri:a1abcbfeadef1ab9d090cb0dfd0c65f9 prov:wasDerivedFrom niiri:8337790d11808f2fb788ee8093e46afe .
+niiri:9aa03bdba011795f1f4d5ac002e49c6c prov:wasDerivedFrom niiri:70b2003559708458bd92e73d3d3c7bf4 .
 
-niiri:f209e76751ccdefc0e9bde5e236ee184
+niiri:bf83c25f85dbf8414669cb3b0b1360b4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:feb1ef85bf7a38f519d22d70f35dd611 ;
+    prov:atLocation niiri:c9f1ea6c398da29c68d0d98d7cd0a738 ;
     prov:value "10.3123865127563"^^xsd:float ;
     nidm_equivalentZStatistic: "5.1402197604635"^^xsd:float ;
     nidm_pValueUncorrected: "1.3720866187672e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0248386091747108"^^xsd:float ;
     nidm_qValueFDR: "0.000165827847161811"^^xsd:float .
 
-niiri:feb1ef85bf7a38f519d22d70f35dd611
+niiri:c9f1ea6c398da29c68d0d98d7cd0a738
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-20,-90,8]"^^xsd:string .
 
-niiri:f209e76751ccdefc0e9bde5e236ee184 prov:wasDerivedFrom niiri:8337790d11808f2fb788ee8093e46afe .
+niiri:bf83c25f85dbf8414669cb3b0b1360b4 prov:wasDerivedFrom niiri:70b2003559708458bd92e73d3d3c7bf4 .
 
-niiri:f066c96dd3c7c0996c0629c5c10cdb17
+niiri:01f425e6980b230ac084a97aaea6f38b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:3183606049158bc6420e12358dd06fd9 ;
+    prov:atLocation niiri:cf65d0a1b44e4d21b33bf5348cb46c49 ;
     prov:value "13.7427864074707"^^xsd:float ;
     nidm_equivalentZStatistic: "6.05489626279796"^^xsd:float ;
     nidm_pValueUncorrected: "7.02540914332417e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000146041348950021"^^xsd:float ;
     nidm_qValueFDR: "5.84165395800085e-06"^^xsd:float .
 
-niiri:3183606049158bc6420e12358dd06fd9
+niiri:cf65d0a1b44e4d21b33bf5348cb46c49
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[22,-98,10]"^^xsd:string .
 
-niiri:f066c96dd3c7c0996c0629c5c10cdb17 prov:wasDerivedFrom niiri:2e44272daecb8718b2883f84f352fc62 .
+niiri:01f425e6980b230ac084a97aaea6f38b prov:wasDerivedFrom niiri:e2b47f512f66716985aee0fe421c3346 .
 
-niiri:69750f3f4beb1c6336b85f6351e576c5
+niiri:9ce1726d88e8e968130e7c320e9c5c3c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:b63737d1991f399dbba4dd7ae8a8acec ;
+    prov:atLocation niiri:3d64faa35ffe99daeb08c99ca68b0f5b ;
     prov:value "12.7449989318848"^^xsd:float ;
     nidm_equivalentZStatistic: "5.80709618365418"^^xsd:float ;
     nidm_pValueUncorrected: "3.17828119378305e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000660688335281101"^^xsd:float ;
     nidm_qValueFDR: "1.54333527599919e-05"^^xsd:float .
 
-niiri:b63737d1991f399dbba4dd7ae8a8acec
+niiri:3d64faa35ffe99daeb08c99ca68b0f5b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[40,-76,-4]"^^xsd:string .
 
-niiri:69750f3f4beb1c6336b85f6351e576c5 prov:wasDerivedFrom niiri:2e44272daecb8718b2883f84f352fc62 .
+niiri:9ce1726d88e8e968130e7c320e9c5c3c prov:wasDerivedFrom niiri:e2b47f512f66716985aee0fe421c3346 .
 
-niiri:e91a1a3ae11967bf367aa53b9ee31c18
+niiri:4b1eff73e32776f0e2fb32014c8cb1a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:98e8748b9e902155aaca94b50263bba1 ;
+    prov:atLocation niiri:ae8b9eff557540ff9e2d82be8ca44920 ;
     prov:value "11.9460592269897"^^xsd:float ;
     nidm_equivalentZStatistic: "5.59865646408728"^^xsd:float ;
     nidm_pValueUncorrected: "1.08009692301181e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00224526225660115"^^xsd:float ;
     nidm_qValueFDR: "3.11841980083494e-05"^^xsd:float .
 
-niiri:98e8748b9e902155aaca94b50263bba1
+niiri:ae8b9eff557540ff9e2d82be8ca44920
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[36,-86,8]"^^xsd:string .
 
-niiri:e91a1a3ae11967bf367aa53b9ee31c18 prov:wasDerivedFrom niiri:2e44272daecb8718b2883f84f352fc62 .
+niiri:4b1eff73e32776f0e2fb32014c8cb1a0 prov:wasDerivedFrom niiri:e2b47f512f66716985aee0fe421c3346 .
 
-niiri:e5c7f01e47c1fbb085b416d97ceddbba
+niiri:ce6df4e02afb3fb751ea9337acc129e5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:7f0badb64e663c1f3676cffc717236fa ;
+    prov:atLocation niiri:fdb17142e8776e5e09fa077af54505c1 ;
     prov:value "10.8997001647949"^^xsd:float ;
     nidm_equivalentZStatistic: "5.31044487629651"^^xsd:float ;
     nidm_pValueUncorrected: "5.46789791222579e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0109446324802115"^^xsd:float ;
     nidm_qValueFDR: "8.7562484520721e-05"^^xsd:float .
 
-niiri:7f0badb64e663c1f3676cffc717236fa
+niiri:fdb17142e8776e5e09fa077af54505c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[32,-66,32]"^^xsd:string .
 
-niiri:e5c7f01e47c1fbb085b416d97ceddbba prov:wasDerivedFrom niiri:c893d69da88fea01efe542f9787608c5 .
+niiri:ce6df4e02afb3fb751ea9337acc129e5 prov:wasDerivedFrom niiri:3c6dd5e94db642fc0c6313fade61752c .
 
-niiri:2f7f807c988a3521e2049074aa842731
+niiri:cf1ae1b8dbb977bd43ccd87582ce99ef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:396e2c008744ecbc64a33278a34fcdbe ;
+    prov:atLocation niiri:9f73dfd775133cf752b6fee383b6a816 ;
     prov:value "5.45807838439941"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39070148271528"^^xsd:float ;
     nidm_pValueUncorrected: "0.000348569950826771"^^xsd:float ;
     nidm_pValueFWER: "0.999999998685327"^^xsd:float ;
     nidm_qValueFDR: "0.0335543570769498"^^xsd:float .
 
-niiri:396e2c008744ecbc64a33278a34fcdbe
+niiri:9f73dfd775133cf752b6fee383b6a816
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[32,-74,38]"^^xsd:string .
 
-niiri:2f7f807c988a3521e2049074aa842731 prov:wasDerivedFrom niiri:c893d69da88fea01efe542f9787608c5 .
+niiri:cf1ae1b8dbb977bd43ccd87582ce99ef prov:wasDerivedFrom niiri:3c6dd5e94db642fc0c6313fade61752c .
 
-niiri:2726200f9b0dcba5079dca1eb1a27ebd
+niiri:feca1010bcfc4933755ffba31c61684b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:575563e9436156ad59d10591a352d56d ;
+    prov:atLocation niiri:e405f5885f3ea041f0fbd1d1a38116d6 ;
     prov:value "10.0041055679321"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04819646859005"^^xsd:float ;
     nidm_pValueUncorrected: "2.23000182986155e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0380835451252286"^^xsd:float ;
     nidm_qValueFDR: "0.000232018725953295"^^xsd:float .
 
-niiri:575563e9436156ad59d10591a352d56d
+niiri:e405f5885f3ea041f0fbd1d1a38116d6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-30,-74,26]"^^xsd:string .
 
-niiri:2726200f9b0dcba5079dca1eb1a27ebd prov:wasDerivedFrom niiri:fafaf22f396d11e8355f5d1e7a7367ea .
+niiri:feca1010bcfc4933755ffba31c61684b prov:wasDerivedFrom niiri:13dc91c36d42d9c0075971b7e2e4340a .
 
-niiri:432182ae1dd08fbc638748dae384100d
+niiri:bb52dac57682aa53c4dcc159d57cd756
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:49cfb4906f7511441f7faddc5a5b8413 ;
+    prov:atLocation niiri:60ef24b2768423f042d35e46f16fce54 ;
     prov:value "9.62718677520752"^^xsd:float ;
     nidm_equivalentZStatistic: "4.933015925023"^^xsd:float ;
     nidm_pValueUncorrected: "4.04847753543436e-07"^^xsd:float ;
     nidm_pValueFWER: "0.063890884133409"^^xsd:float ;
     nidm_qValueFDR: "0.000364320989617512"^^xsd:float .
 
-niiri:49cfb4906f7511441f7faddc5a5b8413
+niiri:60ef24b2768423f042d35e46f16fce54
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-42,24,20]"^^xsd:string .
 
-niiri:432182ae1dd08fbc638748dae384100d prov:wasDerivedFrom niiri:0820636de884fe0d783c5385916ab101 .
+niiri:bb52dac57682aa53c4dcc159d57cd756 prov:wasDerivedFrom niiri:63baaa25c1850e25ff8b59437cf378c6 .
 
-niiri:85988a2f55e19fb0932bdaac88d56310
+niiri:1bec17a9f9ed5b6df70b776d93da494f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:53ed64c5e6de9d8d444e92f8219ed73e ;
+    prov:atLocation niiri:ec0b37c67b2fb07a2714322846d4b004 ;
     prov:value "8.07208061218262"^^xsd:float ;
     nidm_equivalentZStatistic: "4.42255808855286"^^xsd:float ;
     nidm_pValueUncorrected: "4.87695566220303e-06"^^xsd:float ;
     nidm_pValueFWER: "0.443484796305441"^^xsd:float ;
     nidm_qValueFDR: "0.00197238230997959"^^xsd:float .
 
-niiri:53ed64c5e6de9d8d444e92f8219ed73e
+niiri:ec0b37c67b2fb07a2714322846d4b004
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-50,28,22]"^^xsd:string .
 
-niiri:85988a2f55e19fb0932bdaac88d56310 prov:wasDerivedFrom niiri:0820636de884fe0d783c5385916ab101 .
+niiri:1bec17a9f9ed5b6df70b776d93da494f prov:wasDerivedFrom niiri:63baaa25c1850e25ff8b59437cf378c6 .
 
-niiri:b4e90605b1ad8e708a5878d78afbd5df
+niiri:4398173eefb4e1c6b6311db6e2849a12
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:7191009d584b787e22408325fb584516 ;
+    prov:atLocation niiri:640ace8062dc20b9f4349cee1bffe196 ;
     prov:value "9.20645141601562"^^xsd:float ;
     nidm_equivalentZStatistic: "4.80076510146651"^^xsd:float ;
     nidm_pValueUncorrected: "7.90302914999153e-07"^^xsd:float ;
     nidm_pValueFWER: "0.112525268059434"^^xsd:float ;
     nidm_qValueFDR: "0.000576835659463966"^^xsd:float .
 
-niiri:7191009d584b787e22408325fb584516
+niiri:640ace8062dc20b9f4349cee1bffe196
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[-50,8,42]"^^xsd:string .
 
-niiri:b4e90605b1ad8e708a5878d78afbd5df prov:wasDerivedFrom niiri:1e3c8c027b813bda7df5358a8ab4f63a .
+niiri:4398173eefb4e1c6b6311db6e2849a12 prov:wasDerivedFrom niiri:938d8c88ecfbbf04abff04ec2e6740f3 .
 
-niiri:18479155c0b9f7007a2606ee355335a9
+niiri:894a5ac410c5e9f3cf47f79619bb0060
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:8563cb38a4e5f284711af2f862727bd9 ;
+    prov:atLocation niiri:641ff8bf09bceeb5eaacb8a965cbdf20 ;
     prov:value "7.18871355056763"^^xsd:float ;
     nidm_equivalentZStatistic: "4.10255932739581"^^xsd:float ;
     nidm_pValueUncorrected: "2.04302517635702e-05"^^xsd:float ;
     nidm_pValueFWER: "0.864381142749573"^^xsd:float ;
     nidm_qValueFDR: "0.00518559511521378"^^xsd:float .
 
-niiri:8563cb38a4e5f284711af2f862727bd9
+niiri:641ff8bf09bceeb5eaacb8a965cbdf20
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-52,2,48]"^^xsd:string .
 
-niiri:18479155c0b9f7007a2606ee355335a9 prov:wasDerivedFrom niiri:1e3c8c027b813bda7df5358a8ab4f63a .
+niiri:894a5ac410c5e9f3cf47f79619bb0060 prov:wasDerivedFrom niiri:938d8c88ecfbbf04abff04ec2e6740f3 .
 
-niiri:d3c08577d483b22d049b7eb0c6572b7f
+niiri:ac4cea7f8f1bb0436e917fcc6be779b5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:cbf1b8ec0d607ae0da2d1270f1e5401a ;
+    prov:atLocation niiri:8dc4cf1d1a8139a657dd64adfcd3144a ;
     prov:value "8.94470500946045"^^xsd:float ;
     nidm_equivalentZStatistic: "4.71641138081763"^^xsd:float ;
     nidm_pValueUncorrected: "1.20020424165812e-06"^^xsd:float ;
     nidm_pValueFWER: "0.158435738485403"^^xsd:float ;
     nidm_qValueFDR: "0.000760651849406736"^^xsd:float .
 
-niiri:cbf1b8ec0d607ae0da2d1270f1e5401a
+niiri:8dc4cf1d1a8139a657dd64adfcd3144a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-24,-64,66]"^^xsd:string .
 
-niiri:d3c08577d483b22d049b7eb0c6572b7f prov:wasDerivedFrom niiri:e24e457b7371fd1bac7d4cb391bb9432 .
+niiri:ac4cea7f8f1bb0436e917fcc6be779b5 prov:wasDerivedFrom niiri:86d427d519cd54a38aa4d9fc15de80c3 .
 
-niiri:b22647ec49d2b0b297e2ac1f30758018
+niiri:fd225bac392b7701cbc27894453e59cd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:26c07862039b52fa08db4cc5880af9e4 ;
+    prov:atLocation niiri:9fa66d81c9808501c94e931069a39ba8 ;
     prov:value "7.5668888092041"^^xsd:float ;
     nidm_equivalentZStatistic: "4.24258939908316"^^xsd:float ;
     nidm_pValueUncorrected: "1.10477738578529e-05"^^xsd:float ;
     nidm_pValueFWER: "0.693995702855766"^^xsd:float ;
     nidm_qValueFDR: "0.0033973072847523"^^xsd:float .
 
-niiri:26c07862039b52fa08db4cc5880af9e4
+niiri:9fa66d81c9808501c94e931069a39ba8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-32,-56,62]"^^xsd:string .
 
-niiri:b22647ec49d2b0b297e2ac1f30758018 prov:wasDerivedFrom niiri:e24e457b7371fd1bac7d4cb391bb9432 .
+niiri:fd225bac392b7701cbc27894453e59cd prov:wasDerivedFrom niiri:86d427d519cd54a38aa4d9fc15de80c3 .
 
-niiri:17cf8165ad43953b2998aec1ca9ddd0f
+niiri:ff15ef5ba6e10aebe3cbaa8d04230787
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:2945a0dad8e64bb13fdb60092f3a3334 ;
+    prov:atLocation niiri:5fde917c842a1c2f12d320e49a0fe31b ;
     prov:value "8.42212200164795"^^xsd:float ;
     nidm_equivalentZStatistic: "4.54288070436711"^^xsd:float ;
     nidm_pValueUncorrected: "2.77453287811369e-06"^^xsd:float ;
     nidm_pValueFWER: "0.301737952159247"^^xsd:float ;
     nidm_qValueFDR: "0.00135672565933354"^^xsd:float .
 
-niiri:2945a0dad8e64bb13fdb60092f3a3334
+niiri:5fde917c842a1c2f12d320e49a0fe31b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[22,-52,4]"^^xsd:string .
 
-niiri:17cf8165ad43953b2998aec1ca9ddd0f prov:wasDerivedFrom niiri:2f5fcfc4453f648ede4260a16cff5960 .
+niiri:ff15ef5ba6e10aebe3cbaa8d04230787 prov:wasDerivedFrom niiri:d23334e15ca989a88f18103920c37202 .
 
-niiri:8a3dd8fbf2b47192a3e6b6d6690a00b5
+niiri:9bd16aac89c993320304c9eb63a87b57
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:f4392121feaef697f908988f9d45a7b3 ;
+    prov:atLocation niiri:48c2cd130bbd6d709ab32816cec618a4 ;
     prov:value "8.14441299438477"^^xsd:float ;
     nidm_equivalentZStatistic: "4.44770400954001"^^xsd:float ;
     nidm_pValueUncorrected: "4.33965069324138e-06"^^xsd:float ;
     nidm_pValueFWER: "0.411238149698711"^^xsd:float ;
     nidm_qValueFDR: "0.00180683059312593"^^xsd:float .
 
-niiri:f4392121feaef697f908988f9d45a7b3
+niiri:48c2cd130bbd6d709ab32816cec618a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-36,-54,-22]"^^xsd:string .
 
-niiri:8a3dd8fbf2b47192a3e6b6d6690a00b5 prov:wasDerivedFrom niiri:dbbddbece734ef2c5ed154985b15ffe8 .
+niiri:9bd16aac89c993320304c9eb63a87b57 prov:wasDerivedFrom niiri:34d7407deceb41bb05814c58f568aa8a .
 
-niiri:b173db6dde57bc22f0de6bac75f47a5e
+niiri:fb27062a0582a1fce60d6928817c662a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:9f0f16d82e93cbe816f1c8f4ac5e2aa9 ;
+    prov:atLocation niiri:bdb8026c36f785eb5ec07f08ef6cfdc0 ;
     prov:value "7.75212860107422"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30948435197428"^^xsd:float ;
     nidm_pValueUncorrected: "8.18178178840778e-06"^^xsd:float ;
     nidm_pValueFWER: "0.599664226758408"^^xsd:float ;
     nidm_qValueFDR: "0.00278317762946249"^^xsd:float .
 
-niiri:9f0f16d82e93cbe816f1c8f4ac5e2aa9
+niiri:bdb8026c36f785eb5ec07f08ef6cfdc0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[10,-66,-50]"^^xsd:string .
 
-niiri:b173db6dde57bc22f0de6bac75f47a5e prov:wasDerivedFrom niiri:6aecc2d95fe5ba4cd2d39d16afe85407 .
+niiri:fb27062a0582a1fce60d6928817c662a prov:wasDerivedFrom niiri:f11390729469ff5ad94b49a0bdfa4678 .
 
-niiri:956544123ed8213df5fbc7f8d6973e3c
+niiri:657347798992bf8f9378fd7636cc0927
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:c5abac533b273ee4b7bab22f1b00ed76 ;
+    prov:atLocation niiri:0b4836f180573c7e2a074a4b6a46c52f ;
     prov:value "6.59869337081909"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87398612970452"^^xsd:float ;
     nidm_pValueUncorrected: "5.35347545974618e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988687386127249"^^xsd:float ;
     nidm_qValueFDR: "0.0099990013840748"^^xsd:float .
 
-niiri:c5abac533b273ee4b7bab22f1b00ed76
+niiri:0b4836f180573c7e2a074a4b6a46c52f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[26,-72,-50]"^^xsd:string .
 
-niiri:956544123ed8213df5fbc7f8d6973e3c prov:wasDerivedFrom niiri:6aecc2d95fe5ba4cd2d39d16afe85407 .
+niiri:657347798992bf8f9378fd7636cc0927 prov:wasDerivedFrom niiri:f11390729469ff5ad94b49a0bdfa4678 .
 
-niiri:f4dea2e696793591088d280fed0f0584
+niiri:a44b6a2efc6f9acbbcaf0464ac5a681d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:e2a291ea227f61911be316ee6108a55f ;
+    prov:atLocation niiri:56f5ddfaab043af81b9608b017d7f1b7 ;
     prov:value "6.09796094894409"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6691747416434"^^xsd:float ;
     nidm_pValueUncorrected: "0.000121667358184974"^^xsd:float ;
     nidm_pValueFWER: "0.999849800966092"^^xsd:float ;
     nidm_qValueFDR: "0.0170443244379802"^^xsd:float .
 
-niiri:e2a291ea227f61911be316ee6108a55f
+niiri:56f5ddfaab043af81b9608b017d7f1b7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[16,-72,-50]"^^xsd:string .
 
-niiri:f4dea2e696793591088d280fed0f0584 prov:wasDerivedFrom niiri:6aecc2d95fe5ba4cd2d39d16afe85407 .
+niiri:a44b6a2efc6f9acbbcaf0464ac5a681d prov:wasDerivedFrom niiri:f11390729469ff5ad94b49a0bdfa4678 .
 
-niiri:d88a4b6a1eb63bac84a9f87e0794ba20
+niiri:c23aa344df3dfb68c6df15d4b9de0b49
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:2281a2b45d8f90027211445c926232e2 ;
+    prov:atLocation niiri:98a12d2cc55f8a4d4c0966b703d77ddc ;
     prov:value "7.67598438262939"^^xsd:float ;
     nidm_equivalentZStatistic: "4.28211703257948"^^xsd:float ;
     nidm_pValueUncorrected: "9.25617831770698e-06"^^xsd:float ;
     nidm_pValueFWER: "0.638571937641115"^^xsd:float ;
     nidm_qValueFDR: "0.00302106969058158"^^xsd:float .
 
-niiri:2281a2b45d8f90027211445c926232e2
+niiri:98a12d2cc55f8a4d4c0966b703d77ddc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[42,-22,66]"^^xsd:string .
 
-niiri:d88a4b6a1eb63bac84a9f87e0794ba20 prov:wasDerivedFrom niiri:a9c284c82bc4ef4eba48570f53c9c9c4 .
+niiri:c23aa344df3dfb68c6df15d4b9de0b49 prov:wasDerivedFrom niiri:ccdacac7fbef86b94a12c5dabbf08bc2 .
 
-niiri:bfba970dca807cd42c369bc26d27f3eb
+niiri:10eae58327bef44f83f5eadf77bf2b29
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:3253ad166d45aa411a00a879e94115b6 ;
+    prov:atLocation niiri:37e955e48e516a624990fe7106e561e6 ;
     prov:value "6.16005897521973"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6951610937944"^^xsd:float ;
     nidm_pValueUncorrected: "0.000109873708078023"^^xsd:float ;
     nidm_pValueFWER: "0.999696971784475"^^xsd:float ;
     nidm_qValueFDR: "0.0160177852706299"^^xsd:float .
 
-niiri:3253ad166d45aa411a00a879e94115b6
+niiri:37e955e48e516a624990fe7106e561e6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[48,-18,62]"^^xsd:string .
 
-niiri:bfba970dca807cd42c369bc26d27f3eb prov:wasDerivedFrom niiri:a9c284c82bc4ef4eba48570f53c9c9c4 .
+niiri:10eae58327bef44f83f5eadf77bf2b29 prov:wasDerivedFrom niiri:ccdacac7fbef86b94a12c5dabbf08bc2 .
 
-niiri:70cf11cb9bc7570fce0e5ed7c0993493
+niiri:cd26ddfc926406425c12a65ed0b6edd3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:73acbe399f2ef5551e28416ff0886e25 ;
+    prov:atLocation niiri:4fc105ae0a05d4f9532f7a6138101892 ;
     prov:value "7.57218790054321"^^xsd:float ;
     nidm_equivalentZStatistic: "4.24451811148991"^^xsd:float ;
     nidm_pValueUncorrected: "1.09531837353405e-05"^^xsd:float ;
     nidm_pValueFWER: "0.691329596120285"^^xsd:float ;
     nidm_qValueFDR: "0.00338801480937036"^^xsd:float .
 
-niiri:73acbe399f2ef5551e28416ff0886e25
+niiri:4fc105ae0a05d4f9532f7a6138101892
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[30,-36,-22]"^^xsd:string .
 
-niiri:70cf11cb9bc7570fce0e5ed7c0993493 prov:wasDerivedFrom niiri:0637af2e34d8b1c842ae7d1386357498 .
+niiri:cd26ddfc926406425c12a65ed0b6edd3 prov:wasDerivedFrom niiri:13403d7573cd820266b83ff32d0e9707 .
 
-niiri:a37c7f3e671f54bf1aeb9e2159fc0ead
+niiri:e2ba3fc6a82344eb16652a1045af15c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:44277e00fc4cc3cf8ea164e5d184e84d ;
+    prov:atLocation niiri:415b77645b7cdae17b8ad758f5eb8b8d ;
     prov:value "7.4740514755249"^^xsd:float ;
     nidm_equivalentZStatistic: "4.20865253327564"^^xsd:float ;
     nidm_pValueUncorrected: "1.28449040975864e-05"^^xsd:float ;
     nidm_pValueFWER: "0.739935004547452"^^xsd:float ;
     nidm_qValueFDR: "0.00374497115452541"^^xsd:float .
 
-niiri:44277e00fc4cc3cf8ea164e5d184e84d
+niiri:415b77645b7cdae17b8ad758f5eb8b8d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[22,-70,60]"^^xsd:string .
 
-niiri:a37c7f3e671f54bf1aeb9e2159fc0ead prov:wasDerivedFrom niiri:1cd4117828f514ec0fff4b67f780d6b9 .
+niiri:e2ba3fc6a82344eb16652a1045af15c4 prov:wasDerivedFrom niiri:d86187d8105730183f4e8c029a41bf61 .
 
-niiri:95b5e8d1b0a6b737f8baac185d017d03
+niiri:082452054c3dd5d2af374fa654347080
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:bcdd17c062f969757a86cbe2d236afea ;
+    prov:atLocation niiri:799c9d89567bb44e19c70580446205dc ;
     prov:value "7.42476272583008"^^xsd:float ;
     nidm_equivalentZStatistic: "4.19052086074216"^^xsd:float ;
     nidm_pValueUncorrected: "1.39157412012425e-05"^^xsd:float ;
     nidm_pValueFWER: "0.76353829505901"^^xsd:float ;
     nidm_qValueFDR: "0.00397904916843096"^^xsd:float .
 
-niiri:bcdd17c062f969757a86cbe2d236afea
+niiri:799c9d89567bb44e19c70580446205dc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[14,-44,-2]"^^xsd:string .
 
-niiri:95b5e8d1b0a6b737f8baac185d017d03 prov:wasDerivedFrom niiri:d85063f48080f770ca548748f7419e12 .
+niiri:082452054c3dd5d2af374fa654347080 prov:wasDerivedFrom niiri:67556c87393c94a727ee0b764b5d8856 .
 
-niiri:376402188bdf566830cafa900c2e2777
+niiri:76c802f08b9291304a2b64e88d09d6f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:40631caf86fdb1eb06dd8fb89e5e0cdf ;
+    prov:atLocation niiri:7163eea4c853502750a9407c735c9e3c ;
     prov:value "7.41156482696533"^^xsd:float ;
     nidm_equivalentZStatistic: "4.1856522195161"^^xsd:float ;
     nidm_pValueUncorrected: "1.42174217934166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.76974170216107"^^xsd:float ;
     nidm_qValueFDR: "0.00404779744790916"^^xsd:float .
 
-niiri:40631caf86fdb1eb06dd8fb89e5e0cdf
+niiri:7163eea4c853502750a9407c735c9e3c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[0,-22,66]"^^xsd:string .
 
-niiri:376402188bdf566830cafa900c2e2777 prov:wasDerivedFrom niiri:ec3fc3cfa0c303c00f68f5986e44044e .
+niiri:76c802f08b9291304a2b64e88d09d6f7 prov:wasDerivedFrom niiri:8832fdb39eea98ef7aabb68883c63c22 .
 
-niiri:e7535b3f1b2924d6cc2cc7dd1021e6ff
+niiri:cca01f107697356a1cefd866ab455a05
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:1009ccfd64bd14bdf04f231ec38d83db ;
+    prov:atLocation niiri:0153ac1615e7c9789d415c65e4851eae ;
     prov:value "7.3316125869751"^^xsd:float ;
     nidm_equivalentZStatistic: "4.15603434431885"^^xsd:float ;
     nidm_pValueUncorrected: "1.61909583913378e-05"^^xsd:float ;
     nidm_pValueFWER: "0.806071531912271"^^xsd:float ;
     nidm_qValueFDR: "0.00442558415624652"^^xsd:float .
 
-niiri:1009ccfd64bd14bdf04f231ec38d83db
+niiri:0153ac1615e7c9789d415c65e4851eae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-40,-26,-22]"^^xsd:string .
 
-niiri:e7535b3f1b2924d6cc2cc7dd1021e6ff prov:wasDerivedFrom niiri:23c6e94e6643122dcb458402a972758e .
+niiri:cca01f107697356a1cefd866ab455a05 prov:wasDerivedFrom niiri:0a733ee37ab9d8fc5554d22235fb2ebb .
 
-niiri:e8318652b9767749a7b94884a6faf52e
+niiri:f91b302604a192f5e4846ca6deb35991
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:62333962f96d79e4ca7c4f1585c5e395 ;
+    prov:atLocation niiri:e6c18a21b0838652b0739046d24d8b3c ;
     prov:value "7.15871143341064"^^xsd:float ;
     nidm_equivalentZStatistic: "4.09124266610495"^^xsd:float ;
     nidm_pValueUncorrected: "2.14533936502281e-05"^^xsd:float ;
     nidm_pValueFWER: "0.875348981068006"^^xsd:float ;
     nidm_qValueFDR: "0.00534735431216318"^^xsd:float .
 
-niiri:62333962f96d79e4ca7c4f1585c5e395
+niiri:e6c18a21b0838652b0739046d24d8b3c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[-48,-42,58]"^^xsd:string .
 
-niiri:e8318652b9767749a7b94884a6faf52e prov:wasDerivedFrom niiri:68f9a66ca71f514199366c398a2831ab .
+niiri:f91b302604a192f5e4846ca6deb35991 prov:wasDerivedFrom niiri:20f7a6809dd02ee80d08c981d7533384 .
 
-niiri:79db57175bcf213e5f77bd451afdb6fe
+niiri:71d9ea403ed4487a2c2fcef870a5a99d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:4601ef775986b40077d71682573b43a7 ;
+    prov:atLocation niiri:1dcc0de807471f00991bddcea168b316 ;
     prov:value "7.11809158325195"^^xsd:float ;
     nidm_equivalentZStatistic: "4.075870818357"^^xsd:float ;
     nidm_pValueUncorrected: "2.29212322924166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.889420975253515"^^xsd:float ;
     nidm_qValueFDR: "0.00557942469794563"^^xsd:float .
 
-niiri:4601ef775986b40077d71682573b43a7
+niiri:1dcc0de807471f00991bddcea168b316
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-40,-34,66]"^^xsd:string .
 
-niiri:79db57175bcf213e5f77bd451afdb6fe prov:wasDerivedFrom niiri:6f303953fe538a2a99d9b754b92e311e .
+niiri:71d9ea403ed4487a2c2fcef870a5a99d prov:wasDerivedFrom niiri:c1ebe6af3636d8119b6c8c898bc0b9cd .
 
-niiri:36ca195508a8e637007acd8f768fa1c9
+niiri:2a3f1962b93cf1ec51d9f9ce82b5b379
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:9ca689f733bdaa0f890c8fe7e51b6224 ;
+    prov:atLocation niiri:4f5bb05f88295472d544372f5353ad67 ;
     prov:value "7.07621002197266"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05996049269805"^^xsd:float ;
     nidm_pValueUncorrected: "2.45405099345009e-05"^^xsd:float ;
     nidm_pValueFWER: "0.902960652497904"^^xsd:float ;
     nidm_qValueFDR: "0.00587047829619361"^^xsd:float .
 
-niiri:9ca689f733bdaa0f890c8fe7e51b6224
+niiri:4f5bb05f88295472d544372f5353ad67
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-28,-64,36]"^^xsd:string .
 
-niiri:36ca195508a8e637007acd8f768fa1c9 prov:wasDerivedFrom niiri:b32513dc3cebea135a4227a2ff2989c6 .
+niiri:2a3f1962b93cf1ec51d9f9ce82b5b379 prov:wasDerivedFrom niiri:f967cba917487022842df44264a09b9a .
 
-niiri:93964149cf1de70007b3d65bb04b9cd8
+niiri:b06959bff99e3cecbbed58938eb1d757
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:bfbd55e8f2473bad1c11d7526e7f8cbb ;
+    prov:atLocation niiri:8a18e9b312dde5cee1fe6ad6a5724104 ;
     prov:value "6.77566051483154"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94391444392688"^^xsd:float ;
     nidm_pValueUncorrected: "4.0081133562353e-05"^^xsd:float ;
     nidm_pValueFWER: "0.970449378854534"^^xsd:float ;
     nidm_qValueFDR: "0.0083237489519884"^^xsd:float .
 
-niiri:bfbd55e8f2473bad1c11d7526e7f8cbb
+niiri:8a18e9b312dde5cee1fe6ad6a5724104
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[56,-14,52]"^^xsd:string .
 
-niiri:93964149cf1de70007b3d65bb04b9cd8 prov:wasDerivedFrom niiri:b7301eccecd4c049bbeed4467b530024 .
+niiri:b06959bff99e3cecbbed58938eb1d757 prov:wasDerivedFrom niiri:dead248e9a831f2d39ed43c1307d7a6f .
 
-niiri:3e906297c3e2890ce6abb1f2cb9be561
+niiri:881cc335773de76e9b8662888bd13ac4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:c0d2a2f16c1d44209d3e0ceba1cc405d ;
+    prov:atLocation niiri:7ef0341d12f7ee676f32a2804a1f717b ;
     prov:value "6.75197219848633"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9346244929229"^^xsd:float ;
     nidm_pValueUncorrected: "4.16634347842892e-05"^^xsd:float ;
     nidm_pValueFWER: "0.973679338420771"^^xsd:float ;
     nidm_qValueFDR: "0.00848286835858746"^^xsd:float .
 
-niiri:c0d2a2f16c1d44209d3e0ceba1cc405d
+niiri:7ef0341d12f7ee676f32a2804a1f717b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-40,56,6]"^^xsd:string .
 
-niiri:3e906297c3e2890ce6abb1f2cb9be561 prov:wasDerivedFrom niiri:765e5201ffb06ca1f162ea8d7d3f0abd .
+niiri:881cc335773de76e9b8662888bd13ac4 prov:wasDerivedFrom niiri:63395ba4fe844e99193e44b8b12c407b .
 
-niiri:e0515f336cbd787507ad3edf70116d4e
+niiri:09bb3c77498b130e8126aa61c345d374
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:9c7564398039623209ebb464e1410345 ;
+    prov:atLocation niiri:0d5aad91f5d1c2bbd1f6c0c9a4531565 ;
     prov:value "5.62889766693115"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4670438729023"^^xsd:float ;
     nidm_pValueUncorrected: "0.000263107996845591"^^xsd:float ;
     nidm_pValueFWER: "0.999999922471127"^^xsd:float ;
     nidm_qValueFDR: "0.0280636167791234"^^xsd:float .
 
-niiri:9c7564398039623209ebb464e1410345
+niiri:0d5aad91f5d1c2bbd1f6c0c9a4531565
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-34,62,8]"^^xsd:string .
 
-niiri:e0515f336cbd787507ad3edf70116d4e prov:wasDerivedFrom niiri:765e5201ffb06ca1f162ea8d7d3f0abd .
+niiri:09bb3c77498b130e8126aa61c345d374 prov:wasDerivedFrom niiri:63395ba4fe844e99193e44b8b12c407b .
 
-niiri:68d840be62a1d1171faf588a66b45a69
+niiri:e045c46e40d2c8576a9a4ec0c1c78184
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:9020819036c441bf53457a8d05805fd2 ;
+    prov:atLocation niiri:372489fa8f3b978b7aed90c95f4b72f1 ;
     prov:value "6.72361373901367"^^xsd:float ;
     nidm_equivalentZStatistic: "3.92347467532863"^^xsd:float ;
     nidm_pValueUncorrected: "4.3640471964479e-05"^^xsd:float ;
     nidm_pValueFWER: "0.977197537328254"^^xsd:float ;
     nidm_qValueFDR: "0.00877369894078824"^^xsd:float .
 
-niiri:9020819036c441bf53457a8d05805fd2
+niiri:372489fa8f3b978b7aed90c95f4b72f1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-4,-52,6]"^^xsd:string .
 
-niiri:68d840be62a1d1171faf588a66b45a69 prov:wasDerivedFrom niiri:aeb5ca84ea986c7559b385b24d2806c0 .
+niiri:e045c46e40d2c8576a9a4ec0c1c78184 prov:wasDerivedFrom niiri:9e473a48bfa3001fcf429b2b016fa5ea .
 
-niiri:fa083ea775134c459dc1bb371ed1dded
+niiri:78929640a7507b3952794c1ba644e2bc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:4ead7fcdda63c83da247a2a82f447618 ;
+    prov:atLocation niiri:26d159fdd349355fe8abf9a0d1ce02cb ;
     prov:value "5.89449167251587"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58279190167641"^^xsd:float ;
     nidm_pValueUncorrected: "0.000169970706923372"^^xsd:float ;
     nidm_pValueFWER: "0.999990278549049"^^xsd:float ;
     nidm_qValueFDR: "0.0210834330463974"^^xsd:float .
 
-niiri:4ead7fcdda63c83da247a2a82f447618
+niiri:26d159fdd349355fe8abf9a0d1ce02cb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-8,-56,0]"^^xsd:string .
 
-niiri:fa083ea775134c459dc1bb371ed1dded prov:wasDerivedFrom niiri:aeb5ca84ea986c7559b385b24d2806c0 .
+niiri:78929640a7507b3952794c1ba644e2bc prov:wasDerivedFrom niiri:9e473a48bfa3001fcf429b2b016fa5ea .
 
-niiri:bc11584c2cc9c15970a76804b11b842b
+niiri:b818f50374f62975097a22b686287afc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:6f14c51367b87703537f776c0c0dbdf5 ;
+    prov:atLocation niiri:fc3fb595563fd02fd5c9c620a0e410ac ;
     prov:value "6.7043924331665"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91589968256295"^^xsd:float ;
     nidm_pValueUncorrected: "4.5033848123488e-05"^^xsd:float ;
     nidm_pValueFWER: "0.979375630051391"^^xsd:float ;
     nidm_qValueFDR: "0.00887748685076858"^^xsd:float .
 
-niiri:6f14c51367b87703537f776c0c0dbdf5
+niiri:fc3fb595563fd02fd5c9c620a0e410ac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[50,-64,-6]"^^xsd:string .
 
-niiri:bc11584c2cc9c15970a76804b11b842b prov:wasDerivedFrom niiri:d36b472817f6888ac2860c8f78cda4e9 .
+niiri:b818f50374f62975097a22b686287afc prov:wasDerivedFrom niiri:66117305de42f7fc8878b963008d257b .
 
-niiri:8975ccf5a69b1e5ce196d5d0e24ee229
+niiri:657fc4be25ff87694be73a716d31ee88
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:c035e1c674ce2f5002c7510f276ba0d9 ;
+    prov:atLocation niiri:d579053f7af762590e2159cb63c3702b ;
     prov:value "6.67913484573364"^^xsd:float ;
     nidm_equivalentZStatistic: "3.90592399967592"^^xsd:float ;
     nidm_pValueUncorrected: "4.6933006303207e-05"^^xsd:float ;
     nidm_pValueFWER: "0.981996459937482"^^xsd:float ;
     nidm_qValueFDR: "0.00914383746051283"^^xsd:float .
 
-niiri:c035e1c674ce2f5002c7510f276ba0d9
+niiri:d579053f7af762590e2159cb63c3702b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-34,-40,36]"^^xsd:string .
 
-niiri:8975ccf5a69b1e5ce196d5d0e24ee229 prov:wasDerivedFrom niiri:e1375ee26540e9328da498ca97a69cb4 .
+niiri:657fc4be25ff87694be73a716d31ee88 prov:wasDerivedFrom niiri:4b2de1d700d8a7f369f0417da0db1e66 .
 
-niiri:e667e51e095b6fa110b25e9400332357
+niiri:404282759712923e7380deda715286f5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:d10ee59dc87f8fe64f5ed1f2ea11a4cd ;
+    prov:atLocation niiri:b42605abec5347a0ce7def763b3054e4 ;
     prov:value "6.64170026779175"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89109301638303"^^xsd:float ;
     nidm_pValueUncorrected: "4.98968323957572e-05"^^xsd:float ;
     nidm_pValueFWER: "0.985407255166263"^^xsd:float ;
     nidm_qValueFDR: "0.00949872959107623"^^xsd:float .
 
-niiri:d10ee59dc87f8fe64f5ed1f2ea11a4cd
+niiri:b42605abec5347a0ce7def763b3054e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[22,10,-12]"^^xsd:string .
 
-niiri:e667e51e095b6fa110b25e9400332357 prov:wasDerivedFrom niiri:d5f1c18934146a18337779acd9486123 .
+niiri:404282759712923e7380deda715286f5 prov:wasDerivedFrom niiri:f5ac935852ea4b1b9fed377c2aeb3b18 .
 
-niiri:1221262de1e5620b40e4bdfbdeb36776
+niiri:445cd2ad209dc7d0f5567e57dbfdbe57
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:843685ded7e6608a0699d60b38b277bd ;
+    prov:atLocation niiri:04c6ede1d05f4dda32d567b98428ef09 ;
     prov:value "5.66292333602905"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48206928174656"^^xsd:float ;
     nidm_pValueUncorrected: "0.000248777471726358"^^xsd:float ;
     nidm_pValueFWER: "0.999999841793879"^^xsd:float ;
     nidm_qValueFDR: "0.0270792144117247"^^xsd:float .
 
-niiri:843685ded7e6608a0699d60b38b277bd
+niiri:04c6ede1d05f4dda32d567b98428ef09
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[22,10,2]"^^xsd:string .
 
-niiri:1221262de1e5620b40e4bdfbdeb36776 prov:wasDerivedFrom niiri:d5f1c18934146a18337779acd9486123 .
+niiri:445cd2ad209dc7d0f5567e57dbfdbe57 prov:wasDerivedFrom niiri:f5ac935852ea4b1b9fed377c2aeb3b18 .
 
-niiri:b35552ce359f982307861566bbcc356c
+niiri:94f93090d947e5f3aba6f6e0ea3e792c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:769e88496004ebf67fff73d31693db58 ;
+    prov:atLocation niiri:3a2a3e242401e1324c7a782c7dac5ea8 ;
     prov:value "6.58932304382324"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87024913662237"^^xsd:float ;
     nidm_pValueUncorrected: "5.43620931486855e-05"^^xsd:float ;
     nidm_pValueFWER: "0.9893188063809"^^xsd:float ;
     nidm_qValueFDR: "0.0101197978315716"^^xsd:float .
 
-niiri:769e88496004ebf67fff73d31693db58
+niiri:3a2a3e242401e1324c7a782c7dac5ea8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[16,-8,20]"^^xsd:string .
 
-niiri:b35552ce359f982307861566bbcc356c prov:wasDerivedFrom niiri:275de6b748d7ad0f11eed3004edbf892 .
+niiri:94f93090d947e5f3aba6f6e0ea3e792c prov:wasDerivedFrom niiri:e0f3dfa1c85357af4b401994ac38769b .
 
-niiri:0d369bc39b99736fd4f8e779bf6ac134
+niiri:22544d4fd0e5f5fc386047416e17946e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:f6c77de876bf3849b6cec31bea5642c4 ;
+    prov:atLocation niiri:bc0e92bfb4bdfcd2e81499112ddfb5ad ;
     prov:value "6.53873300552368"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8500124840786"^^xsd:float ;
     nidm_pValueUncorrected: "5.90559022480841e-05"^^xsd:float ;
     nidm_pValueFWER: "0.992265133018752"^^xsd:float ;
     nidm_qValueFDR: "0.0107045232421608"^^xsd:float .
 
-niiri:f6c77de876bf3849b6cec31bea5642c4
+niiri:bc0e92bfb4bdfcd2e81499112ddfb5ad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[28,-48,72]"^^xsd:string .
 
-niiri:0d369bc39b99736fd4f8e779bf6ac134 prov:wasDerivedFrom niiri:2dd4cb8812c93538b5902225b29e0471 .
+niiri:22544d4fd0e5f5fc386047416e17946e prov:wasDerivedFrom niiri:614c41139aa842cbd80a44616011d080 .
 
-niiri:203aed58b8f81dce0ecac8be5e863bda
+niiri:b4dcf253fb98a7d02af8a6095383dec3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:219472c226c1003f926096d10ddea706 ;
+    prov:atLocation niiri:8e8dae887c8bcbc322df68e9e8618d47 ;
     prov:value "6.41633129119873"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80061969992356"^^xsd:float ;
     nidm_pValueUncorrected: "7.2167337301976e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996780557608903"^^xsd:float ;
     nidm_qValueFDR: "0.0122368668491247"^^xsd:float .
 
-niiri:219472c226c1003f926096d10ddea706
+niiri:8e8dae887c8bcbc322df68e9e8618d47
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[30,-48,-18]"^^xsd:string .
 
-niiri:203aed58b8f81dce0ecac8be5e863bda prov:wasDerivedFrom niiri:67ae07e7ee0396386eefce6ed5341a79 .
+niiri:b4dcf253fb98a7d02af8a6095383dec3 prov:wasDerivedFrom niiri:c8f3c9da99d7be6a54c536483f0ca346 .
 
-niiri:79605721ecfe71b7f89e29aabbca94a0
+niiri:8fce2c8eb72bd4713a99a07479eb885c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:8aee97ed0bdda3e3420c52669ffbedb8 ;
+    prov:atLocation niiri:9663f7df7f5469003782e730408ea356 ;
     prov:value "6.32824850082397"^^xsd:float ;
     nidm_equivalentZStatistic: "3.764690456476"^^xsd:float ;
     nidm_pValueUncorrected: "8.33777634952071e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998439799137585"^^xsd:float ;
     nidm_qValueFDR: "0.0133433091347082"^^xsd:float .
 
-niiri:8aee97ed0bdda3e3420c52669ffbedb8
+niiri:9663f7df7f5469003782e730408ea356
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[34,64,-2]"^^xsd:string .
 
-niiri:79605721ecfe71b7f89e29aabbca94a0 prov:wasDerivedFrom niiri:c589ee96ca2b908bdd9d337ca523d5af .
+niiri:8fce2c8eb72bd4713a99a07479eb885c prov:wasDerivedFrom niiri:cf1f683799f80f149702b64601072e25 .
 
-niiri:7fae1b8bdbfa6d7b6e2b7098b3c6e4d9
+niiri:6375e0c71e69ce7d6e7030ad6eedc08c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:fac73b3e372e29b6987b728b1ee5fbbf ;
+    prov:atLocation niiri:2812d75f861602f532b1d54b4fb4714b ;
     prov:value "6.23233604431152"^^xsd:float ;
     nidm_equivalentZStatistic: "3.72519134385979"^^xsd:float ;
     nidm_pValueUncorrected: "9.75835625125487e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999359408722565"^^xsd:float ;
     nidm_qValueFDR: "0.0147821614629234"^^xsd:float .
 
-niiri:fac73b3e372e29b6987b728b1ee5fbbf
+niiri:2812d75f861602f532b1d54b4fb4714b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-42,44,26]"^^xsd:string .
 
-niiri:7fae1b8bdbfa6d7b6e2b7098b3c6e4d9 prov:wasDerivedFrom niiri:e43455a02504b9d87a4939904a0ca976 .
+niiri:6375e0c71e69ce7d6e7030ad6eedc08c prov:wasDerivedFrom niiri:fcfdc3edc7e7cbb46b2a5e7bd6a60b5a .
 
-niiri:c2191d22002dea13759e4534d2a99bb2
+niiri:82ccc891a4305f319cce2fc0f607ed1d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:1cd3744caef20860f929658348b743ab ;
+    prov:atLocation niiri:e8db766a541deb9a4c6852ac44059437 ;
     prov:value "6.06225728988647"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6541549978965"^^xsd:float ;
     nidm_pValueUncorrected: "0.000129015181687619"^^xsd:float ;
     nidm_pValueFWER: "0.999902284410057"^^xsd:float ;
     nidm_qValueFDR: "0.0177419633224147"^^xsd:float .
 
-niiri:1cd3744caef20860f929658348b743ab
+niiri:e8db766a541deb9a4c6852ac44059437
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[0,-10,76]"^^xsd:string .
 
-niiri:c2191d22002dea13759e4534d2a99bb2 prov:wasDerivedFrom niiri:5dc937975dc687d7eb55e11a685cdd94 .
+niiri:82ccc891a4305f319cce2fc0f607ed1d prov:wasDerivedFrom niiri:c6b09785e79116c69c0d566f14508194 .
 
-niiri:8e3e340d146c5b9659376513d4c922c7
+niiri:4bc015637a25e94d5335a5387464938f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:7cf3a56c9ff943e6f0580b9ef6f6505c ;
+    prov:atLocation niiri:c5afe2e92d4baf5644d912e4354b4143 ;
     prov:value "6.03189373016357"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64133598155782"^^xsd:float ;
     nidm_pValueUncorrected: "0.000135613449379846"^^xsd:float ;
     nidm_pValueFWER: "0.999933280387137"^^xsd:float ;
     nidm_qValueFDR: "0.0183426760576609"^^xsd:float .
 
-niiri:7cf3a56c9ff943e6f0580b9ef6f6505c
+niiri:c5afe2e92d4baf5644d912e4354b4143
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[34,-16,-12]"^^xsd:string .
 
-niiri:8e3e340d146c5b9659376513d4c922c7 prov:wasDerivedFrom niiri:30c5174c5d495474060913c40bab0961 .
+niiri:4bc015637a25e94d5335a5387464938f prov:wasDerivedFrom niiri:b62d08e7f48d3b48c3d3470c4864b0f5 .
 
-niiri:8766ac26c208ff8612c72111c2100871
+niiri:c7e58eb2aceb0dab12765c4d98d82b9e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:ac6145a41b42dd4e0f5c9807aaabc438 ;
+    prov:atLocation niiri:8f1b0a8e1b537455e75ed1f53fc5590f ;
     prov:value "6.02538537979126"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63858275251093"^^xsd:float ;
     nidm_pValueUncorrected: "0.000137071270502886"^^xsd:float ;
     nidm_pValueFWER: "0.999938640797957"^^xsd:float ;
     nidm_qValueFDR: "0.0183962430264957"^^xsd:float .
 
-niiri:ac6145a41b42dd4e0f5c9807aaabc438
+niiri:8f1b0a8e1b537455e75ed1f53fc5590f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[6,-80,-22]"^^xsd:string .
 
-niiri:8766ac26c208ff8612c72111c2100871 prov:wasDerivedFrom niiri:ea999779ae02d5714142530d4b2e638b .
+niiri:c7e58eb2aceb0dab12765c4d98d82b9e prov:wasDerivedFrom niiri:820eae4f2ecfa96c61f16f68989e60f2 .
 
-niiri:a6e97fb09e03600e49705c493a878db7
+niiri:7c6c80d6afc552a312faa863484d1e87
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:e01d6c7223e76ffbae5e844b5dbe79aa ;
+    prov:atLocation niiri:ed391688f38f5280aa723ad94fb9890d ;
     prov:value "5.95283126831055"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60775727167743"^^xsd:float ;
     nidm_pValueUncorrected: "0.000154427613028529"^^xsd:float ;
     nidm_pValueFWER: "0.999977036852347"^^xsd:float ;
     nidm_qValueFDR: "0.0199653441808624"^^xsd:float .
 
-niiri:e01d6c7223e76ffbae5e844b5dbe79aa
+niiri:ed391688f38f5280aa723ad94fb9890d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-26,-38,-52]"^^xsd:string .
 
-niiri:a6e97fb09e03600e49705c493a878db7 prov:wasDerivedFrom niiri:15b2530019f1c4c6d5e910962b35274b .
+niiri:7c6c80d6afc552a312faa863484d1e87 prov:wasDerivedFrom niiri:0c814c8aa73eb23edb6b0bdf05d875b9 .
 
-niiri:8bcc743e85db485e4a2986804c97c77b
+niiri:4ab14068789abfafe4a80670e95fbd0f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:26a3a76d924a3533d4779f0959a1fbaf ;
+    prov:atLocation niiri:99fa92cce75080e4308b5d4b51ae0f66 ;
     prov:value "5.9493842124939"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60628663469786"^^xsd:float ;
     nidm_pValueUncorrected: "0.000155305014835405"^^xsd:float ;
     nidm_pValueFWER: "0.999978135328144"^^xsd:float ;
     nidm_qValueFDR: "0.0200343508975978"^^xsd:float .
 
-niiri:26a3a76d924a3533d4779f0959a1fbaf
+niiri:99fa92cce75080e4308b5d4b51ae0f66
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[32,-52,46]"^^xsd:string .
 
-niiri:8bcc743e85db485e4a2986804c97c77b prov:wasDerivedFrom niiri:5782e52657a04683a9d9acc635ffc74a .
+niiri:4ab14068789abfafe4a80670e95fbd0f prov:wasDerivedFrom niiri:3237418b7d965d5533963a3817c7547f .
 
-niiri:f70cbe313f78f3bc26491805e90defbf
+niiri:c5e8312043c11a120970a62496ae9d72
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:60032f6ce2504b4763622044467988e0 ;
+    prov:atLocation niiri:0e6a5cde3992a2f46e103d9f26d781ee ;
     prov:value "5.90739822387695"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58832892416593"^^xsd:float ;
     nidm_pValueUncorrected: "0.00016640212943575"^^xsd:float ;
     nidm_pValueFWER: "0.999988176695278"^^xsd:float ;
     nidm_qValueFDR: "0.0208396911967648"^^xsd:float .
 
-niiri:60032f6ce2504b4763622044467988e0
+niiri:0e6a5cde3992a2f46e103d9f26d781ee
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[20,58,6]"^^xsd:string .
 
-niiri:f70cbe313f78f3bc26491805e90defbf prov:wasDerivedFrom niiri:e26340fcd624896679dd2542ec2348be .
+niiri:c5e8312043c11a120970a62496ae9d72 prov:wasDerivedFrom niiri:479583c290f59d278781273768ba65dc .
 
-niiri:3349878166a538e7a54b1390c105c88b
+niiri:b6a20083300f6de427709519fa96ff08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:ddefff6ce2c505804cc2f308814149f9 ;
+    prov:atLocation niiri:1fbdc4f79b52339c73cb35f1986d9dbd ;
     prov:value "5.88568687438965"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57901000852841"^^xsd:float ;
     nidm_pValueUncorrected: "0.000172449130450447"^^xsd:float ;
     nidm_pValueFWER: "0.999991509605729"^^xsd:float ;
     nidm_qValueFDR: "0.0213019172775607"^^xsd:float .
 
-niiri:ddefff6ce2c505804cc2f308814149f9
+niiri:1fbdc4f79b52339c73cb35f1986d9dbd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-28,-70,-52]"^^xsd:string .
 
-niiri:3349878166a538e7a54b1390c105c88b prov:wasDerivedFrom niiri:e4e5f6e0de1fb1456effbec6ec82e736 .
+niiri:b6a20083300f6de427709519fa96ff08 prov:wasDerivedFrom niiri:609da3fb63ae9918c3e77a08cdb6cfc2 .
 
-niiri:8345510a279773a85dbd456831121d91
+niiri:31767e616570435641f143cae011f953
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:3b9c2d356ee88a92c830323a0d5af7c1 ;
+    prov:atLocation niiri:080ac45360879294e37c6287d22fd8b3 ;
     prov:value "5.88288545608521"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57780594841694"^^xsd:float ;
     nidm_pValueUncorrected: "0.000173245266573252"^^xsd:float ;
     nidm_pValueFWER: "0.999991870214044"^^xsd:float ;
     nidm_qValueFDR: "0.0213621903805226"^^xsd:float .
 
-niiri:3b9c2d356ee88a92c830323a0d5af7c1
+niiri:080ac45360879294e37c6287d22fd8b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-16,-58,-38]"^^xsd:string .
 
-niiri:8345510a279773a85dbd456831121d91 prov:wasDerivedFrom niiri:5cf9ae44dc03a8c6493baf09bed014d4 .
+niiri:31767e616570435641f143cae011f953 prov:wasDerivedFrom niiri:76f32299041fc5f4d0b950c566a0624b .
 
-niiri:4bff1d01552bc126cd2623ad4ebf3b9a
+niiri:18dcf52d105ae341a24bc8dcf187bd7d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:a9399ad6017a33693100cb9d9a9888f2 ;
+    prov:atLocation niiri:8d26f8dc7b292242e6151b98e0f835db ;
     prov:value "5.87665224075317"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57512554105657"^^xsd:float ;
     nidm_pValueUncorrected: "0.000175029940004845"^^xsd:float ;
     nidm_pValueFWER: "0.999992622705061"^^xsd:float ;
     nidm_qValueFDR: "0.0214921236782135"^^xsd:float .
 
-niiri:a9399ad6017a33693100cb9d9a9888f2
+niiri:8d26f8dc7b292242e6151b98e0f835db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[-10,-82,-30]"^^xsd:string .
 
-niiri:4bff1d01552bc126cd2623ad4ebf3b9a prov:wasDerivedFrom niiri:dfe1466699f719841d6d98d1188da0c8 .
+niiri:18dcf52d105ae341a24bc8dcf187bd7d prov:wasDerivedFrom niiri:9e864aa27a55745175707c98d46a334c .
 
-niiri:061bf720e78be5f38a4d203be70999ba
+niiri:29d29448ea553b9836a11b3f3932ffc9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:029afc2516914e2a77271d16e01d5717 ;
+    prov:atLocation niiri:0a1bdaff66645f8b1b42fb1660070405 ;
     prov:value "5.86712741851807"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57102607807387"^^xsd:float ;
     nidm_pValueUncorrected: "0.000177792742607208"^^xsd:float ;
     nidm_pValueFWER: "0.999993649803941"^^xsd:float ;
     nidm_qValueFDR: "0.0216816267105749"^^xsd:float .
 
-niiri:029afc2516914e2a77271d16e01d5717
+niiri:0a1bdaff66645f8b1b42fb1660070405
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[50,50,8]"^^xsd:string .
 
-niiri:061bf720e78be5f38a4d203be70999ba prov:wasDerivedFrom niiri:e69a5e282ae0346ca803f55371164aa7 .
+niiri:29d29448ea553b9836a11b3f3932ffc9 prov:wasDerivedFrom niiri:628a97ee4df64877d84868107814f955 .
 
-niiri:b356784762f635ac6a6625d03f3fd1d5
+niiri:136b0dae4c0cc7c691f5df819a046a16
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:6879e2b7fd420a16198270a7fda0c0ec ;
+    prov:atLocation niiri:47c22b00af020d507b9cfcdebf96840b ;
     prov:value "5.85824680328369"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56719995255891"^^xsd:float ;
     nidm_pValueUncorrected: "0.000180408078987448"^^xsd:float ;
     nidm_pValueFWER: "0.999994487319543"^^xsd:float ;
     nidm_qValueFDR: "0.0217930814133279"^^xsd:float .
 
-niiri:6879e2b7fd420a16198270a7fda0c0ec
+niiri:47c22b00af020d507b9cfcdebf96840b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-6,-78,56]"^^xsd:string .
 
-niiri:b356784762f635ac6a6625d03f3fd1d5 prov:wasDerivedFrom niiri:d168d4b61807fc13619ad56c31dad174 .
+niiri:136b0dae4c0cc7c691f5df819a046a16 prov:wasDerivedFrom niiri:52a2c6444b10fca5e154fba0b3e62d50 .
 
-niiri:52474a24c82a42c438dfac7f6b6ebe74
+niiri:7d6ac5abaee75da771fcc4ee9ae756b9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:b536ab3bffaed62ccb1ca6267c85947b ;
+    prov:atLocation niiri:eaa049bc0deda3f95639705970fa8823 ;
     prov:value "5.81644201278687"^^xsd:float ;
     nidm_equivalentZStatistic: "3.54913757298709"^^xsd:float ;
     nidm_pValueUncorrected: "0.000193247549691744"^^xsd:float ;
     nidm_pValueFWER: "0.99999722874557"^^xsd:float ;
     nidm_qValueFDR: "0.022905022613713"^^xsd:float .
 
-niiri:b536ab3bffaed62ccb1ca6267c85947b
+niiri:eaa049bc0deda3f95639705970fa8823
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[44,50,20]"^^xsd:string .
 
-niiri:52474a24c82a42c438dfac7f6b6ebe74 prov:wasDerivedFrom niiri:522e011a3a54e833c99dc9315f577dfe .
+niiri:7d6ac5abaee75da771fcc4ee9ae756b9 prov:wasDerivedFrom niiri:a9bc5d8a6d734a19d1ee638ddfa9e34f .
 
-niiri:63d794c7a20b8c3844c02909a430c400
+niiri:92f780b833bf32893f3b88e89980d8d8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:c04e40e59d081babf861f27fff0bc656 ;
+    prov:atLocation niiri:453445eb90a279054934aeb350144243 ;
     prov:value "5.75350570678711"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52178406559812"^^xsd:float ;
     nidm_pValueUncorrected: "0.000214326572548162"^^xsd:float ;
     nidm_pValueFWER: "0.999999083879168"^^xsd:float ;
     nidm_qValueFDR: "0.0245474913207941"^^xsd:float .
 
-niiri:c04e40e59d081babf861f27fff0bc656
+niiri:453445eb90a279054934aeb350144243
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[-30,-58,-52]"^^xsd:string .
 
-niiri:63d794c7a20b8c3844c02909a430c400 prov:wasDerivedFrom niiri:bcc290b739057f6cb5c02dcc79c4b5bc .
+niiri:92f780b833bf32893f3b88e89980d8d8 prov:wasDerivedFrom niiri:cf869ef162fc61878c8c7fbac7157264 .
 
-niiri:341c565fefe9949adb1369f3da7a2a11
+niiri:253b21a384f1f3314298745cb5d1668d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:6f522d3d3123b608cd947c46fdc012a6 ;
+    prov:atLocation niiri:03ad8275dad57815babc684e230f29da ;
     prov:value "5.74829816818237"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51951200270118"^^xsd:float ;
     nidm_pValueUncorrected: "0.000216170736607735"^^xsd:float ;
     nidm_pValueFWER: "0.999999167412893"^^xsd:float ;
     nidm_qValueFDR: "0.0246525319493899"^^xsd:float .
 
-niiri:6f522d3d3123b608cd947c46fdc012a6
+niiri:03ad8275dad57815babc684e230f29da
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-38,36,-14]"^^xsd:string .
 
-niiri:341c565fefe9949adb1369f3da7a2a11 prov:wasDerivedFrom niiri:6f3de48dca5b4c3a6aca0be63ddd27cd .
+niiri:253b21a384f1f3314298745cb5d1668d prov:wasDerivedFrom niiri:404edd754b52ba04b35f56d4e502f8ce .
 
-niiri:511b02a8bf4a6e0270aa9e4d8188cf98
+niiri:de597d8b3789310d0a77b771a6a6e111
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:08733586f578952e07d3ef0bedd783e7 ;
+    prov:atLocation niiri:44711cdf019c5b4f5b970ff900611073 ;
     prov:value "5.7312970161438"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51208496979963"^^xsd:float ;
     nidm_pValueUncorrected: "0.000222302913436612"^^xsd:float ;
     nidm_pValueFWER: "0.99999939333845"^^xsd:float ;
     nidm_qValueFDR: "0.0250806761204491"^^xsd:float .
 
-niiri:08733586f578952e07d3ef0bedd783e7
+niiri:44711cdf019c5b4f5b970ff900611073
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-50,12,-2]"^^xsd:string .
 
-niiri:511b02a8bf4a6e0270aa9e4d8188cf98 prov:wasDerivedFrom niiri:f77f344a47f917de9a802b78319c354f .
+niiri:de597d8b3789310d0a77b771a6a6e111 prov:wasDerivedFrom niiri:646c9634927ecdb2332ab5dfe7a28006 .
 
-niiri:2f69fd65193eb1b02e7f447cca5b3d63
+niiri:8e7f20532879d495c5a42e5d03642d77
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:ca4ad108c221d6463345f5410c20d1b6 ;
+    prov:atLocation niiri:93b03e2e5d1ab918fd6387ca80923df5 ;
     prov:value "5.61407613754272"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46048027314539"^^xsd:float ;
     nidm_pValueUncorrected: "0.000269606369816766"^^xsd:float ;
     nidm_pValueFWER: "0.999999943721802"^^xsd:float ;
     nidm_qValueFDR: "0.0285650985701987"^^xsd:float .
 
-niiri:ca4ad108c221d6463345f5410c20d1b6
+niiri:93b03e2e5d1ab918fd6387ca80923df5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-52,38,14]"^^xsd:string .
 
-niiri:2f69fd65193eb1b02e7f447cca5b3d63 prov:wasDerivedFrom niiri:9df645a4ce3520ee828e35a6dac32f9f .
+niiri:8e7f20532879d495c5a42e5d03642d77 prov:wasDerivedFrom niiri:c0fd049d894fca767270c43b39b70df9 .
 
-niiri:6fb432a65a1864ebc7f79bd73139967a
+niiri:5c140482468e320e3d5211e55d1b2399
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:05b2d9da6ce7b779041ee7d321cee8e3 ;
+    prov:atLocation niiri:f3b8807229024d21b3f54c200a577a82 ;
     prov:value "5.53163862228394"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42376539987989"^^xsd:float ;
     nidm_pValueUncorrected: "0.000308799561745898"^^xsd:float ;
     nidm_pValueFWER: "0.999999991534363"^^xsd:float ;
     nidm_qValueFDR: "0.0312013208214028"^^xsd:float .
 
-niiri:05b2d9da6ce7b779041ee7d321cee8e3
+niiri:f3b8807229024d21b3f54c200a577a82
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[-14,-80,10]"^^xsd:string .
 
-niiri:6fb432a65a1864ebc7f79bd73139967a prov:wasDerivedFrom niiri:1dea88b1f0062ddb01809c2f336aff3f .
+niiri:5c140482468e320e3d5211e55d1b2399 prov:wasDerivedFrom niiri:9552b4dbfe0833d9f21d39cf5a3f531c .
 
-niiri:ef1964afa02d57f263805ebae4d754c5
+niiri:0456eeedb5dc828ec86c0c36377fb91f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:0d2cac5a83e96f9282820e4e4438c966 ;
+    prov:atLocation niiri:01308065c94d19b3fc7a19a6d160ef56 ;
     prov:value "5.52454996109009"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42059171809414"^^xsd:float ;
     nidm_pValueUncorrected: "0.000312425309546338"^^xsd:float ;
     nidm_pValueFWER: "0.999999992873262"^^xsd:float ;
     nidm_qValueFDR: "0.0313644959462665"^^xsd:float .
 
-niiri:0d2cac5a83e96f9282820e4e4438c966
+niiri:01308065c94d19b3fc7a19a6d160ef56
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-66,-40,18]"^^xsd:string .
 
-niiri:ef1964afa02d57f263805ebae4d754c5 prov:wasDerivedFrom niiri:f424b0ee093c7ca1771bb8144718087b .
+niiri:0456eeedb5dc828ec86c0c36377fb91f prov:wasDerivedFrom niiri:4cb0bf65605055716432884893e5e9c2 .
 
-niiri:bd558d7e2f31e68ed9630cf47a3dc77f
+niiri:c60b521a8155d25ab1d81a437359bcd0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:d292d5aee905fd862dc0c678e3fe9df2 ;
+    prov:atLocation niiri:7c7faa3f4c77dc526122e2f47f62aece ;
     prov:value "5.51989889144897"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41850793238069"^^xsd:float ;
     nidm_pValueUncorrected: "0.000314827412227103"^^xsd:float ;
     nidm_pValueFWER: "0.99999999363976"^^xsd:float ;
     nidm_qValueFDR: "0.0315295603356192"^^xsd:float .
 
-niiri:d292d5aee905fd862dc0c678e3fe9df2
+niiri:7c7faa3f4c77dc526122e2f47f62aece
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-2,-90,16]"^^xsd:string .
 
-niiri:bd558d7e2f31e68ed9630cf47a3dc77f prov:wasDerivedFrom niiri:258ff3de07e51a57d0b27d6699fb2508 .
+niiri:c60b521a8155d25ab1d81a437359bcd0 prov:wasDerivedFrom niiri:d6b37cc773edb870bb55c2d6372f256b .
 
-niiri:cbcc21fd20778a31e84881bfab50ee09
+niiri:228fb7b44d90fa76d0a2bd634ed30bad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:4abf0e8985243764b8b4d826d3ff3cac ;
+    prov:atLocation niiri:344815ee260bb617fd9b0d32cadfc871 ;
     prov:value "5.50013113021851"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40963871850162"^^xsd:float ;
     nidm_pValueUncorrected: "0.000325244937404157"^^xsd:float ;
     nidm_pValueFWER: "0.99999999610751"^^xsd:float ;
     nidm_qValueFDR: "0.0320937892728011"^^xsd:float .
 
-niiri:4abf0e8985243764b8b4d826d3ff3cac
+niiri:344815ee260bb617fd9b0d32cadfc871
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[48,-68,24]"^^xsd:string .
 
-niiri:cbcc21fd20778a31e84881bfab50ee09 prov:wasDerivedFrom niiri:fd669f02bbb8da3eff612dc0d4b807f6 .
+niiri:228fb7b44d90fa76d0a2bd634ed30bad prov:wasDerivedFrom niiri:27724b6869441a042387c9d5c13942d2 .
 
-niiri:76de7fa6ab94ab4a76284547a4e3f1aa
+niiri:3eb9240a880fd3014089aee2ec60e9ee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:91f9c5e62fe3707f1980b1138c4853ca ;
+    prov:atLocation niiri:f8140c6cb955395595441fdd0ac9060f ;
     prov:value "5.47258329391479"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39724406479958"^^xsd:float ;
     nidm_pValueUncorrected: "0.000340341137511579"^^xsd:float ;
     nidm_pValueFWER: "0.999999998076035"^^xsd:float ;
     nidm_qValueFDR: "0.0330219418190176"^^xsd:float .
 
-niiri:91f9c5e62fe3707f1980b1138c4853ca
+niiri:f8140c6cb955395595441fdd0ac9060f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[-66,-52,14]"^^xsd:string .
 
-niiri:76de7fa6ab94ab4a76284547a4e3f1aa prov:wasDerivedFrom niiri:2560564a14e0250f709b385639d02fb9 .
+niiri:3eb9240a880fd3014089aee2ec60e9ee prov:wasDerivedFrom niiri:6c4baced41f2f8c3fb0cb36e9ec2f421 .
 
-niiri:9e085633b6f20c82d2de1068c8944127
+niiri:894e7b5f3c0f1694051eaa36e3339902
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:8940c35372a329a691f251d5f01211da ;
+    prov:atLocation niiri:71f8c30346b0401144bb9a6aafce5d89 ;
     prov:value "5.47253847122192"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39722386451209"^^xsd:float ;
     nidm_pValueUncorrected: "0.000340366263790748"^^xsd:float ;
     nidm_pValueFWER: "0.999999998078278"^^xsd:float ;
     nidm_qValueFDR: "0.0330219418190176"^^xsd:float .
 
-niiri:8940c35372a329a691f251d5f01211da
+niiri:71f8c30346b0401144bb9a6aafce5d89
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-24,-70,-40]"^^xsd:string .
 
-niiri:9e085633b6f20c82d2de1068c8944127 prov:wasDerivedFrom niiri:589d688bdb65a26f0e5afdd4ff33865b .
+niiri:894e7b5f3c0f1694051eaa36e3339902 prov:wasDerivedFrom niiri:8b632dcc185547a7f8ad04edead2291a .
 
-niiri:584625db35fd1e69dc1aeb8466d8899b
+niiri:26000f9c87b50b1ed4cbfc0c38d36776
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:56067390bd867fbe6b52bf178e0f2d8f ;
+    prov:atLocation niiri:e1962c719c187e312f46dbb443ea0ba6 ;
     prov:value "5.40879058837891"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36838466104027"^^xsd:float ;
     nidm_pValueUncorrected: "0.00037805012668235"^^xsd:float ;
     nidm_pValueFWER: "0.999999999657857"^^xsd:float ;
     nidm_qValueFDR: "0.0351846046980527"^^xsd:float .
 
-niiri:56067390bd867fbe6b52bf178e0f2d8f
+niiri:e1962c719c187e312f46dbb443ea0ba6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-52,28,-4]"^^xsd:string .
 
-niiri:584625db35fd1e69dc1aeb8466d8899b prov:wasDerivedFrom niiri:b1e45a95e3b162cbfbb274efa0609a1a .
+niiri:26000f9c87b50b1ed4cbfc0c38d36776 prov:wasDerivedFrom niiri:0b81b51c15877094ca33c61a79325340 .
 
-niiri:923ab0d2b10cd0fb1178741e5f7e4d80
+niiri:66f05ba7ece66064d5053eeba2010534
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:297f004b78125a381f4cc1a5fa03cfa7 ;
+    prov:atLocation niiri:a97959a880c8ff0a4d1b087cca95a7ba ;
     prov:value "5.40180397033691"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36521050637541"^^xsd:float ;
     nidm_pValueUncorrected: "0.000382426408436776"^^xsd:float ;
     nidm_pValueFWER: "0.999999999719179"^^xsd:float ;
     nidm_qValueFDR: "0.0353860600288775"^^xsd:float .
 
-niiri:297f004b78125a381f4cc1a5fa03cfa7
+niiri:a97959a880c8ff0a4d1b087cca95a7ba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[46,40,-20]"^^xsd:string .
 
-niiri:923ab0d2b10cd0fb1178741e5f7e4d80 prov:wasDerivedFrom niiri:5ac022b3dd1da9d78456eb9feccbe272 .
+niiri:66f05ba7ece66064d5053eeba2010534 prov:wasDerivedFrom niiri:39734aff0e8ba70db0c48ce245fe4c87 .
 
-niiri:d2e0beea05ad13eb0757a2f7874a5c30
+niiri:aad41db07b26e0fc135033c3c54c6265
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:f086d252f5f4c91e62368d78b62ac58b ;
+    prov:atLocation niiri:880971a35f2cb80ebdb3cce39907ade3 ;
     prov:value "5.37467432022095"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35285956111335"^^xsd:float ;
     nidm_pValueUncorrected: "0.000399906393667493"^^xsd:float ;
     nidm_pValueFWER: "0.999999999871685"^^xsd:float ;
     nidm_qValueFDR: "0.0362799194266732"^^xsd:float .
 
-niiri:f086d252f5f4c91e62368d78b62ac58b
+niiri:880971a35f2cb80ebdb3cce39907ade3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[-24,-64,-26]"^^xsd:string .
 
-niiri:d2e0beea05ad13eb0757a2f7874a5c30 prov:wasDerivedFrom niiri:0aa8942e14fb246e8d24f1826bdd073f .
+niiri:aad41db07b26e0fc135033c3c54c6265 prov:wasDerivedFrom niiri:715173a69633af936b825645f63d4b6e .
 
-niiri:71949ac8bb1d34c0f6a227d787830b42
+niiri:5d2e7b231ceaa16ac77fce6999cbee79
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:4faa09a4da27e254773d00b12e8ce476 ;
+    prov:atLocation niiri:7fee676079f21de5ddb648922d6cfc96 ;
     prov:value "5.37411737442017"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35260558298398"^^xsd:float ;
     nidm_pValueUncorrected: "0.00040027350203431"^^xsd:float ;
     nidm_pValueFWER: "0.999999999873767"^^xsd:float ;
     nidm_qValueFDR: "0.0362799194266732"^^xsd:float .
 
-niiri:4faa09a4da27e254773d00b12e8ce476
+niiri:7fee676079f21de5ddb648922d6cfc96
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[6,-78,4]"^^xsd:string .
 
-niiri:71949ac8bb1d34c0f6a227d787830b42 prov:wasDerivedFrom niiri:47175a90c2a865c8e7cb888b760d6bf8 .
+niiri:5d2e7b231ceaa16ac77fce6999cbee79 prov:wasDerivedFrom niiri:1c44f60f8e5351b0a92c492ed60e2137 .
 
-niiri:102e3f4f656d62e79230957d3c5b9d14
+niiri:293523500452c1280cc36cd2bec7c9d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:a9650048b29ccca030a5ee54b9940e46 ;
+    prov:atLocation niiri:39d51facd795550d74df67b084209afb ;
     prov:value "5.30396842956543"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32047825714677"^^xsd:float ;
     nidm_pValueUncorrected: "0.000449316793136201"^^xsd:float ;
     nidm_pValueFWER: "0.999999999985317"^^xsd:float ;
     nidm_qValueFDR: "0.038893908226916"^^xsd:float .
 
-niiri:a9650048b29ccca030a5ee54b9940e46
+niiri:39d51facd795550d74df67b084209afb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-18,6,-16]"^^xsd:string .
 
-niiri:102e3f4f656d62e79230957d3c5b9d14 prov:wasDerivedFrom niiri:d3f621d08874a1c4b62c86623e9e9780 .
+niiri:293523500452c1280cc36cd2bec7c9d6 prov:wasDerivedFrom niiri:f2443d4e5be8deae8260b1f1dedfc174 .
 
-niiri:1c9771ed932e3bdfafbe567879a399d9
+niiri:dd17912e2a4135820561e7201f7942dc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:df34c6eabebd48e7dc695cf8cd35940f ;
+    prov:atLocation niiri:1d8c77d2e14a912b0d6091aa51a528ec ;
     prov:value "5.3003044128418"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31879260124815"^^xsd:float ;
     nidm_pValueUncorrected: "0.000452037748311596"^^xsd:float ;
     nidm_pValueFWER: "0.999999999986945"^^xsd:float ;
     nidm_qValueFDR: "0.0390806835204476"^^xsd:float .
 
-niiri:df34c6eabebd48e7dc695cf8cd35940f
+niiri:1d8c77d2e14a912b0d6091aa51a528ec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[44,34,22]"^^xsd:string .
 
-niiri:1c9771ed932e3bdfafbe567879a399d9 prov:wasDerivedFrom niiri:aa8b5e39a34a2c8e9aa3e3a1d45eac56 .
+niiri:dd17912e2a4135820561e7201f7942dc prov:wasDerivedFrom niiri:de6358617bfe8f7769d05d29a4316925 .
 
-niiri:6e63ab7247516f8dc04092e22e2759ec
+niiri:3daf6b4701e8ccb2e1874fd38153c225
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:51436c3b224aac45c74640b1163904f9 ;
+    prov:atLocation niiri:305677c749428098b4af066f04082753 ;
     prov:value "5.2790060043335"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30897907487843"^^xsd:float ;
     nidm_pValueUncorrected: "0.000468184175549835"^^xsd:float ;
     nidm_pValueFWER: "0.999999999993475"^^xsd:float ;
     nidm_qValueFDR: "0.0399946769218688"^^xsd:float .
 
-niiri:51436c3b224aac45c74640b1163904f9
+niiri:305677c749428098b4af066f04082753
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[-16,-70,62]"^^xsd:string .
 
-niiri:6e63ab7247516f8dc04092e22e2759ec prov:wasDerivedFrom niiri:730bd100bdb468af0d3821d0d42d24a3 .
+niiri:3daf6b4701e8ccb2e1874fd38153c225 prov:wasDerivedFrom niiri:28b00390010cb45d9a423be0d041e4eb .
 
-niiri:86c90a2f51f1ad8289191c43b5d97061
+niiri:56ea6a1820785a481a616a83d7912917
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:e46fca08428611170031546e4ef81393 ;
+    prov:atLocation niiri:76e25882363bf74544ee45db516ada9f ;
     prov:value "5.22220420837402"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28268028866984"^^xsd:float ;
     nidm_pValueUncorrected: "0.000514126053509312"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999062"^^xsd:float ;
     nidm_qValueFDR: "0.0424551034128408"^^xsd:float .
 
-niiri:e46fca08428611170031546e4ef81393
+niiri:76e25882363bf74544ee45db516ada9f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-18,-90,34]"^^xsd:string .
 
-niiri:86c90a2f51f1ad8289191c43b5d97061 prov:wasDerivedFrom niiri:c30c1334c3597905fbc441edbc3d5ada .
+niiri:56ea6a1820785a481a616a83d7912917 prov:wasDerivedFrom niiri:6f2458f857e5301314e4c49c53ddab5c .
 
-niiri:545e517cd64f442db87872d4a27b47f7
+niiri:94336fe7b97ca1dbe7f4c74a8e1f26c1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:1042007b111f87e5138bb438f2ae2bc0 ;
+    prov:atLocation niiri:e6fd08976db92d3550930b0866ffd452 ;
     prov:value "5.1730318069458"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25976321879304"^^xsd:float ;
     nidm_pValueUncorrected: "0.000557526302441769"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999843"^^xsd:float ;
     nidm_qValueFDR: "0.0447389446131481"^^xsd:float .
 
-niiri:1042007b111f87e5138bb438f2ae2bc0
+niiri:e6fd08976db92d3550930b0866ffd452
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[36,62,8]"^^xsd:string .
 
-niiri:545e517cd64f442db87872d4a27b47f7 prov:wasDerivedFrom niiri:f3476be8b24ab5bb218fe71d0b0daed0 .
+niiri:94336fe7b97ca1dbe7f4c74a8e1f26c1 prov:wasDerivedFrom niiri:a5ccd12af883dc80ecb285cbc7d90996 .
 
-niiri:f3f05a481523891d44824beadda448ee
+niiri:c7aca18db0a1f6a5280f9703bc935efc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:194bdcb422ae39cd8096994d6fce64ac ;
+    prov:atLocation niiri:e78bdc31a6807cf01d6eaa462befa9d9 ;
     prov:value "5.17224788665771"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25939672404754"^^xsd:float ;
     nidm_pValueUncorrected: "0.000558247108556009"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999848"^^xsd:float ;
     nidm_qValueFDR: "0.0447389446131481"^^xsd:float .
 
-niiri:194bdcb422ae39cd8096994d6fce64ac
+niiri:e78bdc31a6807cf01d6eaa462befa9d9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[44,46,-18]"^^xsd:string .
 
-niiri:f3f05a481523891d44824beadda448ee prov:wasDerivedFrom niiri:e129e49f77be02735062a975f639c82e .
+niiri:c7aca18db0a1f6a5280f9703bc935efc prov:wasDerivedFrom niiri:075cefbcdab0306f76e523f39577afc9 .
 
-niiri:62b1a35b9b004426fc8baefb3985fe01
+niiri:b810043fb497b4b30e67d61f1ef6d95d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:bbea39448c6107a5d4ad5ddee203d4d2 ;
+    prov:atLocation niiri:ac9a89a3bf9c8e03f7d0abfd07ea181a ;
     prov:value "5.13746070861816"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24309671226403"^^xsd:float ;
     nidm_pValueUncorrected: "0.000591190343014691"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999996"^^xsd:float ;
     nidm_qValueFDR: "0.0465822754926653"^^xsd:float .
 
-niiri:bbea39448c6107a5d4ad5ddee203d4d2
+niiri:ac9a89a3bf9c8e03f7d0abfd07ea181a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[22,-18,-10]"^^xsd:string .
 
-niiri:62b1a35b9b004426fc8baefb3985fe01 prov:wasDerivedFrom niiri:f445b49b9174ce8611d41a7cc11e1717 .
+niiri:b810043fb497b4b30e67d61f1ef6d95d prov:wasDerivedFrom niiri:67b2de2f1c8c8f1c6308f97901012c85 .
 
-niiri:7e86c6411e52fa0a7b9b20dcbb6e36b0
+niiri:7b232038d9487e4356e8dfb4323accd3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:5f9f0cd6ac7c81914637716591108924 ;
+    prov:atLocation niiri:b4963c38f81a01898be7895643388317 ;
     prov:value "5.11799764633179"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23394572778211"^^xsd:float ;
     nidm_pValueUncorrected: "0.000610463272072148"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999981"^^xsd:float ;
     nidm_qValueFDR: "0.0474717326152994"^^xsd:float .
 
-niiri:5f9f0cd6ac7c81914637716591108924
+niiri:b4963c38f81a01898be7895643388317
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[-54,34,4]"^^xsd:string .
 
-niiri:7e86c6411e52fa0a7b9b20dcbb6e36b0 prov:wasDerivedFrom niiri:5ca600306779ba8f48c5d087d9fac9a9 .
+niiri:7b232038d9487e4356e8dfb4323accd3 prov:wasDerivedFrom niiri:3e4aab372e14b498f67d8f3af7fe64d4 .
 
-niiri:97c62dc69d6cfc9480ed5f2d7063dc28
+niiri:11ed40cf7c6d1e1b76914519ad648298
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:34c95820a8a121e8a225fd9376361242 ;
+    prov:atLocation niiri:b2c2c2474e5e6fee6e66d413930cd815 ;
     prov:value "5.10930299758911"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22985044435181"^^xsd:float ;
     nidm_pValueUncorrected: "0.000619274939217984"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999987"^^xsd:float ;
     nidm_qValueFDR: "0.047852944668371"^^xsd:float .
 
-niiri:34c95820a8a121e8a225fd9376361242
+niiri:b2c2c2474e5e6fee6e66d413930cd815
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-30,-64,-52]"^^xsd:string .
 
-niiri:97c62dc69d6cfc9480ed5f2d7063dc28 prov:wasDerivedFrom niiri:40bbe1b7b060c1d54f113fd9fcf154aa .
+niiri:11ed40cf7c6d1e1b76914519ad648298 prov:wasDerivedFrom niiri:4e46f866f0c4c884a98d67ad4f286185 .
 
-niiri:fd255fdebba34e1d3d741757f42127cb
+niiri:4d10f48cdd2d3f00f61d037f49b32b4f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:e2093ea5a4830bc016df153a1447adb3 ;
+    prov:atLocation niiri:7016a6fd792cf01d7c320f58e80217f0 ;
     prov:value "5.10401487350464"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22735746106492"^^xsd:float ;
     nidm_pValueUncorrected: "0.000624696357977461"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999989"^^xsd:float ;
     nidm_qValueFDR: "0.0480043833565767"^^xsd:float .
 
-niiri:e2093ea5a4830bc016df153a1447adb3
+niiri:7016a6fd792cf01d7c320f58e80217f0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[-48,-78,18]"^^xsd:string .
 
-niiri:fd255fdebba34e1d3d741757f42127cb prov:wasDerivedFrom niiri:5d9d1b3e1bbc6746185f53561c74bace .
+niiri:4d10f48cdd2d3f00f61d037f49b32b4f prov:wasDerivedFrom niiri:0c4f8238e0d8817ab291795ad931058d .
 
-niiri:d03d3f46620d80d545af7b487f982e5b
+niiri:9a335bf5867319042aef935fdd61a2ca
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:8beacede341a47f3167389d2db31c511 ;
+    prov:atLocation niiri:bdd410f3992b80366097ff8da55c6572 ;
     prov:value "5.09518003463745"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22318870378714"^^xsd:float ;
     nidm_pValueUncorrected: "0.000633860042171808"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.0483657513246105"^^xsd:float .
 
-niiri:8beacede341a47f3167389d2db31c511
+niiri:bdd410f3992b80366097ff8da55c6572
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[4,-86,38]"^^xsd:string .
 
-niiri:d03d3f46620d80d545af7b487f982e5b prov:wasDerivedFrom niiri:4c53636a1293cd4482cb63ff70691d79 .
+niiri:9a335bf5867319042aef935fdd61a2ca prov:wasDerivedFrom niiri:45b239a4d9c3d2d8505e69c949d3d8e8 .
 
-niiri:26a9a6f6ecb327e047fbdaf46b98bd6e
+niiri:71e3044821bf1685ebc1d1ccc482996c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:1be4f6ad62254ca44faf09f21e98b4ef ;
+    prov:atLocation niiri:cbce0e0cb8230da058e27ef6498e9822 ;
     prov:value "5.08291101455688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21739172198432"^^xsd:float ;
     nidm_pValueUncorrected: "0.000646809225746448"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999996"^^xsd:float ;
     nidm_qValueFDR: "0.0489980390158314"^^xsd:float .
 
-niiri:1be4f6ad62254ca44faf09f21e98b4ef
+niiri:cbce0e0cb8230da058e27ef6498e9822
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[-14,-50,-36]"^^xsd:string .
 
-niiri:26a9a6f6ecb327e047fbdaf46b98bd6e prov:wasDerivedFrom niiri:2b3b2f5817481e92102b214f3bf33995 .
+niiri:71e3044821bf1685ebc1d1ccc482996c prov:wasDerivedFrom niiri:d81ab34b3d15a5e83dcac601860e2c67 .
 
-niiri:eed8b6f60fa2ab238d44784bc24f49fc
+niiri:64739c4167dc0d3498f8e2a1c8595f71
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:f840d99aa197bd8d4fa2aca6525dd6b6 ;
+    prov:atLocation niiri:f40d5d8206a7e8bfeb960db99a347c49 ;
     prov:value "5.0689902305603"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21080328886987"^^xsd:float ;
     nidm_pValueUncorrected: "0.000661822545445001"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.0496832380294054"^^xsd:float .
 
-niiri:f840d99aa197bd8d4fa2aca6525dd6b6
+niiri:f40d5d8206a7e8bfeb960db99a347c49
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[30,68,10]"^^xsd:string .
 
-niiri:eed8b6f60fa2ab238d44784bc24f49fc prov:wasDerivedFrom niiri:86437031e803eee8517a97d2e8420009 .
+niiri:64739c4167dc0d3498f8e2a1c8595f71 prov:wasDerivedFrom niiri:17915a4b4045396b3dc9e808d4f43fff .
 
-niiri:5e7cb532886034b9c21ce9230724cf4e
+niiri:a433274bd13730beb4dfc0d55357557e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:fa765c1dff998dba8cec43964f9fd0ac ;
+    prov:atLocation niiri:7c271a5a16a2eba0109c81f0cefb625f ;
     prov:value "5.05907249450684"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20610225272296"^^xsd:float ;
     nidm_pValueUncorrected: "0.000672730842027125"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.0501943510982274"^^xsd:float .
 
-niiri:fa765c1dff998dba8cec43964f9fd0ac
+niiri:7c271a5a16a2eba0109c81f0cefb625f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[10,-30,80]"^^xsd:string .
 
-niiri:5e7cb532886034b9c21ce9230724cf4e prov:wasDerivedFrom niiri:927385c4b1c66020878360a5006a3e3b .
+niiri:a433274bd13730beb4dfc0d55357557e prov:wasDerivedFrom niiri:fb337b3deac825168c6547e71cdf45e4 .
 
-niiri:3b0256e0257667bc847e43ec82712c6a
+niiri:fe448e07f10dd77ad7048bec2935288a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:0513413f42049f48fad742e27fa4823c ;
+    prov:atLocation niiri:2146da53497ad34f011f172dddd97f90 ;
     prov:value "5.05790328979492"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20554765226523"^^xsd:float ;
     nidm_pValueUncorrected: "0.000674028618936839"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.0502551505802037"^^xsd:float .
 
-niiri:0513413f42049f48fad742e27fa4823c
+niiri:2146da53497ad34f011f172dddd97f90
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[44,-76,8]"^^xsd:string .
 
-niiri:3b0256e0257667bc847e43ec82712c6a prov:wasDerivedFrom niiri:0087c0fa9854a20b9b26757b4c0e9a68 .
+niiri:fe448e07f10dd77ad7048bec2935288a prov:wasDerivedFrom niiri:d1e644390766d6283debb5ff26e27399 .
 
-niiri:546a3ae2919066aba8b04feb7eaf222b
+niiri:e39a0ed9969f84905bcc14001d8bf13f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:711f068fef9833519c8dc8540cb0ba53 ;
+    prov:atLocation niiri:2bc5786adf5e16150692c21f687fd1e7 ;
     prov:value "5.04969549179077"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20165202224461"^^xsd:float ;
     nidm_pValueUncorrected: "0.000683209765197312"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.050613270744433"^^xsd:float .
 
-niiri:711f068fef9833519c8dc8540cb0ba53
+niiri:2bc5786adf5e16150692c21f687fd1e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-52,-36,44]"^^xsd:string .
 
-niiri:546a3ae2919066aba8b04feb7eaf222b prov:wasDerivedFrom niiri:679d2ced08c3de3ec63ab76190f2d86d .
+niiri:e39a0ed9969f84905bcc14001d8bf13f prov:wasDerivedFrom niiri:f2c41aa526c7ecfe683fb5b1f2a7588a .
 
-niiri:3c565a898ce1cb8d1a32498833886420
+niiri:5f5dd191ac43989e197e1dc7f76d17b2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:d1361e7764f4b544072c31608b9db437 ;
+    prov:atLocation niiri:fd5647f38306e48b87e44239ec80d981 ;
     prov:value "5.02838468551636"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19151815181806"^^xsd:float ;
     nidm_pValueUncorrected: "0.000707636089146368"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.051650625154872"^^xsd:float .
 
-niiri:d1361e7764f4b544072c31608b9db437
+niiri:fd5647f38306e48b87e44239ec80d981
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-44,-40,42]"^^xsd:string .
 
-niiri:3c565a898ce1cb8d1a32498833886420 prov:wasDerivedFrom niiri:302d0ae98bffba69292672583d115e8c .
+niiri:5f5dd191ac43989e197e1dc7f76d17b2 prov:wasDerivedFrom niiri:b6e3adf39b177b2fe3b6833a47713718 .
 
-niiri:895ab0cb66ad5fe2b8f0ccfda413020f
+niiri:f71c1e2e5f91a95c5712a4d4ba89c40f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:f2b167b359b019d6526e5256b4b2a4e7 ;
+    prov:atLocation niiri:8acbde476f7d16ebe1080128d978f2a5 ;
     prov:value "5.02759695053101"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19114302879552"^^xsd:float ;
     nidm_pValueUncorrected: "0.00070855553886906"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0516996133446043"^^xsd:float .
 
-niiri:f2b167b359b019d6526e5256b4b2a4e7
+niiri:8acbde476f7d16ebe1080128d978f2a5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[-44,54,-6]"^^xsd:string .
 
-niiri:895ab0cb66ad5fe2b8f0ccfda413020f prov:wasDerivedFrom niiri:f443e4b03660a8ad618e307479bf8a95 .
+niiri:f71c1e2e5f91a95c5712a4d4ba89c40f prov:wasDerivedFrom niiri:ac9ee3188f787257a289a9904e28a0df .
 
-niiri:38744d312469d30ea2aad6e112efd815
+niiri:af1ef614c297cb2b0e8df9da0f88d85f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:4e8ff56debee785959e0deb820ab4223 ;
+    prov:atLocation niiri:5e694eb878b5af9458d3d142d8858bc7 ;
     prov:value "5.00743103027344"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18152691683286"^^xsd:float ;
     nidm_pValueUncorrected: "0.000732504543232371"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0526896959368281"^^xsd:float .
 
-niiri:4e8ff56debee785959e0deb820ab4223
+niiri:5e694eb878b5af9458d3d142d8858bc7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[36,58,18]"^^xsd:string .
 
-niiri:38744d312469d30ea2aad6e112efd815 prov:wasDerivedFrom niiri:80e9d7b2bd34593272f3fb19fc9254e9 .
+niiri:af1ef614c297cb2b0e8df9da0f88d85f prov:wasDerivedFrom niiri:499c553f4f05bed3bf262435de53d3b1 .
 
-niiri:6d61e7dcb92b6e6b6f64536ea335f5e2
+niiri:2bc5fdc6aa9851c6ac2a13fe3cadb39d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:19af79f4d565155ceba8d4b51e598b73 ;
+    prov:atLocation niiri:855f018b32553b4caf4fc1bf009968d2 ;
     prov:value "4.99766159057617"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17685933085535"^^xsd:float ;
     nidm_pValueUncorrected: "0.000744396146822202"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0532506765476335"^^xsd:float .
 
-niiri:19af79f4d565155ceba8d4b51e598b73
+niiri:855f018b32553b4caf4fc1bf009968d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[-44,22,40]"^^xsd:string .
 
-niiri:6d61e7dcb92b6e6b6f64536ea335f5e2 prov:wasDerivedFrom niiri:91bc3a2972b2938504904a8d68057f2e .
+niiri:2bc5fdc6aa9851c6ac2a13fe3cadb39d prov:wasDerivedFrom niiri:425b3b59bb1a3d7b86c2c5264b8a6627 .
 
-niiri:9a1ce2e69e3dbc416c997bb0ba8cf8fa
+niiri:5fc1f607a58e2e1e41ba524f5b5569bf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:ddbc2b5e1f26927e114e09c84b260fdd ;
+    prov:atLocation niiri:5af36ea4b1408261746969b90904aa72 ;
     prov:value "4.98628282546997"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1714153864203"^^xsd:float ;
     nidm_pValueUncorrected: "0.00075849026901309"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0537320048825192"^^xsd:float .
 
-niiri:ddbc2b5e1f26927e114e09c84b260fdd
+niiri:5af36ea4b1408261746969b90904aa72
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[32,-24,72]"^^xsd:string .
 
-niiri:9a1ce2e69e3dbc416c997bb0ba8cf8fa prov:wasDerivedFrom niiri:681cc93cdfd04b41012417cfd725953f .
+niiri:5fc1f607a58e2e1e41ba524f5b5569bf prov:wasDerivedFrom niiri:9c92e09c369b8211d4e65fbfbb9c9aa4 .
 
-niiri:1e37e838816ab673f5b1a0e528a618fb
+niiri:d574b1737bae301e87767c0ba911977b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:b33af54063165da162cc0a06d18506f6 ;
+    prov:atLocation niiri:70168be09147ff18f1b4d58e45414ac5 ;
     prov:value "4.97769069671631"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16729931357798"^^xsd:float ;
     nidm_pValueUncorrected: "0.000769309331678514"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0542313534025412"^^xsd:float .
 
-niiri:b33af54063165da162cc0a06d18506f6
+niiri:70168be09147ff18f1b4d58e45414ac5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[50,-30,60]"^^xsd:string .
 
-niiri:1e37e838816ab673f5b1a0e528a618fb prov:wasDerivedFrom niiri:1288217d5c8b70c54915067a87402187 .
+niiri:d574b1737bae301e87767c0ba911977b prov:wasDerivedFrom niiri:d76384fac79adab2f8bcdd74e38b05e5 .
 
-niiri:af091ddb51f232e6c9bd315c31128cde
+niiri:c8377608c568eaa0cdfbf4c747621fa9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:a3d5999988833de22efee90511c9be29 ;
+    prov:atLocation niiri:acdaf7ebdad9ef3b2e6853b153b2cecc ;
     prov:value "4.95973443984985"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15868244743865"^^xsd:float ;
     nidm_pValueUncorrected: "0.000792420371319991"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.05524320395595"^^xsd:float .
 
-niiri:a3d5999988833de22efee90511c9be29
+niiri:acdaf7ebdad9ef3b2e6853b153b2cecc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[-32,-74,-28]"^^xsd:string .
 
-niiri:af091ddb51f232e6c9bd315c31128cde prov:wasDerivedFrom niiri:9a33ec7dcbaf4c333c9be7973d3674ae .
+niiri:c8377608c568eaa0cdfbf4c747621fa9 prov:wasDerivedFrom niiri:66b4285fcdb2a68d01ddbdfea09445d1 .
 
-niiri:040db063243906b03c972dbf813f1e8f
+niiri:e21e14898e4a6342702db7821daa0b6f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:c2ea305012d99e2652d0a3896a349455 ;
+    prov:atLocation niiri:e4ee48571566d6ae17936ca8119e4c6e ;
     prov:value "4.95515823364258"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15648318111342"^^xsd:float ;
     nidm_pValueUncorrected: "0.000798420481037398"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0553418612137989"^^xsd:float .
 
-niiri:c2ea305012d99e2652d0a3896a349455
+niiri:e4ee48571566d6ae17936ca8119e4c6e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-26,-86,40]"^^xsd:string .
 
-niiri:040db063243906b03c972dbf813f1e8f prov:wasDerivedFrom niiri:6e6cc60afe4fc320e4c4f29c4bdf4e73 .
+niiri:e21e14898e4a6342702db7821daa0b6f prov:wasDerivedFrom niiri:ce2fd9609bbaf4260567fecf8334f73a .
 
-niiri:5eaeb3f75f7650cb74f379ed173f7e58
+niiri:ec800b1561a8e211d893b9129cbd17ff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:c72bbf109b350d78e64ee37ee86ef87a ;
+    prov:atLocation niiri:a5b7712f3a3c7ea5cce3b7f25d7840d9 ;
     prov:value "4.93855857849121"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14849453487417"^^xsd:float ;
     nidm_pValueUncorrected: "0.000820568960055779"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0562262327439451"^^xsd:float .
 
-niiri:c72bbf109b350d78e64ee37ee86ef87a
+niiri:a5b7712f3a3c7ea5cce3b7f25d7840d9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[-10,8,6]"^^xsd:string .
 
-niiri:5eaeb3f75f7650cb74f379ed173f7e58 prov:wasDerivedFrom niiri:99af69862e054a4c62b8e6066ff12cfd .
+niiri:ec800b1561a8e211d893b9129cbd17ff prov:wasDerivedFrom niiri:a482e942f85057c7e6150a9211c470d5 .
 
-niiri:3716c38360149956c53c557239c91fd7
+niiri:2acd52cd4d8b0806cc76e3f29c4eff53
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:8947ac3de97fe88382a65c163f842436 ;
+    prov:atLocation niiri:d5d56e7417d11be82b076cdec47aa14c ;
     prov:value "4.90264129638672"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13114947632107"^^xsd:float ;
     nidm_pValueUncorrected: "0.000870617549853403"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.058320641241518"^^xsd:float .
 
-niiri:8947ac3de97fe88382a65c163f842436
+niiri:d5d56e7417d11be82b076cdec47aa14c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[14,8,10]"^^xsd:string .
 
-niiri:3716c38360149956c53c557239c91fd7 prov:wasDerivedFrom niiri:20fc427845c2a14183959299a0d233ce .
+niiri:2acd52cd4d8b0806cc76e3f29c4eff53 prov:wasDerivedFrom niiri:72e4e5b0d793f6bdd394586ab7b319ae .
 
-niiri:17f311b4781af2c645292f1b0c08e56c
+niiri:c96ee0b4ee3228aa7692569b05c9d521
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:90f614e5e280a7d031215612221686fb ;
+    prov:atLocation niiri:5a6d01da2d934174919cb15f04e572d4 ;
     prov:value "4.90243864059448"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1310513773308"^^xsd:float ;
     nidm_pValueUncorrected: "0.000870908426383377"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.058320641241518"^^xsd:float .
 
-niiri:90f614e5e280a7d031215612221686fb
+niiri:5a6d01da2d934174919cb15f04e572d4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[-20,-54,-2]"^^xsd:string .
 
-niiri:17f311b4781af2c645292f1b0c08e56c prov:wasDerivedFrom niiri:0294b8b1f3c4b525a18397bf17d17d63 .
+niiri:c96ee0b4ee3228aa7692569b05c9d521 prov:wasDerivedFrom niiri:698f920512e0bc86196ac5bdf9403706 .
 
-niiri:261827ec7c4ac6d56b850bf7be1a0995
+niiri:1d08526aab6a9a90c5952a579bfe70f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:0dc46ac23cbc0284b413f46af5e9b5bf ;
+    prov:atLocation niiri:4305ea19e546e9f3e09c4e96ecb80222 ;
     prov:value "4.88119602203369"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12075392909771"^^xsd:float ;
     nidm_pValueUncorrected: "0.000901943498395119"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0594947205600118"^^xsd:float .
 
-niiri:0dc46ac23cbc0284b413f46af5e9b5bf
+niiri:4305ea19e546e9f3e09c4e96ecb80222
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[-26,-84,44]"^^xsd:string .
 
-niiri:261827ec7c4ac6d56b850bf7be1a0995 prov:wasDerivedFrom niiri:3dc796cbf0403561b0e6ea42b96ea1a9 .
+niiri:1d08526aab6a9a90c5952a579bfe70f9 prov:wasDerivedFrom niiri:ad1cd56f7d143bd776b5691683c59add .
 
-niiri:2ae246317f788cd3eeea499f36da2784
+niiri:e293b60c32a79f675471d9249f7c74e9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:ba8c00af87b3e78bc9d96bf0d493697c ;
+    prov:atLocation niiri:f76d40c83ee44efc114b2f7748b07ab0 ;
     prov:value "4.86706686019897"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11388868389685"^^xsd:float ;
     nidm_pValueUncorrected: "0.000923195680083033"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0603762016821821"^^xsd:float .
 
-niiri:ba8c00af87b3e78bc9d96bf0d493697c
+niiri:f76d40c83ee44efc114b2f7748b07ab0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-54,22,10]"^^xsd:string .
 
-niiri:2ae246317f788cd3eeea499f36da2784 prov:wasDerivedFrom niiri:14518885ee853fba951013cf73f66bed .
+niiri:e293b60c32a79f675471d9249f7c74e9 prov:wasDerivedFrom niiri:eaa184888e18a33c4f8a743428f908be .
 
-niiri:e7bbc2a18733379b4ba6e4c9b9da44fa
+niiri:a2e6eded6d5f1f58391a348ff3e8a663
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:8726957d4cdde9d04e29bbe51a70e336 ;
+    prov:atLocation niiri:6c3e52ed132f2f99aa602219a7ebe413 ;
     prov:value "4.84812355041504"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10466401400555"^^xsd:float ;
     nidm_pValueUncorrected: "0.000952476397051205"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0616422795595169"^^xsd:float .
 
-niiri:8726957d4cdde9d04e29bbe51a70e336
+niiri:6c3e52ed132f2f99aa602219a7ebe413
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[32,-80,-24]"^^xsd:string .
 
-niiri:e7bbc2a18733379b4ba6e4c9b9da44fa prov:wasDerivedFrom niiri:7666b1a689a3839cdadb86af5e5c7c39 .
+niiri:a2e6eded6d5f1f58391a348ff3e8a663 prov:wasDerivedFrom niiri:7a8727b45ba0d1d9809d83d6afaba387 .
 
-niiri:38f3fc0e0c53bc3fde20e9f5bbf1c52d
+niiri:97ef4abdcfd8473e154e7543d15c3849
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:97cc916bbf9c73be7bceb77865458446 ;
+    prov:atLocation niiri:c0861ab711f9c4ee99cc4d65f2359ec6 ;
     prov:value "4.82597017288208"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09384653195936"^^xsd:float ;
     nidm_pValueUncorrected: "0.00098789830908641"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0629671631402158"^^xsd:float .
 
-niiri:97cc916bbf9c73be7bceb77865458446
+niiri:c0861ab711f9c4ee99cc4d65f2359ec6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[10,-80,4]"^^xsd:string .
 
-niiri:38f3fc0e0c53bc3fde20e9f5bbf1c52d prov:wasDerivedFrom niiri:2cac2c4baab8136a53bdf03e74fdc1c5 .
+niiri:97ef4abdcfd8473e154e7543d15c3849 prov:wasDerivedFrom niiri:e37d9920261de8039f51fb95dfc921a4 .
 
-niiri:c9916a684f8ab6fd7ebe1ce3907a9b34
+niiri:6d05594f0412161046c44eacac40a42a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:302777c17a3ab317d1e6b6ffd24666ff ;
+    prov:atLocation niiri:c299d10452cbc4dd22179d17b089b932 ;
     prov:value "4.82537364959717"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09355480628341"^^xsd:float ;
     nidm_pValueUncorrected: "0.000988870098138084"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0629727239584754"^^xsd:float .
 
-niiri:302777c17a3ab317d1e6b6ffd24666ff
+niiri:c299d10452cbc4dd22179d17b089b932
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[16,-50,-50]"^^xsd:string .
 
-niiri:c9916a684f8ab6fd7ebe1ce3907a9b34 prov:wasDerivedFrom niiri:8768acb96e7e44e4cd45548f0d52dd3f .
+niiri:6d05594f0412161046c44eacac40a42a prov:wasDerivedFrom niiri:69d9b433456370b7c1a9673758c8fe93 .
 
-niiri:380422cca8da791d72bac3c9bd4f903f
+niiri:e51a96651be45131bb9f48a47747e9ef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:6f88b65eb9c9991d816265aa7f3ca79a ;
+    prov:atLocation niiri:11a804aecddacdb1c417a8972e693084 ;
     prov:value "4.82024002075195"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09104327517968"^^xsd:float ;
     nidm_pValueUncorrected: "0.000997272813291428"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0632678542871923"^^xsd:float .
 
-niiri:6f88b65eb9c9991d816265aa7f3ca79a
+niiri:11a804aecddacdb1c417a8972e693084
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[-12,-20,12]"^^xsd:string .
 
-niiri:380422cca8da791d72bac3c9bd4f903f prov:wasDerivedFrom niiri:816f19a8ef8789235a9bd7bfe4396a14 .
+niiri:e51a96651be45131bb9f48a47747e9ef prov:wasDerivedFrom niiri:f8f9f105adf5f8aecb1ef2a7b71b7a33 .
 

--- a/spmexport/ex_spm_full_example001/config.json
+++ b/spmexport/ex_spm_full_example001/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["spm_full_example001/example001_spm_results.ttl"],
+"inclusive": false,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_full_example001/nidm.provn
+++ b/spmexport/ex_spm_full_example001/nidm.provn
@@ -1,0 +1,996 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:07ddd0499ec9f6aa773ab738cdf741eb,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:a97ad5b925ada692efd2d656142cefb4,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:57339932eb6c52187a3aa96543bbf755,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:57339932eb6c52187a3aa96543bbf755, niiri:a97ad5b925ada692efd2d656142cefb4, -)
+  wasGeneratedBy(niiri:07ddd0499ec9f6aa773ab738cdf741eb, niiri:57339932eb6c52187a3aa96543bbf755, 2016-01-11T10:44:05)
+  bundle niiri:07ddd0499ec9f6aa773ab738cdf741eb
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+    prefix nidm_SupraThresholdCluster <http://purl.org/nidash/nidm#NIDM_0000070>
+    prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
+    prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+    prefix nidm_qValueFDR <http://purl.org/nidash/nidm#NIDM_0000119>
+    prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
+    prefix nidm_Peak <http://purl.org/nidash/nidm#NIDM_0000062>
+    prefix nidm_equivalentZStatistic <http://purl.org/nidash/nidm#NIDM_0000092>
+    prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
+    prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
+
+    agent(niiri:e9be5eea1eb67cb49c3b383c9b0a900d,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:9cf22d3de0a7c49713079ebc9830ad3d,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[3, 3, 3]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[53,63,52]" %% xsd:string])
+    entity(niiri:d90857a6787816e85415e456e5aef267,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:3ae1e011cd15c4012b78e209f348c6a4,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:c2278b9b976a48ab0bcfbfb687334955,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:5fd9e61ed87219589941047f99520fd9',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) active*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:3ae1e011cd15c4012b78e209f348c6a4',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:5fd9e61ed87219589941047f99520fd9,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:1d7f39aa206df0fad7d85518864badd8,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:15258c78ab3d3f8cb82b010a67a822b3,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:15258c78ab3d3f8cb82b010a67a822b3, niiri:e9be5eea1eb67cb49c3b383c9b0a900d, -)
+    used(niiri:15258c78ab3d3f8cb82b010a67a822b3, niiri:c2278b9b976a48ab0bcfbfb687334955, -)
+    used(niiri:15258c78ab3d3f8cb82b010a67a822b3, niiri:d90857a6787816e85415e456e5aef267, -)
+    used(niiri:15258c78ab3d3f8cb82b010a67a822b3, niiri:1d7f39aa206df0fad7d85518864badd8, -)
+    entity(niiri:640767d446bbbf134bd858e58a942d48,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        crypto:sha512 = "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875" %% xsd:string])
+    entity(niiri:63fcb632564d62f13ce9cd67436c0ec7,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11" %% xsd:string])
+    wasDerivedFrom(niiri:640767d446bbbf134bd858e58a942d48, niiri:63fcb632564d62f13ce9cd67436c0ec7, -, -, -)
+    wasGeneratedBy(niiri:640767d446bbbf134bd858e58a942d48, niiri:15258c78ab3d3f8cb82b010a67a822b3, -)
+    entity(niiri:a6a920f9195beddba3552de1558eff47,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "132.008995056152" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        crypto:sha512 = "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb" %% xsd:string])
+    wasGeneratedBy(niiri:a6a920f9195beddba3552de1558eff47, niiri:15258c78ab3d3f8cb82b010a67a822b3, -)
+    entity(niiri:5a62c76da360f0025cf33269be72abe9,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d'])
+    entity(niiri:7be821c1aa5fafc219550c15744a926a,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f" %% xsd:string])
+    wasDerivedFrom(niiri:5a62c76da360f0025cf33269be72abe9, niiri:7be821c1aa5fafc219550c15744a926a, -, -, -)
+    wasGeneratedBy(niiri:5a62c76da360f0025cf33269be72abe9, niiri:15258c78ab3d3f8cb82b010a67a822b3, -)
+    entity(niiri:0228f3befc5a61fac386ec758856506d,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d'])
+    entity(niiri:86de7e9f90ab78a7d1b2d477e2ee589f,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008" %% xsd:string])
+    wasDerivedFrom(niiri:0228f3befc5a61fac386ec758856506d, niiri:86de7e9f90ab78a7d1b2d477e2ee589f, -, -, -)
+    wasGeneratedBy(niiri:0228f3befc5a61fac386ec758856506d, niiri:15258c78ab3d3f8cb82b010a67a822b3, -)
+    entity(niiri:f92071b48bcebf4d7560164992961ec8,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        crypto:sha512 = "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b" %% xsd:string])
+    entity(niiri:f4b00c8235f9be695e89d3b8f353fe41,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "1635e0ae420cac1b5989fbc753b95f504dd957ff2986367fc4cd13ff35c44b4ee60994a9cdcab93a7d247fc5a8decb7578fa4c553b0ac905af8c7041db9b4acd" %% xsd:string])
+    wasDerivedFrom(niiri:f92071b48bcebf4d7560164992961ec8, niiri:f4b00c8235f9be695e89d3b8f353fe41, -, -, -)
+    wasGeneratedBy(niiri:f92071b48bcebf4d7560164992961ec8, niiri:15258c78ab3d3f8cb82b010a67a822b3, -)
+    entity(niiri:c2a04e5956c4f5752e93d3406e16c8e0,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        crypto:sha512 = "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a" %% xsd:string])
+    entity(niiri:881f1889c4fc9a152a6fbb7ed8ae914c,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d" %% xsd:string])
+    wasDerivedFrom(niiri:c2a04e5956c4f5752e93d3406e16c8e0, niiri:881f1889c4fc9a152a6fbb7ed8ae914c, -, -, -)
+    wasGeneratedBy(niiri:c2a04e5956c4f5752e93d3406e16c8e0, niiri:15258c78ab3d3f8cb82b010a67a822b3, -)
+    entity(niiri:3dbacfe4e7a5cadd568c0f4f075e8f41,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "passive listening > rest" %% xsd:string,
+        prov:label = "Contrast: passive listening > rest" %% xsd:string,
+        prov:value = "[1, 0]" %% xsd:string])
+    activity(niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, niiri:e9be5eea1eb67cb49c3b383c9b0a900d, -)
+    used(niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, niiri:640767d446bbbf134bd858e58a942d48, -)
+    used(niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, niiri:f92071b48bcebf4d7560164992961ec8, -)
+    used(niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, niiri:c2278b9b976a48ab0bcfbfb687334955, -)
+    used(niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, niiri:3dbacfe4e7a5cadd568c0f4f075e8f41, -)
+    used(niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, niiri:5a62c76da360f0025cf33269be72abe9, -)
+    used(niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, niiri:0228f3befc5a61fac386ec758856506d, -)
+    entity(niiri:dcbd95eb7f689bcc93099252f7431941,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: passive listening > rest" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "passive listening > rest" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "83.9999999999599" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        crypto:sha512 = "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6" %% xsd:string])
+    entity(niiri:64d02b9baf7fb8f2b5c40dc064646f65,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825" %% xsd:string])
+    wasDerivedFrom(niiri:dcbd95eb7f689bcc93099252f7431941, niiri:64d02b9baf7fb8f2b5c40dc064646f65, -, -, -)
+    wasGeneratedBy(niiri:dcbd95eb7f689bcc93099252f7431941, niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, -)
+    entity(niiri:cb0937bd8dcb4e22243d79330d1bab3a,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: passive listening > rest" %% xsd:string,
+        nidm_contrastName: = "passive listening > rest" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        crypto:sha512 = "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2" %% xsd:string])
+    entity(niiri:a8856b4265168ed707cfac251b55a6b8,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "277dd1da13d391c33c172fb8c71060008cc66e173de6362eb857b0055b41e9bae57911f7ec4b45659905103b1139ebf3da0c2d04cf105bbce0cdc3004b643c22" %% xsd:string])
+    wasDerivedFrom(niiri:cb0937bd8dcb4e22243d79330d1bab3a, niiri:a8856b4265168ed707cfac251b55a6b8, -, -, -)
+    wasGeneratedBy(niiri:cb0937bd8dcb4e22243d79330d1bab3a, niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, -)
+    entity(niiri:ee9015bf17c2a510bc6709d2ea55beff,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        crypto:sha512 = "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2" %% xsd:string])
+    wasGeneratedBy(niiri:ee9015bf17c2a510bc6709d2ea55beff, niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6, -)
+    entity(niiri:c99778f99dd4bc6e969b32858b7e9509,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
+        prov:value = "0.000999500223269112" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:0132f07129b5e21715df7c0c2a5e5c00',
+        nidm_equivalentThreshold: = 'niiri:ebc471ce4d28c34fb8349e556ef46abe'])
+    entity(niiri:0132f07129b5e21715df7c0c2a5e5c00,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "3.19011050997122" %% xsd:float])
+    entity(niiri:ebc471ce4d28c34fb8349e556ef46abe,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.996699720287235" %% xsd:float])
+    entity(niiri:1e3a172b4c7ff3728392bd5d35f41443,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:836dfb799fe17a8a1ed21d2462bd0f85',
+        nidm_equivalentThreshold: = 'niiri:9c31cafe3bf52474f0ca04699744871e'])
+    entity(niiri:836dfb799fe17a8a1ed21d2462bd0f85,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:9c31cafe3bf52474f0ca04699744871e,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:585358f33ac87cfe988f01ec045a6686,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:2b78ab4d95faeb8cf2913803d31c3111,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:96101a8fe51166772f56717028626db3,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:96101a8fe51166772f56717028626db3, niiri:e9be5eea1eb67cb49c3b383c9b0a900d, -)
+    used(niiri:96101a8fe51166772f56717028626db3, niiri:c99778f99dd4bc6e969b32858b7e9509, -)
+    used(niiri:96101a8fe51166772f56717028626db3, niiri:1e3a172b4c7ff3728392bd5d35f41443, -)
+    used(niiri:96101a8fe51166772f56717028626db3, niiri:dcbd95eb7f689bcc93099252f7431941, -)
+    used(niiri:96101a8fe51166772f56717028626db3, niiri:c2a04e5956c4f5752e93d3406e16c8e0, -)
+    used(niiri:96101a8fe51166772f56717028626db3, niiri:640767d446bbbf134bd858e58a942d48, -)
+    used(niiri:96101a8fe51166772f56717028626db3, niiri:585358f33ac87cfe988f01ec045a6686, -)
+    used(niiri:96101a8fe51166772f56717028626db3, niiri:2b78ab4d95faeb8cf2913803d31c3111, -)
+    entity(niiri:8b48aa2940f6f6db7a7068249fe258b6,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        nidm_searchVolumeInVoxels: = "69306" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1871262" %% xsd:float,
+        nidm_reselSizeInVoxels: = "132.907586178202" %% xsd:float,
+        nidm_searchVolumeInResels: = "467.07642343881" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[7, 42.96312274763, 269.40914815306, 467.07642343881]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[5.41278985910694, 5.43638957240286, 4.51666658877481]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[16.2383695773208, 16.3091687172086, 13.5499997663244]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "14.4459223425356" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "5.7137480526579" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "4.85241745689539" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "4.71486568450928" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "240" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "240" %% xsd:int,
+        crypto:sha512 = "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875" %% xsd:string])
+    wasGeneratedBy(niiri:8b48aa2940f6f6db7a7068249fe258b6, niiri:96101a8fe51166772f56717028626db3, -)
+    entity(niiri:ec9ed4e9e249fa81baced98c4242ef82,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "18" %% xsd:int,
+        nidm_pValue: = "3.07951542369844e-05" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:8612e61195d1a353629d641acc2bc979',
+        nidm_hasMaximumIntensityProjection: = 'niiri:2ac7cca8ab0c6a71458727a8286f6bf3',
+        nidm_inCoordinateSpace: = 'niiri:9cf22d3de0a7c49713079ebc9830ad3d',
+        crypto:sha512 = "93558ac51dc189b4e191daeba5686720d2fd888f0d62f7b2f543a0d62c96e1c9ff25aed63d98cb14101827d1e2e3a4e46d6966469fda61bbc15e32c5e43eb654" %% xsd:string])
+    entity(niiri:8612e61195d1a353629d641acc2bc979,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:2ac7cca8ab0c6a71458727a8286f6bf3,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:ec9ed4e9e249fa81baced98c4242ef82, niiri:96101a8fe51166772f56717028626db3, -)
+    entity(niiri:78bacdacd554038be4455bbb7dadde7c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1264" %% xsd:int,
+        nidm_clusterSizeInResels: = "9.51036758959141" %% xsd:float,
+        nidm_pValueUncorrected: = "4.48255959369336e-11" %% xsd:float,
+        nidm_pValueFWER: = "2.56122123509783e-10" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "1" %% xsd:int])
+    wasDerivedFrom(niiri:78bacdacd554038be4455bbb7dadde7c, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:88ec84fed7a6d51095a345e1388f336b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1501" %% xsd:int,
+        nidm_clusterSizeInResels: = "11.2935615126398" %% xsd:float,
+        nidm_pValueUncorrected: = "2.48513372869345e-12" %% xsd:float,
+        nidm_pValueFWER: = "1.41994194180484e-11" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "2" %% xsd:int])
+    wasDerivedFrom(niiri:88ec84fed7a6d51095a345e1388f336b, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:3b5bc7e8577d3ad063c1fd52a8ac098d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "83" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.624494074316525" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0206851097491133" %% xsd:float,
+        nidm_pValueFWER: = "0.111472344261274" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "3" %% xsd:int])
+    wasDerivedFrom(niiri:3b5bc7e8577d3ad063c1fd52a8ac098d, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:2bf81c3d14d68055b9d17ee9e724928f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "240" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.80576599802369" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000381388385608752" %% xsd:float,
+        nidm_pValueFWER: = "0.0021767845064099" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "4" %% xsd:int])
+    wasDerivedFrom(niiri:2bf81c3d14d68055b9d17ee9e724928f, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:06e9554bbeea4a431c943fc3ec2cdbbb,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "50" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.376201249588268" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0628910752564052" %% xsd:float,
+        nidm_pValueFWER: = "0.301865679701775" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "5" %% xsd:int])
+    wasDerivedFrom(niiri:06e9554bbeea4a431c943fc3ec2cdbbb, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:a9219cbc769cbb83a3de16f99e5a347d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "93" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.699734324234178" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0152387708209126" %% xsd:float,
+        nidm_pValueFWER: = "0.0833875251685585" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "6" %% xsd:int])
+    wasDerivedFrom(niiri:a9219cbc769cbb83a3de16f99e5a347d, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:67bc5169985a45ee91ee0ba2594d0de1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "39" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.293436974678849" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0959364968442128" %% xsd:float,
+        nidm_pValueFWER: = "0.421985874497329" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "7" %% xsd:int])
+    wasDerivedFrom(niiri:67bc5169985a45ee91ee0ba2594d0de1, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:a8f1a3d7b165fdfa59ef170a03763fef,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "43" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.32353307464591" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0819435156724374" %% xsd:float,
+        nidm_pValueFWER: = "0.373874596648251" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "8" %% xsd:int])
+    wasDerivedFrom(niiri:a8f1a3d7b165fdfa59ef170a03763fef, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:1cf5dfaaee190896215164bb926858be,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "26" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.195624649785899" %% xsd:float,
+        nidm_pValueUncorrected: = "0.167150731119474" %% xsd:float,
+        nidm_pValueFWER: = "0.615209852386826" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "9" %% xsd:int])
+    wasDerivedFrom(niiri:1cf5dfaaee190896215164bb926858be, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:fb9fa9dc2ca1f5d99d08905f70d6ddf4,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "9" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0677162249258882" %% xsd:float,
+        nidm_pValueUncorrected: = "0.413993095492646" %% xsd:float,
+        nidm_pValueFWER: = "0.90609317795635" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "10" %% xsd:int])
+    wasDerivedFrom(niiri:fb9fa9dc2ca1f5d99d08905f70d6ddf4, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:475094716d0d72f0a46a416ad82f1b4a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "29" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.218196724761195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.146029761673043" %% xsd:float,
+        nidm_pValueFWER: = "0.56585524619955" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "11" %% xsd:int])
+    wasDerivedFrom(niiri:475094716d0d72f0a46a416ad82f1b4a, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:c681bc57f45818852f61065cb195b402,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0150480499835307" %% xsd:float,
+        nidm_pValueUncorrected: = "0.72357261092483" %% xsd:float,
+        nidm_pValueFWER: = "0.983986314788855" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "12" %% xsd:int])
+    wasDerivedFrom(niiri:c681bc57f45818852f61065cb195b402, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:8d8544b3de0e4b1df8fca3080acd12ce,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0300960999670614" %% xsd:float,
+        nidm_pValueUncorrected: = "0.59833136351956" %% xsd:float,
+        nidm_pValueFWER: = "0.967245491529494" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "13" %% xsd:int])
+    wasDerivedFrom(niiri:8d8544b3de0e4b1df8fca3080acd12ce, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:797cb2e6b0af99d81cbfc0afe0107928,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0225720749752961" %% xsd:float,
+        nidm_pValueUncorrected: = "0.654439473783549" %% xsd:float,
+        nidm_pValueFWER: = "0.976229317109067" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "14" %% xsd:int])
+    wasDerivedFrom(niiri:797cb2e6b0af99d81cbfc0afe0107928, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:89c0aff109de09bddccd2da4f39e2ff7,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0150480499835307" %% xsd:float,
+        nidm_pValueUncorrected: = "0.72357261092483" %% xsd:float,
+        nidm_pValueFWER: = "0.983986314788855" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "15" %% xsd:int])
+    wasDerivedFrom(niiri:89c0aff109de09bddccd2da4f39e2ff7, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:ba3a0bac50295dbe9628a7da8bbabb44,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0150480499835307" %% xsd:float,
+        nidm_pValueUncorrected: = "0.72357261092483" %% xsd:float,
+        nidm_pValueFWER: = "0.983986314788855" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "16" %% xsd:int])
+    wasDerivedFrom(niiri:ba3a0bac50295dbe9628a7da8bbabb44, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:b47796df89485ea6f991314ad0282c0a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.00752402499176536" %% xsd:float,
+        nidm_pValueUncorrected: = "0.815603878110897" %% xsd:float,
+        nidm_pValueFWER: = "0.990535005451607" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "17" %% xsd:int])
+    wasDerivedFrom(niiri:b47796df89485ea6f991314ad0282c0a, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:aaa8b4bfb02f0be00acdc67ecfcf14f8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.00752402499176536" %% xsd:float,
+        nidm_pValueUncorrected: = "0.815603878110897" %% xsd:float,
+        nidm_pValueFWER: = "0.990535005451607" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "18" %% xsd:int])
+    wasDerivedFrom(niiri:aaa8b4bfb02f0be00acdc67ecfcf14f8, niiri:ec9ed4e9e249fa81baced98c4242ef82, -, -, -)
+    entity(niiri:6e94dd6491017c11ff5bf56e1002cb81,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0001" %% xsd:string,
+        prov:location = 'niiri:9271887753f3c299d83711e4ceababc9',
+        prov:value = "17.5207633972168" %% xsd:float,
+        nidm_equivalentZStatistic: = "INF" %% xsd:float,
+        nidm_pValueUncorrected: = "4.44089209850063e-16" %% xsd:float,
+        nidm_pValueFWER: = "0" %% xsd:float,
+        nidm_qValueFDR: = "0" %% xsd:float])
+    entity(niiri:9271887753f3c299d83711e4ceababc9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0001" %% xsd:string,
+        nidm_coordinateVector: = "[-60,-25,11]" %% xsd:string])
+    wasDerivedFrom(niiri:6e94dd6491017c11ff5bf56e1002cb81, niiri:78bacdacd554038be4455bbb7dadde7c, -, -, -)
+    entity(niiri:9c1342930a4c58f3f38730feec01f2bf,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0002" %% xsd:string,
+        prov:location = 'niiri:33285c0ed9ea2711d10764a1e38499c6',
+        prov:value = "13.0321407318115" %% xsd:float,
+        nidm_equivalentZStatistic: = "INF" %% xsd:float,
+        nidm_pValueUncorrected: = "4.44089209850063e-16" %% xsd:float,
+        nidm_pValueFWER: = "0" %% xsd:float,
+        nidm_qValueFDR: = "0" %% xsd:float])
+    entity(niiri:33285c0ed9ea2711d10764a1e38499c6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0002" %% xsd:string,
+        nidm_coordinateVector: = "[-42,-31,11]" %% xsd:string])
+    wasDerivedFrom(niiri:9c1342930a4c58f3f38730feec01f2bf, niiri:78bacdacd554038be4455bbb7dadde7c, -, -, -)
+    entity(niiri:cf8aaab3245e39853cbaff3905a15c61,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0003" %% xsd:string,
+        prov:location = 'niiri:01d66c85c4653f768af4ed7b850e09f8',
+        prov:value = "10.2856016159058" %% xsd:float,
+        nidm_equivalentZStatistic: = "INF" %% xsd:float,
+        nidm_pValueUncorrected: = "4.44089209850063e-16" %% xsd:float,
+        nidm_pValueFWER: = "7.69451169446711e-12" %% xsd:float,
+        nidm_qValueFDR: = "2.95942757479504e-14" %% xsd:float])
+    entity(niiri:01d66c85c4653f768af4ed7b850e09f8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0003" %% xsd:string,
+        nidm_coordinateVector: = "[-66,-31,-1]" %% xsd:string])
+    wasDerivedFrom(niiri:cf8aaab3245e39853cbaff3905a15c61, niiri:78bacdacd554038be4455bbb7dadde7c, -, -, -)
+    entity(niiri:aaf756444cd6940d07a6497d2018de1a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0004" %% xsd:string,
+        prov:location = 'niiri:c5b1999dab7de52b57d4e63c89ff5b03',
+        prov:value = "13.5425577163696" %% xsd:float,
+        nidm_equivalentZStatistic: = "INF" %% xsd:float,
+        nidm_pValueUncorrected: = "4.44089209850063e-16" %% xsd:float,
+        nidm_pValueFWER: = "0" %% xsd:float,
+        nidm_qValueFDR: = "0" %% xsd:float])
+    entity(niiri:c5b1999dab7de52b57d4e63c89ff5b03,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0004" %% xsd:string,
+        nidm_coordinateVector: = "[63,-13,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:aaf756444cd6940d07a6497d2018de1a, niiri:88ec84fed7a6d51095a345e1388f336b, -, -, -)
+    entity(niiri:f09d161397c2d98f1ae397f52dad72a9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0005" %% xsd:string,
+        prov:location = 'niiri:f9d8e374cdc04136210daaf3e34179ef',
+        prov:value = "12.4728717803955" %% xsd:float,
+        nidm_equivalentZStatistic: = "INF" %% xsd:float,
+        nidm_pValueUncorrected: = "4.44089209850063e-16" %% xsd:float,
+        nidm_pValueFWER: = "0" %% xsd:float,
+        nidm_qValueFDR: = "0" %% xsd:float])
+    entity(niiri:f9d8e374cdc04136210daaf3e34179ef,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0005" %% xsd:string,
+        nidm_coordinateVector: = "[60,-22,11]" %% xsd:string])
+    wasDerivedFrom(niiri:f09d161397c2d98f1ae397f52dad72a9, niiri:88ec84fed7a6d51095a345e1388f336b, -, -, -)
+    entity(niiri:d71a41baf488b215b2a94fd59d9cd193,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0006" %% xsd:string,
+        prov:location = 'niiri:42599dcdf795fe3eb7e8318ec0afb0cb',
+        prov:value = "9.72103404998779" %% xsd:float,
+        nidm_equivalentZStatistic: = "INF" %% xsd:float,
+        nidm_pValueUncorrected: = "1.22124532708767e-15" %% xsd:float,
+        nidm_pValueFWER: = "6.9250605250204e-11" %% xsd:float,
+        nidm_qValueFDR: = "2.24839627435727e-13" %% xsd:float])
+    entity(niiri:42599dcdf795fe3eb7e8318ec0afb0cb,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0006" %% xsd:string,
+        nidm_coordinateVector: = "[57,-40,5]" %% xsd:string])
+    wasDerivedFrom(niiri:d71a41baf488b215b2a94fd59d9cd193, niiri:88ec84fed7a6d51095a345e1388f336b, -, -, -)
+    entity(niiri:79d39a29d61f2323e0a9b86863e61b4b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0007" %% xsd:string,
+        prov:location = 'niiri:305cd536ef8cbd6879fdf68e1fe5876c',
+        prov:value = "6.19558477401733" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.60645028016544" %% xsd:float,
+        nidm_pValueUncorrected: = "1.0325913235576e-08" %% xsd:float,
+        nidm_pValueFWER: = "0.000382453907303626" %% xsd:float,
+        nidm_qValueFDR: = "6.60191630365133e-07" %% xsd:float])
+    entity(niiri:305cd536ef8cbd6879fdf68e1fe5876c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0007" %% xsd:string,
+        nidm_coordinateVector: = "[-33,-31,-16]" %% xsd:string])
+    wasDerivedFrom(niiri:79d39a29d61f2323e0a9b86863e61b4b, niiri:3b5bc7e8577d3ad063c1fd52a8ac098d, -, -, -)
+    entity(niiri:7850f04485929b5a5cd6751d2b16a701,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0008" %% xsd:string,
+        prov:location = 'niiri:323726ceeb25db5892247eda42deb986',
+        prov:value = "4.84209632873535" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.53410879658737" %% xsd:float,
+        nidm_pValueUncorrected: = "2.89236039974217e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.0517130333839199" %% xsd:float,
+        nidm_qValueFDR: = "0.000123816071493245" %% xsd:float])
+    entity(niiri:323726ceeb25db5892247eda42deb986,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0008" %% xsd:string,
+        nidm_coordinateVector: = "[45,17,26]" %% xsd:string])
+    wasDerivedFrom(niiri:7850f04485929b5a5cd6751d2b16a701, niiri:2bf81c3d14d68055b9d17ee9e724928f, -, -, -)
+    entity(niiri:33c6e2c648099e4baddfb1f4524e682a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0009" %% xsd:string,
+        prov:location = 'niiri:a6e65b15c17a9dd28eb690e2e1649982',
+        prov:value = "4.82763147354126" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.52209514540323" %% xsd:float,
+        nidm_pValueUncorrected: = "3.06152617990385e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.0542053020139993" %% xsd:float,
+        nidm_qValueFDR: = "0.000130413311745393" %% xsd:float])
+    entity(niiri:a6e65b15c17a9dd28eb690e2e1649982,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0009" %% xsd:string,
+        nidm_coordinateVector: = "[45,29,23]" %% xsd:string])
+    wasDerivedFrom(niiri:33c6e2c648099e4baddfb1f4524e682a, niiri:2bf81c3d14d68055b9d17ee9e724928f, -, -, -)
+    entity(niiri:5bd2158571ab399c61e9f9bcbc03733d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0010" %% xsd:string,
+        prov:location = 'niiri:fce7a3789578674adbd0ee4c02d9c5b3',
+        prov:value = "4.41708660125732" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.17633392422281" %% xsd:float,
+        nidm_pValueUncorrected: = "1.48122423770936e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.189250331626723" %% xsd:float,
+        nidm_qValueFDR: = "0.000552818994724341" %% xsd:float])
+    entity(niiri:fce7a3789578674adbd0ee4c02d9c5b3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0010" %% xsd:string,
+        nidm_coordinateVector: = "[36,14,23]" %% xsd:string])
+    wasDerivedFrom(niiri:5bd2158571ab399c61e9f9bcbc03733d, niiri:2bf81c3d14d68055b9d17ee9e724928f, -, -, -)
+    entity(niiri:f14d0a739a3920f1bc3323ad331b66a9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0011" %% xsd:string,
+        prov:location = 'niiri:ba6f35e9a1731637640e2ba9973227ae',
+        prov:value = "4.73135995864868" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.44184359868998" %% xsd:float,
+        nidm_pValueUncorrected: = "4.45956909089773e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.0738162589558271" %% xsd:float,
+        nidm_qValueFDR: = "0.000184192839435458" %% xsd:float])
+    entity(niiri:ba6f35e9a1731637640e2ba9973227ae,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0011" %% xsd:string,
+        nidm_coordinateVector: = "[51,-4,47]" %% xsd:string])
+    wasDerivedFrom(niiri:f14d0a739a3920f1bc3323ad331b66a9, niiri:06e9554bbeea4a431c943fc3ec2cdbbb, -, -, -)
+    entity(niiri:ffb88c9368b1ba261ff68d82ed272f22,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0012" %% xsd:string,
+        prov:location = 'niiri:d8aa31ef5acd7fb642db3a01b238f60f',
+        prov:value = "4.71486568450928" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.42804282727638" %% xsd:float,
+        nidm_pValueUncorrected: = "4.75460114568449e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.0777626205502405" %% xsd:float,
+        nidm_qValueFDR: = "0.000195099568008085" %% xsd:float])
+    entity(niiri:d8aa31ef5acd7fb642db3a01b238f60f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0012" %% xsd:string,
+        nidm_coordinateVector: = "[-36,2,35]" %% xsd:string])
+    wasDerivedFrom(niiri:ffb88c9368b1ba261ff68d82ed272f22, niiri:a9219cbc769cbb83a3de16f99e5a347d, -, -, -)
+    entity(niiri:a55b100aee99c0b4f9bd48c5e5d38c2e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0013" %% xsd:string,
+        prov:location = 'niiri:e7cd9ddb9e3da20e8b3d3867ffc1aad7',
+        prov:value = "4.07969188690186" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.88537112992499" %% xsd:float,
+        nidm_pValueUncorrected: = "5.10868406333742e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.439426301421077" %% xsd:float,
+        nidm_qValueFDR: = "0.00167518678592214" %% xsd:float])
+    entity(niiri:e7cd9ddb9e3da20e8b3d3867ffc1aad7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0013" %% xsd:string,
+        nidm_coordinateVector: = "[-33,-7,41]" %% xsd:string])
+    wasDerivedFrom(niiri:a55b100aee99c0b4f9bd48c5e5d38c2e, niiri:a9219cbc769cbb83a3de16f99e5a347d, -, -, -)
+    entity(niiri:0a35a207a0cbcddd75e8f5c414228224,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0014" %% xsd:string,
+        prov:location = 'niiri:9c12c600c2e98fe757d88199d7b300a9',
+        prov:value = "3.73018789291382" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.57769499743383" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000173318801172884" %% xsd:float,
+        nidm_pValueFWER: = "0.78318691512427" %% xsd:float,
+        nidm_qValueFDR: = "0.00489330912828116" %% xsd:float])
+    entity(niiri:9c12c600c2e98fe757d88199d7b300a9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0014" %% xsd:string,
+        nidm_coordinateVector: = "[-51,-4,47]" %% xsd:string])
+    wasDerivedFrom(niiri:0a35a207a0cbcddd75e8f5c414228224, niiri:a9219cbc769cbb83a3de16f99e5a347d, -, -, -)
+    entity(niiri:a365e9a9946ae1d325de16ac5e51b070,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0015" %% xsd:string,
+        prov:location = 'niiri:9c4767fd3e050b4dbe777d100b2c89bd',
+        prov:value = "4.44269752502441" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.19817181421461" %% xsd:float,
+        nidm_pValueUncorrected: = "1.34539226018804e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.176083160116197" %% xsd:float,
+        nidm_qValueFDR: = "0.00050566368349132" %% xsd:float])
+    entity(niiri:9c4767fd3e050b4dbe777d100b2c89bd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0015" %% xsd:string,
+        nidm_coordinateVector: = "[12,14,50]" %% xsd:string])
+    wasDerivedFrom(niiri:a365e9a9946ae1d325de16ac5e51b070, niiri:67bc5169985a45ee91ee0ba2594d0de1, -, -, -)
+    entity(niiri:8ce1625f062ecf73a52b6bf00c88fd0e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0016" %% xsd:string,
+        prov:location = 'niiri:2d732133d427cda3bd74571145d0a134',
+        prov:value = "4.29442167282104" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.0712511023587" %% xsd:float,
+        nidm_pValueUncorrected: = "2.33806545202331e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.263557920290052" %% xsd:float,
+        nidm_qValueFDR: = "0.000835210418779784" %% xsd:float])
+    entity(niiri:2d732133d427cda3bd74571145d0a134,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0016" %% xsd:string,
+        nidm_coordinateVector: = "[-39,20,32]" %% xsd:string])
+    wasDerivedFrom(niiri:8ce1625f062ecf73a52b6bf00c88fd0e, niiri:a8f1a3d7b165fdfa59ef170a03763fef, -, -, -)
+    entity(niiri:37e81450b1f9548f6f1c9c7d6841ba28,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0017" %% xsd:string,
+        prov:location = 'niiri:85459b56430f23f3788d443572d5019d',
+        prov:value = "3.87923645973206" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.70967059113076" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000103764543077145" %% xsd:float,
+        nidm_pValueFWER: = "0.639762512909999" %% xsd:float,
+        nidm_qValueFDR: = "0.00314467798860484" %% xsd:float])
+    entity(niiri:85459b56430f23f3788d443572d5019d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0017" %% xsd:string,
+        nidm_coordinateVector: = "[27,-85,8]" %% xsd:string])
+    wasDerivedFrom(niiri:37e81450b1f9548f6f1c9c7d6841ba28, niiri:1cf5dfaaee190896215164bb926858be, -, -, -)
+    entity(niiri:3dd707ab362eb195cac4faffe483c856,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0018" %% xsd:string,
+        prov:location = 'niiri:99d46b776d179dd3c0fa6e5f24211e9c',
+        prov:value = "3.73632216453552" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.58314871433109" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000169738601991543" %% xsd:float,
+        nidm_pValueFWER: = "0.777763871722966" %% xsd:float,
+        nidm_qValueFDR: = "0.00481182088215744" %% xsd:float])
+    entity(niiri:99d46b776d179dd3c0fa6e5f24211e9c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0018" %% xsd:string,
+        nidm_coordinateVector: = "[-21,-58,35]" %% xsd:string])
+    wasDerivedFrom(niiri:3dd707ab362eb195cac4faffe483c856, niiri:fb9fa9dc2ca1f5d99d08905f70d6ddf4, -, -, -)
+    entity(niiri:93dcc6bb6fa5a51037e879953d20a98f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0019" %% xsd:string,
+        prov:location = 'niiri:d728c0e16ccbf16af866e7982fe587f9',
+        prov:value = "3.65676808357239" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.51227494232489" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000222144058379059" %% xsd:float,
+        nidm_pValueFWER: = "0.843361764475318" %% xsd:float,
+        nidm_qValueFDR: = "0.00602411049254302" %% xsd:float])
+    entity(niiri:d728c0e16ccbf16af866e7982fe587f9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0019" %% xsd:string,
+        nidm_coordinateVector: = "[-42,41,14]" %% xsd:string])
+    wasDerivedFrom(niiri:93dcc6bb6fa5a51037e879953d20a98f, niiri:475094716d0d72f0a46a416ad82f1b4a, -, -, -)
+    entity(niiri:2264eb76e0614f390a310479ab391fbd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0020" %% xsd:string,
+        prov:location = 'niiri:d8c9b89ebb5ac9c1e272f6ffefc8d147',
+        prov:value = "3.60576057434082" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.46666797620338" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000263476182084665" %% xsd:float,
+        nidm_pValueFWER: = "0.879300533851845" %% xsd:float,
+        nidm_qValueFDR: = "0.0069387865877595" %% xsd:float])
+    entity(niiri:d8c9b89ebb5ac9c1e272f6ffefc8d147,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0020" %% xsd:string,
+        nidm_coordinateVector: = "[18,-58,44]" %% xsd:string])
+    wasDerivedFrom(niiri:2264eb76e0614f390a310479ab391fbd, niiri:c681bc57f45818852f61065cb195b402, -, -, -)
+    entity(niiri:a33b9488177099a61408b9cb6e5cea06,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0021" %% xsd:string,
+        prov:location = 'niiri:4befbec854d6dafc0b66817b007205d3',
+        prov:value = "3.44847679138184" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.32523865339962" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00044171440078089" %% xsd:float,
+        nidm_pValueFWER: = "0.956364376874226" %% xsd:float,
+        nidm_qValueFDR: = "0.0106209578407441" %% xsd:float])
+    entity(niiri:4befbec854d6dafc0b66817b007205d3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0021" %% xsd:string,
+        nidm_coordinateVector: = "[-42,-79,-28]" %% xsd:string])
+    wasDerivedFrom(niiri:a33b9488177099a61408b9cb6e5cea06, niiri:8d8544b3de0e4b1df8fca3080acd12ce, -, -, -)
+    entity(niiri:2ca6f7970704b05c192c1987ee5300c5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0022" %% xsd:string,
+        prov:location = 'niiri:9b1721754c8af13103c1b9f163e6cc0e',
+        prov:value = "3.40048027038574" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.28184403768869" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000515653149799067" %% xsd:float,
+        nidm_pValueFWER: = "0.970306417082003" %% xsd:float,
+        nidm_qValueFDR: = "0.0120685599385689" %% xsd:float])
+    entity(niiri:9b1721754c8af13103c1b9f163e6cc0e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0022" %% xsd:string,
+        nidm_coordinateVector: = "[-39,-43,-25]" %% xsd:string])
+    wasDerivedFrom(niiri:2ca6f7970704b05c192c1987ee5300c5, niiri:797cb2e6b0af99d81cbfc0afe0107928, -, -, -)
+    entity(niiri:ec8c4736c425a271902c4cc57b687af4,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0023" %% xsd:string,
+        prov:location = 'niiri:d012f92ad6c65b89b857fb3f1527f304',
+        prov:value = "3.35295486450195" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.23876843364641" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000600234981123826" %% xsd:float,
+        nidm_pValueFWER: = "0.980497627813126" %% xsd:float,
+        nidm_qValueFDR: = "0.0136210721614327" %% xsd:float])
+    entity(niiri:d012f92ad6c65b89b857fb3f1527f304,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0023" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-85,-7]" %% xsd:string])
+    wasDerivedFrom(niiri:ec8c4736c425a271902c4cc57b687af4, niiri:89c0aff109de09bddccd2da4f39e2ff7, -, -, -)
+    entity(niiri:59a8c451f2300dc6f97edc6c2606fb3f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0024" %% xsd:string,
+        prov:location = 'niiri:d2a688c0e3b4347a53d4026a00240618',
+        prov:value = "3.30876755714417" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.19862394478011" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000690425807445161" %% xsd:float,
+        nidm_pValueFWER: = "0.987293526834147" %% xsd:float,
+        nidm_qValueFDR: = "0.0152200881653966" %% xsd:float])
+    entity(niiri:d2a688c0e3b4347a53d4026a00240618,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0024" %% xsd:string,
+        nidm_coordinateVector: = "[-36,-4,20]" %% xsd:string])
+    wasDerivedFrom(niiri:59a8c451f2300dc6f97edc6c2606fb3f, niiri:ba3a0bac50295dbe9628a7da8bbabb44, -, -, -)
+    entity(niiri:67d9305d37ddaf3de7cf0d683a2af90b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0025" %% xsd:string,
+        prov:location = 'niiri:c0218cb6278a616da4a4596ab5591761',
+        prov:value = "3.20888733863831" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.10755204294478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000943218837649473" %% xsd:float,
+        nidm_pValueFWER: = "0.995830646499116" %% xsd:float,
+        nidm_qValueFDR: = "0.0195461965365512" %% xsd:float])
+    entity(niiri:c0218cb6278a616da4a4596ab5591761,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0025" %% xsd:string,
+        nidm_coordinateVector: = "[27,-7,50]" %% xsd:string])
+    wasDerivedFrom(niiri:67d9305d37ddaf3de7cf0d683a2af90b, niiri:b47796df89485ea6f991314ad0282c0a, -, -, -)
+    entity(niiri:f84104908719961c888cf91361dd9ee3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0026" %% xsd:string,
+        prov:location = 'niiri:356d2690aaf84e1c7cc172939eeccece',
+        prov:value = "3.19764351844788" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.09727154524108" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000976554372161376" %% xsd:float,
+        nidm_pValueFWER: = "0.996371746208051" %% xsd:float,
+        nidm_qValueFDR: = "0.020021923705981" %% xsd:float])
+    entity(niiri:356d2690aaf84e1c7cc172939eeccece,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0026" %% xsd:string,
+        nidm_coordinateVector: = "[-36,-7,65]" %% xsd:string])
+    wasDerivedFrom(niiri:f84104908719961c888cf91361dd9ee3, niiri:aaa8b4bfb02f0be00acdc67ecfcf14f8, -, -, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_full_example001/nidm.ttl
+++ b/spmexport/ex_spm_full_example001/nidm.ttl
@@ -1,0 +1,1160 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:07ddd0499ec9f6aa773ab738cdf741eb
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:a97ad5b925ada692efd2d656142cefb4
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:57339932eb6c52187a3aa96543bbf755
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:57339932eb6c52187a3aa96543bbf755 prov:wasAssociatedWith niiri:a97ad5b925ada692efd2d656142cefb4 .
+
+_:blank5 a prov:Generation .
+
+niiri:07ddd0499ec9f6aa773ab738cdf741eb prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:44:05"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070> .
+@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
+@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .
+@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .
+@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082> .
+@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .
+@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092> .
+@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
+@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
+
+niiri:e9be5eea1eb67cb49c3b383c9b0a900d
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:9cf22d3de0a7c49713079ebc9830ad3d
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[3, 3, 3]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[53,63,52]"^^xsd:string .
+
+niiri:d90857a6787816e85415e456e5aef267
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:3ae1e011cd15c4012b78e209f348c6a4
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:c2278b9b976a48ab0bcfbfb687334955
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:5fd9e61ed87219589941047f99520fd9 ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) active*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:3ae1e011cd15c4012b78e209f348c6a4 ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:5fd9e61ed87219589941047f99520fd9
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:1d7f39aa206df0fad7d85518864badd8
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:15258c78ab3d3f8cb82b010a67a822b3
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:15258c78ab3d3f8cb82b010a67a822b3 prov:wasAssociatedWith niiri:e9be5eea1eb67cb49c3b383c9b0a900d .
+
+niiri:15258c78ab3d3f8cb82b010a67a822b3 prov:used niiri:c2278b9b976a48ab0bcfbfb687334955 .
+
+niiri:15258c78ab3d3f8cb82b010a67a822b3 prov:used niiri:d90857a6787816e85415e456e5aef267 .
+
+niiri:15258c78ab3d3f8cb82b010a67a822b3 prov:used niiri:1d7f39aa206df0fad7d85518864badd8 .
+
+niiri:640767d446bbbf134bd858e58a942d48
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    crypto:sha512 "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875"^^xsd:string .
+
+niiri:63fcb632564d62f13ce9cd67436c0ec7
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11"^^xsd:string .
+
+niiri:640767d446bbbf134bd858e58a942d48 prov:wasDerivedFrom niiri:63fcb632564d62f13ce9cd67436c0ec7 .
+
+niiri:640767d446bbbf134bd858e58a942d48 prov:wasGeneratedBy niiri:15258c78ab3d3f8cb82b010a67a822b3 .
+
+niiri:a6a920f9195beddba3552de1558eff47
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "132.008995056152"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    crypto:sha512 "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb"^^xsd:string .
+
+niiri:a6a920f9195beddba3552de1558eff47 prov:wasGeneratedBy niiri:15258c78ab3d3f8cb82b010a67a822b3 .
+
+niiri:5a62c76da360f0025cf33269be72abe9
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d .
+
+niiri:7be821c1aa5fafc219550c15744a926a
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"^^xsd:string .
+
+niiri:5a62c76da360f0025cf33269be72abe9 prov:wasDerivedFrom niiri:7be821c1aa5fafc219550c15744a926a .
+
+niiri:5a62c76da360f0025cf33269be72abe9 prov:wasGeneratedBy niiri:15258c78ab3d3f8cb82b010a67a822b3 .
+
+niiri:0228f3befc5a61fac386ec758856506d
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d .
+
+niiri:86de7e9f90ab78a7d1b2d477e2ee589f
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"^^xsd:string .
+
+niiri:0228f3befc5a61fac386ec758856506d prov:wasDerivedFrom niiri:86de7e9f90ab78a7d1b2d477e2ee589f .
+
+niiri:0228f3befc5a61fac386ec758856506d prov:wasGeneratedBy niiri:15258c78ab3d3f8cb82b010a67a822b3 .
+
+niiri:f92071b48bcebf4d7560164992961ec8
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    crypto:sha512 "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b"^^xsd:string .
+
+niiri:f4b00c8235f9be695e89d3b8f353fe41
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "1635e0ae420cac1b5989fbc753b95f504dd957ff2986367fc4cd13ff35c44b4ee60994a9cdcab93a7d247fc5a8decb7578fa4c553b0ac905af8c7041db9b4acd"^^xsd:string .
+
+niiri:f92071b48bcebf4d7560164992961ec8 prov:wasDerivedFrom niiri:f4b00c8235f9be695e89d3b8f353fe41 .
+
+niiri:f92071b48bcebf4d7560164992961ec8 prov:wasGeneratedBy niiri:15258c78ab3d3f8cb82b010a67a822b3 .
+
+niiri:c2a04e5956c4f5752e93d3406e16c8e0
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    crypto:sha512 "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a"^^xsd:string .
+
+niiri:881f1889c4fc9a152a6fbb7ed8ae914c
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d"^^xsd:string .
+
+niiri:c2a04e5956c4f5752e93d3406e16c8e0 prov:wasDerivedFrom niiri:881f1889c4fc9a152a6fbb7ed8ae914c .
+
+niiri:c2a04e5956c4f5752e93d3406e16c8e0 prov:wasGeneratedBy niiri:15258c78ab3d3f8cb82b010a67a822b3 .
+
+niiri:3dbacfe4e7a5cadd568c0f4f075e8f41
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "passive listening > rest"^^xsd:string ;
+    rdfs:label "Contrast: passive listening > rest" ;
+    prov:value "[1, 0]"^^xsd:string .
+
+niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 prov:wasAssociatedWith niiri:e9be5eea1eb67cb49c3b383c9b0a900d .
+
+niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 prov:used niiri:640767d446bbbf134bd858e58a942d48 .
+
+niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 prov:used niiri:f92071b48bcebf4d7560164992961ec8 .
+
+niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 prov:used niiri:c2278b9b976a48ab0bcfbfb687334955 .
+
+niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 prov:used niiri:3dbacfe4e7a5cadd568c0f4f075e8f41 .
+
+niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 prov:used niiri:5a62c76da360f0025cf33269be72abe9 .
+
+niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 prov:used niiri:0228f3befc5a61fac386ec758856506d .
+
+niiri:dcbd95eb7f689bcc93099252f7431941
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: passive listening > rest" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "passive listening > rest"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "83.9999999999599"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    crypto:sha512 "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6"^^xsd:string .
+
+niiri:64d02b9baf7fb8f2b5c40dc064646f65
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825"^^xsd:string .
+
+niiri:dcbd95eb7f689bcc93099252f7431941 prov:wasDerivedFrom niiri:64d02b9baf7fb8f2b5c40dc064646f65 .
+
+niiri:dcbd95eb7f689bcc93099252f7431941 prov:wasGeneratedBy niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 .
+
+niiri:cb0937bd8dcb4e22243d79330d1bab3a
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: passive listening > rest" ;
+    nidm_contrastName: "passive listening > rest"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    crypto:sha512 "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2"^^xsd:string .
+
+niiri:a8856b4265168ed707cfac251b55a6b8
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "277dd1da13d391c33c172fb8c71060008cc66e173de6362eb857b0055b41e9bae57911f7ec4b45659905103b1139ebf3da0c2d04cf105bbce0cdc3004b643c22"^^xsd:string .
+
+niiri:cb0937bd8dcb4e22243d79330d1bab3a prov:wasDerivedFrom niiri:a8856b4265168ed707cfac251b55a6b8 .
+
+niiri:cb0937bd8dcb4e22243d79330d1bab3a prov:wasGeneratedBy niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 .
+
+niiri:ee9015bf17c2a510bc6709d2ea55beff
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    crypto:sha512 "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2"^^xsd:string .
+
+niiri:ee9015bf17c2a510bc6709d2ea55beff prov:wasGeneratedBy niiri:6b8f5cbc1f1a69be4f67b2a3e45117c6 .
+
+niiri:c99778f99dd4bc6e969b32858b7e9509
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    prov:value "0.000999500223269112"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:0132f07129b5e21715df7c0c2a5e5c00 ;
+    nidm_equivalentThreshold: niiri:ebc471ce4d28c34fb8349e556ef46abe .
+
+niiri:0132f07129b5e21715df7c0c2a5e5c00
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "3.19011050997122"^^xsd:float .
+
+niiri:ebc471ce4d28c34fb8349e556ef46abe
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.996699720287235"^^xsd:float .
+
+niiri:1e3a172b4c7ff3728392bd5d35f41443
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:836dfb799fe17a8a1ed21d2462bd0f85 ;
+    nidm_equivalentThreshold: niiri:9c31cafe3bf52474f0ca04699744871e .
+
+niiri:836dfb799fe17a8a1ed21d2462bd0f85
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:9c31cafe3bf52474f0ca04699744871e
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:585358f33ac87cfe988f01ec045a6686
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:2b78ab4d95faeb8cf2913803d31c3111
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:96101a8fe51166772f56717028626db3
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:96101a8fe51166772f56717028626db3 prov:wasAssociatedWith niiri:e9be5eea1eb67cb49c3b383c9b0a900d .
+
+niiri:96101a8fe51166772f56717028626db3 prov:used niiri:c99778f99dd4bc6e969b32858b7e9509 .
+
+niiri:96101a8fe51166772f56717028626db3 prov:used niiri:1e3a172b4c7ff3728392bd5d35f41443 .
+
+niiri:96101a8fe51166772f56717028626db3 prov:used niiri:dcbd95eb7f689bcc93099252f7431941 .
+
+niiri:96101a8fe51166772f56717028626db3 prov:used niiri:c2a04e5956c4f5752e93d3406e16c8e0 .
+
+niiri:96101a8fe51166772f56717028626db3 prov:used niiri:640767d446bbbf134bd858e58a942d48 .
+
+niiri:96101a8fe51166772f56717028626db3 prov:used niiri:585358f33ac87cfe988f01ec045a6686 .
+
+niiri:96101a8fe51166772f56717028626db3 prov:used niiri:2b78ab4d95faeb8cf2913803d31c3111 .
+
+niiri:8b48aa2940f6f6db7a7068249fe258b6
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    nidm_searchVolumeInVoxels: "69306"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1871262"^^xsd:float ;
+    nidm_reselSizeInVoxels: "132.907586178202"^^xsd:float ;
+    nidm_searchVolumeInResels: "467.07642343881"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[7, 42.96312274763, 269.40914815306, 467.07642343881]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[5.41278985910694, 5.43638957240286, 4.51666658877481]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[16.2383695773208, 16.3091687172086, 13.5499997663244]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "14.4459223425356"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "5.7137480526579"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "4.85241745689539"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "4.71486568450928"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "240"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "240"^^xsd:int ;
+    crypto:sha512 "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875"^^xsd:string .
+
+niiri:8b48aa2940f6f6db7a7068249fe258b6 prov:wasGeneratedBy niiri:96101a8fe51166772f56717028626db3 .
+
+niiri:ec9ed4e9e249fa81baced98c4242ef82
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "18"^^xsd:int ;
+    nidm_pValue: "3.07951542369844e-05"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:8612e61195d1a353629d641acc2bc979 ;
+    nidm_hasMaximumIntensityProjection: niiri:2ac7cca8ab0c6a71458727a8286f6bf3 ;
+    nidm_inCoordinateSpace: niiri:9cf22d3de0a7c49713079ebc9830ad3d ;
+    crypto:sha512 "93558ac51dc189b4e191daeba5686720d2fd888f0d62f7b2f543a0d62c96e1c9ff25aed63d98cb14101827d1e2e3a4e46d6966469fda61bbc15e32c5e43eb654"^^xsd:string .
+
+niiri:8612e61195d1a353629d641acc2bc979
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:2ac7cca8ab0c6a71458727a8286f6bf3
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:ec9ed4e9e249fa81baced98c4242ef82 prov:wasGeneratedBy niiri:96101a8fe51166772f56717028626db3 .
+
+niiri:78bacdacd554038be4455bbb7dadde7c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0001" ;
+    nidm_clusterSizeInVoxels: "1264"^^xsd:int ;
+    nidm_clusterSizeInResels: "9.51036758959141"^^xsd:float ;
+    nidm_pValueUncorrected: "4.48255959369336e-11"^^xsd:float ;
+    nidm_pValueFWER: "2.56122123509783e-10"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "1"^^xsd:int .
+
+niiri:78bacdacd554038be4455bbb7dadde7c prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:88ec84fed7a6d51095a345e1388f336b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0002" ;
+    nidm_clusterSizeInVoxels: "1501"^^xsd:int ;
+    nidm_clusterSizeInResels: "11.2935615126398"^^xsd:float ;
+    nidm_pValueUncorrected: "2.48513372869345e-12"^^xsd:float ;
+    nidm_pValueFWER: "1.41994194180484e-11"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "2"^^xsd:int .
+
+niiri:88ec84fed7a6d51095a345e1388f336b prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:3b5bc7e8577d3ad063c1fd52a8ac098d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0003" ;
+    nidm_clusterSizeInVoxels: "83"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.624494074316525"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0206851097491133"^^xsd:float ;
+    nidm_pValueFWER: "0.111472344261274"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "3"^^xsd:int .
+
+niiri:3b5bc7e8577d3ad063c1fd52a8ac098d prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:2bf81c3d14d68055b9d17ee9e724928f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0004" ;
+    nidm_clusterSizeInVoxels: "240"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.80576599802369"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000381388385608752"^^xsd:float ;
+    nidm_pValueFWER: "0.0021767845064099"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "4"^^xsd:int .
+
+niiri:2bf81c3d14d68055b9d17ee9e724928f prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:06e9554bbeea4a431c943fc3ec2cdbbb
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0005" ;
+    nidm_clusterSizeInVoxels: "50"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.376201249588268"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0628910752564052"^^xsd:float ;
+    nidm_pValueFWER: "0.301865679701775"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "5"^^xsd:int .
+
+niiri:06e9554bbeea4a431c943fc3ec2cdbbb prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:a9219cbc769cbb83a3de16f99e5a347d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0006" ;
+    nidm_clusterSizeInVoxels: "93"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.699734324234178"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0152387708209126"^^xsd:float ;
+    nidm_pValueFWER: "0.0833875251685585"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "6"^^xsd:int .
+
+niiri:a9219cbc769cbb83a3de16f99e5a347d prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:67bc5169985a45ee91ee0ba2594d0de1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0007" ;
+    nidm_clusterSizeInVoxels: "39"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.293436974678849"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0959364968442128"^^xsd:float ;
+    nidm_pValueFWER: "0.421985874497329"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "7"^^xsd:int .
+
+niiri:67bc5169985a45ee91ee0ba2594d0de1 prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:a8f1a3d7b165fdfa59ef170a03763fef
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0008" ;
+    nidm_clusterSizeInVoxels: "43"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.32353307464591"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0819435156724374"^^xsd:float ;
+    nidm_pValueFWER: "0.373874596648251"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "8"^^xsd:int .
+
+niiri:a8f1a3d7b165fdfa59ef170a03763fef prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:1cf5dfaaee190896215164bb926858be
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0009" ;
+    nidm_clusterSizeInVoxels: "26"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.195624649785899"^^xsd:float ;
+    nidm_pValueUncorrected: "0.167150731119474"^^xsd:float ;
+    nidm_pValueFWER: "0.615209852386826"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "9"^^xsd:int .
+
+niiri:1cf5dfaaee190896215164bb926858be prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:fb9fa9dc2ca1f5d99d08905f70d6ddf4
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0010" ;
+    nidm_clusterSizeInVoxels: "9"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0677162249258882"^^xsd:float ;
+    nidm_pValueUncorrected: "0.413993095492646"^^xsd:float ;
+    nidm_pValueFWER: "0.90609317795635"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "10"^^xsd:int .
+
+niiri:fb9fa9dc2ca1f5d99d08905f70d6ddf4 prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:475094716d0d72f0a46a416ad82f1b4a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0011" ;
+    nidm_clusterSizeInVoxels: "29"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.218196724761195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.146029761673043"^^xsd:float ;
+    nidm_pValueFWER: "0.56585524619955"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "11"^^xsd:int .
+
+niiri:475094716d0d72f0a46a416ad82f1b4a prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:c681bc57f45818852f61065cb195b402
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0012" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0150480499835307"^^xsd:float ;
+    nidm_pValueUncorrected: "0.72357261092483"^^xsd:float ;
+    nidm_pValueFWER: "0.983986314788855"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "12"^^xsd:int .
+
+niiri:c681bc57f45818852f61065cb195b402 prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:8d8544b3de0e4b1df8fca3080acd12ce
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0013" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0300960999670614"^^xsd:float ;
+    nidm_pValueUncorrected: "0.59833136351956"^^xsd:float ;
+    nidm_pValueFWER: "0.967245491529494"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "13"^^xsd:int .
+
+niiri:8d8544b3de0e4b1df8fca3080acd12ce prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:797cb2e6b0af99d81cbfc0afe0107928
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0014" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0225720749752961"^^xsd:float ;
+    nidm_pValueUncorrected: "0.654439473783549"^^xsd:float ;
+    nidm_pValueFWER: "0.976229317109067"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "14"^^xsd:int .
+
+niiri:797cb2e6b0af99d81cbfc0afe0107928 prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:89c0aff109de09bddccd2da4f39e2ff7
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0015" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0150480499835307"^^xsd:float ;
+    nidm_pValueUncorrected: "0.72357261092483"^^xsd:float ;
+    nidm_pValueFWER: "0.983986314788855"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "15"^^xsd:int .
+
+niiri:89c0aff109de09bddccd2da4f39e2ff7 prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:ba3a0bac50295dbe9628a7da8bbabb44
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0016" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0150480499835307"^^xsd:float ;
+    nidm_pValueUncorrected: "0.72357261092483"^^xsd:float ;
+    nidm_pValueFWER: "0.983986314788855"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "16"^^xsd:int .
+
+niiri:ba3a0bac50295dbe9628a7da8bbabb44 prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:b47796df89485ea6f991314ad0282c0a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0017" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.00752402499176536"^^xsd:float ;
+    nidm_pValueUncorrected: "0.815603878110897"^^xsd:float ;
+    nidm_pValueFWER: "0.990535005451607"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "17"^^xsd:int .
+
+niiri:b47796df89485ea6f991314ad0282c0a prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:aaa8b4bfb02f0be00acdc67ecfcf14f8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0018" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.00752402499176536"^^xsd:float ;
+    nidm_pValueUncorrected: "0.815603878110897"^^xsd:float ;
+    nidm_pValueFWER: "0.990535005451607"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "18"^^xsd:int .
+
+niiri:aaa8b4bfb02f0be00acdc67ecfcf14f8 prov:wasDerivedFrom niiri:ec9ed4e9e249fa81baced98c4242ef82 .
+
+niiri:6e94dd6491017c11ff5bf56e1002cb81
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0001" ;
+    prov:atLocation niiri:9271887753f3c299d83711e4ceababc9 ;
+    prov:value "17.5207633972168"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_pValueFWER: "0"^^xsd:float ;
+    nidm_qValueFDR: "0"^^xsd:float .
+
+niiri:9271887753f3c299d83711e4ceababc9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0001" ;
+    nidm_coordinateVector: "[-60,-25,11]"^^xsd:string .
+
+niiri:6e94dd6491017c11ff5bf56e1002cb81 prov:wasDerivedFrom niiri:78bacdacd554038be4455bbb7dadde7c .
+
+niiri:9c1342930a4c58f3f38730feec01f2bf
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0002" ;
+    prov:atLocation niiri:33285c0ed9ea2711d10764a1e38499c6 ;
+    prov:value "13.0321407318115"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_pValueFWER: "0"^^xsd:float ;
+    nidm_qValueFDR: "0"^^xsd:float .
+
+niiri:33285c0ed9ea2711d10764a1e38499c6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0002" ;
+    nidm_coordinateVector: "[-42,-31,11]"^^xsd:string .
+
+niiri:9c1342930a4c58f3f38730feec01f2bf prov:wasDerivedFrom niiri:78bacdacd554038be4455bbb7dadde7c .
+
+niiri:cf8aaab3245e39853cbaff3905a15c61
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0003" ;
+    prov:atLocation niiri:01d66c85c4653f768af4ed7b850e09f8 ;
+    prov:value "10.2856016159058"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_pValueFWER: "7.69451169446711e-12"^^xsd:float ;
+    nidm_qValueFDR: "2.95942757479504e-14"^^xsd:float .
+
+niiri:01d66c85c4653f768af4ed7b850e09f8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0003" ;
+    nidm_coordinateVector: "[-66,-31,-1]"^^xsd:string .
+
+niiri:cf8aaab3245e39853cbaff3905a15c61 prov:wasDerivedFrom niiri:78bacdacd554038be4455bbb7dadde7c .
+
+niiri:aaf756444cd6940d07a6497d2018de1a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0004" ;
+    prov:atLocation niiri:c5b1999dab7de52b57d4e63c89ff5b03 ;
+    prov:value "13.5425577163696"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_pValueFWER: "0"^^xsd:float ;
+    nidm_qValueFDR: "0"^^xsd:float .
+
+niiri:c5b1999dab7de52b57d4e63c89ff5b03
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0004" ;
+    nidm_coordinateVector: "[63,-13,-4]"^^xsd:string .
+
+niiri:aaf756444cd6940d07a6497d2018de1a prov:wasDerivedFrom niiri:88ec84fed7a6d51095a345e1388f336b .
+
+niiri:f09d161397c2d98f1ae397f52dad72a9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0005" ;
+    prov:atLocation niiri:f9d8e374cdc04136210daaf3e34179ef ;
+    prov:value "12.4728717803955"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_pValueFWER: "0"^^xsd:float ;
+    nidm_qValueFDR: "0"^^xsd:float .
+
+niiri:f9d8e374cdc04136210daaf3e34179ef
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0005" ;
+    nidm_coordinateVector: "[60,-22,11]"^^xsd:string .
+
+niiri:f09d161397c2d98f1ae397f52dad72a9 prov:wasDerivedFrom niiri:88ec84fed7a6d51095a345e1388f336b .
+
+niiri:d71a41baf488b215b2a94fd59d9cd193
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0006" ;
+    prov:atLocation niiri:42599dcdf795fe3eb7e8318ec0afb0cb ;
+    prov:value "9.72103404998779"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    nidm_pValueUncorrected: "1.22124532708767e-15"^^xsd:float ;
+    nidm_pValueFWER: "6.9250605250204e-11"^^xsd:float ;
+    nidm_qValueFDR: "2.24839627435727e-13"^^xsd:float .
+
+niiri:42599dcdf795fe3eb7e8318ec0afb0cb
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0006" ;
+    nidm_coordinateVector: "[57,-40,5]"^^xsd:string .
+
+niiri:d71a41baf488b215b2a94fd59d9cd193 prov:wasDerivedFrom niiri:88ec84fed7a6d51095a345e1388f336b .
+
+niiri:79d39a29d61f2323e0a9b86863e61b4b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0007" ;
+    prov:atLocation niiri:305cd536ef8cbd6879fdf68e1fe5876c ;
+    prov:value "6.19558477401733"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.60645028016544"^^xsd:float ;
+    nidm_pValueUncorrected: "1.0325913235576e-08"^^xsd:float ;
+    nidm_pValueFWER: "0.000382453907303626"^^xsd:float ;
+    nidm_qValueFDR: "6.60191630365133e-07"^^xsd:float .
+
+niiri:305cd536ef8cbd6879fdf68e1fe5876c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0007" ;
+    nidm_coordinateVector: "[-33,-31,-16]"^^xsd:string .
+
+niiri:79d39a29d61f2323e0a9b86863e61b4b prov:wasDerivedFrom niiri:3b5bc7e8577d3ad063c1fd52a8ac098d .
+
+niiri:7850f04485929b5a5cd6751d2b16a701
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0008" ;
+    prov:atLocation niiri:323726ceeb25db5892247eda42deb986 ;
+    prov:value "4.84209632873535"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.53410879658737"^^xsd:float ;
+    nidm_pValueUncorrected: "2.89236039974217e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.0517130333839199"^^xsd:float ;
+    nidm_qValueFDR: "0.000123816071493245"^^xsd:float .
+
+niiri:323726ceeb25db5892247eda42deb986
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0008" ;
+    nidm_coordinateVector: "[45,17,26]"^^xsd:string .
+
+niiri:7850f04485929b5a5cd6751d2b16a701 prov:wasDerivedFrom niiri:2bf81c3d14d68055b9d17ee9e724928f .
+
+niiri:33c6e2c648099e4baddfb1f4524e682a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0009" ;
+    prov:atLocation niiri:a6e65b15c17a9dd28eb690e2e1649982 ;
+    prov:value "4.82763147354126"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.52209514540323"^^xsd:float ;
+    nidm_pValueUncorrected: "3.06152617990385e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.0542053020139993"^^xsd:float ;
+    nidm_qValueFDR: "0.000130413311745393"^^xsd:float .
+
+niiri:a6e65b15c17a9dd28eb690e2e1649982
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0009" ;
+    nidm_coordinateVector: "[45,29,23]"^^xsd:string .
+
+niiri:33c6e2c648099e4baddfb1f4524e682a prov:wasDerivedFrom niiri:2bf81c3d14d68055b9d17ee9e724928f .
+
+niiri:5bd2158571ab399c61e9f9bcbc03733d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0010" ;
+    prov:atLocation niiri:fce7a3789578674adbd0ee4c02d9c5b3 ;
+    prov:value "4.41708660125732"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.17633392422281"^^xsd:float ;
+    nidm_pValueUncorrected: "1.48122423770936e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.189250331626723"^^xsd:float ;
+    nidm_qValueFDR: "0.000552818994724341"^^xsd:float .
+
+niiri:fce7a3789578674adbd0ee4c02d9c5b3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0010" ;
+    nidm_coordinateVector: "[36,14,23]"^^xsd:string .
+
+niiri:5bd2158571ab399c61e9f9bcbc03733d prov:wasDerivedFrom niiri:2bf81c3d14d68055b9d17ee9e724928f .
+
+niiri:f14d0a739a3920f1bc3323ad331b66a9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0011" ;
+    prov:atLocation niiri:ba6f35e9a1731637640e2ba9973227ae ;
+    prov:value "4.73135995864868"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.44184359868998"^^xsd:float ;
+    nidm_pValueUncorrected: "4.45956909089773e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.0738162589558271"^^xsd:float ;
+    nidm_qValueFDR: "0.000184192839435458"^^xsd:float .
+
+niiri:ba6f35e9a1731637640e2ba9973227ae
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0011" ;
+    nidm_coordinateVector: "[51,-4,47]"^^xsd:string .
+
+niiri:f14d0a739a3920f1bc3323ad331b66a9 prov:wasDerivedFrom niiri:06e9554bbeea4a431c943fc3ec2cdbbb .
+
+niiri:ffb88c9368b1ba261ff68d82ed272f22
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0012" ;
+    prov:atLocation niiri:d8aa31ef5acd7fb642db3a01b238f60f ;
+    prov:value "4.71486568450928"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.42804282727638"^^xsd:float ;
+    nidm_pValueUncorrected: "4.75460114568449e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.0777626205502405"^^xsd:float ;
+    nidm_qValueFDR: "0.000195099568008085"^^xsd:float .
+
+niiri:d8aa31ef5acd7fb642db3a01b238f60f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0012" ;
+    nidm_coordinateVector: "[-36,2,35]"^^xsd:string .
+
+niiri:ffb88c9368b1ba261ff68d82ed272f22 prov:wasDerivedFrom niiri:a9219cbc769cbb83a3de16f99e5a347d .
+
+niiri:a55b100aee99c0b4f9bd48c5e5d38c2e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0013" ;
+    prov:atLocation niiri:e7cd9ddb9e3da20e8b3d3867ffc1aad7 ;
+    prov:value "4.07969188690186"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.88537112992499"^^xsd:float ;
+    nidm_pValueUncorrected: "5.10868406333742e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.439426301421077"^^xsd:float ;
+    nidm_qValueFDR: "0.00167518678592214"^^xsd:float .
+
+niiri:e7cd9ddb9e3da20e8b3d3867ffc1aad7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0013" ;
+    nidm_coordinateVector: "[-33,-7,41]"^^xsd:string .
+
+niiri:a55b100aee99c0b4f9bd48c5e5d38c2e prov:wasDerivedFrom niiri:a9219cbc769cbb83a3de16f99e5a347d .
+
+niiri:0a35a207a0cbcddd75e8f5c414228224
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0014" ;
+    prov:atLocation niiri:9c12c600c2e98fe757d88199d7b300a9 ;
+    prov:value "3.73018789291382"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.57769499743383"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000173318801172884"^^xsd:float ;
+    nidm_pValueFWER: "0.78318691512427"^^xsd:float ;
+    nidm_qValueFDR: "0.00489330912828116"^^xsd:float .
+
+niiri:9c12c600c2e98fe757d88199d7b300a9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0014" ;
+    nidm_coordinateVector: "[-51,-4,47]"^^xsd:string .
+
+niiri:0a35a207a0cbcddd75e8f5c414228224 prov:wasDerivedFrom niiri:a9219cbc769cbb83a3de16f99e5a347d .
+
+niiri:a365e9a9946ae1d325de16ac5e51b070
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0015" ;
+    prov:atLocation niiri:9c4767fd3e050b4dbe777d100b2c89bd ;
+    prov:value "4.44269752502441"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.19817181421461"^^xsd:float ;
+    nidm_pValueUncorrected: "1.34539226018804e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.176083160116197"^^xsd:float ;
+    nidm_qValueFDR: "0.00050566368349132"^^xsd:float .
+
+niiri:9c4767fd3e050b4dbe777d100b2c89bd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0015" ;
+    nidm_coordinateVector: "[12,14,50]"^^xsd:string .
+
+niiri:a365e9a9946ae1d325de16ac5e51b070 prov:wasDerivedFrom niiri:67bc5169985a45ee91ee0ba2594d0de1 .
+
+niiri:8ce1625f062ecf73a52b6bf00c88fd0e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0016" ;
+    prov:atLocation niiri:2d732133d427cda3bd74571145d0a134 ;
+    prov:value "4.29442167282104"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.0712511023587"^^xsd:float ;
+    nidm_pValueUncorrected: "2.33806545202331e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.263557920290052"^^xsd:float ;
+    nidm_qValueFDR: "0.000835210418779784"^^xsd:float .
+
+niiri:2d732133d427cda3bd74571145d0a134
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0016" ;
+    nidm_coordinateVector: "[-39,20,32]"^^xsd:string .
+
+niiri:8ce1625f062ecf73a52b6bf00c88fd0e prov:wasDerivedFrom niiri:a8f1a3d7b165fdfa59ef170a03763fef .
+
+niiri:37e81450b1f9548f6f1c9c7d6841ba28
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0017" ;
+    prov:atLocation niiri:85459b56430f23f3788d443572d5019d ;
+    prov:value "3.87923645973206"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.70967059113076"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000103764543077145"^^xsd:float ;
+    nidm_pValueFWER: "0.639762512909999"^^xsd:float ;
+    nidm_qValueFDR: "0.00314467798860484"^^xsd:float .
+
+niiri:85459b56430f23f3788d443572d5019d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0017" ;
+    nidm_coordinateVector: "[27,-85,8]"^^xsd:string .
+
+niiri:37e81450b1f9548f6f1c9c7d6841ba28 prov:wasDerivedFrom niiri:1cf5dfaaee190896215164bb926858be .
+
+niiri:3dd707ab362eb195cac4faffe483c856
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0018" ;
+    prov:atLocation niiri:99d46b776d179dd3c0fa6e5f24211e9c ;
+    prov:value "3.73632216453552"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.58314871433109"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000169738601991543"^^xsd:float ;
+    nidm_pValueFWER: "0.777763871722966"^^xsd:float ;
+    nidm_qValueFDR: "0.00481182088215744"^^xsd:float .
+
+niiri:99d46b776d179dd3c0fa6e5f24211e9c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0018" ;
+    nidm_coordinateVector: "[-21,-58,35]"^^xsd:string .
+
+niiri:3dd707ab362eb195cac4faffe483c856 prov:wasDerivedFrom niiri:fb9fa9dc2ca1f5d99d08905f70d6ddf4 .
+
+niiri:93dcc6bb6fa5a51037e879953d20a98f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0019" ;
+    prov:atLocation niiri:d728c0e16ccbf16af866e7982fe587f9 ;
+    prov:value "3.65676808357239"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.51227494232489"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000222144058379059"^^xsd:float ;
+    nidm_pValueFWER: "0.843361764475318"^^xsd:float ;
+    nidm_qValueFDR: "0.00602411049254302"^^xsd:float .
+
+niiri:d728c0e16ccbf16af866e7982fe587f9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0019" ;
+    nidm_coordinateVector: "[-42,41,14]"^^xsd:string .
+
+niiri:93dcc6bb6fa5a51037e879953d20a98f prov:wasDerivedFrom niiri:475094716d0d72f0a46a416ad82f1b4a .
+
+niiri:2264eb76e0614f390a310479ab391fbd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0020" ;
+    prov:atLocation niiri:d8c9b89ebb5ac9c1e272f6ffefc8d147 ;
+    prov:value "3.60576057434082"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.46666797620338"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000263476182084665"^^xsd:float ;
+    nidm_pValueFWER: "0.879300533851845"^^xsd:float ;
+    nidm_qValueFDR: "0.0069387865877595"^^xsd:float .
+
+niiri:d8c9b89ebb5ac9c1e272f6ffefc8d147
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0020" ;
+    nidm_coordinateVector: "[18,-58,44]"^^xsd:string .
+
+niiri:2264eb76e0614f390a310479ab391fbd prov:wasDerivedFrom niiri:c681bc57f45818852f61065cb195b402 .
+
+niiri:a33b9488177099a61408b9cb6e5cea06
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0021" ;
+    prov:atLocation niiri:4befbec854d6dafc0b66817b007205d3 ;
+    prov:value "3.44847679138184"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.32523865339962"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00044171440078089"^^xsd:float ;
+    nidm_pValueFWER: "0.956364376874226"^^xsd:float ;
+    nidm_qValueFDR: "0.0106209578407441"^^xsd:float .
+
+niiri:4befbec854d6dafc0b66817b007205d3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0021" ;
+    nidm_coordinateVector: "[-42,-79,-28]"^^xsd:string .
+
+niiri:a33b9488177099a61408b9cb6e5cea06 prov:wasDerivedFrom niiri:8d8544b3de0e4b1df8fca3080acd12ce .
+
+niiri:2ca6f7970704b05c192c1987ee5300c5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0022" ;
+    prov:atLocation niiri:9b1721754c8af13103c1b9f163e6cc0e ;
+    prov:value "3.40048027038574"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.28184403768869"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000515653149799067"^^xsd:float ;
+    nidm_pValueFWER: "0.970306417082003"^^xsd:float ;
+    nidm_qValueFDR: "0.0120685599385689"^^xsd:float .
+
+niiri:9b1721754c8af13103c1b9f163e6cc0e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0022" ;
+    nidm_coordinateVector: "[-39,-43,-25]"^^xsd:string .
+
+niiri:2ca6f7970704b05c192c1987ee5300c5 prov:wasDerivedFrom niiri:797cb2e6b0af99d81cbfc0afe0107928 .
+
+niiri:ec8c4736c425a271902c4cc57b687af4
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0023" ;
+    prov:atLocation niiri:d012f92ad6c65b89b857fb3f1527f304 ;
+    prov:value "3.35295486450195"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.23876843364641"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000600234981123826"^^xsd:float ;
+    nidm_pValueFWER: "0.980497627813126"^^xsd:float ;
+    nidm_qValueFDR: "0.0136210721614327"^^xsd:float .
+
+niiri:d012f92ad6c65b89b857fb3f1527f304
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0023" ;
+    nidm_coordinateVector: "[-24,-85,-7]"^^xsd:string .
+
+niiri:ec8c4736c425a271902c4cc57b687af4 prov:wasDerivedFrom niiri:89c0aff109de09bddccd2da4f39e2ff7 .
+
+niiri:59a8c451f2300dc6f97edc6c2606fb3f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0024" ;
+    prov:atLocation niiri:d2a688c0e3b4347a53d4026a00240618 ;
+    prov:value "3.30876755714417"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.19862394478011"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000690425807445161"^^xsd:float ;
+    nidm_pValueFWER: "0.987293526834147"^^xsd:float ;
+    nidm_qValueFDR: "0.0152200881653966"^^xsd:float .
+
+niiri:d2a688c0e3b4347a53d4026a00240618
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0024" ;
+    nidm_coordinateVector: "[-36,-4,20]"^^xsd:string .
+
+niiri:59a8c451f2300dc6f97edc6c2606fb3f prov:wasDerivedFrom niiri:ba3a0bac50295dbe9628a7da8bbabb44 .
+
+niiri:67d9305d37ddaf3de7cf0d683a2af90b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0025" ;
+    prov:atLocation niiri:c0218cb6278a616da4a4596ab5591761 ;
+    prov:value "3.20888733863831"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.10755204294478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000943218837649473"^^xsd:float ;
+    nidm_pValueFWER: "0.995830646499116"^^xsd:float ;
+    nidm_qValueFDR: "0.0195461965365512"^^xsd:float .
+
+niiri:c0218cb6278a616da4a4596ab5591761
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0025" ;
+    nidm_coordinateVector: "[27,-7,50]"^^xsd:string .
+
+niiri:67d9305d37ddaf3de7cf0d683a2af90b prov:wasDerivedFrom niiri:b47796df89485ea6f991314ad0282c0a .
+
+niiri:f84104908719961c888cf91361dd9ee3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0026" ;
+    prov:atLocation niiri:356d2690aaf84e1c7cc172939eeccece ;
+    prov:value "3.19764351844788"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.09727154524108"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000976554372161376"^^xsd:float ;
+    nidm_pValueFWER: "0.996371746208051"^^xsd:float ;
+    nidm_qValueFDR: "0.020021923705981"^^xsd:float .
+
+niiri:356d2690aaf84e1c7cc172939eeccece
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0026" ;
+    nidm_coordinateVector: "[-36,-7,65]"^^xsd:string .
+
+niiri:f84104908719961c888cf91361dd9ee3 prov:wasDerivedFrom niiri:aaa8b4bfb02f0be00acdc67ecfcf14f8 .
+

--- a/spmexport/ex_spm_non_sphericity/config.json
+++ b/spmexport/ex_spm_non_sphericity/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["non_sphericity/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_non_sphericity/nidm.provn
+++ b/spmexport/ex_spm_non_sphericity/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:25ee938ddb1a1359b5dbfc8ddbffdf98,
+  entity(niiri:7b4cf04d3e03731e8b127b5ef008e6ba,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:9360978694c62922ec5ea1a313b72c46,
+  agent(niiri:b823f4f8cbc1c10feef0f31492474351,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:7a90abf761d31fac1a65bd4bda03a81a,
+  activity(niiri:2df4836000438363ab93c2c037ea1c9f,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:7a90abf761d31fac1a65bd4bda03a81a, niiri:9360978694c62922ec5ea1a313b72c46, -)
-  wasGeneratedBy(niiri:25ee938ddb1a1359b5dbfc8ddbffdf98, niiri:7a90abf761d31fac1a65bd4bda03a81a, 2016-01-11T10:11:35)
-  bundle niiri:25ee938ddb1a1359b5dbfc8ddbffdf98
+  wasAssociatedWith(niiri:2df4836000438363ab93c2c037ea1c9f, niiri:b823f4f8cbc1c10feef0f31492474351, -)
+  wasGeneratedBy(niiri:7b4cf04d3e03731e8b127b5ef008e6ba, niiri:2df4836000438363ab93c2c037ea1c9f, 2016-01-11T10:33:49)
+  bundle niiri:7b4cf04d3e03731e8b127b5ef008e6ba
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -121,12 +121,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:cbb4e09f0c239d9fc253f426daea95ec,
+    agent(niiri:8707d65d3a15dbf845684e80f7df9da7,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:04394321c13e24105925122a5ea9615c,
+    entity(niiri:c91eabb6ae30ecd695a7cf4b3fcab893,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -135,146 +135,146 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:3279b88b6e6cd5ec2237720417dd3d48,
+    entity(niiri:34de00e96ed7c645577a52f0e7289dc5,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "false" %% xsd:boolean])
-    entity(niiri:186f3712419791aaf7a04a3d1b8bd722,
+    entity(niiri:c75f4ff351459ee32fa91d23800efb92,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:b17ee10e3431226e0e680dfd4966a939',
+        dc:description = 'niiri:3065da080a203d349041ec0f402e8e33',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]" %% xsd:string])
-    entity(niiri:b17ee10e3431226e0e680dfd4966a939,
+    entity(niiri:3065da080a203d349041ec0f402e8e33,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:ce59f39b89684ad9fbc37e749e8dc23d,
+    entity(niiri:d6bb9097d5397477b9a2fe34b1e173d1,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_UnstructuredCorrelationStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "false" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:a4e3f64a7d5dde02404b02a2e482b25c,
+    activity(niiri:48bd386fe0be968592a13062b5c43885,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:a4e3f64a7d5dde02404b02a2e482b25c, niiri:cbb4e09f0c239d9fc253f426daea95ec, -)
-    used(niiri:a4e3f64a7d5dde02404b02a2e482b25c, niiri:186f3712419791aaf7a04a3d1b8bd722, -)
-    used(niiri:a4e3f64a7d5dde02404b02a2e482b25c, niiri:3279b88b6e6cd5ec2237720417dd3d48, -)
-    used(niiri:a4e3f64a7d5dde02404b02a2e482b25c, niiri:ce59f39b89684ad9fbc37e749e8dc23d, -)
-    entity(niiri:1d1c92ca0bfb701909eb307868358b1a,
+    wasAssociatedWith(niiri:48bd386fe0be968592a13062b5c43885, niiri:8707d65d3a15dbf845684e80f7df9da7, -)
+    used(niiri:48bd386fe0be968592a13062b5c43885, niiri:c75f4ff351459ee32fa91d23800efb92, -)
+    used(niiri:48bd386fe0be968592a13062b5c43885, niiri:34de00e96ed7c645577a52f0e7289dc5, -)
+    used(niiri:48bd386fe0be968592a13062b5c43885, niiri:d6bb9097d5397477b9a2fe34b1e173d1, -)
+    entity(niiri:9f3d2992eab79fd14d4660154ae8238a,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
         crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
-    entity(niiri:7b426f12cc92d11d7f4d5eb771c95217,
+    entity(niiri:5e1b296cb7615ea4c933955980cef164,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e" %% xsd:string])
-    wasDerivedFrom(niiri:1d1c92ca0bfb701909eb307868358b1a, niiri:7b426f12cc92d11d7f4d5eb771c95217, -, -, -)
-    wasGeneratedBy(niiri:1d1c92ca0bfb701909eb307868358b1a, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
-    entity(niiri:785bae8edf8ea0f5eae2802088ac85b1,
+    wasDerivedFrom(niiri:9f3d2992eab79fd14d4660154ae8238a, niiri:5e1b296cb7615ea4c933955980cef164, -, -, -)
+    wasGeneratedBy(niiri:9f3d2992eab79fd14d4660154ae8238a, niiri:48bd386fe0be968592a13062b5c43885, -)
+    entity(niiri:2907b9f1080a55bf3a3b5fde0463d565,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "0.0511472336947918" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
         crypto:sha512 = "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc" %% xsd:string])
-    wasGeneratedBy(niiri:785bae8edf8ea0f5eae2802088ac85b1, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
-    entity(niiri:9f2d3c6c9d93cbbc83d0629664f66005,
+    wasGeneratedBy(niiri:2907b9f1080a55bf3a3b5fde0463d565, niiri:48bd386fe0be968592a13062b5c43885, -)
+    entity(niiri:fd2e03999ed8a414f71235a7246666d9,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c'])
-    entity(niiri:1273bdcdc1d1987029f9da1d84d22ea2,
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893'])
+    entity(niiri:ba6d197e4b83b9354b3d92dc6cdbe6e7,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f" %% xsd:string])
-    wasDerivedFrom(niiri:9f2d3c6c9d93cbbc83d0629664f66005, niiri:1273bdcdc1d1987029f9da1d84d22ea2, -, -, -)
-    wasGeneratedBy(niiri:9f2d3c6c9d93cbbc83d0629664f66005, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
-    entity(niiri:baf9cccb8eba46b7c5f41863dda48579,
+    wasDerivedFrom(niiri:fd2e03999ed8a414f71235a7246666d9, niiri:ba6d197e4b83b9354b3d92dc6cdbe6e7, -, -, -)
+    wasGeneratedBy(niiri:fd2e03999ed8a414f71235a7246666d9, niiri:48bd386fe0be968592a13062b5c43885, -)
+    entity(niiri:af828ebe888a0cdbc655a60d27afaa91,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c'])
-    entity(niiri:87c6aec787414fb9d08ddd2e2f2c9b55,
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893'])
+    entity(niiri:a4ab3adcdfcd06863c089ef11dfef36a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978" %% xsd:string])
-    wasDerivedFrom(niiri:baf9cccb8eba46b7c5f41863dda48579, niiri:87c6aec787414fb9d08ddd2e2f2c9b55, -, -, -)
-    wasGeneratedBy(niiri:baf9cccb8eba46b7c5f41863dda48579, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
-    entity(niiri:b178295856d95973727b2b358956335e,
+    wasDerivedFrom(niiri:af828ebe888a0cdbc655a60d27afaa91, niiri:a4ab3adcdfcd06863c089ef11dfef36a, -, -, -)
+    wasGeneratedBy(niiri:af828ebe888a0cdbc655a60d27afaa91, niiri:48bd386fe0be968592a13062b5c43885, -)
+    entity(niiri:bd9421d9a41bc778b27e2be0eda0496f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c'])
-    entity(niiri:1263d9ada22b54fa429647fa22af73f9,
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893'])
+    entity(niiri:db047f8eefe5537016244f0bb25e3637,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a" %% xsd:string])
-    wasDerivedFrom(niiri:b178295856d95973727b2b358956335e, niiri:1263d9ada22b54fa429647fa22af73f9, -, -, -)
-    wasGeneratedBy(niiri:b178295856d95973727b2b358956335e, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
-    entity(niiri:0c8cae8f7fd81853bcc8700ee2f1bb91,
+    wasDerivedFrom(niiri:bd9421d9a41bc778b27e2be0eda0496f, niiri:db047f8eefe5537016244f0bb25e3637, -, -, -)
+    wasGeneratedBy(niiri:bd9421d9a41bc778b27e2be0eda0496f, niiri:48bd386fe0be968592a13062b5c43885, -)
+    entity(niiri:dc244080dfe10dc4223d65ff1b5587f2,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
         crypto:sha512 = "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48" %% xsd:string])
-    entity(niiri:3c4935283c58d44dba5a403a5d3b5832,
+    entity(niiri:ade1763484de1aa955eb941d8892ffcb,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868" %% xsd:string])
-    wasDerivedFrom(niiri:0c8cae8f7fd81853bcc8700ee2f1bb91, niiri:3c4935283c58d44dba5a403a5d3b5832, -, -, -)
-    wasGeneratedBy(niiri:0c8cae8f7fd81853bcc8700ee2f1bb91, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
-    entity(niiri:0a2a8817aa6793a351bd0a7021236cd0,
+    wasDerivedFrom(niiri:dc244080dfe10dc4223d65ff1b5587f2, niiri:ade1763484de1aa955eb941d8892ffcb, -, -, -)
+    wasGeneratedBy(niiri:dc244080dfe10dc4223d65ff1b5587f2, niiri:48bd386fe0be968592a13062b5c43885, -)
+    entity(niiri:86e735169b95dc7176008fba7b0cbabd,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
         crypto:sha512 = "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381" %% xsd:string])
-    entity(niiri:3a2ab399f71d1f0e06d2a38d3de41f29,
+    entity(niiri:a2f5143ec88d6b7200a0d1b34f1c06ab,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8" %% xsd:string])
-    wasDerivedFrom(niiri:0a2a8817aa6793a351bd0a7021236cd0, niiri:3a2ab399f71d1f0e06d2a38d3de41f29, -, -, -)
-    wasGeneratedBy(niiri:0a2a8817aa6793a351bd0a7021236cd0, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
-    entity(niiri:df230f4ff3b58783fe139f385597465e,
+    wasDerivedFrom(niiri:86e735169b95dc7176008fba7b0cbabd, niiri:a2f5143ec88d6b7200a0d1b34f1c06ab, -, -, -)
+    wasGeneratedBy(niiri:86e735169b95dc7176008fba7b0cbabd, niiri:48bd386fe0be968592a13062b5c43885, -)
+    entity(niiri:99e218282e31bd12efdffa7662e50016,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_FStatistic:',
         nidm_contrastName: = "Average effect of condition" %% xsd:string,
         prov:label = "Contrast: Average effect of condition" %% xsd:string,
         prov:value = "[1, 1, 1]" %% xsd:string])
-    activity(niiri:2ff41e5681a1c005622be9b68da73a06,
+    activity(niiri:f30c53c09afee24faac70ef520464dcc,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:cbb4e09f0c239d9fc253f426daea95ec, -)
-    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:1d1c92ca0bfb701909eb307868358b1a, -)
-    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:0c8cae8f7fd81853bcc8700ee2f1bb91, -)
-    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:186f3712419791aaf7a04a3d1b8bd722, -)
-    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:df230f4ff3b58783fe139f385597465e, -)
-    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:9f2d3c6c9d93cbbc83d0629664f66005, -)
-    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:baf9cccb8eba46b7c5f41863dda48579, -)
-    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:b178295856d95973727b2b358956335e, -)
-    entity(niiri:50609b22ae1142a0b21014e830b41cae,
+    wasAssociatedWith(niiri:f30c53c09afee24faac70ef520464dcc, niiri:8707d65d3a15dbf845684e80f7df9da7, -)
+    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:9f3d2992eab79fd14d4660154ae8238a, -)
+    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:dc244080dfe10dc4223d65ff1b5587f2, -)
+    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:c75f4ff351459ee32fa91d23800efb92, -)
+    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:99e218282e31bd12efdffa7662e50016, -)
+    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:fd2e03999ed8a414f71235a7246666d9, -)
+    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:af828ebe888a0cdbc655a60d27afaa91, -)
+    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:bd9421d9a41bc778b27e2be0eda0496f, -)
+    entity(niiri:67b4a4f6b336096ca6b563aa31361183,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "FStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "FStatistic.nii.gz" %% xsd:string,
@@ -284,87 +284,87 @@ document
         nidm_contrastName: = "Average effect of condition" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "39" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
         crypto:sha512 = "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960" %% xsd:string])
-    entity(niiri:c59df51d9201082e5f25f11b2f13807f,
+    entity(niiri:70bdd0befd9857e4ff6434527df6ac2c,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmF_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762" %% xsd:string])
-    wasDerivedFrom(niiri:50609b22ae1142a0b21014e830b41cae, niiri:c59df51d9201082e5f25f11b2f13807f, -, -, -)
-    wasGeneratedBy(niiri:50609b22ae1142a0b21014e830b41cae, niiri:2ff41e5681a1c005622be9b68da73a06, -)
-    entity(niiri:2416820ce6beaa983e426560e9ec33ec,
+    wasDerivedFrom(niiri:67b4a4f6b336096ca6b563aa31361183, niiri:70bdd0befd9857e4ff6434527df6ac2c, -, -, -)
+    wasGeneratedBy(niiri:67b4a4f6b336096ca6b563aa31361183, niiri:f30c53c09afee24faac70ef520464dcc, -)
+    entity(niiri:23c30668e6a9efa0ff2e602769536cb0,
         [prov:type = 'nidm_ContrastExplainedMeanSquareMap:',
         prov:location = "ContrastExplainedMeanSquare.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastExplainedMeanSquare.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Explained Mean Square Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
         crypto:sha512 = "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a" %% xsd:string])
-    wasGeneratedBy(niiri:2416820ce6beaa983e426560e9ec33ec, niiri:2ff41e5681a1c005622be9b68da73a06, -)
-    entity(niiri:d16264948a1baffc5b788ff82a41433f,
+    wasGeneratedBy(niiri:23c30668e6a9efa0ff2e602769536cb0, niiri:f30c53c09afee24faac70ef520464dcc, -)
+    entity(niiri:40440229b29f5872d53eef25ecf0f975,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500201896764" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:d6d3c2e8396eddb36c52c8ebf1691170',
-        nidm_equivalentThreshold: = 'niiri:59cbe87bfe988562f71c7863fcee3540'])
-    entity(niiri:d6d3c2e8396eddb36c52c8ebf1691170,
+        nidm_equivalentThreshold: = 'niiri:2c452674a1f81d156e269dbe9725998a',
+        nidm_equivalentThreshold: = 'niiri:15ee33831544a51d39b276ac0d45c0cb'])
+    entity(niiri:2c452674a1f81d156e269dbe9725998a,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "12.6602184255263" %% xsd:float])
-    entity(niiri:59cbe87bfe988562f71c7863fcee3540,
+    entity(niiri:15ee33831544a51d39b276ac0d45c0cb,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999999997" %% xsd:float])
-    entity(niiri:689643975c6d062da3f861f197ffb911,
+    entity(niiri:981d4a611d50d796152b8e8eb6283194,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:979cfefce98a2d163c991361d12cbf64',
-        nidm_equivalentThreshold: = 'niiri:5a949293e4972919cdd1902557e60273'])
-    entity(niiri:979cfefce98a2d163c991361d12cbf64,
+        nidm_equivalentThreshold: = 'niiri:3455442e086debfe280887e4ef34a59a',
+        nidm_equivalentThreshold: = 'niiri:eec7cc036dfbc9f23b1c4ad9eede1da3'])
+    entity(niiri:3455442e086debfe280887e4ef34a59a,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:5a949293e4972919cdd1902557e60273,
+    entity(niiri:eec7cc036dfbc9f23b1c4ad9eede1da3,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:932bf207ec1906155b85201be9afc0ed,
+    entity(niiri:ae1827b0fff51351ca6d76d580243226,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:356327ce3d3e8895d849bb23327e10f5,
+    entity(niiri:00a53452216f98c5cdd45baf25410a08,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:6be0e67690536755101ed426c4c5cfe1,
+    activity(niiri:9ea94d4c881c3057dcce3e08fa91b4db,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:cbb4e09f0c239d9fc253f426daea95ec, -)
-    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:d16264948a1baffc5b788ff82a41433f, -)
-    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:689643975c6d062da3f861f197ffb911, -)
-    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:50609b22ae1142a0b21014e830b41cae, -)
-    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:0a2a8817aa6793a351bd0a7021236cd0, -)
-    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:1d1c92ca0bfb701909eb307868358b1a, -)
-    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:932bf207ec1906155b85201be9afc0ed, -)
-    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:356327ce3d3e8895d849bb23327e10f5, -)
-    entity(niiri:6009f6fd85ea333f9b78564cda2aa83c,
+    wasAssociatedWith(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:8707d65d3a15dbf845684e80f7df9da7, -)
+    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:40440229b29f5872d53eef25ecf0f975, -)
+    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:981d4a611d50d796152b8e8eb6283194, -)
+    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:67b4a4f6b336096ca6b563aa31361183, -)
+    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:86e735169b95dc7176008fba7b0cbabd, -)
+    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:9f3d2992eab79fd14d4660154ae8238a, -)
+    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:ae1827b0fff51351ca6d76d580243226, -)
+    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:00a53452216f98c5cdd45baf25410a08, -)
+    entity(niiri:144940fea03f1e81a40c282fefbe54f4,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
         nidm_searchVolumeInVoxels: = "167222" %% xsd:int,
         nidm_searchVolumeInUnits: = "1337776" %% xsd:float,
         nidm_reselSizeInVoxels: = "68.5679161280351" %% xsd:float,
@@ -380,8 +380,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "99" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "57" %% xsd:int,
         crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
-    wasGeneratedBy(niiri:6009f6fd85ea333f9b78564cda2aa83c, niiri:6be0e67690536755101ed426c4c5cfe1, -)
-    entity(niiri:950be147189508776d90eb2c4280326c,
+    wasGeneratedBy(niiri:144940fea03f1e81a40c282fefbe54f4, niiri:9ea94d4c881c3057dcce3e08fa91b4db, -)
+    entity(niiri:a79e189fef35c2ea79f265fe43ab3fd5,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -389,22 +389,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "71" %% xsd:int,
         nidm_pValue: = "9.36073596413678e-09" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:404ea6617dcd902e2957d9a6b74f7ab3',
-        nidm_hasMaximumIntensityProjection: = 'niiri:a77ea9285b48403a7689ae0b730f7230',
-        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_hasClusterLabelsMap: = 'niiri:f36222cc921e73ce4c2371f2c0ddc287',
+        nidm_hasMaximumIntensityProjection: = 'niiri:cf3dd6a7998b23db2dee0adcb3e1f4d7',
+        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
         crypto:sha512 = "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006" %% xsd:string])
-    entity(niiri:404ea6617dcd902e2957d9a6b74f7ab3,
+    entity(niiri:f36222cc921e73ce4c2371f2c0ddc287,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:a77ea9285b48403a7689ae0b730f7230,
+    entity(niiri:cf3dd6a7998b23db2dee0adcb3e1f4d7,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:950be147189508776d90eb2c4280326c, niiri:6be0e67690536755101ed426c4c5cfe1, -)
-    entity(niiri:ec71581037e524c5fbd95f85fa55b157,
+    wasGeneratedBy(niiri:a79e189fef35c2ea79f265fe43ab3fd5, niiri:9ea94d4c881c3057dcce3e08fa91b4db, -)
+    entity(niiri:fcafd29e2d4984d5ef1a1e4525c5ba42,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "64" %% xsd:int,
@@ -413,8 +413,8 @@ document
         nidm_pValueFWER: = "0.060233823286733" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:ec71581037e524c5fbd95f85fa55b157, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:ddc3a6b40532cc9e86f19a4aa6cba853,
+    wasDerivedFrom(niiri:fcafd29e2d4984d5ef1a1e4525c5ba42, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:444cc626db04f602c9c9011fa5e21c84,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "139" %% xsd:int,
@@ -423,8 +423,8 @@ document
         nidm_pValueFWER: = "0.000881242002104266" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:ddc3a6b40532cc9e86f19a4aa6cba853, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:c1738200f1bc478c78cb4aab2cda0cb1,
+    wasDerivedFrom(niiri:444cc626db04f602c9c9011fa5e21c84, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:b1753f3aee975cc2167fd8ecc371ac5b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "99" %% xsd:int,
@@ -433,8 +433,8 @@ document
         nidm_pValueFWER: = "0.00742042768591067" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:c1738200f1bc478c78cb4aab2cda0cb1, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:91205f3f0676956d1f1039643e3fcd9d,
+    wasDerivedFrom(niiri:b1753f3aee975cc2167fd8ecc371ac5b, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:e217bff071e4c58201ab9d5e50316202,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "100" %% xsd:int,
@@ -443,8 +443,8 @@ document
         nidm_pValueFWER: = "0.00701417162859297" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:91205f3f0676956d1f1039643e3fcd9d, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:a689a0799152fcf397ed6264dff6b7df,
+    wasDerivedFrom(niiri:e217bff071e4c58201ab9d5e50316202, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:293f17b4b9a3d5e7642f3136e988fb69,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "41" %% xsd:int,
@@ -453,8 +453,8 @@ document
         nidm_pValueFWER: = "0.26810099909693" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:a689a0799152fcf397ed6264dff6b7df, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:4f3977b902ab860fce265438ec1666b5,
+    wasDerivedFrom(niiri:293f17b4b9a3d5e7642f3136e988fb69, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:f39819aeb0366241cbbae35a6427fc8b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "42" %% xsd:int,
@@ -463,8 +463,8 @@ document
         nidm_pValueFWER: = "0.251270468559567" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:4f3977b902ab860fce265438ec1666b5, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:e8270a828c6a9c6a7e1a7f948de88a7e,
+    wasDerivedFrom(niiri:f39819aeb0366241cbbae35a6427fc8b, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:804f36b4efe7eb06f1a23107f02c9522,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "27" %% xsd:int,
@@ -473,8 +473,8 @@ document
         nidm_pValueFWER: = "0.621383930767395" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:e8270a828c6a9c6a7e1a7f948de88a7e, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:cda674baaa255a631b19d42763c0930c,
+    wasDerivedFrom(niiri:804f36b4efe7eb06f1a23107f02c9522, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:808fd4e2193f0ed5ab2626fc643077ca,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "57" %% xsd:int,
@@ -483,8 +483,8 @@ document
         nidm_pValueFWER: = "0.0943507032156397" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:cda674baaa255a631b19d42763c0930c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:b9beda96f738803fb567cd0d0d5ac126,
+    wasDerivedFrom(niiri:808fd4e2193f0ed5ab2626fc643077ca, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:2667f28dbb2bce2c8e774ae24bc32c34,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "33" %% xsd:int,
@@ -493,8 +493,8 @@ document
         nidm_pValueFWER: = "0.443203909376631" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:b9beda96f738803fb567cd0d0d5ac126, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:24686319b3c7b6b6793dbf6e90029199,
+    wasDerivedFrom(niiri:2667f28dbb2bce2c8e774ae24bc32c34, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:81153168c82f38e0344a3da5990713f4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -503,8 +503,8 @@ document
         nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:24686319b3c7b6b6793dbf6e90029199, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:ef45eced4ec473fc374602efe1d44af2,
+    wasDerivedFrom(niiri:81153168c82f38e0344a3da5990713f4, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:51df67b679cd0aa1c10588b2540f80ff,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -513,8 +513,8 @@ document
         nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:ef45eced4ec473fc374602efe1d44af2, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:1a8d727934cbec38f1fdcc84430d7857,
+    wasDerivedFrom(niiri:51df67b679cd0aa1c10588b2540f80ff, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:c3859302a7f8a3aa876923fe5311fdeb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "26" %% xsd:int,
@@ -523,8 +523,8 @@ document
         nidm_pValueFWER: = "0.653681229272869" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:1a8d727934cbec38f1fdcc84430d7857, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:0ea4cdb2fb21bb5f5f9588416f8a0986,
+    wasDerivedFrom(niiri:c3859302a7f8a3aa876923fe5311fdeb, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:a9683c02ec255a54e2147300ce75147c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -533,8 +533,8 @@ document
         nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:0ea4cdb2fb21bb5f5f9588416f8a0986, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:e96a0a75cfbda16324a620530f8ac979,
+    wasDerivedFrom(niiri:a9683c02ec255a54e2147300ce75147c, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:4b0d5b1cbdc197add17ddae11c60a960,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -543,8 +543,8 @@ document
         nidm_pValueFWER: = "0.936111008142629" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:e96a0a75cfbda16324a620530f8ac979, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:bc4b7adbe33f91a695fde03bf4b200ed,
+    wasDerivedFrom(niiri:4b0d5b1cbdc197add17ddae11c60a960, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:074f24af2809bb5962437625180d87d8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "14" %% xsd:int,
@@ -553,8 +553,8 @@ document
         nidm_pValueFWER: = "0.966679694237215" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:bc4b7adbe33f91a695fde03bf4b200ed, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:71a412f82e6ea8cb947b5be72c8efcff,
+    wasDerivedFrom(niiri:074f24af2809bb5962437625180d87d8, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:3950399d3cc373d8735fcf48ad86f542,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "35" %% xsd:int,
@@ -563,8 +563,8 @@ document
         nidm_pValueFWER: = "0.392344720913691" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:71a412f82e6ea8cb947b5be72c8efcff, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:93e18b25ba3aeb399e6fd41cb9dfca97,
+    wasDerivedFrom(niiri:3950399d3cc373d8735fcf48ad86f542, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:bab302ab1de7ceb32ee2a4553bab718d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "32" %% xsd:int,
@@ -573,8 +573,8 @@ document
         nidm_pValueFWER: = "0.470398116431399" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:93e18b25ba3aeb399e6fd41cb9dfca97, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:3d33e1d8e7da5c593e7ad094c154132a,
+    wasDerivedFrom(niiri:bab302ab1de7ceb32ee2a4553bab718d, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:14ab5f557514798d8218e39a2199e27a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "46" %% xsd:int,
@@ -583,8 +583,8 @@ document
         nidm_pValueFWER: = "0.193521561130372" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:3d33e1d8e7da5c593e7ad094c154132a, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4,
+    wasDerivedFrom(niiri:14ab5f557514798d8218e39a2199e27a, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:bc603717c0c5d8a8779b8aa6c28564b3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "15" %% xsd:int,
@@ -593,8 +593,8 @@ document
         nidm_pValueFWER: = "0.952887583051913" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:7c11ea6d552baec493b21ecdef64c785,
+    wasDerivedFrom(niiri:bc603717c0c5d8a8779b8aa6c28564b3, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:106ee2638843f2793b5ac6735acad91e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "20" %% xsd:int,
@@ -603,8 +603,8 @@ document
         nidm_pValueFWER: = "0.841775430461368" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:7c11ea6d552baec493b21ecdef64c785, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:56fa7a2fed0946da7dd3299da637b245,
+    wasDerivedFrom(niiri:106ee2638843f2793b5ac6735acad91e, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:01c1ab06b5a4997e0980bcddb0f69696,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -613,8 +613,8 @@ document
         nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:56fa7a2fed0946da7dd3299da637b245, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:c74b1ddb4c9a5395bf0b4d826708ce5a,
+    wasDerivedFrom(niiri:01c1ab06b5a4997e0980bcddb0f69696, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:8f249184eec9591adc7a3fc1c7e37936,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "32" %% xsd:int,
@@ -623,8 +623,8 @@ document
         nidm_pValueFWER: = "0.470398116431399" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:c74b1ddb4c9a5395bf0b4d826708ce5a, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:10bec2b1f4f72ee8eedb38e17e1faab3,
+    wasDerivedFrom(niiri:8f249184eec9591adc7a3fc1c7e37936, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:c7ba1e0ca7a63ee914a7fa6cddbda281,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -633,8 +633,8 @@ document
         nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:10bec2b1f4f72ee8eedb38e17e1faab3, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:f725bd9a5656b07d43f8eba6c3be2858,
+    wasDerivedFrom(niiri:c7ba1e0ca7a63ee914a7fa6cddbda281, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:91987e35b1d8c15af66e3327a6e4b602,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -643,8 +643,8 @@ document
         nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:f725bd9a5656b07d43f8eba6c3be2858, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:83f438c66d3cf32344b7255377c7499d,
+    wasDerivedFrom(niiri:91987e35b1d8c15af66e3327a6e4b602, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:c09f3990ca4bd168f93fa27a56eeb56c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -653,8 +653,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:83f438c66d3cf32344b7255377c7499d, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:cc9360b64b21e281dcfb851074b574b6,
+    wasDerivedFrom(niiri:c09f3990ca4bd168f93fa27a56eeb56c, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:4f39525fd234b098e759c0ffc971fd5b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "21" %% xsd:int,
@@ -663,8 +663,8 @@ document
         nidm_pValueFWER: = "0.812786836270519" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:cc9360b64b21e281dcfb851074b574b6, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:4728de35ba855317aeef4e0a7b91801c,
+    wasDerivedFrom(niiri:4f39525fd234b098e759c0ffc971fd5b, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:66eca61ada8ceb626c8ffd13d3efa1cc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "25" %% xsd:int,
@@ -673,8 +673,8 @@ document
         nidm_pValueFWER: = "0.686218175845877" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:4728de35ba855317aeef4e0a7b91801c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:f435923c3d5e3915c4aa5159c5bbc4a0,
+    wasDerivedFrom(niiri:66eca61ada8ceb626c8ffd13d3efa1cc, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:5cf9402b2b494a87640a66aec1a6fdaf,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -683,8 +683,8 @@ document
         nidm_pValueFWER: = "0.999014041359979" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:f435923c3d5e3915c4aa5159c5bbc4a0, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:b39b9cce118cf858149cdd53ebcda7bd,
+    wasDerivedFrom(niiri:5cf9402b2b494a87640a66aec1a6fdaf, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:1cd1f14fea72d133db88783e1b907b7f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -693,8 +693,8 @@ document
         nidm_pValueFWER: = "0.985744636441848" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:b39b9cce118cf858149cdd53ebcda7bd, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:97e0a9bea1289493ad46d8a4c2b75485,
+    wasDerivedFrom(niiri:1cd1f14fea72d133db88783e1b907b7f, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:c3340fa012c626e62e86cdb279a4e883,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -703,8 +703,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:97e0a9bea1289493ad46d8a4c2b75485, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:e9e94038b5b1dbcf9f8a4d4208e34928,
+    wasDerivedFrom(niiri:c3340fa012c626e62e86cdb279a4e883, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -713,8 +713,8 @@ document
         nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "31" %% xsd:int])
-    wasDerivedFrom(niiri:e9e94038b5b1dbcf9f8a4d4208e34928, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:0857328371989db393f2fc4d7d5346bd,
+    wasDerivedFrom(niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:8b25738f634743abd67e5fd856e90f74,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -723,8 +723,8 @@ document
         nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "32" %% xsd:int])
-    wasDerivedFrom(niiri:0857328371989db393f2fc4d7d5346bd, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:7e693a4a3e70d39b916aa2a95911a3c8,
+    wasDerivedFrom(niiri:8b25738f634743abd67e5fd856e90f74, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:1c59a22b32098831723dc21703615fd1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -733,8 +733,8 @@ document
         nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "33" %% xsd:int])
-    wasDerivedFrom(niiri:7e693a4a3e70d39b916aa2a95911a3c8, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:d8dc459a110e4898c23019ee42154713,
+    wasDerivedFrom(niiri:1c59a22b32098831723dc21703615fd1, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:139b6ecf5fdad735a51b4385a24aded9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -743,8 +743,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "34" %% xsd:int])
-    wasDerivedFrom(niiri:d8dc459a110e4898c23019ee42154713, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:cd795f902776ad9170549b8fde8996ba,
+    wasDerivedFrom(niiri:139b6ecf5fdad735a51b4385a24aded9, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:e6a138032615b9872d9261e35d2455f4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -753,8 +753,8 @@ document
         nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "35" %% xsd:int])
-    wasDerivedFrom(niiri:cd795f902776ad9170549b8fde8996ba, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:ed1df7c28737883d905ca0a8f2093992,
+    wasDerivedFrom(niiri:e6a138032615b9872d9261e35d2455f4, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:37bc5cb5a158a9f86c496a5d1935903c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -763,8 +763,8 @@ document
         nidm_pValueFWER: = "0.99963404273418" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "36" %% xsd:int])
-    wasDerivedFrom(niiri:ed1df7c28737883d905ca0a8f2093992, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:ca7bfed8d8dbca676ba25fca93d29e2c,
+    wasDerivedFrom(niiri:37bc5cb5a158a9f86c496a5d1935903c, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:f86c9bb022fe2e7bb4f2a1d963869d32,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -773,8 +773,8 @@ document
         nidm_pValueFWER: = "0.999014041359979" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "37" %% xsd:int])
-    wasDerivedFrom(niiri:ca7bfed8d8dbca676ba25fca93d29e2c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:1dcd9b5514190f867e3e9b0b57227395,
+    wasDerivedFrom(niiri:f86c9bb022fe2e7bb4f2a1d963869d32, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:cecab36bcbd915f7841bff34cd7f59a6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -783,8 +783,8 @@ document
         nidm_pValueFWER: = "0.985744636441848" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "38" %% xsd:int])
-    wasDerivedFrom(niiri:1dcd9b5514190f867e3e9b0b57227395, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:79097d11179e49abc9f2bdf5ba7bb932,
+    wasDerivedFrom(niiri:cecab36bcbd915f7841bff34cd7f59a6, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:752ff8a0ff1912e3b3a3cc0b0af92bac,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -793,8 +793,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "39" %% xsd:int])
-    wasDerivedFrom(niiri:79097d11179e49abc9f2bdf5ba7bb932, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:d339d6251d3c159dbe2427fd1bcc1fc1,
+    wasDerivedFrom(niiri:752ff8a0ff1912e3b3a3cc0b0af92bac, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:bbfdc94758422f4cdfa2d461f26c652c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -803,8 +803,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "40" %% xsd:int])
-    wasDerivedFrom(niiri:d339d6251d3c159dbe2427fd1bcc1fc1, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:b0978b4f683201d3539ace75681c8b65,
+    wasDerivedFrom(niiri:bbfdc94758422f4cdfa2d461f26c652c, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:412f44bb99fe0b4ac5111c8bb0d6824f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -813,8 +813,8 @@ document
         nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "41" %% xsd:int])
-    wasDerivedFrom(niiri:b0978b4f683201d3539ace75681c8b65, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:133c074788eed1fa9d50d9e4608e3c1c,
+    wasDerivedFrom(niiri:412f44bb99fe0b4ac5111c8bb0d6824f, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:ae1cd8d0dfca9341507b66eafba6459d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -823,8 +823,8 @@ document
         nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "42" %% xsd:int])
-    wasDerivedFrom(niiri:133c074788eed1fa9d50d9e4608e3c1c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:93bdd51f373f8659382785eb36932971,
+    wasDerivedFrom(niiri:ae1cd8d0dfca9341507b66eafba6459d, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:089292d98902368bd347bcdfa162cfda,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -833,8 +833,8 @@ document
         nidm_pValueFWER: = "0.997730485940405" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "43" %% xsd:int])
-    wasDerivedFrom(niiri:93bdd51f373f8659382785eb36932971, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:522536a75466fe7c0e757947afe21547,
+    wasDerivedFrom(niiri:089292d98902368bd347bcdfa162cfda, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:716ffa34870ad39bf06d8e49c18b9bce,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -843,8 +843,8 @@ document
         nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "44" %% xsd:int])
-    wasDerivedFrom(niiri:522536a75466fe7c0e757947afe21547, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:acdb22704e8e3566aa17ca0ccdff7a03,
+    wasDerivedFrom(niiri:716ffa34870ad39bf06d8e49c18b9bce, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:8c7ca240ed7a4d85316011dd6f1768ff,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -853,8 +853,8 @@ document
         nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "45" %% xsd:int])
-    wasDerivedFrom(niiri:acdb22704e8e3566aa17ca0ccdff7a03, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:e1cde03f80af40c7004f16340827c9a6,
+    wasDerivedFrom(niiri:8c7ca240ed7a4d85316011dd6f1768ff, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:08593ccb1d9e49118b073d271565bd78,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -863,8 +863,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "46" %% xsd:int])
-    wasDerivedFrom(niiri:e1cde03f80af40c7004f16340827c9a6, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:1a861a102938105fb0e599c28c89f0df,
+    wasDerivedFrom(niiri:08593ccb1d9e49118b073d271565bd78, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:b52f4fded36d906e3611187b1ea82271,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -873,8 +873,8 @@ document
         nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "47" %% xsd:int])
-    wasDerivedFrom(niiri:1a861a102938105fb0e599c28c89f0df, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:28c829a636fe7679be2b8fe3fc083d99,
+    wasDerivedFrom(niiri:b52f4fded36d906e3611187b1ea82271, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:900eebea134685a11022813f19903499,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -883,8 +883,8 @@ document
         nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "48" %% xsd:int])
-    wasDerivedFrom(niiri:28c829a636fe7679be2b8fe3fc083d99, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:4bb1f06cdf753bfe2cb9742585fc5f63,
+    wasDerivedFrom(niiri:900eebea134685a11022813f19903499, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:a20506ad4a845975db3365e7c162d818,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -893,8 +893,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "49" %% xsd:int])
-    wasDerivedFrom(niiri:4bb1f06cdf753bfe2cb9742585fc5f63, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:cca6dc1b6e22a99533fb4839e0e808cf,
+    wasDerivedFrom(niiri:a20506ad4a845975db3365e7c162d818, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:cfde284823e7c32d74bec0b81232bb7a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -903,8 +903,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "50" %% xsd:int])
-    wasDerivedFrom(niiri:cca6dc1b6e22a99533fb4839e0e808cf, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:894db077f6ce41dde7580196422f5b65,
+    wasDerivedFrom(niiri:cfde284823e7c32d74bec0b81232bb7a, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:496bec06cfc8ef95b3cbe0997c654d26,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -913,8 +913,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "51" %% xsd:int])
-    wasDerivedFrom(niiri:894db077f6ce41dde7580196422f5b65, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:e8143c5b2cddc4ad2f401f2b27a4cab2,
+    wasDerivedFrom(niiri:496bec06cfc8ef95b3cbe0997c654d26, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:e4bff32759970a1099e3a417cf7206b0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -923,8 +923,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "52" %% xsd:int])
-    wasDerivedFrom(niiri:e8143c5b2cddc4ad2f401f2b27a4cab2, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:09cd915bf2b2b51b32d56249f304bbce,
+    wasDerivedFrom(niiri:e4bff32759970a1099e3a417cf7206b0, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:40337b736645244404b84afb6772e7a9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -933,8 +933,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "53" %% xsd:int])
-    wasDerivedFrom(niiri:09cd915bf2b2b51b32d56249f304bbce, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:bf2d35b880b3d0657d2a03298074406e,
+    wasDerivedFrom(niiri:40337b736645244404b84afb6772e7a9, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:42bc55f4f90f29daf9e12be119e1ddab,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -943,8 +943,8 @@ document
         nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "54" %% xsd:int])
-    wasDerivedFrom(niiri:bf2d35b880b3d0657d2a03298074406e, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:56bc4504cec954daf4a701610ddf59b3,
+    wasDerivedFrom(niiri:42bc55f4f90f29daf9e12be119e1ddab, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:067c79f86db85b508893737af41699ce,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -953,8 +953,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "55" %% xsd:int])
-    wasDerivedFrom(niiri:56bc4504cec954daf4a701610ddf59b3, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:baa1270c4a9c0f72989c973b2fbb309d,
+    wasDerivedFrom(niiri:067c79f86db85b508893737af41699ce, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:1a35a6d628eed4f2fc8c554a4a579a19,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -963,8 +963,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "56" %% xsd:int])
-    wasDerivedFrom(niiri:baa1270c4a9c0f72989c973b2fbb309d, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:39b258c34ddafd00d7dff6d208f62918,
+    wasDerivedFrom(niiri:1a35a6d628eed4f2fc8c554a4a579a19, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:0e92ac2d77c091672e014daf15280170,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -973,8 +973,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "57" %% xsd:int])
-    wasDerivedFrom(niiri:39b258c34ddafd00d7dff6d208f62918, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:ea112296db729b94dfce05991c3d6989,
+    wasDerivedFrom(niiri:0e92ac2d77c091672e014daf15280170, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:0d2b802df946de1efd390f218ef63fce,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -983,8 +983,8 @@ document
         nidm_pValueFWER: = "0.999999982398778" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "58" %% xsd:int])
-    wasDerivedFrom(niiri:ea112296db729b94dfce05991c3d6989, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:a41eeb9ba04d7788ba686542607ff1cc,
+    wasDerivedFrom(niiri:0d2b802df946de1efd390f218ef63fce, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:627d75e08350cce3541dd568e3ddaa39,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -993,8 +993,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "59" %% xsd:int])
-    wasDerivedFrom(niiri:a41eeb9ba04d7788ba686542607ff1cc, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:9c7b81143edac28cf680878e9177494c,
+    wasDerivedFrom(niiri:627d75e08350cce3541dd568e3ddaa39, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:20516921d28241951d08251e80cac5b5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1003,8 +1003,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "60" %% xsd:int])
-    wasDerivedFrom(niiri:9c7b81143edac28cf680878e9177494c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:e854403c8636e3e481bc993eb6180f44,
+    wasDerivedFrom(niiri:20516921d28241951d08251e80cac5b5, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:3822c0fa262ca8cb8a67590f3eec2fe6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1013,8 +1013,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "61" %% xsd:int])
-    wasDerivedFrom(niiri:e854403c8636e3e481bc993eb6180f44, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:7f3ebf5e2a10fd569c91dd091c7af147,
+    wasDerivedFrom(niiri:3822c0fa262ca8cb8a67590f3eec2fe6, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:51287994298816d649ba6908b4e3d0bb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1023,8 +1023,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "62" %% xsd:int])
-    wasDerivedFrom(niiri:7f3ebf5e2a10fd569c91dd091c7af147, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:b36c20212016b9bc7a603f3e83aca676,
+    wasDerivedFrom(niiri:51287994298816d649ba6908b4e3d0bb, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:36a1ff3bd64efa589db6c3a56ccf9d25,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1033,8 +1033,8 @@ document
         nidm_pValueFWER: = "0.999999982398778" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "63" %% xsd:int])
-    wasDerivedFrom(niiri:b36c20212016b9bc7a603f3e83aca676, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:05115f2e683a3386f641d5816019de27,
+    wasDerivedFrom(niiri:36a1ff3bd64efa589db6c3a56ccf9d25, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:1c0a11fe168926616610d5836c36d35f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1043,8 +1043,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "64" %% xsd:int])
-    wasDerivedFrom(niiri:05115f2e683a3386f641d5816019de27, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:1ee8276c32c1e03b7e0b4b1717c44a57,
+    wasDerivedFrom(niiri:1c0a11fe168926616610d5836c36d35f, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:aa0d58d5cc7671539d09308038edb0f1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1053,8 +1053,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "65" %% xsd:int])
-    wasDerivedFrom(niiri:1ee8276c32c1e03b7e0b4b1717c44a57, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:aa58a012c4a942174e0325d4c0b944fd,
+    wasDerivedFrom(niiri:aa0d58d5cc7671539d09308038edb0f1, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:fc71e9e9a2574cbd9d5094f50275b3c2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1063,8 +1063,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "66" %% xsd:int])
-    wasDerivedFrom(niiri:aa58a012c4a942174e0325d4c0b944fd, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:69b1d9ea8525a6a583365384e39cf9e8,
+    wasDerivedFrom(niiri:fc71e9e9a2574cbd9d5094f50275b3c2, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:c23970716bccffb656edae94cc34e353,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1073,8 +1073,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "67" %% xsd:int])
-    wasDerivedFrom(niiri:69b1d9ea8525a6a583365384e39cf9e8, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:f6d9af16709f321130aa58504e6604c5,
+    wasDerivedFrom(niiri:c23970716bccffb656edae94cc34e353, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:8e2363110cdebe114cbe95493b19fa9d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1083,8 +1083,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "68" %% xsd:int])
-    wasDerivedFrom(niiri:f6d9af16709f321130aa58504e6604c5, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:be347b3d17b0cf1b2b8f3ad6860ae399,
+    wasDerivedFrom(niiri:8e2363110cdebe114cbe95493b19fa9d, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:eb4122935f1afa2c8b532875de5f0ef9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1093,8 +1093,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "69" %% xsd:int])
-    wasDerivedFrom(niiri:be347b3d17b0cf1b2b8f3ad6860ae399, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:fb10f43ffe914843271a8cdefab5f898,
+    wasDerivedFrom(niiri:eb4122935f1afa2c8b532875de5f0ef9, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:25018fb0acd6d245a4f445c35c5f92eb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1103,8 +1103,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "70" %% xsd:int])
-    wasDerivedFrom(niiri:fb10f43ffe914843271a8cdefab5f898, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:ac129c99f1ae280d6d0a6f24c04b617a,
+    wasDerivedFrom(niiri:25018fb0acd6d245a4f445c35c5f92eb, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:ccd2969f60f8b0222713472b0a037361,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1113,1146 +1113,1146 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "71" %% xsd:int])
-    wasDerivedFrom(niiri:ac129c99f1ae280d6d0a6f24c04b617a, niiri:950be147189508776d90eb2c4280326c, -, -, -)
-    entity(niiri:0259aad92a78e6c87148ce920416a4eb,
+    wasDerivedFrom(niiri:ccd2969f60f8b0222713472b0a037361, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
+    entity(niiri:baa4e7252d8424602eff0da2b334e0ea,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:dd5db5be9e69824ffb62949c8582d5be',
+        prov:location = 'niiri:3dcaa7f03a6601fd8a98a0250eb396ce',
         prov:value = "39.0658683776855" %% xsd:float,
         nidm_equivalentZStatistic: = "5.04009751746769" %% xsd:float,
         nidm_pValueUncorrected: = "2.3264734660966e-07" %% xsd:float,
         nidm_pValueFWER: = "0.0389037590875805" %% xsd:float,
         nidm_qValueFDR: = "0.0302216629065993" %% xsd:float])
-    entity(niiri:dd5db5be9e69824ffb62949c8582d5be,
+    entity(niiri:3dcaa7f03a6601fd8a98a0250eb396ce,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[-2,-90,28]" %% xsd:string])
-    wasDerivedFrom(niiri:0259aad92a78e6c87148ce920416a4eb, niiri:ec71581037e524c5fbd95f85fa55b157, -, -, -)
-    entity(niiri:7e799bbd6f335fd540a4021e61075cf8,
+    wasDerivedFrom(niiri:baa4e7252d8424602eff0da2b334e0ea, niiri:fcafd29e2d4984d5ef1a1e4525c5ba42, -, -, -)
+    entity(niiri:ef00983a1ab378c0ed62a4e8080df8cf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:d3f6be55abbd687279e07d932188a32e',
+        prov:location = 'niiri:a3fcc5c0311ede9dd4d7b167cd4e683f',
         prov:value = "36.2393341064453" %% xsd:float,
         nidm_equivalentZStatistic: = "4.89725160225159" %% xsd:float,
         nidm_pValueUncorrected: = "4.85931842320042e-07" %% xsd:float,
         nidm_pValueFWER: = "0.071761896035709" %% xsd:float,
         nidm_qValueFDR: = "0.0302216629065993" %% xsd:float])
-    entity(niiri:d3f6be55abbd687279e07d932188a32e,
+    entity(niiri:a3fcc5c0311ede9dd4d7b167cd4e683f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[-42,-64,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:7e799bbd6f335fd540a4021e61075cf8, niiri:ddc3a6b40532cc9e86f19a4aa6cba853, -, -, -)
-    entity(niiri:0818768d40973c28e4e870de99f7a12e,
+    wasDerivedFrom(niiri:ef00983a1ab378c0ed62a4e8080df8cf, niiri:444cc626db04f602c9c9011fa5e21c84, -, -, -)
+    entity(niiri:915137b9c7e5154400a1f1cc8692da57,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:e10e6b887d937b13d419913e96b50eb4',
+        prov:location = 'niiri:6b30d660a4ad3dfdee42a3cd8d2d46f0',
         prov:value = "17.9251842498779" %% xsd:float,
         nidm_equivalentZStatistic: = "3.64201416072196" %% xsd:float,
         nidm_pValueUncorrected: = "0.000135256594276711" %% xsd:float,
         nidm_pValueFWER: = "0.999417997648594" %% xsd:float,
         nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
-    entity(niiri:e10e6b887d937b13d419913e96b50eb4,
+    entity(niiri:6b30d660a4ad3dfdee42a3cd8d2d46f0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[-40,-52,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:0818768d40973c28e4e870de99f7a12e, niiri:ddc3a6b40532cc9e86f19a4aa6cba853, -, -, -)
-    entity(niiri:2e69720344eeade04945a9294efe1c46,
+    wasDerivedFrom(niiri:915137b9c7e5154400a1f1cc8692da57, niiri:444cc626db04f602c9c9011fa5e21c84, -, -, -)
+    entity(niiri:e99d8d782cf7659baaf6c7a11fd75959,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:43f273420f486c1569872beaefa26851',
+        prov:location = 'niiri:deb2e3be4bbfe246eccd4c8e2cb277c9',
         prov:value = "13.454288482666" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18324713734782" %% xsd:float,
         nidm_pValueUncorrected: = "0.000728166268399777" %% xsd:float,
         nidm_pValueFWER: = "0.999999999996872" %% xsd:float,
         nidm_qValueFDR: = "0.140840039531724" %% xsd:float])
-    entity(niiri:43f273420f486c1569872beaefa26851,
+    entity(niiri:deb2e3be4bbfe246eccd4c8e2cb277c9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[-38,-70,0]" %% xsd:string])
-    wasDerivedFrom(niiri:2e69720344eeade04945a9294efe1c46, niiri:ddc3a6b40532cc9e86f19a4aa6cba853, -, -, -)
-    entity(niiri:0b61d4f645e8030fa41b599c3b7220dd,
+    wasDerivedFrom(niiri:e99d8d782cf7659baaf6c7a11fd75959, niiri:444cc626db04f602c9c9011fa5e21c84, -, -, -)
+    entity(niiri:887edacd038795695bc5935681d9ec60,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:a9b1c3d0f5af3d460c038461141f2a06',
+        prov:location = 'niiri:149ea3c3b924b56714ebbd48bd4cf7eb',
         prov:value = "29.4676361083984" %% xsd:float,
         nidm_equivalentZStatistic: = "4.51162164706026" %% xsd:float,
         nidm_pValueUncorrected: = "3.21669348379849e-06" %% xsd:float,
         nidm_pValueFWER: = "0.305525019896507" %% xsd:float,
         nidm_qValueFDR: = "0.0356596612461515" %% xsd:float])
-    entity(niiri:a9b1c3d0f5af3d460c038461141f2a06,
+    entity(niiri:149ea3c3b924b56714ebbd48bd4cf7eb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[16,-88,24]" %% xsd:string])
-    wasDerivedFrom(niiri:0b61d4f645e8030fa41b599c3b7220dd, niiri:c1738200f1bc478c78cb4aab2cda0cb1, -, -, -)
-    entity(niiri:211afdee4625abd8fd61f5e2da4e7851,
+    wasDerivedFrom(niiri:887edacd038795695bc5935681d9ec60, niiri:b1753f3aee975cc2167fd8ecc371ac5b, -, -, -)
+    entity(niiri:966afe2baff599cc271b19f81f50e736,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:21d2bcb65d9792fab52c653d5e34433a',
+        prov:location = 'niiri:de9e01b6bf2a659aa4d3377d86836307',
         prov:value = "28.5631580352783" %% xsd:float,
         nidm_equivalentZStatistic: = "4.45459114773779" %% xsd:float,
         nidm_pValueUncorrected: = "4.20266075706888e-06" %% xsd:float,
         nidm_pValueFWER: = "0.365688847752494" %% xsd:float,
         nidm_qValueFDR: = "0.0376032685416481" %% xsd:float])
-    entity(niiri:21d2bcb65d9792fab52c653d5e34433a,
+    entity(niiri:de9e01b6bf2a659aa4d3377d86836307,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[28,-72,26]" %% xsd:string])
-    wasDerivedFrom(niiri:211afdee4625abd8fd61f5e2da4e7851, niiri:91205f3f0676956d1f1039643e3fcd9d, -, -, -)
-    entity(niiri:36f1bebef6aafa905f0a57417a9a9409,
+    wasDerivedFrom(niiri:966afe2baff599cc271b19f81f50e736, niiri:e217bff071e4c58201ab9d5e50316202, -, -, -)
+    entity(niiri:25bc992eccfc2b6a6a24289f4e757203,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:d149b750b624172908054300ba57fa0d',
+        prov:location = 'niiri:e01e6d8bfc3791e75a43288c36fa1d9c',
         prov:value = "26.9945106506348" %% xsd:float,
         nidm_equivalentZStatistic: = "4.35204306383375" %% xsd:float,
         nidm_pValueUncorrected: = "6.7437380493196e-06" %% xsd:float,
         nidm_pValueFWER: = "0.489729172437052" %% xsd:float,
         nidm_qValueFDR: = "0.0406203661092224" %% xsd:float])
-    entity(niiri:d149b750b624172908054300ba57fa0d,
+    entity(niiri:e01e6d8bfc3791e75a43288c36fa1d9c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[-32,20,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:36f1bebef6aafa905f0a57417a9a9409, niiri:a689a0799152fcf397ed6264dff6b7df, -, -, -)
-    entity(niiri:2b42ff26513d8bb2fad2bee3fac979bd,
+    wasDerivedFrom(niiri:25bc992eccfc2b6a6a24289f4e757203, niiri:293f17b4b9a3d5e7642f3136e988fb69, -, -, -)
+    entity(niiri:f9405b475d3bdca76e81a6717bca04c2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:00172712096fe22fbb4c6cb0abae056c',
+        prov:location = 'niiri:d382a0c6c03aa0a2f6ee3c758f66a342',
         prov:value = "26.8606586456299" %% xsd:float,
         nidm_equivalentZStatistic: = "4.34306775687574" %% xsd:float,
         nidm_pValueUncorrected: = "7.02533878071954e-06" %% xsd:float,
         nidm_pValueFWER: = "0.501353785238145" %% xsd:float,
         nidm_qValueFDR: = "0.0406203661092224" %% xsd:float])
-    entity(niiri:00172712096fe22fbb4c6cb0abae056c,
+    entity(niiri:d382a0c6c03aa0a2f6ee3c758f66a342,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[-8,50,32]" %% xsd:string])
-    wasDerivedFrom(niiri:2b42ff26513d8bb2fad2bee3fac979bd, niiri:4f3977b902ab860fce265438ec1666b5, -, -, -)
-    entity(niiri:570e544597bcf68c47263d141cd82ca4,
+    wasDerivedFrom(niiri:f9405b475d3bdca76e81a6717bca04c2, niiri:f39819aeb0366241cbbae35a6427fc8b, -, -, -)
+    entity(niiri:5f02b40490d007ae68a92b4316e9efd9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:4488b6dfe10aa9fffe9d9fa5f038987f',
+        prov:location = 'niiri:dd4a0e1012831b8affc68995057a1120',
         prov:value = "25.8067512512207" %% xsd:float,
         nidm_equivalentZStatistic: = "4.27109313660164" %% xsd:float,
         nidm_pValueUncorrected: = "9.72585724245967e-06" %% xsd:float,
         nidm_pValueFWER: = "0.597019202761311" %% xsd:float,
         nidm_qValueFDR: = "0.0439563569939673" %% xsd:float])
-    entity(niiri:4488b6dfe10aa9fffe9d9fa5f038987f,
+    entity(niiri:dd4a0e1012831b8affc68995057a1120,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[-34,8,58]" %% xsd:string])
-    wasDerivedFrom(niiri:570e544597bcf68c47263d141cd82ca4, niiri:e8270a828c6a9c6a7e1a7f948de88a7e, -, -, -)
-    entity(niiri:be4c08d3fca48f05de0ae62f8b673305,
+    wasDerivedFrom(niiri:5f02b40490d007ae68a92b4316e9efd9, niiri:804f36b4efe7eb06f1a23107f02c9522, -, -, -)
+    entity(niiri:9eb8c305928cd26af5d735f290a7ce8a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:43ecbb57ee775f4cbb1dd4af236cfbff',
+        prov:location = 'niiri:c53ceb2c4d2e390230752c97501ffbd1',
         prov:value = "25.0769119262695" %% xsd:float,
         nidm_equivalentZStatistic: = "4.21983658750018" %% xsd:float,
         nidm_pValueUncorrected: = "1.22239732009977e-05" %% xsd:float,
         nidm_pValueFWER: = "0.665677647955296" %% xsd:float,
         nidm_qValueFDR: = "0.0444376030498989" %% xsd:float])
-    entity(niiri:43ecbb57ee775f4cbb1dd4af236cfbff,
+    entity(niiri:c53ceb2c4d2e390230752c97501ffbd1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[32,-86,0]" %% xsd:string])
-    wasDerivedFrom(niiri:be4c08d3fca48f05de0ae62f8b673305, niiri:cda674baaa255a631b19d42763c0930c, -, -, -)
-    entity(niiri:340ff54b0274dd2288512da30ba70b15,
+    wasDerivedFrom(niiri:9eb8c305928cd26af5d735f290a7ce8a, niiri:808fd4e2193f0ed5ab2626fc643077ca, -, -, -)
+    entity(niiri:11109932f0e2675cb40f05a3edc02ba0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:9b59dfd3cd6fe92f527a2d11dc8e5ad5',
+        prov:location = 'niiri:03754f6422c542b58050fa515c5326b7',
         prov:value = "24.5828113555908" %% xsd:float,
         nidm_equivalentZStatistic: = "4.18444689049798" %% xsd:float,
         nidm_pValueUncorrected: = "1.42930633414418e-05" %% xsd:float,
         nidm_pValueFWER: = "0.711939170732988" %% xsd:float,
         nidm_qValueFDR: = "0.04475687830922" %% xsd:float])
-    entity(niiri:9b59dfd3cd6fe92f527a2d11dc8e5ad5,
+    entity(niiri:03754f6422c542b58050fa515c5326b7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[66,-32,30]" %% xsd:string])
-    wasDerivedFrom(niiri:340ff54b0274dd2288512da30ba70b15, niiri:b9beda96f738803fb567cd0d0d5ac126, -, -, -)
-    entity(niiri:bfd29eeffd577f81b1028084dd3cafbb,
+    wasDerivedFrom(niiri:11109932f0e2675cb40f05a3edc02ba0, niiri:2667f28dbb2bce2c8e774ae24bc32c34, -, -, -)
+    entity(niiri:4fefff5985067f520ab89234bd477dd4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:afdc90796927d6b5b5d8e26a0c89d918',
+        prov:location = 'niiri:35dc6728bd9b0380bd0c34c5ef999f15',
         prov:value = "14.2693071365356" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27451594161643" %% xsd:float,
         nidm_pValueUncorrected: = "0.000529215834762176" %% xsd:float,
         nidm_pValueFWER: = "0.999999999209483" %% xsd:float,
         nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
-    entity(niiri:afdc90796927d6b5b5d8e26a0c89d918,
+    entity(niiri:35dc6728bd9b0380bd0c34c5ef999f15,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[60,-38,28]" %% xsd:string])
-    wasDerivedFrom(niiri:bfd29eeffd577f81b1028084dd3cafbb, niiri:b9beda96f738803fb567cd0d0d5ac126, -, -, -)
-    entity(niiri:3de1d3b3fd47f85802886f79af4dc678,
+    wasDerivedFrom(niiri:4fefff5985067f520ab89234bd477dd4, niiri:2667f28dbb2bce2c8e774ae24bc32c34, -, -, -)
+    entity(niiri:0a247f47177e119fa9edf6e9f6f98b5e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:533d4d268893416ecb4d1151faad2ef6',
+        prov:location = 'niiri:3717dcf5b4b7f3fadfa70b271f5a347b',
         prov:value = "23.3039436340332" %% xsd:float,
         nidm_equivalentZStatistic: = "4.09011898331566" %% xsd:float,
         nidm_pValueUncorrected: = "2.15575975488491e-05" %% xsd:float,
         nidm_pValueFWER: = "0.823947459995523" %% xsd:float,
         nidm_qValueFDR: = "0.0478656864369739" %% xsd:float])
-    entity(niiri:533d4d268893416ecb4d1151faad2ef6,
+    entity(niiri:3717dcf5b4b7f3fadfa70b271f5a347b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[28,30,52]" %% xsd:string])
-    wasDerivedFrom(niiri:3de1d3b3fd47f85802886f79af4dc678, niiri:24686319b3c7b6b6793dbf6e90029199, -, -, -)
-    entity(niiri:4c793b1434ab014669b8e4ce2cf2139b,
+    wasDerivedFrom(niiri:0a247f47177e119fa9edf6e9f6f98b5e, niiri:81153168c82f38e0344a3da5990713f4, -, -, -)
+    entity(niiri:07aa292e8e64264cf6b16262dd9b0461,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:f6d485f30b70a6db61c96e28aa7f2753',
+        prov:location = 'niiri:17d984ec4e21314566bdf4644fb07af0',
         prov:value = "22.6157932281494" %% xsd:float,
         nidm_equivalentZStatistic: = "4.03763886298215" %% xsd:float,
         nidm_pValueUncorrected: = "2.69959426782984e-05" %% xsd:float,
         nidm_pValueFWER: = "0.87538446987651" %% xsd:float,
         nidm_qValueFDR: = "0.0515719459796674" %% xsd:float])
-    entity(niiri:f6d485f30b70a6db61c96e28aa7f2753,
+    entity(niiri:17d984ec4e21314566bdf4644fb07af0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[-30,-34,6]" %% xsd:string])
-    wasDerivedFrom(niiri:4c793b1434ab014669b8e4ce2cf2139b, niiri:ef45eced4ec473fc374602efe1d44af2, -, -, -)
-    entity(niiri:f9a42b90df039166ca0e5fa02d3d604f,
+    wasDerivedFrom(niiri:07aa292e8e64264cf6b16262dd9b0461, niiri:51df67b679cd0aa1c10588b2540f80ff, -, -, -)
+    entity(niiri:c09425629406f190de8edebf54022f2d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:55a6eaf2f3b34f1854c5cc88fea7e153',
+        prov:location = 'niiri:cd4e978cbe4323a391c6fa96ba73890b',
         prov:value = "21.8558578491211" %% xsd:float,
         nidm_equivalentZStatistic: = "3.97819185113407" %% xsd:float,
         nidm_pValueUncorrected: = "3.47206660495925e-05" %% xsd:float,
         nidm_pValueFWER: = "0.921823721412592" %% xsd:float,
         nidm_qValueFDR: = "0.053734847831518" %% xsd:float])
-    entity(niiri:55a6eaf2f3b34f1854c5cc88fea7e153,
+    entity(niiri:cd4e978cbe4323a391c6fa96ba73890b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[-28,0,30]" %% xsd:string])
-    wasDerivedFrom(niiri:f9a42b90df039166ca0e5fa02d3d604f, niiri:1a8d727934cbec38f1fdcc84430d7857, -, -, -)
-    entity(niiri:de93eaf377bd0a9992922d03e47c7423,
+    wasDerivedFrom(niiri:c09425629406f190de8edebf54022f2d, niiri:c3859302a7f8a3aa876923fe5311fdeb, -, -, -)
+    entity(niiri:00455682ca694ef095f7439ab81ebd12,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:b0a8a5b4d1ad632e303792bb14434ab1',
+        prov:location = 'niiri:a61981cb739588894bbdc415c7c87afe',
         prov:value = "21.8296661376953" %% xsd:float,
         nidm_equivalentZStatistic: = "3.97611404363788" %% xsd:float,
         nidm_pValueUncorrected: = "3.50252708366527e-05" %% xsd:float,
         nidm_pValueFWER: = "0.923209894114283" %% xsd:float,
         nidm_qValueFDR: = "0.053734847831518" %% xsd:float])
-    entity(niiri:b0a8a5b4d1ad632e303792bb14434ab1,
+    entity(niiri:a61981cb739588894bbdc415c7c87afe,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[8,34,10]" %% xsd:string])
-    wasDerivedFrom(niiri:de93eaf377bd0a9992922d03e47c7423, niiri:0ea4cdb2fb21bb5f5f9588416f8a0986, -, -, -)
-    entity(niiri:e354a84565e5c296d9efa7317a911cfe,
+    wasDerivedFrom(niiri:00455682ca694ef095f7439ab81ebd12, niiri:a9683c02ec255a54e2147300ce75147c, -, -, -)
+    entity(niiri:5cc633c2d1685a757beeaecee1a48008,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:6cd3c9ec2c82b8b60104f15adb91982c',
+        prov:location = 'niiri:b7a12cc701147c2a30416bd9e767f926',
         prov:value = "21.7287845611572" %% xsd:float,
         nidm_equivalentZStatistic: = "3.96809263472704" %% xsd:float,
         nidm_pValueUncorrected: = "3.6225086553876e-05" %% xsd:float,
         nidm_pValueFWER: = "0.928411428313329" %% xsd:float,
         nidm_qValueFDR: = "0.0540587737624357" %% xsd:float])
-    entity(niiri:6cd3c9ec2c82b8b60104f15adb91982c,
+    entity(niiri:b7a12cc701147c2a30416bd9e767f926,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[46,-56,10]" %% xsd:string])
-    wasDerivedFrom(niiri:e354a84565e5c296d9efa7317a911cfe, niiri:e96a0a75cfbda16324a620530f8ac979, -, -, -)
-    entity(niiri:08e6714e83b23af817c91a38ea817a9d,
+    wasDerivedFrom(niiri:5cc633c2d1685a757beeaecee1a48008, niiri:4b0d5b1cbdc197add17ddae11c60a960, -, -, -)
+    entity(niiri:bc5fb74855b827b626fd1eebefaa6d4d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:18511209fae629ef4fc05e9115d24b3d',
+        prov:location = 'niiri:352d0e5787411f3cc15519e7582cf21f',
         prov:value = "14.2801656723022" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27570591680179" %% xsd:float,
         nidm_pValueUncorrected: = "0.000526991241768693" %% xsd:float,
         nidm_pValueFWER: = "0.999999999156251" %% xsd:float,
         nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
-    entity(niiri:18511209fae629ef4fc05e9115d24b3d,
+    entity(niiri:352d0e5787411f3cc15519e7582cf21f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[48,-48,16]" %% xsd:string])
-    wasDerivedFrom(niiri:08e6714e83b23af817c91a38ea817a9d, niiri:e96a0a75cfbda16324a620530f8ac979, -, -, -)
-    entity(niiri:27a4396719d910dc755a3ae8f5919b75,
+    wasDerivedFrom(niiri:bc5fb74855b827b626fd1eebefaa6d4d, niiri:4b0d5b1cbdc197add17ddae11c60a960, -, -, -)
+    entity(niiri:90dc79d65e7f32dfb01b08b18c3ce762,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:11308bc9db92e428a2f7e9a8d4420c7f',
+        prov:location = 'niiri:33a1d7fed96c259799c80dc81ed84ff7',
         prov:value = "21.4629364013672" %% xsd:float,
         nidm_equivalentZStatistic: = "3.9468129149843" %% xsd:float,
         nidm_pValueUncorrected: = "3.95991966499754e-05" %% xsd:float,
         nidm_pValueFWER: = "0.941069307565192" %% xsd:float,
         nidm_qValueFDR: = "0.0555984329583215" %% xsd:float])
-    entity(niiri:11308bc9db92e428a2f7e9a8d4420c7f,
+    entity(niiri:33a1d7fed96c259799c80dc81ed84ff7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[46,-62,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:27a4396719d910dc755a3ae8f5919b75, niiri:bc4b7adbe33f91a695fde03bf4b200ed, -, -, -)
-    entity(niiri:cc9face0d8fe5a7de8a150a20acca2d8,
+    wasDerivedFrom(niiri:90dc79d65e7f32dfb01b08b18c3ce762, niiri:074f24af2809bb5962437625180d87d8, -, -, -)
+    entity(niiri:865765b8e81628e180cd32d69ff2a873,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:73a9a071ca8380ed9df7a551dfd73dfa',
+        prov:location = 'niiri:572e00e92909efbb8dbfa749a8192c13',
         prov:value = "21.4269542694092" %% xsd:float,
         nidm_equivalentZStatistic: = "3.94391683979485" %% xsd:float,
         nidm_pValueUncorrected: = "4.00807329147268e-05" %% xsd:float,
         nidm_pValueFWER: = "0.942665676683549" %% xsd:float,
         nidm_qValueFDR: = "0.0555984329583215" %% xsd:float])
-    entity(niiri:73a9a071ca8380ed9df7a551dfd73dfa,
+    entity(niiri:572e00e92909efbb8dbfa749a8192c13,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[-8,-32,36]" %% xsd:string])
-    wasDerivedFrom(niiri:cc9face0d8fe5a7de8a150a20acca2d8, niiri:71a412f82e6ea8cb947b5be72c8efcff, -, -, -)
-    entity(niiri:5af15d290c54073ba4518037ca306358,
+    wasDerivedFrom(niiri:865765b8e81628e180cd32d69ff2a873, niiri:3950399d3cc373d8735fcf48ad86f542, -, -, -)
+    entity(niiri:016b2fb8ca4f729da187a0f0b71608cc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:924073fc7007784464acebdf52dfccca',
+        prov:location = 'niiri:98776a828aca5a643515928e94c4cdc1',
         prov:value = "20.0413494110107" %% xsd:float,
         nidm_equivalentZStatistic: = "3.82938429557992" %% xsd:float,
         nidm_pValueUncorrected: = "6.42321325474704e-05" %% xsd:float,
         nidm_pValueFWER: = "0.984364018223445" %% xsd:float,
         nidm_qValueFDR: = "0.0674959642175569" %% xsd:float])
-    entity(niiri:924073fc7007784464acebdf52dfccca,
+    entity(niiri:98776a828aca5a643515928e94c4cdc1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[-34,-84,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:5af15d290c54073ba4518037ca306358, niiri:93e18b25ba3aeb399e6fd41cb9dfca97, -, -, -)
-    entity(niiri:ea651b661b6bfe3969159c6f0ec70642,
+    wasDerivedFrom(niiri:016b2fb8ca4f729da187a0f0b71608cc, niiri:bab302ab1de7ceb32ee2a4553bab718d, -, -, -)
+    entity(niiri:ca802812c6d952e6eb53d6a2598748c3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:6150a0cc589ec407bbf5b278e34fe8c0',
+        prov:location = 'niiri:305b4d132dad573dd2e91152abf41d15',
         prov:value = "19.5813789367676" %% xsd:float,
         nidm_equivalentZStatistic: = "3.79000141974546" %% xsd:float,
         nidm_pValueUncorrected: = "7.53232118573255e-05" %% xsd:float,
         nidm_pValueFWER: = "0.991038394814884" %% xsd:float,
         nidm_qValueFDR: = "0.0718990170223714" %% xsd:float])
-    entity(niiri:6150a0cc589ec407bbf5b278e34fe8c0,
+    entity(niiri:305b4d132dad573dd2e91152abf41d15,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[-50,2,40]" %% xsd:string])
-    wasDerivedFrom(niiri:ea651b661b6bfe3969159c6f0ec70642, niiri:3d33e1d8e7da5c593e7ad094c154132a, -, -, -)
-    entity(niiri:8c7a07db4f3345bbb5e3dec281596f82,
+    wasDerivedFrom(niiri:ca802812c6d952e6eb53d6a2598748c3, niiri:14ab5f557514798d8218e39a2199e27a, -, -, -)
+    entity(niiri:2cd7edd94889650191f6f242b9a4c176,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:8801d1d1f53291499c55fe97c82abf06',
+        prov:location = 'niiri:0d995ab3826e8df7675b6f8b8f4c2673',
         prov:value = "16.7666301727295" %% xsd:float,
         nidm_equivalentZStatistic: = "3.53217184854778" %% xsd:float,
         nidm_pValueUncorrected: = "0.00020608070787731" %% xsd:float,
         nidm_pValueFWER: = "0.99996648470095" %% xsd:float,
         nidm_qValueFDR: = "0.0942608471449251" %% xsd:float])
-    entity(niiri:8801d1d1f53291499c55fe97c82abf06,
+    entity(niiri:0d995ab3826e8df7675b6f8b8f4c2673,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-52,-6,46]" %% xsd:string])
-    wasDerivedFrom(niiri:8c7a07db4f3345bbb5e3dec281596f82, niiri:3d33e1d8e7da5c593e7ad094c154132a, -, -, -)
-    entity(niiri:0d7a35acc2e01b8de53dab1cd6885030,
+    wasDerivedFrom(niiri:2cd7edd94889650191f6f242b9a4c176, niiri:14ab5f557514798d8218e39a2199e27a, -, -, -)
+    entity(niiri:390e65b5876e189721e8386b64e468ba,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:5ca0f95ce3edb5b98b519299dce96767',
+        prov:location = 'niiri:8e65f05088e65ca40cdab4f7b8c45feb',
         prov:value = "19.3040504455566" %% xsd:float,
         nidm_equivalentZStatistic: = "3.76590943131268" %% xsd:float,
         nidm_pValueUncorrected: = "8.2971971291701e-05" %% xsd:float,
         nidm_pValueFWER: = "0.993825462793153" %% xsd:float,
         nidm_qValueFDR: = "0.0737314974355366" %% xsd:float])
-    entity(niiri:5ca0f95ce3edb5b98b519299dce96767,
+    entity(niiri:8e65f05088e65ca40cdab4f7b8c45feb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[24,-46,32]" %% xsd:string])
-    wasDerivedFrom(niiri:0d7a35acc2e01b8de53dab1cd6885030, niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4, -, -, -)
-    entity(niiri:0ea3ba62f32a9ee428c5ea4b5cef35cb,
+    wasDerivedFrom(niiri:390e65b5876e189721e8386b64e468ba, niiri:bc603717c0c5d8a8779b8aa6c28564b3, -, -, -)
+    entity(niiri:613f7d1a72653a094215c0c7838598d6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:140460982182cf8d062436969406364b',
+        prov:location = 'niiri:261bf2d0efecb03152c6e1cdf2df18c0',
         prov:value = "19.1409015655518" %% xsd:float,
         nidm_equivalentZStatistic: = "3.75161143600874" %% xsd:float,
         nidm_pValueUncorrected: = "8.7850813353163e-05" %% xsd:float,
         nidm_pValueFWER: = "0.995110302012489" %% xsd:float,
         nidm_qValueFDR: = "0.0738147834753255" %% xsd:float])
-    entity(niiri:140460982182cf8d062436969406364b,
+    entity(niiri:261bf2d0efecb03152c6e1cdf2df18c0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[6,16,50]" %% xsd:string])
-    wasDerivedFrom(niiri:0ea3ba62f32a9ee428c5ea4b5cef35cb, niiri:7c11ea6d552baec493b21ecdef64c785, -, -, -)
-    entity(niiri:c9ac5ab5461375e94e4d7324a6bedc98,
+    wasDerivedFrom(niiri:613f7d1a72653a094215c0c7838598d6, niiri:106ee2638843f2793b5ac6735acad91e, -, -, -)
+    entity(niiri:dbe73b14c812ef0bb874edaf583e9d7c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:c7cab9ce4ae0697e1f4eb6ec314ebc4d',
+        prov:location = 'niiri:64529db73025d3ebe03ab8490a2c7588',
         prov:value = "19.098669052124" %% xsd:float,
         nidm_equivalentZStatistic: = "3.74789498829157" %% xsd:float,
         nidm_pValueUncorrected: = "8.91624398706714e-05" %% xsd:float,
         nidm_pValueFWER: = "0.995405100064856" %% xsd:float,
         nidm_qValueFDR: = "0.0738147834753255" %% xsd:float])
-    entity(niiri:c7cab9ce4ae0697e1f4eb6ec314ebc4d,
+    entity(niiri:64529db73025d3ebe03ab8490a2c7588,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[-4,-24,6]" %% xsd:string])
-    wasDerivedFrom(niiri:c9ac5ab5461375e94e4d7324a6bedc98, niiri:56fa7a2fed0946da7dd3299da637b245, -, -, -)
-    entity(niiri:d787aaae02f2d49ff3e8f709b3e0ffe2,
+    wasDerivedFrom(niiri:dbe73b14c812ef0bb874edaf583e9d7c, niiri:01c1ab06b5a4997e0980bcddb0f69696, -, -, -)
+    entity(niiri:d74cbd45e77a6bd61d201389470b3f9d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:27e6b2cc327f93c6462c9e5686d7c493',
+        prov:location = 'niiri:2a23dfb2262a16b99ed1460c9726d32d',
         prov:value = "19.0145893096924" %% xsd:float,
         nidm_equivalentZStatistic: = "3.7404771295496" %% xsd:float,
         nidm_pValueUncorrected: = "9.1835629583259e-05" %% xsd:float,
         nidm_pValueFWER: = "0.995949293325196" %% xsd:float,
         nidm_qValueFDR: = "0.0741915113542509" %% xsd:float])
-    entity(niiri:27e6b2cc327f93c6462c9e5686d7c493,
+    entity(niiri:2a23dfb2262a16b99ed1460c9726d32d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[-4,0,54]" %% xsd:string])
-    wasDerivedFrom(niiri:d787aaae02f2d49ff3e8f709b3e0ffe2, niiri:c74b1ddb4c9a5395bf0b4d826708ce5a, -, -, -)
-    entity(niiri:9db9efc1edd783d8cbdaf22ba831fdaf,
+    wasDerivedFrom(niiri:d74cbd45e77a6bd61d201389470b3f9d, niiri:8f249184eec9591adc7a3fc1c7e37936, -, -, -)
+    entity(niiri:4bb899cd9f06bf6ba2fefa26066f1718,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:1c5529d2dc429e1471abb89100522dbc',
+        prov:location = 'niiri:84e6c234c35fdc2fa131ca05716bd905',
         prov:value = "18.8265838623047" %% xsd:float,
         nidm_equivalentZStatistic: = "3.72379883766124" %% xsd:float,
         nidm_pValueUncorrected: = "9.81236582245915e-05" %% xsd:float,
         nidm_pValueFWER: = "0.996978299202392" %% xsd:float,
         nidm_qValueFDR: = "0.0777669728451003" %% xsd:float])
-    entity(niiri:1c5529d2dc429e1471abb89100522dbc,
+    entity(niiri:84e6c234c35fdc2fa131ca05716bd905,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[42,-28,30]" %% xsd:string])
-    wasDerivedFrom(niiri:9db9efc1edd783d8cbdaf22ba831fdaf, niiri:10bec2b1f4f72ee8eedb38e17e1faab3, -, -, -)
-    entity(niiri:a25f9de80ac191e47f1660393e75473f,
+    wasDerivedFrom(niiri:4bb899cd9f06bf6ba2fefa26066f1718, niiri:c7ba1e0ca7a63ee914a7fa6cddbda281, -, -, -)
+    entity(niiri:2fcf4f5e0a9409e59f9b3a198af722a2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:4fa2fadc00e657efdd63b3a39309c84a',
+        prov:location = 'niiri:dfeeafe9412e26a98688ac2eb5eedc76',
         prov:value = "18.5199432373047" %% xsd:float,
         nidm_equivalentZStatistic: = "3.69631988620818" %% xsd:float,
         nidm_pValueUncorrected: = "0.000109373660980738" %% xsd:float,
         nidm_pValueFWER: = "0.998191254166604" %% xsd:float,
         nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
-    entity(niiri:4fa2fadc00e657efdd63b3a39309c84a,
+    entity(niiri:dfeeafe9412e26a98688ac2eb5eedc76,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[52,-12,44]" %% xsd:string])
-    wasDerivedFrom(niiri:a25f9de80ac191e47f1660393e75473f, niiri:f725bd9a5656b07d43f8eba6c3be2858, -, -, -)
-    entity(niiri:f484fb8e47371d4dd3f5ee9736deeca9,
+    wasDerivedFrom(niiri:2fcf4f5e0a9409e59f9b3a198af722a2, niiri:91987e35b1d8c15af66e3327a6e4b602, -, -, -)
+    entity(niiri:01dc6fc72b88495c5e6c08fc0cc0bc35,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:33fd7ada9f41a7443fa610a81c719475',
+        prov:location = 'niiri:a785670f070730f0b5dad30427a1e8f7',
         prov:value = "18.516544342041" %% xsd:float,
         nidm_equivalentZStatistic: = "3.69601335434539" %% xsd:float,
         nidm_pValueUncorrected: = "0.000109505728679404" %% xsd:float,
         nidm_pValueFWER: = "0.998201975106935" %% xsd:float,
         nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
-    entity(niiri:33fd7ada9f41a7443fa610a81c719475,
+    entity(niiri:a785670f070730f0b5dad30427a1e8f7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[-40,-28,30]" %% xsd:string])
-    wasDerivedFrom(niiri:f484fb8e47371d4dd3f5ee9736deeca9, niiri:83f438c66d3cf32344b7255377c7499d, -, -, -)
-    entity(niiri:8582459cfedf8c404f54867fe9956065,
+    wasDerivedFrom(niiri:01dc6fc72b88495c5e6c08fc0cc0bc35, niiri:c09f3990ca4bd168f93fa27a56eeb56c, -, -, -)
+    entity(niiri:cf74bac84d8f51cb7fb8a579dd4b736b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:7574fcc563cda88fe39a2f517cefd40a',
+        prov:location = 'niiri:62e6d759392d4c5a22e393f530aba130',
         prov:value = "18.4609222412109" %% xsd:float,
         nidm_equivalentZStatistic: = "3.69099090519778" %% xsd:float,
         nidm_pValueUncorrected: = "0.000111691062804176" %% xsd:float,
         nidm_pValueFWER: = "0.998370011058266" %% xsd:float,
         nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
-    entity(niiri:7574fcc563cda88fe39a2f517cefd40a,
+    entity(niiri:62e6d759392d4c5a22e393f530aba130,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[32,22,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:8582459cfedf8c404f54867fe9956065, niiri:cc9360b64b21e281dcfb851074b574b6, -, -, -)
-    entity(niiri:ba6bc791d8adb783ff5181c1594590b6,
+    wasDerivedFrom(niiri:cf74bac84d8f51cb7fb8a579dd4b736b, niiri:4f39525fd234b098e759c0ffc971fd5b, -, -, -)
+    entity(niiri:39ca307d31c5892250f913783b4db62c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:2398781ef2e524c6173a32e0bb244b23',
+        prov:location = 'niiri:d6626578cce8299da3656ac371463365',
         prov:value = "17.9312534332275" %% xsd:float,
         nidm_equivalentZStatistic: = "3.64257521175179" %% xsd:float,
         nidm_pValueUncorrected: = "0.00013496203699781" %% xsd:float,
         nidm_pValueFWER: = "0.99941063068466" %% xsd:float,
         nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
-    entity(niiri:2398781ef2e524c6173a32e0bb244b23,
+    entity(niiri:d6626578cce8299da3656ac371463365,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[64,-4,10]" %% xsd:string])
-    wasDerivedFrom(niiri:ba6bc791d8adb783ff5181c1594590b6, niiri:4728de35ba855317aeef4e0a7b91801c, -, -, -)
-    entity(niiri:74387d11b1e18aa01c68936614d323d2,
+    wasDerivedFrom(niiri:39ca307d31c5892250f913783b4db62c, niiri:66eca61ada8ceb626c8ffd13d3efa1cc, -, -, -)
+    entity(niiri:1f3bee85e377a2130e061374ce19f6ab,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0033" %% xsd:string,
-        prov:location = 'niiri:719551878f20f48ff5a59d8a7a9c8229',
+        prov:location = 'niiri:a706a639a6105ecabcfe5a088abd9d25',
         prov:value = "17.8439044952393" %% xsd:float,
         nidm_equivalentZStatistic: = "3.63448648232359" %% xsd:float,
         nidm_pValueUncorrected: = "0.000139267429951739" %% xsd:float,
         nidm_pValueFWER: = "0.999509275806277" %% xsd:float,
         nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
-    entity(niiri:719551878f20f48ff5a59d8a7a9c8229,
+    entity(niiri:a706a639a6105ecabcfe5a088abd9d25,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0033" %% xsd:string,
         nidm_coordinateVector: = "[-22,-72,34]" %% xsd:string])
-    wasDerivedFrom(niiri:74387d11b1e18aa01c68936614d323d2, niiri:f435923c3d5e3915c4aa5159c5bbc4a0, -, -, -)
-    entity(niiri:f515406c4386dbba20e09dfc286cad01,
+    wasDerivedFrom(niiri:1f3bee85e377a2130e061374ce19f6ab, niiri:5cf9402b2b494a87640a66aec1a6fdaf, -, -, -)
+    entity(niiri:7f7625524d177fe4781c28633ad04fb0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0034" %% xsd:string,
-        prov:location = 'niiri:53dfe63ffbecb2b80528e9f6b0729406',
+        prov:location = 'niiri:dde299cfdeb368ced964fe7a498cc703',
         prov:value = "17.552827835083" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60731294050443" %% xsd:float,
         nidm_pValueUncorrected: = "0.000154692216466135" %% xsd:float,
         nidm_pValueFWER: = "0.999742486133075" %% xsd:float,
         nidm_qValueFDR: = "0.0862331427095326" %% xsd:float])
-    entity(niiri:53dfe63ffbecb2b80528e9f6b0729406,
+    entity(niiri:dde299cfdeb368ced964fe7a498cc703,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0034" %% xsd:string,
         nidm_coordinateVector: = "[-6,-44,40]" %% xsd:string])
-    wasDerivedFrom(niiri:f515406c4386dbba20e09dfc286cad01, niiri:b39b9cce118cf858149cdd53ebcda7bd, -, -, -)
-    entity(niiri:1b3fb965c01205049ccc6b0cbe41747e,
+    wasDerivedFrom(niiri:7f7625524d177fe4781c28633ad04fb0, niiri:1cd1f14fea72d133db88783e1b907b7f, -, -, -)
+    entity(niiri:ea8dfff70bef204151c3aa37de438b0f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0035" %% xsd:string,
-        prov:location = 'niiri:f27eb00800ba18fb1542d4dada966f33',
+        prov:location = 'niiri:d703077133d717f4a9d9411fe4c791a6',
         prov:value = "17.2906818389893" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58254613965863" %% xsd:float,
         nidm_pValueUncorrected: = "0.000170130746602659" %% xsd:float,
         nidm_pValueFWER: = "0.99986271355264" %% xsd:float,
         nidm_qValueFDR: = "0.0895859395735557" %% xsd:float])
-    entity(niiri:f27eb00800ba18fb1542d4dada966f33,
+    entity(niiri:d703077133d717f4a9d9411fe4c791a6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0035" %% xsd:string,
         nidm_coordinateVector: = "[-34,-38,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:1b3fb965c01205049ccc6b0cbe41747e, niiri:97e0a9bea1289493ad46d8a4c2b75485, -, -, -)
-    entity(niiri:1db1dcb7ac31be92db03ea6f49276709,
+    wasDerivedFrom(niiri:ea8dfff70bef204151c3aa37de438b0f, niiri:c3340fa012c626e62e86cdb279a4e883, -, -, -)
+    entity(niiri:1f8b76bc5a6e0e44d52dc38f77dfb573,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0036" %% xsd:string,
-        prov:location = 'niiri:c2aa93c26b662b0231d80c11fa4a9ef6',
+        prov:location = 'niiri:52d6deef40815f931bff80e4a0c0e30e',
         prov:value = "17.1612319946289" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57021115022413" %% xsd:float,
         nidm_pValueUncorrected: = "0.000178346794309836" %% xsd:float,
         nidm_pValueFWER: = "0.999901168620001" %% xsd:float,
         nidm_qValueFDR: = "0.0903823255084056" %% xsd:float])
-    entity(niiri:c2aa93c26b662b0231d80c11fa4a9ef6,
+    entity(niiri:52d6deef40815f931bff80e4a0c0e30e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0036" %% xsd:string,
         nidm_coordinateVector: = "[-46,-16,20]" %% xsd:string])
-    wasDerivedFrom(niiri:1db1dcb7ac31be92db03ea6f49276709, niiri:e9e94038b5b1dbcf9f8a4d4208e34928, -, -, -)
-    entity(niiri:e52b244ba436c001a08d0e1a0f3fc101,
+    wasDerivedFrom(niiri:1f8b76bc5a6e0e44d52dc38f77dfb573, niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd, -, -, -)
+    entity(niiri:ebb56262d90fa761f5c469bbcf6709b0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0037" %% xsd:string,
-        prov:location = 'niiri:8379336830251a7cbd5eb4a5b2b7e6c0',
+        prov:location = 'niiri:bd5feebad73f603c2c5027f05c096a98',
         prov:value = "17.0075950622559" %% xsd:float,
         nidm_equivalentZStatistic: = "3.55547987606237" %% xsd:float,
         nidm_pValueUncorrected: = "0.000188644912021529" %% xsd:float,
         nidm_pValueFWER: = "0.999934173907998" %% xsd:float,
         nidm_qValueFDR: = "0.0920555845860752" %% xsd:float])
-    entity(niiri:8379336830251a7cbd5eb4a5b2b7e6c0,
+    entity(niiri:bd5feebad73f603c2c5027f05c096a98,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0037" %% xsd:string,
         nidm_coordinateVector: = "[24,32,2]" %% xsd:string])
-    wasDerivedFrom(niiri:e52b244ba436c001a08d0e1a0f3fc101, niiri:0857328371989db393f2fc4d7d5346bd, -, -, -)
-    entity(niiri:58c50def173085b4eacf834a8b4704ff,
+    wasDerivedFrom(niiri:ebb56262d90fa761f5c469bbcf6709b0, niiri:8b25738f634743abd67e5fd856e90f74, -, -, -)
+    entity(niiri:66c1ec432c1811911fdd6cd83f434d1b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0038" %% xsd:string,
-        prov:location = 'niiri:0b671ab6136c76ed072d17a2c0f74a10',
+        prov:location = 'niiri:e5c4443633b94c1fa86927c7c92b220e',
         prov:value = "16.5308303833008" %% xsd:float,
         nidm_equivalentZStatistic: = "3.50911812032442" %% xsd:float,
         nidm_pValueUncorrected: = "0.000224797592033421" %% xsd:float,
         nidm_pValueFWER: = "0.999983487413756" %% xsd:float,
         nidm_qValueFDR: = "0.0959555780965771" %% xsd:float])
-    entity(niiri:0b671ab6136c76ed072d17a2c0f74a10,
+    entity(niiri:e5c4443633b94c1fa86927c7c92b220e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0038" %% xsd:string,
         nidm_coordinateVector: = "[-26,-90,16]" %% xsd:string])
-    wasDerivedFrom(niiri:58c50def173085b4eacf834a8b4704ff, niiri:7e693a4a3e70d39b916aa2a95911a3c8, -, -, -)
-    entity(niiri:29090a193cda0ed62625301b681522a5,
+    wasDerivedFrom(niiri:66c1ec432c1811911fdd6cd83f434d1b, niiri:1c59a22b32098831723dc21703615fd1, -, -, -)
+    entity(niiri:5f67ac778b6bca3e423969c609840ac8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0039" %% xsd:string,
-        prov:location = 'niiri:baefd951dc2ab5a50c39cd840ad1f17e',
+        prov:location = 'niiri:a555880be249de2c84bc634ee280dbd7',
         prov:value = "16.5225524902344" %% xsd:float,
         nidm_equivalentZStatistic: = "3.50830432871627" %% xsd:float,
         nidm_pValueUncorrected: = "0.0002254864217901" %% xsd:float,
         nidm_pValueFWER: = "0.999983907066973" %% xsd:float,
         nidm_qValueFDR: = "0.0959555780965771" %% xsd:float])
-    entity(niiri:baefd951dc2ab5a50c39cd840ad1f17e,
+    entity(niiri:a555880be249de2c84bc634ee280dbd7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0039" %% xsd:string,
         nidm_coordinateVector: = "[-28,-4,16]" %% xsd:string])
-    wasDerivedFrom(niiri:29090a193cda0ed62625301b681522a5, niiri:d8dc459a110e4898c23019ee42154713, -, -, -)
-    entity(niiri:b7d5268eabb9490b67684ed7ceb301c9,
+    wasDerivedFrom(niiri:5f67ac778b6bca3e423969c609840ac8, niiri:139b6ecf5fdad735a51b4385a24aded9, -, -, -)
+    entity(niiri:5acb0f78fc88ddc60b2b62de835c1f34,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0040" %% xsd:string,
-        prov:location = 'niiri:9375ad74a7d7acce22a9a6dc5fa1d47d',
+        prov:location = 'niiri:eb3468c7ba505890d9c51ddfff00f74f',
         prov:value = "16.1374092102051" %% xsd:float,
         nidm_equivalentZStatistic: = "3.47009871338807" %% xsd:float,
         nidm_pValueUncorrected: = "0.00026013355917065" %% xsd:float,
         nidm_pValueFWER: = "0.999995475747835" %% xsd:float,
         nidm_qValueFDR: = "0.101886915515055" %% xsd:float])
-    entity(niiri:9375ad74a7d7acce22a9a6dc5fa1d47d,
+    entity(niiri:eb3468c7ba505890d9c51ddfff00f74f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0040" %% xsd:string,
         nidm_coordinateVector: = "[12,60,20]" %% xsd:string])
-    wasDerivedFrom(niiri:b7d5268eabb9490b67684ed7ceb301c9, niiri:cd795f902776ad9170549b8fde8996ba, -, -, -)
-    entity(niiri:9db92d56d94d661dd685256f317dbe48,
+    wasDerivedFrom(niiri:5acb0f78fc88ddc60b2b62de835c1f34, niiri:e6a138032615b9872d9261e35d2455f4, -, -, -)
+    entity(niiri:0da938bd32e898d2174c988f1eaf4581,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0041" %% xsd:string,
-        prov:location = 'niiri:e35f3a6956a4d9893c3760d30968fce5',
+        prov:location = 'niiri:4a0acfe4d96a811a5bbd2fea220ee9f8',
         prov:value = "15.9136981964111" %% xsd:float,
         nidm_equivalentZStatistic: = "3.44759277757755" %% xsd:float,
         nidm_pValueUncorrected: = "0.000282803055741021" %% xsd:float,
         nidm_pValueFWER: = "0.999997977474125" %% xsd:float,
         nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
-    entity(niiri:e35f3a6956a4d9893c3760d30968fce5,
+    entity(niiri:4a0acfe4d96a811a5bbd2fea220ee9f8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0041" %% xsd:string,
         nidm_coordinateVector: = "[4,-84,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:9db92d56d94d661dd685256f317dbe48, niiri:ed1df7c28737883d905ca0a8f2093992, -, -, -)
-    entity(niiri:95049e965261ae17e6141f440c65aade,
+    wasDerivedFrom(niiri:0da938bd32e898d2174c988f1eaf4581, niiri:37bc5cb5a158a9f86c496a5d1935903c, -, -, -)
+    entity(niiri:8c6a5d705c064da10637a02bbcea89bb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0042" %% xsd:string,
-        prov:location = 'niiri:8907a4706c52ef0acbd6db140d02de82',
+        prov:location = 'niiri:a7922d8059c11028e4ec965953a381f4',
         prov:value = "15.8536109924316" %% xsd:float,
         nidm_equivalentZStatistic: = "3.44150764421068" %% xsd:float,
         nidm_pValueUncorrected: = "0.000289241063091916" %% xsd:float,
         nidm_pValueFWER: = "0.999998385530387" %% xsd:float,
         nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
-    entity(niiri:8907a4706c52ef0acbd6db140d02de82,
+    entity(niiri:a7922d8059c11028e4ec965953a381f4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0042" %% xsd:string,
         nidm_coordinateVector: = "[62,-18,22]" %% xsd:string])
-    wasDerivedFrom(niiri:95049e965261ae17e6141f440c65aade, niiri:ca7bfed8d8dbca676ba25fca93d29e2c, -, -, -)
-    entity(niiri:bc2dfd54c7c011e3626f64ebd840c082,
+    wasDerivedFrom(niiri:8c6a5d705c064da10637a02bbcea89bb, niiri:f86c9bb022fe2e7bb4f2a1d963869d32, -, -, -)
+    entity(niiri:cf7dcc23115c0b40b60445223ba951c9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0043" %% xsd:string,
-        prov:location = 'niiri:8d0fe36db64dfbb57c50be778e56fc0b',
+        prov:location = 'niiri:f42b18360ea8f8af980f3d406996a6b7',
         prov:value = "15.8288412094116" %% xsd:float,
         nidm_equivalentZStatistic: = "3.43899416081302" %% xsd:float,
         nidm_pValueUncorrected: = "0.000291939913913408" %% xsd:float,
         nidm_pValueFWER: = "0.999998530446399" %% xsd:float,
         nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
-    entity(niiri:8d0fe36db64dfbb57c50be778e56fc0b,
+    entity(niiri:f42b18360ea8f8af980f3d406996a6b7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0043" %% xsd:string,
         nidm_coordinateVector: = "[28,-58,44]" %% xsd:string])
-    wasDerivedFrom(niiri:bc2dfd54c7c011e3626f64ebd840c082, niiri:1dcd9b5514190f867e3e9b0b57227395, -, -, -)
-    entity(niiri:b861ffa726f69dca943d1bc1e39e3f21,
+    wasDerivedFrom(niiri:cf7dcc23115c0b40b60445223ba951c9, niiri:cecab36bcbd915f7841bff34cd7f59a6, -, -, -)
+    entity(niiri:c7e7aa913113f6519557c66a5087a3a8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0044" %% xsd:string,
-        prov:location = 'niiri:358c40d8401882be55ffa3aa51e8c703',
+        prov:location = 'niiri:b8359b6165a7f498d646c290e8cd1c6c',
         prov:value = "15.7273988723755" %% xsd:float,
         nidm_equivalentZStatistic: = "3.42866974555038" %% xsd:float,
         nidm_pValueUncorrected: = "0.000303273553249328" %% xsd:float,
         nidm_pValueFWER: = "0.999999007347173" %% xsd:float,
         nidm_qValueFDR: = "0.106558197028572" %% xsd:float])
-    entity(niiri:358c40d8401882be55ffa3aa51e8c703,
+    entity(niiri:b8359b6165a7f498d646c290e8cd1c6c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0044" %% xsd:string,
         nidm_coordinateVector: = "[38,44,0]" %% xsd:string])
-    wasDerivedFrom(niiri:b861ffa726f69dca943d1bc1e39e3f21, niiri:79097d11179e49abc9f2bdf5ba7bb932, -, -, -)
-    entity(niiri:48b5c01001fb7600fbd4531a0e1761c4,
+    wasDerivedFrom(niiri:c7e7aa913113f6519557c66a5087a3a8, niiri:752ff8a0ff1912e3b3a3cc0b0af92bac, -, -, -)
+    entity(niiri:84d2dd552da32536ba619bf257b99a8e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0045" %% xsd:string,
-        prov:location = 'niiri:ae647fef7b776cfa997ad53eb4b2fc5b',
+        prov:location = 'niiri:a8431b89c9e7b5310335b9441226ea8e',
         prov:value = "15.4726600646973" %% xsd:float,
         nidm_equivalentZStatistic: = "3.40252319694713" %% xsd:float,
         nidm_pValueUncorrected: = "0.000333833435672726" %% xsd:float,
         nidm_pValueFWER: = "0.999999648429928" %% xsd:float,
         nidm_qValueFDR: = "0.109105594368073" %% xsd:float])
-    entity(niiri:ae647fef7b776cfa997ad53eb4b2fc5b,
+    entity(niiri:a8431b89c9e7b5310335b9441226ea8e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0045" %% xsd:string,
         nidm_coordinateVector: = "[40,-6,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:48b5c01001fb7600fbd4531a0e1761c4, niiri:d339d6251d3c159dbe2427fd1bcc1fc1, -, -, -)
-    entity(niiri:c46952610583f569f9152387a8bc54d9,
+    wasDerivedFrom(niiri:84d2dd552da32536ba619bf257b99a8e, niiri:bbfdc94758422f4cdfa2d461f26c652c, -, -, -)
+    entity(niiri:ac77b7c2f4ff41e88896e4ba87eadac1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0046" %% xsd:string,
-        prov:location = 'niiri:cd6aeb3993ad5aeb4e69f7fde5b6d7dc',
+        prov:location = 'niiri:c99f7fc58da7232a1f42538844fca3ae',
         prov:value = "15.3332357406616" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38807697766079" %% xsd:float,
         nidm_pValueUncorrected: = "0.00035192253822891" %% xsd:float,
         nidm_pValueFWER: = "0.999999807374102" %% xsd:float,
         nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
-    entity(niiri:cd6aeb3993ad5aeb4e69f7fde5b6d7dc,
+    entity(niiri:c99f7fc58da7232a1f42538844fca3ae,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0046" %% xsd:string,
         nidm_coordinateVector: = "[32,14,58]" %% xsd:string])
-    wasDerivedFrom(niiri:c46952610583f569f9152387a8bc54d9, niiri:b0978b4f683201d3539ace75681c8b65, -, -, -)
-    entity(niiri:549a9bbee50f3775d812947136680afd,
+    wasDerivedFrom(niiri:ac77b7c2f4ff41e88896e4ba87eadac1, niiri:412f44bb99fe0b4ac5111c8bb0d6824f, -, -, -)
+    entity(niiri:fd0d7457e6ffb07f08eca126631606af,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0047" %% xsd:string,
-        prov:location = 'niiri:eb0736b11222caa828e4419e72562692',
+        prov:location = 'niiri:d5fba9940a2400106183302f6016bc4b',
         prov:value = "15.3172578811646" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38641524500992" %% xsd:float,
         nidm_pValueUncorrected: = "0.000354060730342054" %% xsd:float,
         nidm_pValueFWER: = "0.99999982049151" %% xsd:float,
         nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
-    entity(niiri:eb0736b11222caa828e4419e72562692,
+    entity(niiri:d5fba9940a2400106183302f6016bc4b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0047" %% xsd:string,
         nidm_coordinateVector: = "[4,-86,4]" %% xsd:string])
-    wasDerivedFrom(niiri:549a9bbee50f3775d812947136680afd, niiri:133c074788eed1fa9d50d9e4608e3c1c, -, -, -)
-    entity(niiri:a70159564d5e15398a8e6af937070b21,
+    wasDerivedFrom(niiri:fd0d7457e6ffb07f08eca126631606af, niiri:ae1cd8d0dfca9341507b66eafba6459d, -, -, -)
+    entity(niiri:49269ead5464f020f20ecbdb76e9e6fa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0048" %% xsd:string,
-        prov:location = 'niiri:0cd5c4445b3ca0198be2f8b0ac1c5ff7',
+        prov:location = 'niiri:de463eb97f5bdebf8c7c86e1b3c0390b',
         prov:value = "15.3137311935425" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38604828864924" %% xsd:float,
         nidm_pValueUncorrected: = "0.000354534526388783" %% xsd:float,
         nidm_pValueFWER: = "0.999999823272138" %% xsd:float,
         nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
-    entity(niiri:0cd5c4445b3ca0198be2f8b0ac1c5ff7,
+    entity(niiri:de463eb97f5bdebf8c7c86e1b3c0390b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0048" %% xsd:string,
         nidm_coordinateVector: = "[62,-36,46]" %% xsd:string])
-    wasDerivedFrom(niiri:a70159564d5e15398a8e6af937070b21, niiri:93bdd51f373f8659382785eb36932971, -, -, -)
-    entity(niiri:d7e71a37d659eb3e8ffc416baa8d822a,
+    wasDerivedFrom(niiri:49269ead5464f020f20ecbdb76e9e6fa, niiri:089292d98902368bd347bcdfa162cfda, -, -, -)
+    entity(niiri:7e757cfd5d9ab4dc7b7ed7c707af0b92,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0049" %% xsd:string,
-        prov:location = 'niiri:2e67727cc0cfd1e78600ff3d8e948bb7',
+        prov:location = 'niiri:f64c41b60e15a328c7edf5b31cc35bb6',
         prov:value = "15.1916456222534" %% xsd:float,
         nidm_equivalentZStatistic: = "3.37330635701462" %% xsd:float,
         nidm_pValueUncorrected: = "0.000371356333789152" %% xsd:float,
         nidm_pValueFWER: = "0.999999898084819" %% xsd:float,
         nidm_qValueFDR: = "0.113182641774622" %% xsd:float])
-    entity(niiri:2e67727cc0cfd1e78600ff3d8e948bb7,
+    entity(niiri:f64c41b60e15a328c7edf5b31cc35bb6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0049" %% xsd:string,
         nidm_coordinateVector: = "[-24,18,58]" %% xsd:string])
-    wasDerivedFrom(niiri:d7e71a37d659eb3e8ffc416baa8d822a, niiri:522536a75466fe7c0e757947afe21547, -, -, -)
-    entity(niiri:03f8d483a6d2c4d5e2df0d2834d90bc1,
+    wasDerivedFrom(niiri:7e757cfd5d9ab4dc7b7ed7c707af0b92, niiri:716ffa34870ad39bf06d8e49c18b9bce, -, -, -)
+    entity(niiri:1187cc9f9751060cd5bdbcc8bc4b20ce,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0050" %% xsd:string,
-        prov:location = 'niiri:017fc7f20be266bd229d46d23c92c88e',
+        prov:location = 'niiri:fe5b4275099b74097635eb9f7b4bc414',
         prov:value = "15.0888338088989" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36251708484568" %% xsd:float,
         nidm_pValueUncorrected: = "0.000386176732959709" %% xsd:float,
         nidm_pValueFWER: = "0.999999936876428" %% xsd:float,
         nidm_qValueFDR: = "0.114724188214818" %% xsd:float])
-    entity(niiri:017fc7f20be266bd229d46d23c92c88e,
+    entity(niiri:fe5b4275099b74097635eb9f7b4bc414,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0050" %% xsd:string,
         nidm_coordinateVector: = "[8,-22,-44]" %% xsd:string])
-    wasDerivedFrom(niiri:03f8d483a6d2c4d5e2df0d2834d90bc1, niiri:acdb22704e8e3566aa17ca0ccdff7a03, -, -, -)
-    entity(niiri:7065d45e419e04080dbcbe72642fe102,
+    wasDerivedFrom(niiri:1187cc9f9751060cd5bdbcc8bc4b20ce, niiri:8c7ca240ed7a4d85316011dd6f1768ff, -, -, -)
+    entity(niiri:aa80010f717675a3a90dd7af1d9b1867,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0051" %% xsd:string,
-        prov:location = 'niiri:64d776bee75666af4e2b1252a3fd0002',
+        prov:location = 'niiri:8a342a7e8ab4849998a118155ae4e602',
         prov:value = "14.8200588226318" %% xsd:float,
         nidm_equivalentZStatistic: = "3.33405240591422" %% xsd:float,
         nidm_pValueUncorrected: = "0.000427952650791097" %% xsd:float,
         nidm_pValueFWER: = "0.999999983180231" %% xsd:float,
         nidm_qValueFDR: = "0.119307804764224" %% xsd:float])
-    entity(niiri:64d776bee75666af4e2b1252a3fd0002,
+    entity(niiri:8a342a7e8ab4849998a118155ae4e602,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0051" %% xsd:string,
         nidm_coordinateVector: = "[38,34,22]" %% xsd:string])
-    wasDerivedFrom(niiri:7065d45e419e04080dbcbe72642fe102, niiri:e1cde03f80af40c7004f16340827c9a6, -, -, -)
-    entity(niiri:f232f46f47a241ff82eee6a194ff86ad,
+    wasDerivedFrom(niiri:aa80010f717675a3a90dd7af1d9b1867, niiri:08593ccb1d9e49118b073d271565bd78, -, -, -)
+    entity(niiri:ba5d10a86acf3f4093c769c8fa361c7c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0052" %% xsd:string,
-        prov:location = 'niiri:b744cd533ab253d9b8023ced422dcd4e',
+        prov:location = 'niiri:efbdced299f9a874e778dd97925cd80e',
         prov:value = "14.696608543396" %% xsd:float,
         nidm_equivalentZStatistic: = "3.32085065286489" %% xsd:float,
         nidm_pValueUncorrected: = "0.000448717729613968" %% xsd:float,
         nidm_pValueFWER: = "0.9999999911592" %% xsd:float,
         nidm_qValueFDR: = "0.121223400645327" %% xsd:float])
-    entity(niiri:b744cd533ab253d9b8023ced422dcd4e,
+    entity(niiri:efbdced299f9a874e778dd97925cd80e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0052" %% xsd:string,
         nidm_coordinateVector: = "[0,-26,-28]" %% xsd:string])
-    wasDerivedFrom(niiri:f232f46f47a241ff82eee6a194ff86ad, niiri:1a861a102938105fb0e599c28c89f0df, -, -, -)
-    entity(niiri:d07297142ea27f1aadd2a2d0fc18eaa5,
+    wasDerivedFrom(niiri:ba5d10a86acf3f4093c769c8fa361c7c, niiri:b52f4fded36d906e3611187b1ea82271, -, -, -)
+    entity(niiri:10055d39115bd79bb71ae44a1b641f14,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0053" %% xsd:string,
-        prov:location = 'niiri:3df6f0cc55b55ccf745b4ed025159201',
+        prov:location = 'niiri:f1ba673212538f0ac2d79c06bd68cf16',
         prov:value = "14.2414035797119" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27145497586776" %% xsd:float,
         nidm_pValueUncorrected: = "0.00053497811978398" %% xsd:float,
         nidm_pValueFWER: = "0.99999999933201" %% xsd:float,
         nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
-    entity(niiri:3df6f0cc55b55ccf745b4ed025159201,
+    entity(niiri:f1ba673212538f0ac2d79c06bd68cf16,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0053" %% xsd:string,
         nidm_coordinateVector: = "[40,-50,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:d07297142ea27f1aadd2a2d0fc18eaa5, niiri:28c829a636fe7679be2b8fe3fc083d99, -, -, -)
-    entity(niiri:04eb8dd4e9ab8ac46c751092d04da10d,
+    wasDerivedFrom(niiri:10055d39115bd79bb71ae44a1b641f14, niiri:900eebea134685a11022813f19903499, -, -, -)
+    entity(niiri:024cfe8a8af184572999a9d180792536,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0054" %% xsd:string,
-        prov:location = 'niiri:ff9d4a014bd4e0dc8a92264c7b200ed9',
+        prov:location = 'niiri:8bd27ef17ea505784747393676c66e61',
         prov:value = "14.0012445449829" %% xsd:float,
         nidm_equivalentZStatistic: = "3.24492687341108" %% xsd:float,
         nidm_pValueUncorrected: = "0.000587403942481801" %% xsd:float,
         nidm_pValueFWER: = "0.999999999852106" %% xsd:float,
         nidm_qValueFDR: = "0.131447065854217" %% xsd:float])
-    entity(niiri:ff9d4a014bd4e0dc8a92264c7b200ed9,
+    entity(niiri:8bd27ef17ea505784747393676c66e61,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0054" %% xsd:string,
         nidm_coordinateVector: = "[8,52,32]" %% xsd:string])
-    wasDerivedFrom(niiri:04eb8dd4e9ab8ac46c751092d04da10d, niiri:4bb1f06cdf753bfe2cb9742585fc5f63, -, -, -)
-    entity(niiri:d80002080097776aa38277bc80033aa3,
+    wasDerivedFrom(niiri:024cfe8a8af184572999a9d180792536, niiri:a20506ad4a845975db3365e7c162d818, -, -, -)
+    entity(niiri:7a1112a488de76696afff578ff73b63a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0055" %% xsd:string,
-        prov:location = 'niiri:ce74cab636a5f2efe71e98f6ae695f3c',
+        prov:location = 'niiri:c3e118566488fbb275af41e9caa2d23e',
         prov:value = "13.9842071533203" %% xsd:float,
         nidm_equivalentZStatistic: = "3.2430323166614" %% xsd:float,
         nidm_pValueUncorrected: = "0.000591323980175695" %% xsd:float,
         nidm_pValueFWER: = "0.999999999867649" %% xsd:float,
         nidm_qValueFDR: = "0.131695068372973" %% xsd:float])
-    entity(niiri:ce74cab636a5f2efe71e98f6ae695f3c,
+    entity(niiri:c3e118566488fbb275af41e9caa2d23e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0055" %% xsd:string,
         nidm_coordinateVector: = "[-14,-48,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:d80002080097776aa38277bc80033aa3, niiri:cca6dc1b6e22a99533fb4839e0e808cf, -, -, -)
-    entity(niiri:d4c1b62bf34355cc27a8c18d2fe4f53b,
+    wasDerivedFrom(niiri:7a1112a488de76696afff578ff73b63a, niiri:cfde284823e7c32d74bec0b81232bb7a, -, -, -)
+    entity(niiri:d17f027d268c7f08e9841c1c575cf23e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0056" %% xsd:string,
-        prov:location = 'niiri:ea5c28625592b62bd93bf315cb8d38f1',
+        prov:location = 'niiri:ae9a839905051fcbf3c519761251289d',
         prov:value = "13.9203996658325" %% xsd:float,
         nidm_equivalentZStatistic: = "3.23592192136056" %% xsd:float,
         nidm_pValueUncorrected: = "0.000606252725692924" %% xsd:float,
         nidm_pValueFWER: = "0.999999999913111" %% xsd:float,
         nidm_qValueFDR: = "0.13226466740541" %% xsd:float])
-    entity(niiri:ea5c28625592b62bd93bf315cb8d38f1,
+    entity(niiri:ae9a839905051fcbf3c519761251289d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0056" %% xsd:string,
         nidm_coordinateVector: = "[20,0,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:d4c1b62bf34355cc27a8c18d2fe4f53b, niiri:894db077f6ce41dde7580196422f5b65, -, -, -)
-    entity(niiri:22da22dab16541f8e410ae72c92290f3,
+    wasDerivedFrom(niiri:d17f027d268c7f08e9841c1c575cf23e, niiri:496bec06cfc8ef95b3cbe0997c654d26, -, -, -)
+    entity(niiri:9a81d2292183627c111fac27998c2da6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0057" %% xsd:string,
-        prov:location = 'niiri:183de3503fa5b331b636ff710340ee17',
+        prov:location = 'niiri:84fa347a32d4bf011d58a0338bec2648',
         prov:value = "13.8925752639771" %% xsd:float,
         nidm_equivalentZStatistic: = "3.23281385809669" %% xsd:float,
         nidm_pValueUncorrected: = "0.000612887021428588" %% xsd:float,
         nidm_pValueFWER: = "0.999999999927857" %% xsd:float,
         nidm_qValueFDR: = "0.13226466740541" %% xsd:float])
-    entity(niiri:183de3503fa5b331b636ff710340ee17,
+    entity(niiri:84fa347a32d4bf011d58a0338bec2648,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0057" %% xsd:string,
         nidm_coordinateVector: = "[40,-14,60]" %% xsd:string])
-    wasDerivedFrom(niiri:22da22dab16541f8e410ae72c92290f3, niiri:e8143c5b2cddc4ad2f401f2b27a4cab2, -, -, -)
-    entity(niiri:ed8e5afdf4dfba0fb8266ec7bb6e05ea,
+    wasDerivedFrom(niiri:9a81d2292183627c111fac27998c2da6, niiri:e4bff32759970a1099e3a417cf7206b0, -, -, -)
+    entity(niiri:8b4c54efdd01e22033ec948028b376c6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0058" %% xsd:string,
-        prov:location = 'niiri:bb26c37ea84abd4f8e5aab60783b1ef4',
+        prov:location = 'niiri:cec9885ccb4c5eddad3e16791941394f',
         prov:value = "13.8641185760498" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22963046726961" %% xsd:float,
         nidm_pValueUncorrected: = "0.000619751563460058" %% xsd:float,
         nidm_pValueFWER: = "0.999999999940447" %% xsd:float,
         nidm_qValueFDR: = "0.132333123904287" %% xsd:float])
-    entity(niiri:bb26c37ea84abd4f8e5aab60783b1ef4,
+    entity(niiri:cec9885ccb4c5eddad3e16791941394f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0058" %% xsd:string,
         nidm_coordinateVector: = "[-36,10,24]" %% xsd:string])
-    wasDerivedFrom(niiri:ed8e5afdf4dfba0fb8266ec7bb6e05ea, niiri:09cd915bf2b2b51b32d56249f304bbce, -, -, -)
-    entity(niiri:8999f6eb178b306d0ec123f3b221f83e,
+    wasDerivedFrom(niiri:8b4c54efdd01e22033ec948028b376c6, niiri:40337b736645244404b84afb6772e7a9, -, -, -)
+    entity(niiri:dc9b5b7925435de1e123f050c0f32db2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0059" %% xsd:string,
-        prov:location = 'niiri:2fbd5acd6bb5ef2ba1473f87c213d4aa',
+        prov:location = 'niiri:abc2ee78bd07cda0b6ddcacbac427081',
         prov:value = "13.7912406921387" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22145599369965" %% xsd:float,
         nidm_pValueUncorrected: = "0.000637705235827735" %% xsd:float,
         nidm_pValueFWER: = "0.999999999963824" %% xsd:float,
         nidm_qValueFDR: = "0.133173984174016" %% xsd:float])
-    entity(niiri:2fbd5acd6bb5ef2ba1473f87c213d4aa,
+    entity(niiri:abc2ee78bd07cda0b6ddcacbac427081,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0059" %% xsd:string,
         nidm_coordinateVector: = "[30,-78,14]" %% xsd:string])
-    wasDerivedFrom(niiri:8999f6eb178b306d0ec123f3b221f83e, niiri:bf2d35b880b3d0657d2a03298074406e, -, -, -)
-    entity(niiri:089d2f5ca65585c3d01817a9bdbf214f,
+    wasDerivedFrom(niiri:dc9b5b7925435de1e123f050c0f32db2, niiri:42bc55f4f90f29daf9e12be119e1ddab, -, -, -)
+    entity(niiri:98a17ff5e5165fb8c24152b264b38518,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0060" %% xsd:string,
-        prov:location = 'niiri:b64d2f396f19bac0e190ab99328b9677',
+        prov:location = 'niiri:4ff470161927caacc784743cebf1ff5c',
         prov:value = "13.629490852356" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20320002112963" %% xsd:float,
         nidm_pValueUncorrected: = "0.000679547746644249" %% xsd:float,
         nidm_pValueFWER: = "0.999999999988489" %% xsd:float,
         nidm_qValueFDR: = "0.136764826883915" %% xsd:float])
-    entity(niiri:b64d2f396f19bac0e190ab99328b9677,
+    entity(niiri:4ff470161927caacc784743cebf1ff5c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0060" %% xsd:string,
         nidm_coordinateVector: = "[18,-78,12]" %% xsd:string])
-    wasDerivedFrom(niiri:089d2f5ca65585c3d01817a9bdbf214f, niiri:56bc4504cec954daf4a701610ddf59b3, -, -, -)
-    entity(niiri:e1eec1e6fba3322a1a6483846b8a91d8,
+    wasDerivedFrom(niiri:98a17ff5e5165fb8c24152b264b38518, niiri:067c79f86db85b508893737af41699ce, -, -, -)
+    entity(niiri:457b57ff4d2f772e5a87d72e416d55f7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0061" %% xsd:string,
-        prov:location = 'niiri:dc2ecabdf71bb61760c0219ad76cb53e',
+        prov:location = 'niiri:642bfe0fc88a3e08454fca298ff2547d',
         prov:value = "13.5061225891113" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18916981007524" %% xsd:float,
         nidm_pValueUncorrected: = "0.000713410180681495" %% xsd:float,
         nidm_pValueFWER: = "0.999999999995369" %% xsd:float,
         nidm_qValueFDR: = "0.139253735873803" %% xsd:float])
-    entity(niiri:dc2ecabdf71bb61760c0219ad76cb53e,
+    entity(niiri:642bfe0fc88a3e08454fca298ff2547d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0061" %% xsd:string,
         nidm_coordinateVector: = "[46,8,-16]" %% xsd:string])
-    wasDerivedFrom(niiri:e1eec1e6fba3322a1a6483846b8a91d8, niiri:baa1270c4a9c0f72989c973b2fbb309d, -, -, -)
-    entity(niiri:d434f3bdadeaac5eb9b817cb94e825e9,
+    wasDerivedFrom(niiri:457b57ff4d2f772e5a87d72e416d55f7, niiri:1a35a6d628eed4f2fc8c554a4a579a19, -, -, -)
+    entity(niiri:983d2f990b97c775c7da5a27177fc0f6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0062" %% xsd:string,
-        prov:location = 'niiri:3a03e910b24e3e930f0b6b6c9e5c737b',
+        prov:location = 'niiri:b7b5b47e2538aa1f088bf22667e716bc',
         prov:value = "13.4754667282104" %% xsd:float,
         nidm_equivalentZStatistic: = "3.1856690050705" %% xsd:float,
         nidm_pValueUncorrected: = "0.000722098618250455" %% xsd:float,
         nidm_pValueFWER: = "0.999999999996325" %% xsd:float,
         nidm_qValueFDR: = "0.1402954623971" %% xsd:float])
-    entity(niiri:3a03e910b24e3e930f0b6b6c9e5c737b,
+    entity(niiri:b7b5b47e2538aa1f088bf22667e716bc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0062" %% xsd:string,
         nidm_coordinateVector: = "[58,-40,50]" %% xsd:string])
-    wasDerivedFrom(niiri:d434f3bdadeaac5eb9b817cb94e825e9, niiri:39b258c34ddafd00d7dff6d208f62918, -, -, -)
-    entity(niiri:73253ea75fa4c291c1dccb3b8aadedf9,
+    wasDerivedFrom(niiri:983d2f990b97c775c7da5a27177fc0f6, niiri:0e92ac2d77c091672e014daf15280170, -, -, -)
+    entity(niiri:0d84f12f1eecf02fd70239d18b674632,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0063" %% xsd:string,
-        prov:location = 'niiri:843cc3a9443e428c80dd3e5419ef67ec',
+        prov:location = 'niiri:b200c3101378d90c3289227f2f311490',
         prov:value = "13.4480972290039" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18253860543696" %% xsd:float,
         nidm_pValueUncorrected: = "0.000729950259848011" %% xsd:float,
         nidm_pValueFWER: = "0.999999999997016" %% xsd:float,
         nidm_qValueFDR: = "0.140840039531724" %% xsd:float])
-    entity(niiri:843cc3a9443e428c80dd3e5419ef67ec,
+    entity(niiri:b200c3101378d90c3289227f2f311490,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0063" %% xsd:string,
         nidm_coordinateVector: = "[46,-66,32]" %% xsd:string])
-    wasDerivedFrom(niiri:73253ea75fa4c291c1dccb3b8aadedf9, niiri:ea112296db729b94dfce05991c3d6989, -, -, -)
-    entity(niiri:0250c5bfb4ece9672c03eeceb0f7b02f,
+    wasDerivedFrom(niiri:0d84f12f1eecf02fd70239d18b674632, niiri:0d2b802df946de1efd390f218ef63fce, -, -, -)
+    entity(niiri:1106844ff3c3aa841e131a1c8b3cee03,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0064" %% xsd:string,
-        prov:location = 'niiri:3c2b90faeb19728391b223147a6272ef',
+        prov:location = 'niiri:2c69785e6a1162eaef0e8d5fb846e6be',
         prov:value = "13.2857608795166" %% xsd:float,
         nidm_equivalentZStatistic: = "3.16387572537233" %% xsd:float,
         nidm_pValueUncorrected: = "0.000778416284459293" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999163" %% xsd:float,
         nidm_qValueFDR: = "0.14332751949213" %% xsd:float])
-    entity(niiri:3c2b90faeb19728391b223147a6272ef,
+    entity(niiri:2c69785e6a1162eaef0e8d5fb846e6be,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0064" %% xsd:string,
         nidm_coordinateVector: = "[2,-76,8]" %% xsd:string])
-    wasDerivedFrom(niiri:0250c5bfb4ece9672c03eeceb0f7b02f, niiri:a41eeb9ba04d7788ba686542607ff1cc, -, -, -)
-    entity(niiri:9efe1a64a6e8c8950d8b7cab41638bf4,
+    wasDerivedFrom(niiri:1106844ff3c3aa841e131a1c8b3cee03, niiri:627d75e08350cce3541dd568e3ddaa39, -, -, -)
+    entity(niiri:8f5c2c4423ccd494ee5e86fe3deb293e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0065" %% xsd:string,
-        prov:location = 'niiri:6cd33ece9349946e05442ff70eafc454',
+        prov:location = 'niiri:611027fbd0882487ef894fa5a6a8e4e5',
         prov:value = "13.2286987304688" %% xsd:float,
         nidm_equivalentZStatistic: = "3.15727638472708" %% xsd:float,
         nidm_pValueUncorrected: = "0.000796251631906664" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999472" %% xsd:float,
         nidm_qValueFDR: = "0.143821550671959" %% xsd:float])
-    entity(niiri:6cd33ece9349946e05442ff70eafc454,
+    entity(niiri:611027fbd0882487ef894fa5a6a8e4e5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0065" %% xsd:string,
         nidm_coordinateVector: = "[14,-24,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:9efe1a64a6e8c8950d8b7cab41638bf4, niiri:9c7b81143edac28cf680878e9177494c, -, -, -)
-    entity(niiri:6a326f32141b8c0a3055d65d9f6a8649,
+    wasDerivedFrom(niiri:8f5c2c4423ccd494ee5e86fe3deb293e, niiri:20516921d28241951d08251e80cac5b5, -, -, -)
+    entity(niiri:ec7eede0d453f71f84e10d81d45a185d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0066" %% xsd:string,
-        prov:location = 'niiri:b5b1c97968ad3124f2e761ecead8345e',
+        prov:location = 'niiri:4bd2715c430b33d70e84b77b850d16be',
         prov:value = "13.0621271133423" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13789355719639" %% xsd:float,
         nidm_pValueUncorrected: = "0.00085083330089919" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999869" %% xsd:float,
         nidm_qValueFDR: = "0.146648454262555" %% xsd:float])
-    entity(niiri:b5b1c97968ad3124f2e761ecead8345e,
+    entity(niiri:4bd2715c430b33d70e84b77b850d16be,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0066" %% xsd:string,
         nidm_coordinateVector: = "[-36,0,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:6a326f32141b8c0a3055d65d9f6a8649, niiri:e854403c8636e3e481bc993eb6180f44, -, -, -)
-    entity(niiri:cd1be6a68508e7a4ef251e742d0b5209,
+    wasDerivedFrom(niiri:ec7eede0d453f71f84e10d81d45a185d, niiri:3822c0fa262ca8cb8a67590f3eec2fe6, -, -, -)
+    entity(niiri:4ee980646f678b94fcd5772eb72db1d4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0067" %% xsd:string,
-        prov:location = 'niiri:7e8c996c334e2b3e54960324857470e1',
+        prov:location = 'niiri:34b06f9fb053f163bc7a00ce986a8123',
         prov:value = "13.0451946258545" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13591325616981" %% xsd:float,
         nidm_pValueUncorrected: = "0.000856599341067521" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999886" %% xsd:float,
         nidm_qValueFDR: = "0.146787157394689" %% xsd:float])
-    entity(niiri:7e8c996c334e2b3e54960324857470e1,
+    entity(niiri:34b06f9fb053f163bc7a00ce986a8123,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0067" %% xsd:string,
         nidm_coordinateVector: = "[12,6,62]" %% xsd:string])
-    wasDerivedFrom(niiri:cd1be6a68508e7a4ef251e742d0b5209, niiri:7f3ebf5e2a10fd569c91dd091c7af147, -, -, -)
-    entity(niiri:4df08c0c2756eb1b10566b4b6f695464,
+    wasDerivedFrom(niiri:4ee980646f678b94fcd5772eb72db1d4, niiri:51287994298816d649ba6908b4e3d0bb, -, -, -)
+    entity(niiri:f672ee780ba0dc20dc0aa8808e3c2090,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0068" %% xsd:string,
-        prov:location = 'niiri:8fe3ed1f49a1014532022d8ff15e4b33',
+        prov:location = 'niiri:729e387de0d5316ccf723a049f2cd632',
         prov:value = "13.0064306259155" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13137270324883" %% xsd:float,
         nidm_pValueUncorrected: = "0.000869955985260296" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999919" %% xsd:float,
         nidm_qValueFDR: = "0.146787157394689" %% xsd:float])
-    entity(niiri:8fe3ed1f49a1014532022d8ff15e4b33,
+    entity(niiri:729e387de0d5316ccf723a049f2cd632,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0068" %% xsd:string,
         nidm_coordinateVector: = "[-8,-4,24]" %% xsd:string])
-    wasDerivedFrom(niiri:4df08c0c2756eb1b10566b4b6f695464, niiri:b36c20212016b9bc7a603f3e83aca676, -, -, -)
-    entity(niiri:f493daa250a5ea19aa9efa8d626c010a,
+    wasDerivedFrom(niiri:f672ee780ba0dc20dc0aa8808e3c2090, niiri:36a1ff3bd64efa589db6c3a56ccf9d25, -, -, -)
+    entity(niiri:133da124dca5a66efd13ce67c41fded3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0069" %% xsd:string,
-        prov:location = 'niiri:a6c74b8d30fbdf526011335c2d35ae6a',
+        prov:location = 'niiri:1eb746ff728a0d069a40542bb5f7a689',
         prov:value = "12.968074798584" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12687033926247" %% xsd:float,
         nidm_pValueUncorrected: = "0.00088338914171493" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999942" %% xsd:float,
         nidm_qValueFDR: = "0.147244283960254" %% xsd:float])
-    entity(niiri:a6c74b8d30fbdf526011335c2d35ae6a,
+    entity(niiri:1eb746ff728a0d069a40542bb5f7a689,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0069" %% xsd:string,
         nidm_coordinateVector: = "[8,-36,40]" %% xsd:string])
-    wasDerivedFrom(niiri:f493daa250a5ea19aa9efa8d626c010a, niiri:05115f2e683a3386f641d5816019de27, -, -, -)
-    entity(niiri:8be7214c24c5b037d7fba75f4e6093e0,
+    wasDerivedFrom(niiri:133da124dca5a66efd13ce67c41fded3, niiri:1c0a11fe168926616610d5836c36d35f, -, -, -)
+    entity(niiri:9801cb1bbda1a53d0101f519d9d19df1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0070" %% xsd:string,
-        prov:location = 'niiri:2b0b836ebf6d584148281ed6f01ff393',
+        prov:location = 'niiri:f1edc34f43382229a619f2254f87a59c',
         prov:value = "12.9628992080688" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12626207199886" %% xsd:float,
         nidm_pValueUncorrected: = "0.000885218504765861" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999944" %% xsd:float,
         nidm_qValueFDR: = "0.147244283960254" %% xsd:float])
-    entity(niiri:2b0b836ebf6d584148281ed6f01ff393,
+    entity(niiri:f1edc34f43382229a619f2254f87a59c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0070" %% xsd:string,
         nidm_coordinateVector: = "[24,38,0]" %% xsd:string])
-    wasDerivedFrom(niiri:8be7214c24c5b037d7fba75f4e6093e0, niiri:1ee8276c32c1e03b7e0b4b1717c44a57, -, -, -)
-    entity(niiri:3fb670bc4bf41b489875540e653fafdd,
+    wasDerivedFrom(niiri:9801cb1bbda1a53d0101f519d9d19df1, niiri:aa0d58d5cc7671539d09308038edb0f1, -, -, -)
+    entity(niiri:04821e6510237840cbf335fef76d5cdc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0071" %% xsd:string,
-        prov:location = 'niiri:60bbc4af8445689f911587e2015c11e0',
+        prov:location = 'niiri:1f4eb737906c00c0031d9ee2356ab46d',
         prov:value = "12.9482192993164" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12453584528173" %% xsd:float,
         nidm_pValueUncorrected: = "0.000890429112242686" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999951" %% xsd:float,
         nidm_qValueFDR: = "0.14749076092896" %% xsd:float])
-    entity(niiri:60bbc4af8445689f911587e2015c11e0,
+    entity(niiri:1f4eb737906c00c0031d9ee2356ab46d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0071" %% xsd:string,
         nidm_coordinateVector: = "[26,-50,46]" %% xsd:string])
-    wasDerivedFrom(niiri:3fb670bc4bf41b489875540e653fafdd, niiri:aa58a012c4a942174e0325d4c0b944fd, -, -, -)
-    entity(niiri:82c6fba725d300ee5b57d9b99b507dd1,
+    wasDerivedFrom(niiri:04821e6510237840cbf335fef76d5cdc, niiri:fc71e9e9a2574cbd9d5094f50275b3c2, -, -, -)
+    entity(niiri:febde3f603b3693a20767813beb5bd71,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0072" %% xsd:string,
-        prov:location = 'niiri:26c578b46a7a236fd0e9ec4b50b4b8a5',
+        prov:location = 'niiri:aa6eef7396e2ed67c9ab5d0bb298088e',
         prov:value = "12.9151954650879" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12064737190897" %% xsd:float,
         nidm_pValueUncorrected: = "0.000902269894699104" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999964" %% xsd:float,
         nidm_qValueFDR: = "0.147598889605401" %% xsd:float])
-    entity(niiri:26c578b46a7a236fd0e9ec4b50b4b8a5,
+    entity(niiri:aa6eef7396e2ed67c9ab5d0bb298088e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0072" %% xsd:string,
         nidm_coordinateVector: = "[-30,-86,8]" %% xsd:string])
-    wasDerivedFrom(niiri:82c6fba725d300ee5b57d9b99b507dd1, niiri:69b1d9ea8525a6a583365384e39cf9e8, -, -, -)
-    entity(niiri:f6b78515f73bc27f172ee4971b59d62c,
+    wasDerivedFrom(niiri:febde3f603b3693a20767813beb5bd71, niiri:c23970716bccffb656edae94cc34e353, -, -, -)
+    entity(niiri:b52c3eeba29b97da2b661dd4df58cef0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0073" %% xsd:string,
-        prov:location = 'niiri:df70ae256a22280944b76c315708af2e',
+        prov:location = 'niiri:dacf1036163cfbe9703b73ef87a5b977',
         prov:value = "12.8661985397339" %% xsd:float,
         nidm_equivalentZStatistic: = "3.11486488202419" %% xsd:float,
         nidm_pValueUncorrected: = "0.00092014594111034" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999977" %% xsd:float,
         nidm_qValueFDR: = "0.147847736781403" %% xsd:float])
-    entity(niiri:df70ae256a22280944b76c315708af2e,
+    entity(niiri:dacf1036163cfbe9703b73ef87a5b977,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0073" %% xsd:string,
         nidm_coordinateVector: = "[22,-24,38]" %% xsd:string])
-    wasDerivedFrom(niiri:f6b78515f73bc27f172ee4971b59d62c, niiri:f6d9af16709f321130aa58504e6604c5, -, -, -)
-    entity(niiri:7da556aa1244db607c1e49d0f196cfa5,
+    wasDerivedFrom(niiri:b52c3eeba29b97da2b661dd4df58cef0, niiri:8e2363110cdebe114cbe95493b19fa9d, -, -, -)
+    entity(niiri:9c19f778bd965a28a5a95c2a44273e2f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0074" %% xsd:string,
-        prov:location = 'niiri:bc4dcce56afafebd60de994b46b169af',
+        prov:location = 'niiri:3342cfcb637deb366202637575b9bf6e',
         prov:value = "12.8156299591064" %% xsd:float,
         nidm_equivalentZStatistic: = "3.10888025138563" %% xsd:float,
         nidm_pValueUncorrected: = "0.000938989080538355" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999985" %% xsd:float,
         nidm_qValueFDR: = "0.148123448926347" %% xsd:float])
-    entity(niiri:bc4dcce56afafebd60de994b46b169af,
+    entity(niiri:3342cfcb637deb366202637575b9bf6e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0074" %% xsd:string,
         nidm_coordinateVector: = "[48,50,2]" %% xsd:string])
-    wasDerivedFrom(niiri:7da556aa1244db607c1e49d0f196cfa5, niiri:be347b3d17b0cf1b2b8f3ad6860ae399, -, -, -)
-    entity(niiri:23689147c9f9a1cfc3640674405fb6af,
+    wasDerivedFrom(niiri:9c19f778bd965a28a5a95c2a44273e2f, niiri:eb4122935f1afa2c8b532875de5f0ef9, -, -, -)
+    entity(niiri:ad2e6a4a1bd4b49e04b2f5ce6f700bf1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0075" %% xsd:string,
-        prov:location = 'niiri:856080bfa95af62a2310e7f77d678b86',
+        prov:location = 'niiri:51217ecd4042ac5a689d5913af7f97c4',
         prov:value = "12.7734069824219" %% xsd:float,
         nidm_equivalentZStatistic: = "3.10387025917553" %% xsd:float,
         nidm_pValueUncorrected: = "0.000955035352381506" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999999" %% xsd:float,
         nidm_qValueFDR: = "0.149144835108449" %% xsd:float])
-    entity(niiri:856080bfa95af62a2310e7f77d678b86,
+    entity(niiri:51217ecd4042ac5a689d5913af7f97c4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0075" %% xsd:string,
         nidm_coordinateVector: = "[-48,-68,20]" %% xsd:string])
-    wasDerivedFrom(niiri:23689147c9f9a1cfc3640674405fb6af, niiri:fb10f43ffe914843271a8cdefab5f898, -, -, -)
-    entity(niiri:7dccdae3f638e89023329e9d2f66c954,
+    wasDerivedFrom(niiri:ad2e6a4a1bd4b49e04b2f5ce6f700bf1, niiri:25018fb0acd6d245a4f445c35c5f92eb, -, -, -)
+    entity(niiri:40ede6bfbdf28e2cb70db26b715172d6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0076" %% xsd:string,
-        prov:location = 'niiri:aec1651baeec9ebce473514a2520d9ac',
+        prov:location = 'niiri:32049f907c1ff3c54deff6f919d2ee46',
         prov:value = "12.7362623214722" %% xsd:float,
         nidm_equivalentZStatistic: = "3.0994529756118" %% xsd:float,
         nidm_pValueUncorrected: = "0.000969391758882221" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999993" %% xsd:float,
         nidm_qValueFDR: = "0.150376120259304" %% xsd:float])
-    entity(niiri:aec1651baeec9ebce473514a2520d9ac,
+    entity(niiri:32049f907c1ff3c54deff6f919d2ee46,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0076" %% xsd:string,
         nidm_coordinateVector: = "[24,-22,36]" %% xsd:string])
-    wasDerivedFrom(niiri:7dccdae3f638e89023329e9d2f66c954, niiri:ac129c99f1ae280d6d0a6f24c04b617a, -, -, -)
+    wasDerivedFrom(niiri:40ede6bfbdf28e2cb70db26b715172d6, niiri:ccd2969f60f8b0222713472b0a037361, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_non_sphericity/nidm.provn
+++ b/spmexport/ex_spm_non_sphericity/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:7b4cf04d3e03731e8b127b5ef008e6ba,
+  entity(niiri:99dc1e7d9ba53c5c6f18c0f640fee6e0,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:b823f4f8cbc1c10feef0f31492474351,
+  agent(niiri:b7874a1ae03c388637bdda802a0ec6d0,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:2df4836000438363ab93c2c037ea1c9f,
+  activity(niiri:8406d28dc5a6ff3dcee923e5b77a172c,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:2df4836000438363ab93c2c037ea1c9f, niiri:b823f4f8cbc1c10feef0f31492474351, -)
-  wasGeneratedBy(niiri:7b4cf04d3e03731e8b127b5ef008e6ba, niiri:2df4836000438363ab93c2c037ea1c9f, 2016-01-11T10:33:49)
-  bundle niiri:7b4cf04d3e03731e8b127b5ef008e6ba
+  wasAssociatedWith(niiri:8406d28dc5a6ff3dcee923e5b77a172c, niiri:b7874a1ae03c388637bdda802a0ec6d0, -)
+  wasGeneratedBy(niiri:99dc1e7d9ba53c5c6f18c0f640fee6e0, niiri:8406d28dc5a6ff3dcee923e5b77a172c, 2016-01-11T10:44:11)
+  bundle niiri:99dc1e7d9ba53c5c6f18c0f640fee6e0
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -121,12 +121,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:8707d65d3a15dbf845684e80f7df9da7,
+    agent(niiri:234c7e043e4aca8ed9fefeb09a8d256c,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:c91eabb6ae30ecd695a7cf4b3fcab893,
+    entity(niiri:762e57d57e56c8570d19ee32ae1e75c3,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -135,146 +135,146 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:34de00e96ed7c645577a52f0e7289dc5,
+    entity(niiri:6d6a8f3ee06f679449aee413b3618fcf,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "false" %% xsd:boolean])
-    entity(niiri:c75f4ff351459ee32fa91d23800efb92,
+    entity(niiri:9b05a6ff4dfa65e2cb2f77532ccb5456,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:3065da080a203d349041ec0f402e8e33',
+        dc:description = 'niiri:bebd9964776e1393e484606bdc3b8b5c',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]" %% xsd:string])
-    entity(niiri:3065da080a203d349041ec0f402e8e33,
+    entity(niiri:bebd9964776e1393e484606bdc3b8b5c,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:d6bb9097d5397477b9a2fe34b1e173d1,
+    entity(niiri:c4151781347f6d33fd68abb19f8b2ec3,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_UnstructuredCorrelationStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "false" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:48bd386fe0be968592a13062b5c43885,
+    activity(niiri:d9ae952dd939b0fc1e59859df92ddc2a,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:48bd386fe0be968592a13062b5c43885, niiri:8707d65d3a15dbf845684e80f7df9da7, -)
-    used(niiri:48bd386fe0be968592a13062b5c43885, niiri:c75f4ff351459ee32fa91d23800efb92, -)
-    used(niiri:48bd386fe0be968592a13062b5c43885, niiri:34de00e96ed7c645577a52f0e7289dc5, -)
-    used(niiri:48bd386fe0be968592a13062b5c43885, niiri:d6bb9097d5397477b9a2fe34b1e173d1, -)
-    entity(niiri:9f3d2992eab79fd14d4660154ae8238a,
+    wasAssociatedWith(niiri:d9ae952dd939b0fc1e59859df92ddc2a, niiri:234c7e043e4aca8ed9fefeb09a8d256c, -)
+    used(niiri:d9ae952dd939b0fc1e59859df92ddc2a, niiri:9b05a6ff4dfa65e2cb2f77532ccb5456, -)
+    used(niiri:d9ae952dd939b0fc1e59859df92ddc2a, niiri:6d6a8f3ee06f679449aee413b3618fcf, -)
+    used(niiri:d9ae952dd939b0fc1e59859df92ddc2a, niiri:c4151781347f6d33fd68abb19f8b2ec3, -)
+    entity(niiri:4f82f60faefd085ffe16261907d905b5,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3',
         crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
-    entity(niiri:5e1b296cb7615ea4c933955980cef164,
+    entity(niiri:793decdab241256463612be93f874e2e,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e" %% xsd:string])
-    wasDerivedFrom(niiri:9f3d2992eab79fd14d4660154ae8238a, niiri:5e1b296cb7615ea4c933955980cef164, -, -, -)
-    wasGeneratedBy(niiri:9f3d2992eab79fd14d4660154ae8238a, niiri:48bd386fe0be968592a13062b5c43885, -)
-    entity(niiri:2907b9f1080a55bf3a3b5fde0463d565,
+    wasDerivedFrom(niiri:4f82f60faefd085ffe16261907d905b5, niiri:793decdab241256463612be93f874e2e, -, -, -)
+    wasGeneratedBy(niiri:4f82f60faefd085ffe16261907d905b5, niiri:d9ae952dd939b0fc1e59859df92ddc2a, -)
+    entity(niiri:49b46b2346703f97e806a5849e3e5d9d,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "0.0511472336947918" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3',
         crypto:sha512 = "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc" %% xsd:string])
-    wasGeneratedBy(niiri:2907b9f1080a55bf3a3b5fde0463d565, niiri:48bd386fe0be968592a13062b5c43885, -)
-    entity(niiri:fd2e03999ed8a414f71235a7246666d9,
+    wasGeneratedBy(niiri:49b46b2346703f97e806a5849e3e5d9d, niiri:d9ae952dd939b0fc1e59859df92ddc2a, -)
+    entity(niiri:8514e027e15dd49a399e30c4b202c1f3,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893'])
-    entity(niiri:ba6d197e4b83b9354b3d92dc6cdbe6e7,
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3'])
+    entity(niiri:142a5fc026254184050862a8debfcca8,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f" %% xsd:string])
-    wasDerivedFrom(niiri:fd2e03999ed8a414f71235a7246666d9, niiri:ba6d197e4b83b9354b3d92dc6cdbe6e7, -, -, -)
-    wasGeneratedBy(niiri:fd2e03999ed8a414f71235a7246666d9, niiri:48bd386fe0be968592a13062b5c43885, -)
-    entity(niiri:af828ebe888a0cdbc655a60d27afaa91,
+    wasDerivedFrom(niiri:8514e027e15dd49a399e30c4b202c1f3, niiri:142a5fc026254184050862a8debfcca8, -, -, -)
+    wasGeneratedBy(niiri:8514e027e15dd49a399e30c4b202c1f3, niiri:d9ae952dd939b0fc1e59859df92ddc2a, -)
+    entity(niiri:74aaa5804ac9ac06ff6ffa92cb2b4204,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893'])
-    entity(niiri:a4ab3adcdfcd06863c089ef11dfef36a,
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3'])
+    entity(niiri:db601c927922d2467db6d794e787485a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978" %% xsd:string])
-    wasDerivedFrom(niiri:af828ebe888a0cdbc655a60d27afaa91, niiri:a4ab3adcdfcd06863c089ef11dfef36a, -, -, -)
-    wasGeneratedBy(niiri:af828ebe888a0cdbc655a60d27afaa91, niiri:48bd386fe0be968592a13062b5c43885, -)
-    entity(niiri:bd9421d9a41bc778b27e2be0eda0496f,
+    wasDerivedFrom(niiri:74aaa5804ac9ac06ff6ffa92cb2b4204, niiri:db601c927922d2467db6d794e787485a, -, -, -)
+    wasGeneratedBy(niiri:74aaa5804ac9ac06ff6ffa92cb2b4204, niiri:d9ae952dd939b0fc1e59859df92ddc2a, -)
+    entity(niiri:b69ac8eaca662c7c4998f0d7ed7d5c1a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893'])
-    entity(niiri:db047f8eefe5537016244f0bb25e3637,
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3'])
+    entity(niiri:4c1d5f9c25d6cc2aa583c90fb8fd5662,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a" %% xsd:string])
-    wasDerivedFrom(niiri:bd9421d9a41bc778b27e2be0eda0496f, niiri:db047f8eefe5537016244f0bb25e3637, -, -, -)
-    wasGeneratedBy(niiri:bd9421d9a41bc778b27e2be0eda0496f, niiri:48bd386fe0be968592a13062b5c43885, -)
-    entity(niiri:dc244080dfe10dc4223d65ff1b5587f2,
+    wasDerivedFrom(niiri:b69ac8eaca662c7c4998f0d7ed7d5c1a, niiri:4c1d5f9c25d6cc2aa583c90fb8fd5662, -, -, -)
+    wasGeneratedBy(niiri:b69ac8eaca662c7c4998f0d7ed7d5c1a, niiri:d9ae952dd939b0fc1e59859df92ddc2a, -)
+    entity(niiri:2756551f850c95c68505ddc97c07c28c,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3',
         crypto:sha512 = "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48" %% xsd:string])
-    entity(niiri:ade1763484de1aa955eb941d8892ffcb,
+    entity(niiri:c7212c5edf8cabf87aaf95d8e4fd4b1f,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868" %% xsd:string])
-    wasDerivedFrom(niiri:dc244080dfe10dc4223d65ff1b5587f2, niiri:ade1763484de1aa955eb941d8892ffcb, -, -, -)
-    wasGeneratedBy(niiri:dc244080dfe10dc4223d65ff1b5587f2, niiri:48bd386fe0be968592a13062b5c43885, -)
-    entity(niiri:86e735169b95dc7176008fba7b0cbabd,
+    wasDerivedFrom(niiri:2756551f850c95c68505ddc97c07c28c, niiri:c7212c5edf8cabf87aaf95d8e4fd4b1f, -, -, -)
+    wasGeneratedBy(niiri:2756551f850c95c68505ddc97c07c28c, niiri:d9ae952dd939b0fc1e59859df92ddc2a, -)
+    entity(niiri:db3b899f360335973148454d21c7bf0b,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3',
         crypto:sha512 = "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381" %% xsd:string])
-    entity(niiri:a2f5143ec88d6b7200a0d1b34f1c06ab,
+    entity(niiri:c126d1c14db853f6fffea497964fa3ea,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8" %% xsd:string])
-    wasDerivedFrom(niiri:86e735169b95dc7176008fba7b0cbabd, niiri:a2f5143ec88d6b7200a0d1b34f1c06ab, -, -, -)
-    wasGeneratedBy(niiri:86e735169b95dc7176008fba7b0cbabd, niiri:48bd386fe0be968592a13062b5c43885, -)
-    entity(niiri:99e218282e31bd12efdffa7662e50016,
+    wasDerivedFrom(niiri:db3b899f360335973148454d21c7bf0b, niiri:c126d1c14db853f6fffea497964fa3ea, -, -, -)
+    wasGeneratedBy(niiri:db3b899f360335973148454d21c7bf0b, niiri:d9ae952dd939b0fc1e59859df92ddc2a, -)
+    entity(niiri:36290d7c38277ec084868686167f98c6,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_FStatistic:',
         nidm_contrastName: = "Average effect of condition" %% xsd:string,
         prov:label = "Contrast: Average effect of condition" %% xsd:string,
         prov:value = "[1, 1, 1]" %% xsd:string])
-    activity(niiri:f30c53c09afee24faac70ef520464dcc,
+    activity(niiri:3c77450bfe975012c43cc1c35a7e8df9,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:f30c53c09afee24faac70ef520464dcc, niiri:8707d65d3a15dbf845684e80f7df9da7, -)
-    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:9f3d2992eab79fd14d4660154ae8238a, -)
-    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:dc244080dfe10dc4223d65ff1b5587f2, -)
-    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:c75f4ff351459ee32fa91d23800efb92, -)
-    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:99e218282e31bd12efdffa7662e50016, -)
-    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:fd2e03999ed8a414f71235a7246666d9, -)
-    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:af828ebe888a0cdbc655a60d27afaa91, -)
-    used(niiri:f30c53c09afee24faac70ef520464dcc, niiri:bd9421d9a41bc778b27e2be0eda0496f, -)
-    entity(niiri:67b4a4f6b336096ca6b563aa31361183,
+    wasAssociatedWith(niiri:3c77450bfe975012c43cc1c35a7e8df9, niiri:234c7e043e4aca8ed9fefeb09a8d256c, -)
+    used(niiri:3c77450bfe975012c43cc1c35a7e8df9, niiri:4f82f60faefd085ffe16261907d905b5, -)
+    used(niiri:3c77450bfe975012c43cc1c35a7e8df9, niiri:2756551f850c95c68505ddc97c07c28c, -)
+    used(niiri:3c77450bfe975012c43cc1c35a7e8df9, niiri:9b05a6ff4dfa65e2cb2f77532ccb5456, -)
+    used(niiri:3c77450bfe975012c43cc1c35a7e8df9, niiri:36290d7c38277ec084868686167f98c6, -)
+    used(niiri:3c77450bfe975012c43cc1c35a7e8df9, niiri:8514e027e15dd49a399e30c4b202c1f3, -)
+    used(niiri:3c77450bfe975012c43cc1c35a7e8df9, niiri:74aaa5804ac9ac06ff6ffa92cb2b4204, -)
+    used(niiri:3c77450bfe975012c43cc1c35a7e8df9, niiri:b69ac8eaca662c7c4998f0d7ed7d5c1a, -)
+    entity(niiri:577e331ed1c3ff69dc99e6f96e20ad41,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "FStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "FStatistic.nii.gz" %% xsd:string,
@@ -284,87 +284,87 @@ document
         nidm_contrastName: = "Average effect of condition" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "39" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3',
         crypto:sha512 = "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960" %% xsd:string])
-    entity(niiri:70bdd0befd9857e4ff6434527df6ac2c,
+    entity(niiri:4e1d261dffd37f590ebc9108f1036f1b,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmF_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762" %% xsd:string])
-    wasDerivedFrom(niiri:67b4a4f6b336096ca6b563aa31361183, niiri:70bdd0befd9857e4ff6434527df6ac2c, -, -, -)
-    wasGeneratedBy(niiri:67b4a4f6b336096ca6b563aa31361183, niiri:f30c53c09afee24faac70ef520464dcc, -)
-    entity(niiri:23c30668e6a9efa0ff2e602769536cb0,
+    wasDerivedFrom(niiri:577e331ed1c3ff69dc99e6f96e20ad41, niiri:4e1d261dffd37f590ebc9108f1036f1b, -, -, -)
+    wasGeneratedBy(niiri:577e331ed1c3ff69dc99e6f96e20ad41, niiri:3c77450bfe975012c43cc1c35a7e8df9, -)
+    entity(niiri:6411aeed5f90e0dc568d5646456b0c89,
         [prov:type = 'nidm_ContrastExplainedMeanSquareMap:',
         prov:location = "ContrastExplainedMeanSquare.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastExplainedMeanSquare.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Explained Mean Square Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3',
         crypto:sha512 = "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a" %% xsd:string])
-    wasGeneratedBy(niiri:23c30668e6a9efa0ff2e602769536cb0, niiri:f30c53c09afee24faac70ef520464dcc, -)
-    entity(niiri:40440229b29f5872d53eef25ecf0f975,
+    wasGeneratedBy(niiri:6411aeed5f90e0dc568d5646456b0c89, niiri:3c77450bfe975012c43cc1c35a7e8df9, -)
+    entity(niiri:5a23de0647497e69518d9ecbd7dd2993,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500201896764" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:2c452674a1f81d156e269dbe9725998a',
-        nidm_equivalentThreshold: = 'niiri:15ee33831544a51d39b276ac0d45c0cb'])
-    entity(niiri:2c452674a1f81d156e269dbe9725998a,
+        nidm_equivalentThreshold: = 'niiri:9589dc23e84a662f161ab3515e2f989b',
+        nidm_equivalentThreshold: = 'niiri:d19aebd9783b84a7c2479ca6e65ba6ac'])
+    entity(niiri:9589dc23e84a662f161ab3515e2f989b,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "12.6602184255263" %% xsd:float])
-    entity(niiri:15ee33831544a51d39b276ac0d45c0cb,
+    entity(niiri:d19aebd9783b84a7c2479ca6e65ba6ac,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999999997" %% xsd:float])
-    entity(niiri:981d4a611d50d796152b8e8eb6283194,
+    entity(niiri:b7917679b11eb67ab1ab21dfde06646f,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:3455442e086debfe280887e4ef34a59a',
-        nidm_equivalentThreshold: = 'niiri:eec7cc036dfbc9f23b1c4ad9eede1da3'])
-    entity(niiri:3455442e086debfe280887e4ef34a59a,
+        nidm_equivalentThreshold: = 'niiri:d50e394152f7c5db5c7133e1470974d6',
+        nidm_equivalentThreshold: = 'niiri:4f1457a0836d72fad4ea9d0eead06e77'])
+    entity(niiri:d50e394152f7c5db5c7133e1470974d6,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:eec7cc036dfbc9f23b1c4ad9eede1da3,
+    entity(niiri:4f1457a0836d72fad4ea9d0eead06e77,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:ae1827b0fff51351ca6d76d580243226,
+    entity(niiri:423f12bcbd6d374ee66c9f2a2e4c948f,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:00a53452216f98c5cdd45baf25410a08,
+    entity(niiri:7487ab156945a06f5c7ec5c417b4ea5b,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:9ea94d4c881c3057dcce3e08fa91b4db,
+    activity(niiri:b5d284eb0075094514b80a3e61142bca,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:8707d65d3a15dbf845684e80f7df9da7, -)
-    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:40440229b29f5872d53eef25ecf0f975, -)
-    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:981d4a611d50d796152b8e8eb6283194, -)
-    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:67b4a4f6b336096ca6b563aa31361183, -)
-    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:86e735169b95dc7176008fba7b0cbabd, -)
-    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:9f3d2992eab79fd14d4660154ae8238a, -)
-    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:ae1827b0fff51351ca6d76d580243226, -)
-    used(niiri:9ea94d4c881c3057dcce3e08fa91b4db, niiri:00a53452216f98c5cdd45baf25410a08, -)
-    entity(niiri:144940fea03f1e81a40c282fefbe54f4,
+    wasAssociatedWith(niiri:b5d284eb0075094514b80a3e61142bca, niiri:234c7e043e4aca8ed9fefeb09a8d256c, -)
+    used(niiri:b5d284eb0075094514b80a3e61142bca, niiri:5a23de0647497e69518d9ecbd7dd2993, -)
+    used(niiri:b5d284eb0075094514b80a3e61142bca, niiri:b7917679b11eb67ab1ab21dfde06646f, -)
+    used(niiri:b5d284eb0075094514b80a3e61142bca, niiri:577e331ed1c3ff69dc99e6f96e20ad41, -)
+    used(niiri:b5d284eb0075094514b80a3e61142bca, niiri:db3b899f360335973148454d21c7bf0b, -)
+    used(niiri:b5d284eb0075094514b80a3e61142bca, niiri:4f82f60faefd085ffe16261907d905b5, -)
+    used(niiri:b5d284eb0075094514b80a3e61142bca, niiri:423f12bcbd6d374ee66c9f2a2e4c948f, -)
+    used(niiri:b5d284eb0075094514b80a3e61142bca, niiri:7487ab156945a06f5c7ec5c417b4ea5b, -)
+    entity(niiri:6ddf1c015bd8fb5b1a30ef647d9f65e2,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3',
         nidm_searchVolumeInVoxels: = "167222" %% xsd:int,
         nidm_searchVolumeInUnits: = "1337776" %% xsd:float,
         nidm_reselSizeInVoxels: = "68.5679161280351" %% xsd:float,
@@ -380,8 +380,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "99" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "57" %% xsd:int,
         crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
-    wasGeneratedBy(niiri:144940fea03f1e81a40c282fefbe54f4, niiri:9ea94d4c881c3057dcce3e08fa91b4db, -)
-    entity(niiri:a79e189fef35c2ea79f265fe43ab3fd5,
+    wasGeneratedBy(niiri:6ddf1c015bd8fb5b1a30ef647d9f65e2, niiri:b5d284eb0075094514b80a3e61142bca, -)
+    entity(niiri:3306774fd09ce4866577fe9443b964ef,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -389,22 +389,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "71" %% xsd:int,
         nidm_pValue: = "9.36073596413678e-09" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:f36222cc921e73ce4c2371f2c0ddc287',
-        nidm_hasMaximumIntensityProjection: = 'niiri:cf3dd6a7998b23db2dee0adcb3e1f4d7',
-        nidm_inCoordinateSpace: = 'niiri:c91eabb6ae30ecd695a7cf4b3fcab893',
+        nidm_hasClusterLabelsMap: = 'niiri:e45e235dce1fd30780f52611e0c22812',
+        nidm_hasMaximumIntensityProjection: = 'niiri:a0d4a6364727910bf49b77221a804961',
+        nidm_inCoordinateSpace: = 'niiri:762e57d57e56c8570d19ee32ae1e75c3',
         crypto:sha512 = "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006" %% xsd:string])
-    entity(niiri:f36222cc921e73ce4c2371f2c0ddc287,
+    entity(niiri:e45e235dce1fd30780f52611e0c22812,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:cf3dd6a7998b23db2dee0adcb3e1f4d7,
+    entity(niiri:a0d4a6364727910bf49b77221a804961,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:a79e189fef35c2ea79f265fe43ab3fd5, niiri:9ea94d4c881c3057dcce3e08fa91b4db, -)
-    entity(niiri:fcafd29e2d4984d5ef1a1e4525c5ba42,
+    wasGeneratedBy(niiri:3306774fd09ce4866577fe9443b964ef, niiri:b5d284eb0075094514b80a3e61142bca, -)
+    entity(niiri:4c1f276d9af9d476ea0e6263c11e3928,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "64" %% xsd:int,
@@ -413,8 +413,8 @@ document
         nidm_pValueFWER: = "0.060233823286733" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:fcafd29e2d4984d5ef1a1e4525c5ba42, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:444cc626db04f602c9c9011fa5e21c84,
+    wasDerivedFrom(niiri:4c1f276d9af9d476ea0e6263c11e3928, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:6dfa7cc864f8425fe2ca83d23d9f375e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "139" %% xsd:int,
@@ -423,8 +423,8 @@ document
         nidm_pValueFWER: = "0.000881242002104266" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:444cc626db04f602c9c9011fa5e21c84, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:b1753f3aee975cc2167fd8ecc371ac5b,
+    wasDerivedFrom(niiri:6dfa7cc864f8425fe2ca83d23d9f375e, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:e1dc5ba7de5b768eb8d9fdd13abef0cf,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "99" %% xsd:int,
@@ -433,8 +433,8 @@ document
         nidm_pValueFWER: = "0.00742042768591067" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:b1753f3aee975cc2167fd8ecc371ac5b, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:e217bff071e4c58201ab9d5e50316202,
+    wasDerivedFrom(niiri:e1dc5ba7de5b768eb8d9fdd13abef0cf, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:ec2dccfb1ebaaaf8d91e33c14f11f3ea,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "100" %% xsd:int,
@@ -443,8 +443,8 @@ document
         nidm_pValueFWER: = "0.00701417162859297" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:e217bff071e4c58201ab9d5e50316202, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:293f17b4b9a3d5e7642f3136e988fb69,
+    wasDerivedFrom(niiri:ec2dccfb1ebaaaf8d91e33c14f11f3ea, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:122c2e266aeef305c550f167cf916f71,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "41" %% xsd:int,
@@ -453,8 +453,8 @@ document
         nidm_pValueFWER: = "0.26810099909693" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:293f17b4b9a3d5e7642f3136e988fb69, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:f39819aeb0366241cbbae35a6427fc8b,
+    wasDerivedFrom(niiri:122c2e266aeef305c550f167cf916f71, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:1f521c6f09c963d12ee383c50f6388b1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "42" %% xsd:int,
@@ -463,8 +463,8 @@ document
         nidm_pValueFWER: = "0.251270468559567" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:f39819aeb0366241cbbae35a6427fc8b, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:804f36b4efe7eb06f1a23107f02c9522,
+    wasDerivedFrom(niiri:1f521c6f09c963d12ee383c50f6388b1, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:27132a256d54493c9f080d2bc58b4156,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "27" %% xsd:int,
@@ -473,8 +473,8 @@ document
         nidm_pValueFWER: = "0.621383930767395" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:804f36b4efe7eb06f1a23107f02c9522, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:808fd4e2193f0ed5ab2626fc643077ca,
+    wasDerivedFrom(niiri:27132a256d54493c9f080d2bc58b4156, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:7054c75c48fb30d1f27ab2bbb0333840,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "57" %% xsd:int,
@@ -483,8 +483,8 @@ document
         nidm_pValueFWER: = "0.0943507032156397" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:808fd4e2193f0ed5ab2626fc643077ca, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:2667f28dbb2bce2c8e774ae24bc32c34,
+    wasDerivedFrom(niiri:7054c75c48fb30d1f27ab2bbb0333840, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:40921ed9322bcbb9736f38620e4e285a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "33" %% xsd:int,
@@ -493,8 +493,8 @@ document
         nidm_pValueFWER: = "0.443203909376631" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:2667f28dbb2bce2c8e774ae24bc32c34, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:81153168c82f38e0344a3da5990713f4,
+    wasDerivedFrom(niiri:40921ed9322bcbb9736f38620e4e285a, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:7d90f7765940a5ab337f7643782ed47c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -503,8 +503,8 @@ document
         nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:81153168c82f38e0344a3da5990713f4, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:51df67b679cd0aa1c10588b2540f80ff,
+    wasDerivedFrom(niiri:7d90f7765940a5ab337f7643782ed47c, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:adb148e8a32d9f1ce4153efd0ac2dbc6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -513,8 +513,8 @@ document
         nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:51df67b679cd0aa1c10588b2540f80ff, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:c3859302a7f8a3aa876923fe5311fdeb,
+    wasDerivedFrom(niiri:adb148e8a32d9f1ce4153efd0ac2dbc6, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:4b83b464e56c198d5b02a944ed283f4f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "26" %% xsd:int,
@@ -523,8 +523,8 @@ document
         nidm_pValueFWER: = "0.653681229272869" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:c3859302a7f8a3aa876923fe5311fdeb, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:a9683c02ec255a54e2147300ce75147c,
+    wasDerivedFrom(niiri:4b83b464e56c198d5b02a944ed283f4f, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:0c7c2733a41b8cb85ab46d0144d6798a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -533,8 +533,8 @@ document
         nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:a9683c02ec255a54e2147300ce75147c, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:4b0d5b1cbdc197add17ddae11c60a960,
+    wasDerivedFrom(niiri:0c7c2733a41b8cb85ab46d0144d6798a, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:f4caac7418e57d3e43a996a7ba654c2f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -543,8 +543,8 @@ document
         nidm_pValueFWER: = "0.936111008142629" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:4b0d5b1cbdc197add17ddae11c60a960, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:074f24af2809bb5962437625180d87d8,
+    wasDerivedFrom(niiri:f4caac7418e57d3e43a996a7ba654c2f, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:cd181349ed02b711f1a6828158bcf43a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "14" %% xsd:int,
@@ -553,8 +553,8 @@ document
         nidm_pValueFWER: = "0.966679694237215" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:074f24af2809bb5962437625180d87d8, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:3950399d3cc373d8735fcf48ad86f542,
+    wasDerivedFrom(niiri:cd181349ed02b711f1a6828158bcf43a, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:e79df66e13024ab7771ec5eb685083aa,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "35" %% xsd:int,
@@ -563,8 +563,8 @@ document
         nidm_pValueFWER: = "0.392344720913691" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:3950399d3cc373d8735fcf48ad86f542, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:bab302ab1de7ceb32ee2a4553bab718d,
+    wasDerivedFrom(niiri:e79df66e13024ab7771ec5eb685083aa, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:196e757350d816ffa8ac1b4ae4acb7b7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "32" %% xsd:int,
@@ -573,8 +573,8 @@ document
         nidm_pValueFWER: = "0.470398116431399" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:bab302ab1de7ceb32ee2a4553bab718d, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:14ab5f557514798d8218e39a2199e27a,
+    wasDerivedFrom(niiri:196e757350d816ffa8ac1b4ae4acb7b7, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:fe44f10323dac9699d3966ced3bfaa90,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "46" %% xsd:int,
@@ -583,8 +583,8 @@ document
         nidm_pValueFWER: = "0.193521561130372" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:14ab5f557514798d8218e39a2199e27a, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:bc603717c0c5d8a8779b8aa6c28564b3,
+    wasDerivedFrom(niiri:fe44f10323dac9699d3966ced3bfaa90, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:ec03a5611c90a708dd60390dcb8ecc38,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "15" %% xsd:int,
@@ -593,8 +593,8 @@ document
         nidm_pValueFWER: = "0.952887583051913" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:bc603717c0c5d8a8779b8aa6c28564b3, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:106ee2638843f2793b5ac6735acad91e,
+    wasDerivedFrom(niiri:ec03a5611c90a708dd60390dcb8ecc38, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:56e6c7924a2f68ad79e3f7a7ae002bc4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "20" %% xsd:int,
@@ -603,8 +603,8 @@ document
         nidm_pValueFWER: = "0.841775430461368" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:106ee2638843f2793b5ac6735acad91e, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:01c1ab06b5a4997e0980bcddb0f69696,
+    wasDerivedFrom(niiri:56e6c7924a2f68ad79e3f7a7ae002bc4, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:cdfaf6b796e2c2557787c484faec4633,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -613,8 +613,8 @@ document
         nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:01c1ab06b5a4997e0980bcddb0f69696, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:8f249184eec9591adc7a3fc1c7e37936,
+    wasDerivedFrom(niiri:cdfaf6b796e2c2557787c484faec4633, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:f3fd301ca5fc6b876a28a4e840896ae7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "32" %% xsd:int,
@@ -623,8 +623,8 @@ document
         nidm_pValueFWER: = "0.470398116431399" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:8f249184eec9591adc7a3fc1c7e37936, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:c7ba1e0ca7a63ee914a7fa6cddbda281,
+    wasDerivedFrom(niiri:f3fd301ca5fc6b876a28a4e840896ae7, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:384bbe6b71ec2ae3109307c983930490,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -633,8 +633,8 @@ document
         nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:c7ba1e0ca7a63ee914a7fa6cddbda281, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:91987e35b1d8c15af66e3327a6e4b602,
+    wasDerivedFrom(niiri:384bbe6b71ec2ae3109307c983930490, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:19cd545bb290d6b4b5d50c3ca0b0d8e8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -643,8 +643,8 @@ document
         nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:91987e35b1d8c15af66e3327a6e4b602, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:c09f3990ca4bd168f93fa27a56eeb56c,
+    wasDerivedFrom(niiri:19cd545bb290d6b4b5d50c3ca0b0d8e8, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:1e795237a34002c8edd0e85dd55bd6db,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -653,8 +653,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:c09f3990ca4bd168f93fa27a56eeb56c, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:4f39525fd234b098e759c0ffc971fd5b,
+    wasDerivedFrom(niiri:1e795237a34002c8edd0e85dd55bd6db, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:a4f5ae0b708bf7e12619874d39f89768,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "21" %% xsd:int,
@@ -663,8 +663,8 @@ document
         nidm_pValueFWER: = "0.812786836270519" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:4f39525fd234b098e759c0ffc971fd5b, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:66eca61ada8ceb626c8ffd13d3efa1cc,
+    wasDerivedFrom(niiri:a4f5ae0b708bf7e12619874d39f89768, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:98a7f50d7445498f6d5c6b8931b0b269,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "25" %% xsd:int,
@@ -673,8 +673,8 @@ document
         nidm_pValueFWER: = "0.686218175845877" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:66eca61ada8ceb626c8ffd13d3efa1cc, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:5cf9402b2b494a87640a66aec1a6fdaf,
+    wasDerivedFrom(niiri:98a7f50d7445498f6d5c6b8931b0b269, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:0f673bfb48646ef7ce92732ddcd2561d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -683,8 +683,8 @@ document
         nidm_pValueFWER: = "0.999014041359979" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:5cf9402b2b494a87640a66aec1a6fdaf, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:1cd1f14fea72d133db88783e1b907b7f,
+    wasDerivedFrom(niiri:0f673bfb48646ef7ce92732ddcd2561d, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:e4e7c604a0dfd11b952f2d763f8365a1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -693,8 +693,8 @@ document
         nidm_pValueFWER: = "0.985744636441848" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:1cd1f14fea72d133db88783e1b907b7f, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:c3340fa012c626e62e86cdb279a4e883,
+    wasDerivedFrom(niiri:e4e7c604a0dfd11b952f2d763f8365a1, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:4fec6e6678455cee0511a392e629ec66,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -703,8 +703,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:c3340fa012c626e62e86cdb279a4e883, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd,
+    wasDerivedFrom(niiri:4fec6e6678455cee0511a392e629ec66, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:df39775c5b1f38c8f9be672ec1fd63ff,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -713,8 +713,8 @@ document
         nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "31" %% xsd:int])
-    wasDerivedFrom(niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:8b25738f634743abd67e5fd856e90f74,
+    wasDerivedFrom(niiri:df39775c5b1f38c8f9be672ec1fd63ff, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:d89f1264b6a74fc289ac86f3b1b14dde,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -723,8 +723,8 @@ document
         nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "32" %% xsd:int])
-    wasDerivedFrom(niiri:8b25738f634743abd67e5fd856e90f74, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:1c59a22b32098831723dc21703615fd1,
+    wasDerivedFrom(niiri:d89f1264b6a74fc289ac86f3b1b14dde, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:6b099ac0f252fd44544d43dc12a3d6df,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -733,8 +733,8 @@ document
         nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "33" %% xsd:int])
-    wasDerivedFrom(niiri:1c59a22b32098831723dc21703615fd1, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:139b6ecf5fdad735a51b4385a24aded9,
+    wasDerivedFrom(niiri:6b099ac0f252fd44544d43dc12a3d6df, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:de2e4a4014cc48ae0a2f90c80c8aa267,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -743,8 +743,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "34" %% xsd:int])
-    wasDerivedFrom(niiri:139b6ecf5fdad735a51b4385a24aded9, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:e6a138032615b9872d9261e35d2455f4,
+    wasDerivedFrom(niiri:de2e4a4014cc48ae0a2f90c80c8aa267, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:0fde32a1a3d9efae8053253baac76ffc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -753,8 +753,8 @@ document
         nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "35" %% xsd:int])
-    wasDerivedFrom(niiri:e6a138032615b9872d9261e35d2455f4, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:37bc5cb5a158a9f86c496a5d1935903c,
+    wasDerivedFrom(niiri:0fde32a1a3d9efae8053253baac76ffc, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:93cac87b0b2603caa2e73e808a49aa59,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -763,8 +763,8 @@ document
         nidm_pValueFWER: = "0.99963404273418" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "36" %% xsd:int])
-    wasDerivedFrom(niiri:37bc5cb5a158a9f86c496a5d1935903c, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:f86c9bb022fe2e7bb4f2a1d963869d32,
+    wasDerivedFrom(niiri:93cac87b0b2603caa2e73e808a49aa59, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:5869329bf3b962a832bb7acb7781cebd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -773,8 +773,8 @@ document
         nidm_pValueFWER: = "0.999014041359979" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "37" %% xsd:int])
-    wasDerivedFrom(niiri:f86c9bb022fe2e7bb4f2a1d963869d32, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:cecab36bcbd915f7841bff34cd7f59a6,
+    wasDerivedFrom(niiri:5869329bf3b962a832bb7acb7781cebd, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:10ed6be507db860ee020a597d2bcfbc3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -783,8 +783,8 @@ document
         nidm_pValueFWER: = "0.985744636441848" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "38" %% xsd:int])
-    wasDerivedFrom(niiri:cecab36bcbd915f7841bff34cd7f59a6, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:752ff8a0ff1912e3b3a3cc0b0af92bac,
+    wasDerivedFrom(niiri:10ed6be507db860ee020a597d2bcfbc3, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:d4cffec5c689a35b7bf1bec1606134a5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -793,8 +793,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "39" %% xsd:int])
-    wasDerivedFrom(niiri:752ff8a0ff1912e3b3a3cc0b0af92bac, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:bbfdc94758422f4cdfa2d461f26c652c,
+    wasDerivedFrom(niiri:d4cffec5c689a35b7bf1bec1606134a5, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:2f94714c99bebff5b4831f0cfafa8496,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -803,8 +803,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "40" %% xsd:int])
-    wasDerivedFrom(niiri:bbfdc94758422f4cdfa2d461f26c652c, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:412f44bb99fe0b4ac5111c8bb0d6824f,
+    wasDerivedFrom(niiri:2f94714c99bebff5b4831f0cfafa8496, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:ca58cacd0a13b44f43d59156a4c52a6a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -813,8 +813,8 @@ document
         nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "41" %% xsd:int])
-    wasDerivedFrom(niiri:412f44bb99fe0b4ac5111c8bb0d6824f, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:ae1cd8d0dfca9341507b66eafba6459d,
+    wasDerivedFrom(niiri:ca58cacd0a13b44f43d59156a4c52a6a, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:61377f406c900484318b0d2817a3c523,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -823,8 +823,8 @@ document
         nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "42" %% xsd:int])
-    wasDerivedFrom(niiri:ae1cd8d0dfca9341507b66eafba6459d, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:089292d98902368bd347bcdfa162cfda,
+    wasDerivedFrom(niiri:61377f406c900484318b0d2817a3c523, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:307dd0ecb797aef0ce055f67fc2fa294,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -833,8 +833,8 @@ document
         nidm_pValueFWER: = "0.997730485940405" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "43" %% xsd:int])
-    wasDerivedFrom(niiri:089292d98902368bd347bcdfa162cfda, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:716ffa34870ad39bf06d8e49c18b9bce,
+    wasDerivedFrom(niiri:307dd0ecb797aef0ce055f67fc2fa294, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:e1f1160e4c3acdd85c621d64903334ab,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -843,8 +843,8 @@ document
         nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "44" %% xsd:int])
-    wasDerivedFrom(niiri:716ffa34870ad39bf06d8e49c18b9bce, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:8c7ca240ed7a4d85316011dd6f1768ff,
+    wasDerivedFrom(niiri:e1f1160e4c3acdd85c621d64903334ab, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:bcd49735a6a0a30da7b9fe3278d6f064,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -853,8 +853,8 @@ document
         nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "45" %% xsd:int])
-    wasDerivedFrom(niiri:8c7ca240ed7a4d85316011dd6f1768ff, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:08593ccb1d9e49118b073d271565bd78,
+    wasDerivedFrom(niiri:bcd49735a6a0a30da7b9fe3278d6f064, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:290672736f8553a55089385f6b74f206,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -863,8 +863,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "46" %% xsd:int])
-    wasDerivedFrom(niiri:08593ccb1d9e49118b073d271565bd78, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:b52f4fded36d906e3611187b1ea82271,
+    wasDerivedFrom(niiri:290672736f8553a55089385f6b74f206, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:5ecd1cdffe7971283f7ba38938b61b2c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -873,8 +873,8 @@ document
         nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "47" %% xsd:int])
-    wasDerivedFrom(niiri:b52f4fded36d906e3611187b1ea82271, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:900eebea134685a11022813f19903499,
+    wasDerivedFrom(niiri:5ecd1cdffe7971283f7ba38938b61b2c, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:e1e08c2b6ca06aabfd4b12e4367167be,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -883,8 +883,8 @@ document
         nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "48" %% xsd:int])
-    wasDerivedFrom(niiri:900eebea134685a11022813f19903499, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:a20506ad4a845975db3365e7c162d818,
+    wasDerivedFrom(niiri:e1e08c2b6ca06aabfd4b12e4367167be, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:ef50676f067416d91bba713a2fc0321a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -893,8 +893,8 @@ document
         nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "49" %% xsd:int])
-    wasDerivedFrom(niiri:a20506ad4a845975db3365e7c162d818, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:cfde284823e7c32d74bec0b81232bb7a,
+    wasDerivedFrom(niiri:ef50676f067416d91bba713a2fc0321a, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:947bdfd650d750aaad83d695fd5ff821,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -903,8 +903,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "50" %% xsd:int])
-    wasDerivedFrom(niiri:cfde284823e7c32d74bec0b81232bb7a, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:496bec06cfc8ef95b3cbe0997c654d26,
+    wasDerivedFrom(niiri:947bdfd650d750aaad83d695fd5ff821, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:51e987ef34cc607991dc3fcd1b06d12d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -913,8 +913,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "51" %% xsd:int])
-    wasDerivedFrom(niiri:496bec06cfc8ef95b3cbe0997c654d26, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:e4bff32759970a1099e3a417cf7206b0,
+    wasDerivedFrom(niiri:51e987ef34cc607991dc3fcd1b06d12d, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:9e0d3d51afc26653e6ee900965729d85,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -923,8 +923,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "52" %% xsd:int])
-    wasDerivedFrom(niiri:e4bff32759970a1099e3a417cf7206b0, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:40337b736645244404b84afb6772e7a9,
+    wasDerivedFrom(niiri:9e0d3d51afc26653e6ee900965729d85, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:9d7d7cea0614241978504c478df9b65a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -933,8 +933,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "53" %% xsd:int])
-    wasDerivedFrom(niiri:40337b736645244404b84afb6772e7a9, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:42bc55f4f90f29daf9e12be119e1ddab,
+    wasDerivedFrom(niiri:9d7d7cea0614241978504c478df9b65a, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:20b5974d23f3286a95aa7fbb587ef438,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -943,8 +943,8 @@ document
         nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "54" %% xsd:int])
-    wasDerivedFrom(niiri:42bc55f4f90f29daf9e12be119e1ddab, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:067c79f86db85b508893737af41699ce,
+    wasDerivedFrom(niiri:20b5974d23f3286a95aa7fbb587ef438, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:9a32bcfd38e5afc90a14c0c217161efa,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -953,8 +953,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "55" %% xsd:int])
-    wasDerivedFrom(niiri:067c79f86db85b508893737af41699ce, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:1a35a6d628eed4f2fc8c554a4a579a19,
+    wasDerivedFrom(niiri:9a32bcfd38e5afc90a14c0c217161efa, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:210435c4c0603b37239c262e4c742cd7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -963,8 +963,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "56" %% xsd:int])
-    wasDerivedFrom(niiri:1a35a6d628eed4f2fc8c554a4a579a19, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:0e92ac2d77c091672e014daf15280170,
+    wasDerivedFrom(niiri:210435c4c0603b37239c262e4c742cd7, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:7c7c96862dfaf19b5ad9f27652329ae0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -973,8 +973,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "57" %% xsd:int])
-    wasDerivedFrom(niiri:0e92ac2d77c091672e014daf15280170, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:0d2b802df946de1efd390f218ef63fce,
+    wasDerivedFrom(niiri:7c7c96862dfaf19b5ad9f27652329ae0, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:3cb44c7fa017003278142567fd208f77,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -983,8 +983,8 @@ document
         nidm_pValueFWER: = "0.999999982398778" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "58" %% xsd:int])
-    wasDerivedFrom(niiri:0d2b802df946de1efd390f218ef63fce, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:627d75e08350cce3541dd568e3ddaa39,
+    wasDerivedFrom(niiri:3cb44c7fa017003278142567fd208f77, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:d0db4687f221096cb9c4f8413c4f75c6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -993,8 +993,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "59" %% xsd:int])
-    wasDerivedFrom(niiri:627d75e08350cce3541dd568e3ddaa39, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:20516921d28241951d08251e80cac5b5,
+    wasDerivedFrom(niiri:d0db4687f221096cb9c4f8413c4f75c6, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:7ef8baaeb7357f28badb11366679f71c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1003,8 +1003,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "60" %% xsd:int])
-    wasDerivedFrom(niiri:20516921d28241951d08251e80cac5b5, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:3822c0fa262ca8cb8a67590f3eec2fe6,
+    wasDerivedFrom(niiri:7ef8baaeb7357f28badb11366679f71c, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:cec5df2d95985851dd02c6d0db6fe243,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1013,8 +1013,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "61" %% xsd:int])
-    wasDerivedFrom(niiri:3822c0fa262ca8cb8a67590f3eec2fe6, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:51287994298816d649ba6908b4e3d0bb,
+    wasDerivedFrom(niiri:cec5df2d95985851dd02c6d0db6fe243, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:f0dffbbec6ed840a50eeb67367cfa4d5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1023,8 +1023,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "62" %% xsd:int])
-    wasDerivedFrom(niiri:51287994298816d649ba6908b4e3d0bb, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:36a1ff3bd64efa589db6c3a56ccf9d25,
+    wasDerivedFrom(niiri:f0dffbbec6ed840a50eeb67367cfa4d5, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:67c3a7b5cc3c3fe392535195f3bad2ad,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1033,8 +1033,8 @@ document
         nidm_pValueFWER: = "0.999999982398778" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "63" %% xsd:int])
-    wasDerivedFrom(niiri:36a1ff3bd64efa589db6c3a56ccf9d25, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:1c0a11fe168926616610d5836c36d35f,
+    wasDerivedFrom(niiri:67c3a7b5cc3c3fe392535195f3bad2ad, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:db97ffa2bd8c5823f405fd68ff718eee,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1043,8 +1043,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "64" %% xsd:int])
-    wasDerivedFrom(niiri:1c0a11fe168926616610d5836c36d35f, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:aa0d58d5cc7671539d09308038edb0f1,
+    wasDerivedFrom(niiri:db97ffa2bd8c5823f405fd68ff718eee, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:2d47c7ce748aeebd84bed25e87007425,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1053,8 +1053,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "65" %% xsd:int])
-    wasDerivedFrom(niiri:aa0d58d5cc7671539d09308038edb0f1, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:fc71e9e9a2574cbd9d5094f50275b3c2,
+    wasDerivedFrom(niiri:2d47c7ce748aeebd84bed25e87007425, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:8b7c26257640b1664a72209e6721cdcd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1063,8 +1063,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "66" %% xsd:int])
-    wasDerivedFrom(niiri:fc71e9e9a2574cbd9d5094f50275b3c2, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:c23970716bccffb656edae94cc34e353,
+    wasDerivedFrom(niiri:8b7c26257640b1664a72209e6721cdcd, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:4e2a5af599e4e60cf34c225aefbe86cb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1073,8 +1073,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "67" %% xsd:int])
-    wasDerivedFrom(niiri:c23970716bccffb656edae94cc34e353, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:8e2363110cdebe114cbe95493b19fa9d,
+    wasDerivedFrom(niiri:4e2a5af599e4e60cf34c225aefbe86cb, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:3a69dd386e787d840309add4c3d8288a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1083,8 +1083,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "68" %% xsd:int])
-    wasDerivedFrom(niiri:8e2363110cdebe114cbe95493b19fa9d, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:eb4122935f1afa2c8b532875de5f0ef9,
+    wasDerivedFrom(niiri:3a69dd386e787d840309add4c3d8288a, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:6026278153ba92cecad8e5b03e166074,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1093,8 +1093,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "69" %% xsd:int])
-    wasDerivedFrom(niiri:eb4122935f1afa2c8b532875de5f0ef9, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:25018fb0acd6d245a4f445c35c5f92eb,
+    wasDerivedFrom(niiri:6026278153ba92cecad8e5b03e166074, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:5df20a4fb89cbcd4160591f81dc70a0d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1103,8 +1103,8 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "70" %% xsd:int])
-    wasDerivedFrom(niiri:25018fb0acd6d245a4f445c35c5f92eb, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:ccd2969f60f8b0222713472b0a037361,
+    wasDerivedFrom(niiri:5df20a4fb89cbcd4160591f81dc70a0d, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:32dc10b2a989e36bb73d9c695b9ace8f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1113,1146 +1113,1146 @@ document
         nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "71" %% xsd:int])
-    wasDerivedFrom(niiri:ccd2969f60f8b0222713472b0a037361, niiri:a79e189fef35c2ea79f265fe43ab3fd5, -, -, -)
-    entity(niiri:baa4e7252d8424602eff0da2b334e0ea,
+    wasDerivedFrom(niiri:32dc10b2a989e36bb73d9c695b9ace8f, niiri:3306774fd09ce4866577fe9443b964ef, -, -, -)
+    entity(niiri:a4b5d66106f3fdd4bbb70333fc014ed9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:3dcaa7f03a6601fd8a98a0250eb396ce',
+        prov:location = 'niiri:e6c8661d28f8dd23040b47851749cfd0',
         prov:value = "39.0658683776855" %% xsd:float,
         nidm_equivalentZStatistic: = "5.04009751746769" %% xsd:float,
         nidm_pValueUncorrected: = "2.3264734660966e-07" %% xsd:float,
         nidm_pValueFWER: = "0.0389037590875805" %% xsd:float,
         nidm_qValueFDR: = "0.0302216629065993" %% xsd:float])
-    entity(niiri:3dcaa7f03a6601fd8a98a0250eb396ce,
+    entity(niiri:e6c8661d28f8dd23040b47851749cfd0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[-2,-90,28]" %% xsd:string])
-    wasDerivedFrom(niiri:baa4e7252d8424602eff0da2b334e0ea, niiri:fcafd29e2d4984d5ef1a1e4525c5ba42, -, -, -)
-    entity(niiri:ef00983a1ab378c0ed62a4e8080df8cf,
+    wasDerivedFrom(niiri:a4b5d66106f3fdd4bbb70333fc014ed9, niiri:4c1f276d9af9d476ea0e6263c11e3928, -, -, -)
+    entity(niiri:80b273a8f471de09518cdb5beddadab1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:a3fcc5c0311ede9dd4d7b167cd4e683f',
+        prov:location = 'niiri:e7e7b7bf2afd8637c397bcad07b85708',
         prov:value = "36.2393341064453" %% xsd:float,
         nidm_equivalentZStatistic: = "4.89725160225159" %% xsd:float,
         nidm_pValueUncorrected: = "4.85931842320042e-07" %% xsd:float,
         nidm_pValueFWER: = "0.071761896035709" %% xsd:float,
         nidm_qValueFDR: = "0.0302216629065993" %% xsd:float])
-    entity(niiri:a3fcc5c0311ede9dd4d7b167cd4e683f,
+    entity(niiri:e7e7b7bf2afd8637c397bcad07b85708,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[-42,-64,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:ef00983a1ab378c0ed62a4e8080df8cf, niiri:444cc626db04f602c9c9011fa5e21c84, -, -, -)
-    entity(niiri:915137b9c7e5154400a1f1cc8692da57,
+    wasDerivedFrom(niiri:80b273a8f471de09518cdb5beddadab1, niiri:6dfa7cc864f8425fe2ca83d23d9f375e, -, -, -)
+    entity(niiri:3f7650665beafba93222678f20a6dd8c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:6b30d660a4ad3dfdee42a3cd8d2d46f0',
+        prov:location = 'niiri:8e42064393b892a0c8085557be17c943',
         prov:value = "17.9251842498779" %% xsd:float,
         nidm_equivalentZStatistic: = "3.64201416072196" %% xsd:float,
         nidm_pValueUncorrected: = "0.000135256594276711" %% xsd:float,
         nidm_pValueFWER: = "0.999417997648594" %% xsd:float,
         nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
-    entity(niiri:6b30d660a4ad3dfdee42a3cd8d2d46f0,
+    entity(niiri:8e42064393b892a0c8085557be17c943,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[-40,-52,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:915137b9c7e5154400a1f1cc8692da57, niiri:444cc626db04f602c9c9011fa5e21c84, -, -, -)
-    entity(niiri:e99d8d782cf7659baaf6c7a11fd75959,
+    wasDerivedFrom(niiri:3f7650665beafba93222678f20a6dd8c, niiri:6dfa7cc864f8425fe2ca83d23d9f375e, -, -, -)
+    entity(niiri:4b55fa30e44c1ef889886e6cde14c762,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:deb2e3be4bbfe246eccd4c8e2cb277c9',
+        prov:location = 'niiri:ff21d0b06b48639a5d45597abb5c09d7',
         prov:value = "13.454288482666" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18324713734782" %% xsd:float,
         nidm_pValueUncorrected: = "0.000728166268399777" %% xsd:float,
         nidm_pValueFWER: = "0.999999999996872" %% xsd:float,
         nidm_qValueFDR: = "0.140840039531724" %% xsd:float])
-    entity(niiri:deb2e3be4bbfe246eccd4c8e2cb277c9,
+    entity(niiri:ff21d0b06b48639a5d45597abb5c09d7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[-38,-70,0]" %% xsd:string])
-    wasDerivedFrom(niiri:e99d8d782cf7659baaf6c7a11fd75959, niiri:444cc626db04f602c9c9011fa5e21c84, -, -, -)
-    entity(niiri:887edacd038795695bc5935681d9ec60,
+    wasDerivedFrom(niiri:4b55fa30e44c1ef889886e6cde14c762, niiri:6dfa7cc864f8425fe2ca83d23d9f375e, -, -, -)
+    entity(niiri:5dabdb8ba436106d06e1c8c00d3c0062,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:149ea3c3b924b56714ebbd48bd4cf7eb',
+        prov:location = 'niiri:5cc65ad8be948f162cac2e722174df85',
         prov:value = "29.4676361083984" %% xsd:float,
         nidm_equivalentZStatistic: = "4.51162164706026" %% xsd:float,
         nidm_pValueUncorrected: = "3.21669348379849e-06" %% xsd:float,
         nidm_pValueFWER: = "0.305525019896507" %% xsd:float,
         nidm_qValueFDR: = "0.0356596612461515" %% xsd:float])
-    entity(niiri:149ea3c3b924b56714ebbd48bd4cf7eb,
+    entity(niiri:5cc65ad8be948f162cac2e722174df85,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[16,-88,24]" %% xsd:string])
-    wasDerivedFrom(niiri:887edacd038795695bc5935681d9ec60, niiri:b1753f3aee975cc2167fd8ecc371ac5b, -, -, -)
-    entity(niiri:966afe2baff599cc271b19f81f50e736,
+    wasDerivedFrom(niiri:5dabdb8ba436106d06e1c8c00d3c0062, niiri:e1dc5ba7de5b768eb8d9fdd13abef0cf, -, -, -)
+    entity(niiri:2cc88f86b0896997e77e8ae4db3466fa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:de9e01b6bf2a659aa4d3377d86836307',
+        prov:location = 'niiri:f3c58ba1b59b55104e6a67eb2a49bfe7',
         prov:value = "28.5631580352783" %% xsd:float,
         nidm_equivalentZStatistic: = "4.45459114773779" %% xsd:float,
         nidm_pValueUncorrected: = "4.20266075706888e-06" %% xsd:float,
         nidm_pValueFWER: = "0.365688847752494" %% xsd:float,
         nidm_qValueFDR: = "0.0376032685416481" %% xsd:float])
-    entity(niiri:de9e01b6bf2a659aa4d3377d86836307,
+    entity(niiri:f3c58ba1b59b55104e6a67eb2a49bfe7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[28,-72,26]" %% xsd:string])
-    wasDerivedFrom(niiri:966afe2baff599cc271b19f81f50e736, niiri:e217bff071e4c58201ab9d5e50316202, -, -, -)
-    entity(niiri:25bc992eccfc2b6a6a24289f4e757203,
+    wasDerivedFrom(niiri:2cc88f86b0896997e77e8ae4db3466fa, niiri:ec2dccfb1ebaaaf8d91e33c14f11f3ea, -, -, -)
+    entity(niiri:074e638017a74cef02a16c08d8e42006,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:e01e6d8bfc3791e75a43288c36fa1d9c',
+        prov:location = 'niiri:01fc9cdf27d2103b7930391f8b2ea3d3',
         prov:value = "26.9945106506348" %% xsd:float,
         nidm_equivalentZStatistic: = "4.35204306383375" %% xsd:float,
         nidm_pValueUncorrected: = "6.7437380493196e-06" %% xsd:float,
         nidm_pValueFWER: = "0.489729172437052" %% xsd:float,
         nidm_qValueFDR: = "0.0406203661092224" %% xsd:float])
-    entity(niiri:e01e6d8bfc3791e75a43288c36fa1d9c,
+    entity(niiri:01fc9cdf27d2103b7930391f8b2ea3d3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[-32,20,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:25bc992eccfc2b6a6a24289f4e757203, niiri:293f17b4b9a3d5e7642f3136e988fb69, -, -, -)
-    entity(niiri:f9405b475d3bdca76e81a6717bca04c2,
+    wasDerivedFrom(niiri:074e638017a74cef02a16c08d8e42006, niiri:122c2e266aeef305c550f167cf916f71, -, -, -)
+    entity(niiri:8d7cd6dcbd82a0f5592c3c44c8dd84ff,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:d382a0c6c03aa0a2f6ee3c758f66a342',
+        prov:location = 'niiri:252f7991c4a1845b01ddb30503d8d863',
         prov:value = "26.8606586456299" %% xsd:float,
         nidm_equivalentZStatistic: = "4.34306775687574" %% xsd:float,
         nidm_pValueUncorrected: = "7.02533878071954e-06" %% xsd:float,
         nidm_pValueFWER: = "0.501353785238145" %% xsd:float,
         nidm_qValueFDR: = "0.0406203661092224" %% xsd:float])
-    entity(niiri:d382a0c6c03aa0a2f6ee3c758f66a342,
+    entity(niiri:252f7991c4a1845b01ddb30503d8d863,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[-8,50,32]" %% xsd:string])
-    wasDerivedFrom(niiri:f9405b475d3bdca76e81a6717bca04c2, niiri:f39819aeb0366241cbbae35a6427fc8b, -, -, -)
-    entity(niiri:5f02b40490d007ae68a92b4316e9efd9,
+    wasDerivedFrom(niiri:8d7cd6dcbd82a0f5592c3c44c8dd84ff, niiri:1f521c6f09c963d12ee383c50f6388b1, -, -, -)
+    entity(niiri:71fb9ba017dcd88efbdbf312b4d060d9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:dd4a0e1012831b8affc68995057a1120',
+        prov:location = 'niiri:6a71ac7754a9b7fbfc6bfaa02c11d530',
         prov:value = "25.8067512512207" %% xsd:float,
         nidm_equivalentZStatistic: = "4.27109313660164" %% xsd:float,
         nidm_pValueUncorrected: = "9.72585724245967e-06" %% xsd:float,
         nidm_pValueFWER: = "0.597019202761311" %% xsd:float,
         nidm_qValueFDR: = "0.0439563569939673" %% xsd:float])
-    entity(niiri:dd4a0e1012831b8affc68995057a1120,
+    entity(niiri:6a71ac7754a9b7fbfc6bfaa02c11d530,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[-34,8,58]" %% xsd:string])
-    wasDerivedFrom(niiri:5f02b40490d007ae68a92b4316e9efd9, niiri:804f36b4efe7eb06f1a23107f02c9522, -, -, -)
-    entity(niiri:9eb8c305928cd26af5d735f290a7ce8a,
+    wasDerivedFrom(niiri:71fb9ba017dcd88efbdbf312b4d060d9, niiri:27132a256d54493c9f080d2bc58b4156, -, -, -)
+    entity(niiri:c6195964f0ecba12db98dfb166219c62,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:c53ceb2c4d2e390230752c97501ffbd1',
+        prov:location = 'niiri:c5898b1fb96ddd15f3391d41ff541d6a',
         prov:value = "25.0769119262695" %% xsd:float,
         nidm_equivalentZStatistic: = "4.21983658750018" %% xsd:float,
         nidm_pValueUncorrected: = "1.22239732009977e-05" %% xsd:float,
         nidm_pValueFWER: = "0.665677647955296" %% xsd:float,
         nidm_qValueFDR: = "0.0444376030498989" %% xsd:float])
-    entity(niiri:c53ceb2c4d2e390230752c97501ffbd1,
+    entity(niiri:c5898b1fb96ddd15f3391d41ff541d6a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[32,-86,0]" %% xsd:string])
-    wasDerivedFrom(niiri:9eb8c305928cd26af5d735f290a7ce8a, niiri:808fd4e2193f0ed5ab2626fc643077ca, -, -, -)
-    entity(niiri:11109932f0e2675cb40f05a3edc02ba0,
+    wasDerivedFrom(niiri:c6195964f0ecba12db98dfb166219c62, niiri:7054c75c48fb30d1f27ab2bbb0333840, -, -, -)
+    entity(niiri:ce340d21c8afc601ee08ecb7a457da25,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:03754f6422c542b58050fa515c5326b7',
+        prov:location = 'niiri:8488d4cb4456e28be487f199b4d97608',
         prov:value = "24.5828113555908" %% xsd:float,
         nidm_equivalentZStatistic: = "4.18444689049798" %% xsd:float,
         nidm_pValueUncorrected: = "1.42930633414418e-05" %% xsd:float,
         nidm_pValueFWER: = "0.711939170732988" %% xsd:float,
         nidm_qValueFDR: = "0.04475687830922" %% xsd:float])
-    entity(niiri:03754f6422c542b58050fa515c5326b7,
+    entity(niiri:8488d4cb4456e28be487f199b4d97608,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[66,-32,30]" %% xsd:string])
-    wasDerivedFrom(niiri:11109932f0e2675cb40f05a3edc02ba0, niiri:2667f28dbb2bce2c8e774ae24bc32c34, -, -, -)
-    entity(niiri:4fefff5985067f520ab89234bd477dd4,
+    wasDerivedFrom(niiri:ce340d21c8afc601ee08ecb7a457da25, niiri:40921ed9322bcbb9736f38620e4e285a, -, -, -)
+    entity(niiri:f03ec4c103041b877b9cae5a2d180a74,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:35dc6728bd9b0380bd0c34c5ef999f15',
+        prov:location = 'niiri:7e06c1af22bc9c2b12f6cc76c8c7f66e',
         prov:value = "14.2693071365356" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27451594161643" %% xsd:float,
         nidm_pValueUncorrected: = "0.000529215834762176" %% xsd:float,
         nidm_pValueFWER: = "0.999999999209483" %% xsd:float,
         nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
-    entity(niiri:35dc6728bd9b0380bd0c34c5ef999f15,
+    entity(niiri:7e06c1af22bc9c2b12f6cc76c8c7f66e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[60,-38,28]" %% xsd:string])
-    wasDerivedFrom(niiri:4fefff5985067f520ab89234bd477dd4, niiri:2667f28dbb2bce2c8e774ae24bc32c34, -, -, -)
-    entity(niiri:0a247f47177e119fa9edf6e9f6f98b5e,
+    wasDerivedFrom(niiri:f03ec4c103041b877b9cae5a2d180a74, niiri:40921ed9322bcbb9736f38620e4e285a, -, -, -)
+    entity(niiri:380064f5294cac972c58e3ea6c97bd61,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:3717dcf5b4b7f3fadfa70b271f5a347b',
+        prov:location = 'niiri:f539c472e21c00876796de97ec02e302',
         prov:value = "23.3039436340332" %% xsd:float,
         nidm_equivalentZStatistic: = "4.09011898331566" %% xsd:float,
         nidm_pValueUncorrected: = "2.15575975488491e-05" %% xsd:float,
         nidm_pValueFWER: = "0.823947459995523" %% xsd:float,
         nidm_qValueFDR: = "0.0478656864369739" %% xsd:float])
-    entity(niiri:3717dcf5b4b7f3fadfa70b271f5a347b,
+    entity(niiri:f539c472e21c00876796de97ec02e302,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[28,30,52]" %% xsd:string])
-    wasDerivedFrom(niiri:0a247f47177e119fa9edf6e9f6f98b5e, niiri:81153168c82f38e0344a3da5990713f4, -, -, -)
-    entity(niiri:07aa292e8e64264cf6b16262dd9b0461,
+    wasDerivedFrom(niiri:380064f5294cac972c58e3ea6c97bd61, niiri:7d90f7765940a5ab337f7643782ed47c, -, -, -)
+    entity(niiri:73a8b070f80bf9bc91a66c26d61eccd7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:17d984ec4e21314566bdf4644fb07af0',
+        prov:location = 'niiri:bb014a1ef20c2696675ef76b2e0ee76f',
         prov:value = "22.6157932281494" %% xsd:float,
         nidm_equivalentZStatistic: = "4.03763886298215" %% xsd:float,
         nidm_pValueUncorrected: = "2.69959426782984e-05" %% xsd:float,
         nidm_pValueFWER: = "0.87538446987651" %% xsd:float,
         nidm_qValueFDR: = "0.0515719459796674" %% xsd:float])
-    entity(niiri:17d984ec4e21314566bdf4644fb07af0,
+    entity(niiri:bb014a1ef20c2696675ef76b2e0ee76f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[-30,-34,6]" %% xsd:string])
-    wasDerivedFrom(niiri:07aa292e8e64264cf6b16262dd9b0461, niiri:51df67b679cd0aa1c10588b2540f80ff, -, -, -)
-    entity(niiri:c09425629406f190de8edebf54022f2d,
+    wasDerivedFrom(niiri:73a8b070f80bf9bc91a66c26d61eccd7, niiri:adb148e8a32d9f1ce4153efd0ac2dbc6, -, -, -)
+    entity(niiri:89f052acead95535f656ffcba48e3b7d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:cd4e978cbe4323a391c6fa96ba73890b',
+        prov:location = 'niiri:971a1775ef89417b195708fdf276dbdd',
         prov:value = "21.8558578491211" %% xsd:float,
         nidm_equivalentZStatistic: = "3.97819185113407" %% xsd:float,
         nidm_pValueUncorrected: = "3.47206660495925e-05" %% xsd:float,
         nidm_pValueFWER: = "0.921823721412592" %% xsd:float,
         nidm_qValueFDR: = "0.053734847831518" %% xsd:float])
-    entity(niiri:cd4e978cbe4323a391c6fa96ba73890b,
+    entity(niiri:971a1775ef89417b195708fdf276dbdd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[-28,0,30]" %% xsd:string])
-    wasDerivedFrom(niiri:c09425629406f190de8edebf54022f2d, niiri:c3859302a7f8a3aa876923fe5311fdeb, -, -, -)
-    entity(niiri:00455682ca694ef095f7439ab81ebd12,
+    wasDerivedFrom(niiri:89f052acead95535f656ffcba48e3b7d, niiri:4b83b464e56c198d5b02a944ed283f4f, -, -, -)
+    entity(niiri:a461f7f85b7c93e0257a2abe934b8cd1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:a61981cb739588894bbdc415c7c87afe',
+        prov:location = 'niiri:ee07dc885b0177dec74aed7571cb797c',
         prov:value = "21.8296661376953" %% xsd:float,
         nidm_equivalentZStatistic: = "3.97611404363788" %% xsd:float,
         nidm_pValueUncorrected: = "3.50252708366527e-05" %% xsd:float,
         nidm_pValueFWER: = "0.923209894114283" %% xsd:float,
         nidm_qValueFDR: = "0.053734847831518" %% xsd:float])
-    entity(niiri:a61981cb739588894bbdc415c7c87afe,
+    entity(niiri:ee07dc885b0177dec74aed7571cb797c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[8,34,10]" %% xsd:string])
-    wasDerivedFrom(niiri:00455682ca694ef095f7439ab81ebd12, niiri:a9683c02ec255a54e2147300ce75147c, -, -, -)
-    entity(niiri:5cc633c2d1685a757beeaecee1a48008,
+    wasDerivedFrom(niiri:a461f7f85b7c93e0257a2abe934b8cd1, niiri:0c7c2733a41b8cb85ab46d0144d6798a, -, -, -)
+    entity(niiri:1ac086531bc098af131e9714a3b83b12,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:b7a12cc701147c2a30416bd9e767f926',
+        prov:location = 'niiri:ebdc7b10afb6bea822ede76d7fdbb5a5',
         prov:value = "21.7287845611572" %% xsd:float,
         nidm_equivalentZStatistic: = "3.96809263472704" %% xsd:float,
         nidm_pValueUncorrected: = "3.6225086553876e-05" %% xsd:float,
         nidm_pValueFWER: = "0.928411428313329" %% xsd:float,
         nidm_qValueFDR: = "0.0540587737624357" %% xsd:float])
-    entity(niiri:b7a12cc701147c2a30416bd9e767f926,
+    entity(niiri:ebdc7b10afb6bea822ede76d7fdbb5a5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[46,-56,10]" %% xsd:string])
-    wasDerivedFrom(niiri:5cc633c2d1685a757beeaecee1a48008, niiri:4b0d5b1cbdc197add17ddae11c60a960, -, -, -)
-    entity(niiri:bc5fb74855b827b626fd1eebefaa6d4d,
+    wasDerivedFrom(niiri:1ac086531bc098af131e9714a3b83b12, niiri:f4caac7418e57d3e43a996a7ba654c2f, -, -, -)
+    entity(niiri:bf746b5c92e282960a90d715da3e9348,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:352d0e5787411f3cc15519e7582cf21f',
+        prov:location = 'niiri:dfde90eec39f9b1b9a3c0f23d4a02625',
         prov:value = "14.2801656723022" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27570591680179" %% xsd:float,
         nidm_pValueUncorrected: = "0.000526991241768693" %% xsd:float,
         nidm_pValueFWER: = "0.999999999156251" %% xsd:float,
         nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
-    entity(niiri:352d0e5787411f3cc15519e7582cf21f,
+    entity(niiri:dfde90eec39f9b1b9a3c0f23d4a02625,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[48,-48,16]" %% xsd:string])
-    wasDerivedFrom(niiri:bc5fb74855b827b626fd1eebefaa6d4d, niiri:4b0d5b1cbdc197add17ddae11c60a960, -, -, -)
-    entity(niiri:90dc79d65e7f32dfb01b08b18c3ce762,
+    wasDerivedFrom(niiri:bf746b5c92e282960a90d715da3e9348, niiri:f4caac7418e57d3e43a996a7ba654c2f, -, -, -)
+    entity(niiri:a447b0cecc50da0ea88347128197c345,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:33a1d7fed96c259799c80dc81ed84ff7',
+        prov:location = 'niiri:088da6b8de973e2cae4da24790c12a93',
         prov:value = "21.4629364013672" %% xsd:float,
         nidm_equivalentZStatistic: = "3.9468129149843" %% xsd:float,
         nidm_pValueUncorrected: = "3.95991966499754e-05" %% xsd:float,
         nidm_pValueFWER: = "0.941069307565192" %% xsd:float,
         nidm_qValueFDR: = "0.0555984329583215" %% xsd:float])
-    entity(niiri:33a1d7fed96c259799c80dc81ed84ff7,
+    entity(niiri:088da6b8de973e2cae4da24790c12a93,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[46,-62,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:90dc79d65e7f32dfb01b08b18c3ce762, niiri:074f24af2809bb5962437625180d87d8, -, -, -)
-    entity(niiri:865765b8e81628e180cd32d69ff2a873,
+    wasDerivedFrom(niiri:a447b0cecc50da0ea88347128197c345, niiri:cd181349ed02b711f1a6828158bcf43a, -, -, -)
+    entity(niiri:ae5abe12c74c45cfd3926ba1612ffba2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:572e00e92909efbb8dbfa749a8192c13',
+        prov:location = 'niiri:197ad10ce797561392405a298e974d2f',
         prov:value = "21.4269542694092" %% xsd:float,
         nidm_equivalentZStatistic: = "3.94391683979485" %% xsd:float,
         nidm_pValueUncorrected: = "4.00807329147268e-05" %% xsd:float,
         nidm_pValueFWER: = "0.942665676683549" %% xsd:float,
         nidm_qValueFDR: = "0.0555984329583215" %% xsd:float])
-    entity(niiri:572e00e92909efbb8dbfa749a8192c13,
+    entity(niiri:197ad10ce797561392405a298e974d2f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[-8,-32,36]" %% xsd:string])
-    wasDerivedFrom(niiri:865765b8e81628e180cd32d69ff2a873, niiri:3950399d3cc373d8735fcf48ad86f542, -, -, -)
-    entity(niiri:016b2fb8ca4f729da187a0f0b71608cc,
+    wasDerivedFrom(niiri:ae5abe12c74c45cfd3926ba1612ffba2, niiri:e79df66e13024ab7771ec5eb685083aa, -, -, -)
+    entity(niiri:1f2ba07ccc62e5275dd063020505b5a0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:98776a828aca5a643515928e94c4cdc1',
+        prov:location = 'niiri:e20b66260ee51af0dcd93cc998bd40e3',
         prov:value = "20.0413494110107" %% xsd:float,
         nidm_equivalentZStatistic: = "3.82938429557992" %% xsd:float,
         nidm_pValueUncorrected: = "6.42321325474704e-05" %% xsd:float,
         nidm_pValueFWER: = "0.984364018223445" %% xsd:float,
         nidm_qValueFDR: = "0.0674959642175569" %% xsd:float])
-    entity(niiri:98776a828aca5a643515928e94c4cdc1,
+    entity(niiri:e20b66260ee51af0dcd93cc998bd40e3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[-34,-84,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:016b2fb8ca4f729da187a0f0b71608cc, niiri:bab302ab1de7ceb32ee2a4553bab718d, -, -, -)
-    entity(niiri:ca802812c6d952e6eb53d6a2598748c3,
+    wasDerivedFrom(niiri:1f2ba07ccc62e5275dd063020505b5a0, niiri:196e757350d816ffa8ac1b4ae4acb7b7, -, -, -)
+    entity(niiri:ce16f70f7779546dfadce90aa2b616c4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:305b4d132dad573dd2e91152abf41d15',
+        prov:location = 'niiri:f567e22563c6428fe26c5d6d093f4f90',
         prov:value = "19.5813789367676" %% xsd:float,
         nidm_equivalentZStatistic: = "3.79000141974546" %% xsd:float,
         nidm_pValueUncorrected: = "7.53232118573255e-05" %% xsd:float,
         nidm_pValueFWER: = "0.991038394814884" %% xsd:float,
         nidm_qValueFDR: = "0.0718990170223714" %% xsd:float])
-    entity(niiri:305b4d132dad573dd2e91152abf41d15,
+    entity(niiri:f567e22563c6428fe26c5d6d093f4f90,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[-50,2,40]" %% xsd:string])
-    wasDerivedFrom(niiri:ca802812c6d952e6eb53d6a2598748c3, niiri:14ab5f557514798d8218e39a2199e27a, -, -, -)
-    entity(niiri:2cd7edd94889650191f6f242b9a4c176,
+    wasDerivedFrom(niiri:ce16f70f7779546dfadce90aa2b616c4, niiri:fe44f10323dac9699d3966ced3bfaa90, -, -, -)
+    entity(niiri:ac087026e1fae344bef102ebc6369217,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:0d995ab3826e8df7675b6f8b8f4c2673',
+        prov:location = 'niiri:65fc106af51b8b5701b029fa54f23b6b',
         prov:value = "16.7666301727295" %% xsd:float,
         nidm_equivalentZStatistic: = "3.53217184854778" %% xsd:float,
         nidm_pValueUncorrected: = "0.00020608070787731" %% xsd:float,
         nidm_pValueFWER: = "0.99996648470095" %% xsd:float,
         nidm_qValueFDR: = "0.0942608471449251" %% xsd:float])
-    entity(niiri:0d995ab3826e8df7675b6f8b8f4c2673,
+    entity(niiri:65fc106af51b8b5701b029fa54f23b6b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-52,-6,46]" %% xsd:string])
-    wasDerivedFrom(niiri:2cd7edd94889650191f6f242b9a4c176, niiri:14ab5f557514798d8218e39a2199e27a, -, -, -)
-    entity(niiri:390e65b5876e189721e8386b64e468ba,
+    wasDerivedFrom(niiri:ac087026e1fae344bef102ebc6369217, niiri:fe44f10323dac9699d3966ced3bfaa90, -, -, -)
+    entity(niiri:635b0e02961f2a78b72796a9c2e17324,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:8e65f05088e65ca40cdab4f7b8c45feb',
+        prov:location = 'niiri:b46abfb5190d694712f1f4c11de9d701',
         prov:value = "19.3040504455566" %% xsd:float,
         nidm_equivalentZStatistic: = "3.76590943131268" %% xsd:float,
         nidm_pValueUncorrected: = "8.2971971291701e-05" %% xsd:float,
         nidm_pValueFWER: = "0.993825462793153" %% xsd:float,
         nidm_qValueFDR: = "0.0737314974355366" %% xsd:float])
-    entity(niiri:8e65f05088e65ca40cdab4f7b8c45feb,
+    entity(niiri:b46abfb5190d694712f1f4c11de9d701,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[24,-46,32]" %% xsd:string])
-    wasDerivedFrom(niiri:390e65b5876e189721e8386b64e468ba, niiri:bc603717c0c5d8a8779b8aa6c28564b3, -, -, -)
-    entity(niiri:613f7d1a72653a094215c0c7838598d6,
+    wasDerivedFrom(niiri:635b0e02961f2a78b72796a9c2e17324, niiri:ec03a5611c90a708dd60390dcb8ecc38, -, -, -)
+    entity(niiri:9ec9ec5e398bddae9b7e40ae59725d63,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:261bf2d0efecb03152c6e1cdf2df18c0',
+        prov:location = 'niiri:4a185ebc5f4d1de8ede7b1068b95bee7',
         prov:value = "19.1409015655518" %% xsd:float,
         nidm_equivalentZStatistic: = "3.75161143600874" %% xsd:float,
         nidm_pValueUncorrected: = "8.7850813353163e-05" %% xsd:float,
         nidm_pValueFWER: = "0.995110302012489" %% xsd:float,
         nidm_qValueFDR: = "0.0738147834753255" %% xsd:float])
-    entity(niiri:261bf2d0efecb03152c6e1cdf2df18c0,
+    entity(niiri:4a185ebc5f4d1de8ede7b1068b95bee7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[6,16,50]" %% xsd:string])
-    wasDerivedFrom(niiri:613f7d1a72653a094215c0c7838598d6, niiri:106ee2638843f2793b5ac6735acad91e, -, -, -)
-    entity(niiri:dbe73b14c812ef0bb874edaf583e9d7c,
+    wasDerivedFrom(niiri:9ec9ec5e398bddae9b7e40ae59725d63, niiri:56e6c7924a2f68ad79e3f7a7ae002bc4, -, -, -)
+    entity(niiri:a9c8d878bf0f79a4e19e5fcba292c1d0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:64529db73025d3ebe03ab8490a2c7588',
+        prov:location = 'niiri:02c035a9817a3caa54dd18a13e2035f0',
         prov:value = "19.098669052124" %% xsd:float,
         nidm_equivalentZStatistic: = "3.74789498829157" %% xsd:float,
         nidm_pValueUncorrected: = "8.91624398706714e-05" %% xsd:float,
         nidm_pValueFWER: = "0.995405100064856" %% xsd:float,
         nidm_qValueFDR: = "0.0738147834753255" %% xsd:float])
-    entity(niiri:64529db73025d3ebe03ab8490a2c7588,
+    entity(niiri:02c035a9817a3caa54dd18a13e2035f0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[-4,-24,6]" %% xsd:string])
-    wasDerivedFrom(niiri:dbe73b14c812ef0bb874edaf583e9d7c, niiri:01c1ab06b5a4997e0980bcddb0f69696, -, -, -)
-    entity(niiri:d74cbd45e77a6bd61d201389470b3f9d,
+    wasDerivedFrom(niiri:a9c8d878bf0f79a4e19e5fcba292c1d0, niiri:cdfaf6b796e2c2557787c484faec4633, -, -, -)
+    entity(niiri:06f5e32a866b81a387b9af05e7bb4dd0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:2a23dfb2262a16b99ed1460c9726d32d',
+        prov:location = 'niiri:37aa56db8b87ee90b242d01a374785c7',
         prov:value = "19.0145893096924" %% xsd:float,
         nidm_equivalentZStatistic: = "3.7404771295496" %% xsd:float,
         nidm_pValueUncorrected: = "9.1835629583259e-05" %% xsd:float,
         nidm_pValueFWER: = "0.995949293325196" %% xsd:float,
         nidm_qValueFDR: = "0.0741915113542509" %% xsd:float])
-    entity(niiri:2a23dfb2262a16b99ed1460c9726d32d,
+    entity(niiri:37aa56db8b87ee90b242d01a374785c7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[-4,0,54]" %% xsd:string])
-    wasDerivedFrom(niiri:d74cbd45e77a6bd61d201389470b3f9d, niiri:8f249184eec9591adc7a3fc1c7e37936, -, -, -)
-    entity(niiri:4bb899cd9f06bf6ba2fefa26066f1718,
+    wasDerivedFrom(niiri:06f5e32a866b81a387b9af05e7bb4dd0, niiri:f3fd301ca5fc6b876a28a4e840896ae7, -, -, -)
+    entity(niiri:1ee6d6112a6b6d3536ce8264fcb7b4c2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:84e6c234c35fdc2fa131ca05716bd905',
+        prov:location = 'niiri:2fd08c9a53a8e9fb7b04c521a2a1cd17',
         prov:value = "18.8265838623047" %% xsd:float,
         nidm_equivalentZStatistic: = "3.72379883766124" %% xsd:float,
         nidm_pValueUncorrected: = "9.81236582245915e-05" %% xsd:float,
         nidm_pValueFWER: = "0.996978299202392" %% xsd:float,
         nidm_qValueFDR: = "0.0777669728451003" %% xsd:float])
-    entity(niiri:84e6c234c35fdc2fa131ca05716bd905,
+    entity(niiri:2fd08c9a53a8e9fb7b04c521a2a1cd17,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[42,-28,30]" %% xsd:string])
-    wasDerivedFrom(niiri:4bb899cd9f06bf6ba2fefa26066f1718, niiri:c7ba1e0ca7a63ee914a7fa6cddbda281, -, -, -)
-    entity(niiri:2fcf4f5e0a9409e59f9b3a198af722a2,
+    wasDerivedFrom(niiri:1ee6d6112a6b6d3536ce8264fcb7b4c2, niiri:384bbe6b71ec2ae3109307c983930490, -, -, -)
+    entity(niiri:d16c30636db69b3fdadc372725e795b3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:dfeeafe9412e26a98688ac2eb5eedc76',
+        prov:location = 'niiri:83dd62bd96860aa2272e2459d7254fbf',
         prov:value = "18.5199432373047" %% xsd:float,
         nidm_equivalentZStatistic: = "3.69631988620818" %% xsd:float,
         nidm_pValueUncorrected: = "0.000109373660980738" %% xsd:float,
         nidm_pValueFWER: = "0.998191254166604" %% xsd:float,
         nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
-    entity(niiri:dfeeafe9412e26a98688ac2eb5eedc76,
+    entity(niiri:83dd62bd96860aa2272e2459d7254fbf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[52,-12,44]" %% xsd:string])
-    wasDerivedFrom(niiri:2fcf4f5e0a9409e59f9b3a198af722a2, niiri:91987e35b1d8c15af66e3327a6e4b602, -, -, -)
-    entity(niiri:01dc6fc72b88495c5e6c08fc0cc0bc35,
+    wasDerivedFrom(niiri:d16c30636db69b3fdadc372725e795b3, niiri:19cd545bb290d6b4b5d50c3ca0b0d8e8, -, -, -)
+    entity(niiri:dd3ea80bed9326c0c1e5f9d969330df1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:a785670f070730f0b5dad30427a1e8f7',
+        prov:location = 'niiri:f1bd534575da07c1a675a049095b255b',
         prov:value = "18.516544342041" %% xsd:float,
         nidm_equivalentZStatistic: = "3.69601335434539" %% xsd:float,
         nidm_pValueUncorrected: = "0.000109505728679404" %% xsd:float,
         nidm_pValueFWER: = "0.998201975106935" %% xsd:float,
         nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
-    entity(niiri:a785670f070730f0b5dad30427a1e8f7,
+    entity(niiri:f1bd534575da07c1a675a049095b255b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[-40,-28,30]" %% xsd:string])
-    wasDerivedFrom(niiri:01dc6fc72b88495c5e6c08fc0cc0bc35, niiri:c09f3990ca4bd168f93fa27a56eeb56c, -, -, -)
-    entity(niiri:cf74bac84d8f51cb7fb8a579dd4b736b,
+    wasDerivedFrom(niiri:dd3ea80bed9326c0c1e5f9d969330df1, niiri:1e795237a34002c8edd0e85dd55bd6db, -, -, -)
+    entity(niiri:7e2b0e69ab0d6650bcdb2ff672f6931b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:62e6d759392d4c5a22e393f530aba130',
+        prov:location = 'niiri:fe5c4a2eb46fc779cf97d7894da36e0f',
         prov:value = "18.4609222412109" %% xsd:float,
         nidm_equivalentZStatistic: = "3.69099090519778" %% xsd:float,
         nidm_pValueUncorrected: = "0.000111691062804176" %% xsd:float,
         nidm_pValueFWER: = "0.998370011058266" %% xsd:float,
         nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
-    entity(niiri:62e6d759392d4c5a22e393f530aba130,
+    entity(niiri:fe5c4a2eb46fc779cf97d7894da36e0f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[32,22,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:cf74bac84d8f51cb7fb8a579dd4b736b, niiri:4f39525fd234b098e759c0ffc971fd5b, -, -, -)
-    entity(niiri:39ca307d31c5892250f913783b4db62c,
+    wasDerivedFrom(niiri:7e2b0e69ab0d6650bcdb2ff672f6931b, niiri:a4f5ae0b708bf7e12619874d39f89768, -, -, -)
+    entity(niiri:517f5bd6e8d2babbc82e5c44d3c343a0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:d6626578cce8299da3656ac371463365',
+        prov:location = 'niiri:bb394618dc108a4c0f8a031886a63a5f',
         prov:value = "17.9312534332275" %% xsd:float,
         nidm_equivalentZStatistic: = "3.64257521175179" %% xsd:float,
         nidm_pValueUncorrected: = "0.00013496203699781" %% xsd:float,
         nidm_pValueFWER: = "0.99941063068466" %% xsd:float,
         nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
-    entity(niiri:d6626578cce8299da3656ac371463365,
+    entity(niiri:bb394618dc108a4c0f8a031886a63a5f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[64,-4,10]" %% xsd:string])
-    wasDerivedFrom(niiri:39ca307d31c5892250f913783b4db62c, niiri:66eca61ada8ceb626c8ffd13d3efa1cc, -, -, -)
-    entity(niiri:1f3bee85e377a2130e061374ce19f6ab,
+    wasDerivedFrom(niiri:517f5bd6e8d2babbc82e5c44d3c343a0, niiri:98a7f50d7445498f6d5c6b8931b0b269, -, -, -)
+    entity(niiri:f2d996e53248a5f49b8f38bd51dd3713,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0033" %% xsd:string,
-        prov:location = 'niiri:a706a639a6105ecabcfe5a088abd9d25',
+        prov:location = 'niiri:bac756dc194de6c4d757026e3fff1c1f',
         prov:value = "17.8439044952393" %% xsd:float,
         nidm_equivalentZStatistic: = "3.63448648232359" %% xsd:float,
         nidm_pValueUncorrected: = "0.000139267429951739" %% xsd:float,
         nidm_pValueFWER: = "0.999509275806277" %% xsd:float,
         nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
-    entity(niiri:a706a639a6105ecabcfe5a088abd9d25,
+    entity(niiri:bac756dc194de6c4d757026e3fff1c1f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0033" %% xsd:string,
         nidm_coordinateVector: = "[-22,-72,34]" %% xsd:string])
-    wasDerivedFrom(niiri:1f3bee85e377a2130e061374ce19f6ab, niiri:5cf9402b2b494a87640a66aec1a6fdaf, -, -, -)
-    entity(niiri:7f7625524d177fe4781c28633ad04fb0,
+    wasDerivedFrom(niiri:f2d996e53248a5f49b8f38bd51dd3713, niiri:0f673bfb48646ef7ce92732ddcd2561d, -, -, -)
+    entity(niiri:6f930a9d11797b87f44c2badce80aec6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0034" %% xsd:string,
-        prov:location = 'niiri:dde299cfdeb368ced964fe7a498cc703',
+        prov:location = 'niiri:d0c138010f71ad70be1e51fe2d839397',
         prov:value = "17.552827835083" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60731294050443" %% xsd:float,
         nidm_pValueUncorrected: = "0.000154692216466135" %% xsd:float,
         nidm_pValueFWER: = "0.999742486133075" %% xsd:float,
         nidm_qValueFDR: = "0.0862331427095326" %% xsd:float])
-    entity(niiri:dde299cfdeb368ced964fe7a498cc703,
+    entity(niiri:d0c138010f71ad70be1e51fe2d839397,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0034" %% xsd:string,
         nidm_coordinateVector: = "[-6,-44,40]" %% xsd:string])
-    wasDerivedFrom(niiri:7f7625524d177fe4781c28633ad04fb0, niiri:1cd1f14fea72d133db88783e1b907b7f, -, -, -)
-    entity(niiri:ea8dfff70bef204151c3aa37de438b0f,
+    wasDerivedFrom(niiri:6f930a9d11797b87f44c2badce80aec6, niiri:e4e7c604a0dfd11b952f2d763f8365a1, -, -, -)
+    entity(niiri:327a241b1d9f4509ded23784092fa3b7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0035" %% xsd:string,
-        prov:location = 'niiri:d703077133d717f4a9d9411fe4c791a6',
+        prov:location = 'niiri:9054a9c70fe461e9d187a84b5dd0908f',
         prov:value = "17.2906818389893" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58254613965863" %% xsd:float,
         nidm_pValueUncorrected: = "0.000170130746602659" %% xsd:float,
         nidm_pValueFWER: = "0.99986271355264" %% xsd:float,
         nidm_qValueFDR: = "0.0895859395735557" %% xsd:float])
-    entity(niiri:d703077133d717f4a9d9411fe4c791a6,
+    entity(niiri:9054a9c70fe461e9d187a84b5dd0908f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0035" %% xsd:string,
         nidm_coordinateVector: = "[-34,-38,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:ea8dfff70bef204151c3aa37de438b0f, niiri:c3340fa012c626e62e86cdb279a4e883, -, -, -)
-    entity(niiri:1f8b76bc5a6e0e44d52dc38f77dfb573,
+    wasDerivedFrom(niiri:327a241b1d9f4509ded23784092fa3b7, niiri:4fec6e6678455cee0511a392e629ec66, -, -, -)
+    entity(niiri:41b9df925c1027d8561ada2ee95218ca,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0036" %% xsd:string,
-        prov:location = 'niiri:52d6deef40815f931bff80e4a0c0e30e',
+        prov:location = 'niiri:f774990d88d82217c54c2bfadc119a0c',
         prov:value = "17.1612319946289" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57021115022413" %% xsd:float,
         nidm_pValueUncorrected: = "0.000178346794309836" %% xsd:float,
         nidm_pValueFWER: = "0.999901168620001" %% xsd:float,
         nidm_qValueFDR: = "0.0903823255084056" %% xsd:float])
-    entity(niiri:52d6deef40815f931bff80e4a0c0e30e,
+    entity(niiri:f774990d88d82217c54c2bfadc119a0c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0036" %% xsd:string,
         nidm_coordinateVector: = "[-46,-16,20]" %% xsd:string])
-    wasDerivedFrom(niiri:1f8b76bc5a6e0e44d52dc38f77dfb573, niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd, -, -, -)
-    entity(niiri:ebb56262d90fa761f5c469bbcf6709b0,
+    wasDerivedFrom(niiri:41b9df925c1027d8561ada2ee95218ca, niiri:df39775c5b1f38c8f9be672ec1fd63ff, -, -, -)
+    entity(niiri:80957271b12bb9a1c487565b2838bb66,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0037" %% xsd:string,
-        prov:location = 'niiri:bd5feebad73f603c2c5027f05c096a98',
+        prov:location = 'niiri:ff6c352882928d5baedf221a22bda6d2',
         prov:value = "17.0075950622559" %% xsd:float,
         nidm_equivalentZStatistic: = "3.55547987606237" %% xsd:float,
         nidm_pValueUncorrected: = "0.000188644912021529" %% xsd:float,
         nidm_pValueFWER: = "0.999934173907998" %% xsd:float,
         nidm_qValueFDR: = "0.0920555845860752" %% xsd:float])
-    entity(niiri:bd5feebad73f603c2c5027f05c096a98,
+    entity(niiri:ff6c352882928d5baedf221a22bda6d2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0037" %% xsd:string,
         nidm_coordinateVector: = "[24,32,2]" %% xsd:string])
-    wasDerivedFrom(niiri:ebb56262d90fa761f5c469bbcf6709b0, niiri:8b25738f634743abd67e5fd856e90f74, -, -, -)
-    entity(niiri:66c1ec432c1811911fdd6cd83f434d1b,
+    wasDerivedFrom(niiri:80957271b12bb9a1c487565b2838bb66, niiri:d89f1264b6a74fc289ac86f3b1b14dde, -, -, -)
+    entity(niiri:57a55f1ccdf43052d26c74811ccaab55,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0038" %% xsd:string,
-        prov:location = 'niiri:e5c4443633b94c1fa86927c7c92b220e',
+        prov:location = 'niiri:950617618298bf3334ffddbd55a7a1cc',
         prov:value = "16.5308303833008" %% xsd:float,
         nidm_equivalentZStatistic: = "3.50911812032442" %% xsd:float,
         nidm_pValueUncorrected: = "0.000224797592033421" %% xsd:float,
         nidm_pValueFWER: = "0.999983487413756" %% xsd:float,
         nidm_qValueFDR: = "0.0959555780965771" %% xsd:float])
-    entity(niiri:e5c4443633b94c1fa86927c7c92b220e,
+    entity(niiri:950617618298bf3334ffddbd55a7a1cc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0038" %% xsd:string,
         nidm_coordinateVector: = "[-26,-90,16]" %% xsd:string])
-    wasDerivedFrom(niiri:66c1ec432c1811911fdd6cd83f434d1b, niiri:1c59a22b32098831723dc21703615fd1, -, -, -)
-    entity(niiri:5f67ac778b6bca3e423969c609840ac8,
+    wasDerivedFrom(niiri:57a55f1ccdf43052d26c74811ccaab55, niiri:6b099ac0f252fd44544d43dc12a3d6df, -, -, -)
+    entity(niiri:9c8c48700682cf318494852b869a0c02,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0039" %% xsd:string,
-        prov:location = 'niiri:a555880be249de2c84bc634ee280dbd7',
+        prov:location = 'niiri:a06e98a6f7670fca9ff5bf0157004bb3',
         prov:value = "16.5225524902344" %% xsd:float,
         nidm_equivalentZStatistic: = "3.50830432871627" %% xsd:float,
         nidm_pValueUncorrected: = "0.0002254864217901" %% xsd:float,
         nidm_pValueFWER: = "0.999983907066973" %% xsd:float,
         nidm_qValueFDR: = "0.0959555780965771" %% xsd:float])
-    entity(niiri:a555880be249de2c84bc634ee280dbd7,
+    entity(niiri:a06e98a6f7670fca9ff5bf0157004bb3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0039" %% xsd:string,
         nidm_coordinateVector: = "[-28,-4,16]" %% xsd:string])
-    wasDerivedFrom(niiri:5f67ac778b6bca3e423969c609840ac8, niiri:139b6ecf5fdad735a51b4385a24aded9, -, -, -)
-    entity(niiri:5acb0f78fc88ddc60b2b62de835c1f34,
+    wasDerivedFrom(niiri:9c8c48700682cf318494852b869a0c02, niiri:de2e4a4014cc48ae0a2f90c80c8aa267, -, -, -)
+    entity(niiri:cc9b8d795bbac958aaf9b43fbd529026,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0040" %% xsd:string,
-        prov:location = 'niiri:eb3468c7ba505890d9c51ddfff00f74f',
+        prov:location = 'niiri:2b50c69d0b92059509b14d9acfd238e9',
         prov:value = "16.1374092102051" %% xsd:float,
         nidm_equivalentZStatistic: = "3.47009871338807" %% xsd:float,
         nidm_pValueUncorrected: = "0.00026013355917065" %% xsd:float,
         nidm_pValueFWER: = "0.999995475747835" %% xsd:float,
         nidm_qValueFDR: = "0.101886915515055" %% xsd:float])
-    entity(niiri:eb3468c7ba505890d9c51ddfff00f74f,
+    entity(niiri:2b50c69d0b92059509b14d9acfd238e9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0040" %% xsd:string,
         nidm_coordinateVector: = "[12,60,20]" %% xsd:string])
-    wasDerivedFrom(niiri:5acb0f78fc88ddc60b2b62de835c1f34, niiri:e6a138032615b9872d9261e35d2455f4, -, -, -)
-    entity(niiri:0da938bd32e898d2174c988f1eaf4581,
+    wasDerivedFrom(niiri:cc9b8d795bbac958aaf9b43fbd529026, niiri:0fde32a1a3d9efae8053253baac76ffc, -, -, -)
+    entity(niiri:9caf9d8c07b2f7bfff509850711f496c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0041" %% xsd:string,
-        prov:location = 'niiri:4a0acfe4d96a811a5bbd2fea220ee9f8',
+        prov:location = 'niiri:054f48629a0bfc1fc6f90348fd2784fb',
         prov:value = "15.9136981964111" %% xsd:float,
         nidm_equivalentZStatistic: = "3.44759277757755" %% xsd:float,
         nidm_pValueUncorrected: = "0.000282803055741021" %% xsd:float,
         nidm_pValueFWER: = "0.999997977474125" %% xsd:float,
         nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
-    entity(niiri:4a0acfe4d96a811a5bbd2fea220ee9f8,
+    entity(niiri:054f48629a0bfc1fc6f90348fd2784fb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0041" %% xsd:string,
         nidm_coordinateVector: = "[4,-84,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:0da938bd32e898d2174c988f1eaf4581, niiri:37bc5cb5a158a9f86c496a5d1935903c, -, -, -)
-    entity(niiri:8c6a5d705c064da10637a02bbcea89bb,
+    wasDerivedFrom(niiri:9caf9d8c07b2f7bfff509850711f496c, niiri:93cac87b0b2603caa2e73e808a49aa59, -, -, -)
+    entity(niiri:f8ee304b70c41fce6525bce376facf90,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0042" %% xsd:string,
-        prov:location = 'niiri:a7922d8059c11028e4ec965953a381f4',
+        prov:location = 'niiri:0991de2b116957894edf7f933f355265',
         prov:value = "15.8536109924316" %% xsd:float,
         nidm_equivalentZStatistic: = "3.44150764421068" %% xsd:float,
         nidm_pValueUncorrected: = "0.000289241063091916" %% xsd:float,
         nidm_pValueFWER: = "0.999998385530387" %% xsd:float,
         nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
-    entity(niiri:a7922d8059c11028e4ec965953a381f4,
+    entity(niiri:0991de2b116957894edf7f933f355265,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0042" %% xsd:string,
         nidm_coordinateVector: = "[62,-18,22]" %% xsd:string])
-    wasDerivedFrom(niiri:8c6a5d705c064da10637a02bbcea89bb, niiri:f86c9bb022fe2e7bb4f2a1d963869d32, -, -, -)
-    entity(niiri:cf7dcc23115c0b40b60445223ba951c9,
+    wasDerivedFrom(niiri:f8ee304b70c41fce6525bce376facf90, niiri:5869329bf3b962a832bb7acb7781cebd, -, -, -)
+    entity(niiri:b7d0e95b32356b2041707271fcfca84e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0043" %% xsd:string,
-        prov:location = 'niiri:f42b18360ea8f8af980f3d406996a6b7',
+        prov:location = 'niiri:0b435d3e5fef1995961220d7e0a8de62',
         prov:value = "15.8288412094116" %% xsd:float,
         nidm_equivalentZStatistic: = "3.43899416081302" %% xsd:float,
         nidm_pValueUncorrected: = "0.000291939913913408" %% xsd:float,
         nidm_pValueFWER: = "0.999998530446399" %% xsd:float,
         nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
-    entity(niiri:f42b18360ea8f8af980f3d406996a6b7,
+    entity(niiri:0b435d3e5fef1995961220d7e0a8de62,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0043" %% xsd:string,
         nidm_coordinateVector: = "[28,-58,44]" %% xsd:string])
-    wasDerivedFrom(niiri:cf7dcc23115c0b40b60445223ba951c9, niiri:cecab36bcbd915f7841bff34cd7f59a6, -, -, -)
-    entity(niiri:c7e7aa913113f6519557c66a5087a3a8,
+    wasDerivedFrom(niiri:b7d0e95b32356b2041707271fcfca84e, niiri:10ed6be507db860ee020a597d2bcfbc3, -, -, -)
+    entity(niiri:d57aa193b6ac9bb96b274e5259bb5ae7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0044" %% xsd:string,
-        prov:location = 'niiri:b8359b6165a7f498d646c290e8cd1c6c',
+        prov:location = 'niiri:0678547c45e4ded802195d443e1b4adb',
         prov:value = "15.7273988723755" %% xsd:float,
         nidm_equivalentZStatistic: = "3.42866974555038" %% xsd:float,
         nidm_pValueUncorrected: = "0.000303273553249328" %% xsd:float,
         nidm_pValueFWER: = "0.999999007347173" %% xsd:float,
         nidm_qValueFDR: = "0.106558197028572" %% xsd:float])
-    entity(niiri:b8359b6165a7f498d646c290e8cd1c6c,
+    entity(niiri:0678547c45e4ded802195d443e1b4adb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0044" %% xsd:string,
         nidm_coordinateVector: = "[38,44,0]" %% xsd:string])
-    wasDerivedFrom(niiri:c7e7aa913113f6519557c66a5087a3a8, niiri:752ff8a0ff1912e3b3a3cc0b0af92bac, -, -, -)
-    entity(niiri:84d2dd552da32536ba619bf257b99a8e,
+    wasDerivedFrom(niiri:d57aa193b6ac9bb96b274e5259bb5ae7, niiri:d4cffec5c689a35b7bf1bec1606134a5, -, -, -)
+    entity(niiri:c7422a129ab7f2a919babb4fa7c89159,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0045" %% xsd:string,
-        prov:location = 'niiri:a8431b89c9e7b5310335b9441226ea8e',
+        prov:location = 'niiri:29d5f4d8321f3255dc444a6bd52bd9a1',
         prov:value = "15.4726600646973" %% xsd:float,
         nidm_equivalentZStatistic: = "3.40252319694713" %% xsd:float,
         nidm_pValueUncorrected: = "0.000333833435672726" %% xsd:float,
         nidm_pValueFWER: = "0.999999648429928" %% xsd:float,
         nidm_qValueFDR: = "0.109105594368073" %% xsd:float])
-    entity(niiri:a8431b89c9e7b5310335b9441226ea8e,
+    entity(niiri:29d5f4d8321f3255dc444a6bd52bd9a1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0045" %% xsd:string,
         nidm_coordinateVector: = "[40,-6,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:84d2dd552da32536ba619bf257b99a8e, niiri:bbfdc94758422f4cdfa2d461f26c652c, -, -, -)
-    entity(niiri:ac77b7c2f4ff41e88896e4ba87eadac1,
+    wasDerivedFrom(niiri:c7422a129ab7f2a919babb4fa7c89159, niiri:2f94714c99bebff5b4831f0cfafa8496, -, -, -)
+    entity(niiri:762a5a8c225478c6703d3b26ca737450,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0046" %% xsd:string,
-        prov:location = 'niiri:c99f7fc58da7232a1f42538844fca3ae',
+        prov:location = 'niiri:8375751b34f073f3570bda0fc5b04a2d',
         prov:value = "15.3332357406616" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38807697766079" %% xsd:float,
         nidm_pValueUncorrected: = "0.00035192253822891" %% xsd:float,
         nidm_pValueFWER: = "0.999999807374102" %% xsd:float,
         nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
-    entity(niiri:c99f7fc58da7232a1f42538844fca3ae,
+    entity(niiri:8375751b34f073f3570bda0fc5b04a2d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0046" %% xsd:string,
         nidm_coordinateVector: = "[32,14,58]" %% xsd:string])
-    wasDerivedFrom(niiri:ac77b7c2f4ff41e88896e4ba87eadac1, niiri:412f44bb99fe0b4ac5111c8bb0d6824f, -, -, -)
-    entity(niiri:fd0d7457e6ffb07f08eca126631606af,
+    wasDerivedFrom(niiri:762a5a8c225478c6703d3b26ca737450, niiri:ca58cacd0a13b44f43d59156a4c52a6a, -, -, -)
+    entity(niiri:e4fbf72406459fb025e130aa2aca989d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0047" %% xsd:string,
-        prov:location = 'niiri:d5fba9940a2400106183302f6016bc4b',
+        prov:location = 'niiri:8330ad3bc2d7bb7815f7ea6b52f22b4e',
         prov:value = "15.3172578811646" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38641524500992" %% xsd:float,
         nidm_pValueUncorrected: = "0.000354060730342054" %% xsd:float,
         nidm_pValueFWER: = "0.99999982049151" %% xsd:float,
         nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
-    entity(niiri:d5fba9940a2400106183302f6016bc4b,
+    entity(niiri:8330ad3bc2d7bb7815f7ea6b52f22b4e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0047" %% xsd:string,
         nidm_coordinateVector: = "[4,-86,4]" %% xsd:string])
-    wasDerivedFrom(niiri:fd0d7457e6ffb07f08eca126631606af, niiri:ae1cd8d0dfca9341507b66eafba6459d, -, -, -)
-    entity(niiri:49269ead5464f020f20ecbdb76e9e6fa,
+    wasDerivedFrom(niiri:e4fbf72406459fb025e130aa2aca989d, niiri:61377f406c900484318b0d2817a3c523, -, -, -)
+    entity(niiri:0d880252d15ec80597ff6a66d3ce357d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0048" %% xsd:string,
-        prov:location = 'niiri:de463eb97f5bdebf8c7c86e1b3c0390b',
+        prov:location = 'niiri:b58a47985494e5da2d970330b8999204',
         prov:value = "15.3137311935425" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38604828864924" %% xsd:float,
         nidm_pValueUncorrected: = "0.000354534526388783" %% xsd:float,
         nidm_pValueFWER: = "0.999999823272138" %% xsd:float,
         nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
-    entity(niiri:de463eb97f5bdebf8c7c86e1b3c0390b,
+    entity(niiri:b58a47985494e5da2d970330b8999204,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0048" %% xsd:string,
         nidm_coordinateVector: = "[62,-36,46]" %% xsd:string])
-    wasDerivedFrom(niiri:49269ead5464f020f20ecbdb76e9e6fa, niiri:089292d98902368bd347bcdfa162cfda, -, -, -)
-    entity(niiri:7e757cfd5d9ab4dc7b7ed7c707af0b92,
+    wasDerivedFrom(niiri:0d880252d15ec80597ff6a66d3ce357d, niiri:307dd0ecb797aef0ce055f67fc2fa294, -, -, -)
+    entity(niiri:cd398237ebe4e31d44e2353895ac40a5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0049" %% xsd:string,
-        prov:location = 'niiri:f64c41b60e15a328c7edf5b31cc35bb6',
+        prov:location = 'niiri:1e6c367b3ff399bd1b032ff38c100b12',
         prov:value = "15.1916456222534" %% xsd:float,
         nidm_equivalentZStatistic: = "3.37330635701462" %% xsd:float,
         nidm_pValueUncorrected: = "0.000371356333789152" %% xsd:float,
         nidm_pValueFWER: = "0.999999898084819" %% xsd:float,
         nidm_qValueFDR: = "0.113182641774622" %% xsd:float])
-    entity(niiri:f64c41b60e15a328c7edf5b31cc35bb6,
+    entity(niiri:1e6c367b3ff399bd1b032ff38c100b12,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0049" %% xsd:string,
         nidm_coordinateVector: = "[-24,18,58]" %% xsd:string])
-    wasDerivedFrom(niiri:7e757cfd5d9ab4dc7b7ed7c707af0b92, niiri:716ffa34870ad39bf06d8e49c18b9bce, -, -, -)
-    entity(niiri:1187cc9f9751060cd5bdbcc8bc4b20ce,
+    wasDerivedFrom(niiri:cd398237ebe4e31d44e2353895ac40a5, niiri:e1f1160e4c3acdd85c621d64903334ab, -, -, -)
+    entity(niiri:dd807d68bb7b271fd59c4bb70c811249,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0050" %% xsd:string,
-        prov:location = 'niiri:fe5b4275099b74097635eb9f7b4bc414',
+        prov:location = 'niiri:56d93aaec0edfdfc89387314b3e56566',
         prov:value = "15.0888338088989" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36251708484568" %% xsd:float,
         nidm_pValueUncorrected: = "0.000386176732959709" %% xsd:float,
         nidm_pValueFWER: = "0.999999936876428" %% xsd:float,
         nidm_qValueFDR: = "0.114724188214818" %% xsd:float])
-    entity(niiri:fe5b4275099b74097635eb9f7b4bc414,
+    entity(niiri:56d93aaec0edfdfc89387314b3e56566,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0050" %% xsd:string,
         nidm_coordinateVector: = "[8,-22,-44]" %% xsd:string])
-    wasDerivedFrom(niiri:1187cc9f9751060cd5bdbcc8bc4b20ce, niiri:8c7ca240ed7a4d85316011dd6f1768ff, -, -, -)
-    entity(niiri:aa80010f717675a3a90dd7af1d9b1867,
+    wasDerivedFrom(niiri:dd807d68bb7b271fd59c4bb70c811249, niiri:bcd49735a6a0a30da7b9fe3278d6f064, -, -, -)
+    entity(niiri:6853db33c1053711f824bd586141fabe,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0051" %% xsd:string,
-        prov:location = 'niiri:8a342a7e8ab4849998a118155ae4e602',
+        prov:location = 'niiri:54059f59333fed994723eddb0e55b65b',
         prov:value = "14.8200588226318" %% xsd:float,
         nidm_equivalentZStatistic: = "3.33405240591422" %% xsd:float,
         nidm_pValueUncorrected: = "0.000427952650791097" %% xsd:float,
         nidm_pValueFWER: = "0.999999983180231" %% xsd:float,
         nidm_qValueFDR: = "0.119307804764224" %% xsd:float])
-    entity(niiri:8a342a7e8ab4849998a118155ae4e602,
+    entity(niiri:54059f59333fed994723eddb0e55b65b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0051" %% xsd:string,
         nidm_coordinateVector: = "[38,34,22]" %% xsd:string])
-    wasDerivedFrom(niiri:aa80010f717675a3a90dd7af1d9b1867, niiri:08593ccb1d9e49118b073d271565bd78, -, -, -)
-    entity(niiri:ba5d10a86acf3f4093c769c8fa361c7c,
+    wasDerivedFrom(niiri:6853db33c1053711f824bd586141fabe, niiri:290672736f8553a55089385f6b74f206, -, -, -)
+    entity(niiri:b1e8f19541d681f48c5129bb66dcf335,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0052" %% xsd:string,
-        prov:location = 'niiri:efbdced299f9a874e778dd97925cd80e',
+        prov:location = 'niiri:f06fe90d336d6fbe71a1db3b413c7d3c',
         prov:value = "14.696608543396" %% xsd:float,
         nidm_equivalentZStatistic: = "3.32085065286489" %% xsd:float,
         nidm_pValueUncorrected: = "0.000448717729613968" %% xsd:float,
         nidm_pValueFWER: = "0.9999999911592" %% xsd:float,
         nidm_qValueFDR: = "0.121223400645327" %% xsd:float])
-    entity(niiri:efbdced299f9a874e778dd97925cd80e,
+    entity(niiri:f06fe90d336d6fbe71a1db3b413c7d3c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0052" %% xsd:string,
         nidm_coordinateVector: = "[0,-26,-28]" %% xsd:string])
-    wasDerivedFrom(niiri:ba5d10a86acf3f4093c769c8fa361c7c, niiri:b52f4fded36d906e3611187b1ea82271, -, -, -)
-    entity(niiri:10055d39115bd79bb71ae44a1b641f14,
+    wasDerivedFrom(niiri:b1e8f19541d681f48c5129bb66dcf335, niiri:5ecd1cdffe7971283f7ba38938b61b2c, -, -, -)
+    entity(niiri:65eaa4cbcb457da0734c9ff7d3a21b4a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0053" %% xsd:string,
-        prov:location = 'niiri:f1ba673212538f0ac2d79c06bd68cf16',
+        prov:location = 'niiri:c4a7634f1b2d594c6140cd5bc8cd1af9',
         prov:value = "14.2414035797119" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27145497586776" %% xsd:float,
         nidm_pValueUncorrected: = "0.00053497811978398" %% xsd:float,
         nidm_pValueFWER: = "0.99999999933201" %% xsd:float,
         nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
-    entity(niiri:f1ba673212538f0ac2d79c06bd68cf16,
+    entity(niiri:c4a7634f1b2d594c6140cd5bc8cd1af9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0053" %% xsd:string,
         nidm_coordinateVector: = "[40,-50,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:10055d39115bd79bb71ae44a1b641f14, niiri:900eebea134685a11022813f19903499, -, -, -)
-    entity(niiri:024cfe8a8af184572999a9d180792536,
+    wasDerivedFrom(niiri:65eaa4cbcb457da0734c9ff7d3a21b4a, niiri:e1e08c2b6ca06aabfd4b12e4367167be, -, -, -)
+    entity(niiri:680883c3efa292a156e1ca9912880f20,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0054" %% xsd:string,
-        prov:location = 'niiri:8bd27ef17ea505784747393676c66e61',
+        prov:location = 'niiri:f318aaee15be61d5b8484fc4ad854618',
         prov:value = "14.0012445449829" %% xsd:float,
         nidm_equivalentZStatistic: = "3.24492687341108" %% xsd:float,
         nidm_pValueUncorrected: = "0.000587403942481801" %% xsd:float,
         nidm_pValueFWER: = "0.999999999852106" %% xsd:float,
         nidm_qValueFDR: = "0.131447065854217" %% xsd:float])
-    entity(niiri:8bd27ef17ea505784747393676c66e61,
+    entity(niiri:f318aaee15be61d5b8484fc4ad854618,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0054" %% xsd:string,
         nidm_coordinateVector: = "[8,52,32]" %% xsd:string])
-    wasDerivedFrom(niiri:024cfe8a8af184572999a9d180792536, niiri:a20506ad4a845975db3365e7c162d818, -, -, -)
-    entity(niiri:7a1112a488de76696afff578ff73b63a,
+    wasDerivedFrom(niiri:680883c3efa292a156e1ca9912880f20, niiri:ef50676f067416d91bba713a2fc0321a, -, -, -)
+    entity(niiri:3886b26bb74aeadfd7fd0758d5ac87fa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0055" %% xsd:string,
-        prov:location = 'niiri:c3e118566488fbb275af41e9caa2d23e',
+        prov:location = 'niiri:aed32c56cb51ebf9a918441830579843',
         prov:value = "13.9842071533203" %% xsd:float,
         nidm_equivalentZStatistic: = "3.2430323166614" %% xsd:float,
         nidm_pValueUncorrected: = "0.000591323980175695" %% xsd:float,
         nidm_pValueFWER: = "0.999999999867649" %% xsd:float,
         nidm_qValueFDR: = "0.131695068372973" %% xsd:float])
-    entity(niiri:c3e118566488fbb275af41e9caa2d23e,
+    entity(niiri:aed32c56cb51ebf9a918441830579843,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0055" %% xsd:string,
         nidm_coordinateVector: = "[-14,-48,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:7a1112a488de76696afff578ff73b63a, niiri:cfde284823e7c32d74bec0b81232bb7a, -, -, -)
-    entity(niiri:d17f027d268c7f08e9841c1c575cf23e,
+    wasDerivedFrom(niiri:3886b26bb74aeadfd7fd0758d5ac87fa, niiri:947bdfd650d750aaad83d695fd5ff821, -, -, -)
+    entity(niiri:a85de1f634e031040b045156e50b8663,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0056" %% xsd:string,
-        prov:location = 'niiri:ae9a839905051fcbf3c519761251289d',
+        prov:location = 'niiri:3e2bc5e98bf9e6fab0870d2c4bdf5d34',
         prov:value = "13.9203996658325" %% xsd:float,
         nidm_equivalentZStatistic: = "3.23592192136056" %% xsd:float,
         nidm_pValueUncorrected: = "0.000606252725692924" %% xsd:float,
         nidm_pValueFWER: = "0.999999999913111" %% xsd:float,
         nidm_qValueFDR: = "0.13226466740541" %% xsd:float])
-    entity(niiri:ae9a839905051fcbf3c519761251289d,
+    entity(niiri:3e2bc5e98bf9e6fab0870d2c4bdf5d34,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0056" %% xsd:string,
         nidm_coordinateVector: = "[20,0,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:d17f027d268c7f08e9841c1c575cf23e, niiri:496bec06cfc8ef95b3cbe0997c654d26, -, -, -)
-    entity(niiri:9a81d2292183627c111fac27998c2da6,
+    wasDerivedFrom(niiri:a85de1f634e031040b045156e50b8663, niiri:51e987ef34cc607991dc3fcd1b06d12d, -, -, -)
+    entity(niiri:c9c453badd84eb33004fcf72af23bf1b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0057" %% xsd:string,
-        prov:location = 'niiri:84fa347a32d4bf011d58a0338bec2648',
+        prov:location = 'niiri:cfec8710cf8e7ba581e0267ad4b2319e',
         prov:value = "13.8925752639771" %% xsd:float,
         nidm_equivalentZStatistic: = "3.23281385809669" %% xsd:float,
         nidm_pValueUncorrected: = "0.000612887021428588" %% xsd:float,
         nidm_pValueFWER: = "0.999999999927857" %% xsd:float,
         nidm_qValueFDR: = "0.13226466740541" %% xsd:float])
-    entity(niiri:84fa347a32d4bf011d58a0338bec2648,
+    entity(niiri:cfec8710cf8e7ba581e0267ad4b2319e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0057" %% xsd:string,
         nidm_coordinateVector: = "[40,-14,60]" %% xsd:string])
-    wasDerivedFrom(niiri:9a81d2292183627c111fac27998c2da6, niiri:e4bff32759970a1099e3a417cf7206b0, -, -, -)
-    entity(niiri:8b4c54efdd01e22033ec948028b376c6,
+    wasDerivedFrom(niiri:c9c453badd84eb33004fcf72af23bf1b, niiri:9e0d3d51afc26653e6ee900965729d85, -, -, -)
+    entity(niiri:8fb7990e2a3094e39c98804faf3476c6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0058" %% xsd:string,
-        prov:location = 'niiri:cec9885ccb4c5eddad3e16791941394f',
+        prov:location = 'niiri:a32e14841e7c0ca58935af8a10051a91',
         prov:value = "13.8641185760498" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22963046726961" %% xsd:float,
         nidm_pValueUncorrected: = "0.000619751563460058" %% xsd:float,
         nidm_pValueFWER: = "0.999999999940447" %% xsd:float,
         nidm_qValueFDR: = "0.132333123904287" %% xsd:float])
-    entity(niiri:cec9885ccb4c5eddad3e16791941394f,
+    entity(niiri:a32e14841e7c0ca58935af8a10051a91,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0058" %% xsd:string,
         nidm_coordinateVector: = "[-36,10,24]" %% xsd:string])
-    wasDerivedFrom(niiri:8b4c54efdd01e22033ec948028b376c6, niiri:40337b736645244404b84afb6772e7a9, -, -, -)
-    entity(niiri:dc9b5b7925435de1e123f050c0f32db2,
+    wasDerivedFrom(niiri:8fb7990e2a3094e39c98804faf3476c6, niiri:9d7d7cea0614241978504c478df9b65a, -, -, -)
+    entity(niiri:e27123a684d62fdc9d18f0a3d92960cf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0059" %% xsd:string,
-        prov:location = 'niiri:abc2ee78bd07cda0b6ddcacbac427081',
+        prov:location = 'niiri:44105d28c46d8cf49561d64d83b7f67e',
         prov:value = "13.7912406921387" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22145599369965" %% xsd:float,
         nidm_pValueUncorrected: = "0.000637705235827735" %% xsd:float,
         nidm_pValueFWER: = "0.999999999963824" %% xsd:float,
         nidm_qValueFDR: = "0.133173984174016" %% xsd:float])
-    entity(niiri:abc2ee78bd07cda0b6ddcacbac427081,
+    entity(niiri:44105d28c46d8cf49561d64d83b7f67e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0059" %% xsd:string,
         nidm_coordinateVector: = "[30,-78,14]" %% xsd:string])
-    wasDerivedFrom(niiri:dc9b5b7925435de1e123f050c0f32db2, niiri:42bc55f4f90f29daf9e12be119e1ddab, -, -, -)
-    entity(niiri:98a17ff5e5165fb8c24152b264b38518,
+    wasDerivedFrom(niiri:e27123a684d62fdc9d18f0a3d92960cf, niiri:20b5974d23f3286a95aa7fbb587ef438, -, -, -)
+    entity(niiri:fe8bc9afc41b8b24738b1ecc268430b0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0060" %% xsd:string,
-        prov:location = 'niiri:4ff470161927caacc784743cebf1ff5c',
+        prov:location = 'niiri:4ad634e819e7502cb6e973e21f01dcb5',
         prov:value = "13.629490852356" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20320002112963" %% xsd:float,
         nidm_pValueUncorrected: = "0.000679547746644249" %% xsd:float,
         nidm_pValueFWER: = "0.999999999988489" %% xsd:float,
         nidm_qValueFDR: = "0.136764826883915" %% xsd:float])
-    entity(niiri:4ff470161927caacc784743cebf1ff5c,
+    entity(niiri:4ad634e819e7502cb6e973e21f01dcb5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0060" %% xsd:string,
         nidm_coordinateVector: = "[18,-78,12]" %% xsd:string])
-    wasDerivedFrom(niiri:98a17ff5e5165fb8c24152b264b38518, niiri:067c79f86db85b508893737af41699ce, -, -, -)
-    entity(niiri:457b57ff4d2f772e5a87d72e416d55f7,
+    wasDerivedFrom(niiri:fe8bc9afc41b8b24738b1ecc268430b0, niiri:9a32bcfd38e5afc90a14c0c217161efa, -, -, -)
+    entity(niiri:ae7ee486258f0dae48d5e8bf50ad8f9a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0061" %% xsd:string,
-        prov:location = 'niiri:642bfe0fc88a3e08454fca298ff2547d',
+        prov:location = 'niiri:4bbc0d3a18913695fb71f3e69866cdac',
         prov:value = "13.5061225891113" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18916981007524" %% xsd:float,
         nidm_pValueUncorrected: = "0.000713410180681495" %% xsd:float,
         nidm_pValueFWER: = "0.999999999995369" %% xsd:float,
         nidm_qValueFDR: = "0.139253735873803" %% xsd:float])
-    entity(niiri:642bfe0fc88a3e08454fca298ff2547d,
+    entity(niiri:4bbc0d3a18913695fb71f3e69866cdac,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0061" %% xsd:string,
         nidm_coordinateVector: = "[46,8,-16]" %% xsd:string])
-    wasDerivedFrom(niiri:457b57ff4d2f772e5a87d72e416d55f7, niiri:1a35a6d628eed4f2fc8c554a4a579a19, -, -, -)
-    entity(niiri:983d2f990b97c775c7da5a27177fc0f6,
+    wasDerivedFrom(niiri:ae7ee486258f0dae48d5e8bf50ad8f9a, niiri:210435c4c0603b37239c262e4c742cd7, -, -, -)
+    entity(niiri:6d75431b8cc59654b1625ba7727b2c99,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0062" %% xsd:string,
-        prov:location = 'niiri:b7b5b47e2538aa1f088bf22667e716bc',
+        prov:location = 'niiri:e074496b841b67475a31a93f47d65ce3',
         prov:value = "13.4754667282104" %% xsd:float,
         nidm_equivalentZStatistic: = "3.1856690050705" %% xsd:float,
         nidm_pValueUncorrected: = "0.000722098618250455" %% xsd:float,
         nidm_pValueFWER: = "0.999999999996325" %% xsd:float,
         nidm_qValueFDR: = "0.1402954623971" %% xsd:float])
-    entity(niiri:b7b5b47e2538aa1f088bf22667e716bc,
+    entity(niiri:e074496b841b67475a31a93f47d65ce3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0062" %% xsd:string,
         nidm_coordinateVector: = "[58,-40,50]" %% xsd:string])
-    wasDerivedFrom(niiri:983d2f990b97c775c7da5a27177fc0f6, niiri:0e92ac2d77c091672e014daf15280170, -, -, -)
-    entity(niiri:0d84f12f1eecf02fd70239d18b674632,
+    wasDerivedFrom(niiri:6d75431b8cc59654b1625ba7727b2c99, niiri:7c7c96862dfaf19b5ad9f27652329ae0, -, -, -)
+    entity(niiri:f0af53a4324f48d47ab9a0666034d93c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0063" %% xsd:string,
-        prov:location = 'niiri:b200c3101378d90c3289227f2f311490',
+        prov:location = 'niiri:620f27d7626b16337913220c7107c4a5',
         prov:value = "13.4480972290039" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18253860543696" %% xsd:float,
         nidm_pValueUncorrected: = "0.000729950259848011" %% xsd:float,
         nidm_pValueFWER: = "0.999999999997016" %% xsd:float,
         nidm_qValueFDR: = "0.140840039531724" %% xsd:float])
-    entity(niiri:b200c3101378d90c3289227f2f311490,
+    entity(niiri:620f27d7626b16337913220c7107c4a5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0063" %% xsd:string,
         nidm_coordinateVector: = "[46,-66,32]" %% xsd:string])
-    wasDerivedFrom(niiri:0d84f12f1eecf02fd70239d18b674632, niiri:0d2b802df946de1efd390f218ef63fce, -, -, -)
-    entity(niiri:1106844ff3c3aa841e131a1c8b3cee03,
+    wasDerivedFrom(niiri:f0af53a4324f48d47ab9a0666034d93c, niiri:3cb44c7fa017003278142567fd208f77, -, -, -)
+    entity(niiri:cef34ffd29ba805c930823965884c6ae,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0064" %% xsd:string,
-        prov:location = 'niiri:2c69785e6a1162eaef0e8d5fb846e6be',
+        prov:location = 'niiri:44bfba582c9b94d11f800bc7e4460a5e',
         prov:value = "13.2857608795166" %% xsd:float,
         nidm_equivalentZStatistic: = "3.16387572537233" %% xsd:float,
         nidm_pValueUncorrected: = "0.000778416284459293" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999163" %% xsd:float,
         nidm_qValueFDR: = "0.14332751949213" %% xsd:float])
-    entity(niiri:2c69785e6a1162eaef0e8d5fb846e6be,
+    entity(niiri:44bfba582c9b94d11f800bc7e4460a5e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0064" %% xsd:string,
         nidm_coordinateVector: = "[2,-76,8]" %% xsd:string])
-    wasDerivedFrom(niiri:1106844ff3c3aa841e131a1c8b3cee03, niiri:627d75e08350cce3541dd568e3ddaa39, -, -, -)
-    entity(niiri:8f5c2c4423ccd494ee5e86fe3deb293e,
+    wasDerivedFrom(niiri:cef34ffd29ba805c930823965884c6ae, niiri:d0db4687f221096cb9c4f8413c4f75c6, -, -, -)
+    entity(niiri:1aa2f72fc93fb6973ae744cebc511ef4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0065" %% xsd:string,
-        prov:location = 'niiri:611027fbd0882487ef894fa5a6a8e4e5',
+        prov:location = 'niiri:f91f42faf168af767e942f38ff2367c2',
         prov:value = "13.2286987304688" %% xsd:float,
         nidm_equivalentZStatistic: = "3.15727638472708" %% xsd:float,
         nidm_pValueUncorrected: = "0.000796251631906664" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999472" %% xsd:float,
         nidm_qValueFDR: = "0.143821550671959" %% xsd:float])
-    entity(niiri:611027fbd0882487ef894fa5a6a8e4e5,
+    entity(niiri:f91f42faf168af767e942f38ff2367c2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0065" %% xsd:string,
         nidm_coordinateVector: = "[14,-24,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:8f5c2c4423ccd494ee5e86fe3deb293e, niiri:20516921d28241951d08251e80cac5b5, -, -, -)
-    entity(niiri:ec7eede0d453f71f84e10d81d45a185d,
+    wasDerivedFrom(niiri:1aa2f72fc93fb6973ae744cebc511ef4, niiri:7ef8baaeb7357f28badb11366679f71c, -, -, -)
+    entity(niiri:442356249320781048907ca9e1850c5a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0066" %% xsd:string,
-        prov:location = 'niiri:4bd2715c430b33d70e84b77b850d16be',
+        prov:location = 'niiri:7a37cc3e0a15fcfdece2cd392b603adc',
         prov:value = "13.0621271133423" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13789355719639" %% xsd:float,
         nidm_pValueUncorrected: = "0.00085083330089919" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999869" %% xsd:float,
         nidm_qValueFDR: = "0.146648454262555" %% xsd:float])
-    entity(niiri:4bd2715c430b33d70e84b77b850d16be,
+    entity(niiri:7a37cc3e0a15fcfdece2cd392b603adc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0066" %% xsd:string,
         nidm_coordinateVector: = "[-36,0,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:ec7eede0d453f71f84e10d81d45a185d, niiri:3822c0fa262ca8cb8a67590f3eec2fe6, -, -, -)
-    entity(niiri:4ee980646f678b94fcd5772eb72db1d4,
+    wasDerivedFrom(niiri:442356249320781048907ca9e1850c5a, niiri:cec5df2d95985851dd02c6d0db6fe243, -, -, -)
+    entity(niiri:82f53a0a6c8b368ff5c21bd17bdf95fe,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0067" %% xsd:string,
-        prov:location = 'niiri:34b06f9fb053f163bc7a00ce986a8123',
+        prov:location = 'niiri:4f84af5759966f61ee9c71d98847736a',
         prov:value = "13.0451946258545" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13591325616981" %% xsd:float,
         nidm_pValueUncorrected: = "0.000856599341067521" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999886" %% xsd:float,
         nidm_qValueFDR: = "0.146787157394689" %% xsd:float])
-    entity(niiri:34b06f9fb053f163bc7a00ce986a8123,
+    entity(niiri:4f84af5759966f61ee9c71d98847736a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0067" %% xsd:string,
         nidm_coordinateVector: = "[12,6,62]" %% xsd:string])
-    wasDerivedFrom(niiri:4ee980646f678b94fcd5772eb72db1d4, niiri:51287994298816d649ba6908b4e3d0bb, -, -, -)
-    entity(niiri:f672ee780ba0dc20dc0aa8808e3c2090,
+    wasDerivedFrom(niiri:82f53a0a6c8b368ff5c21bd17bdf95fe, niiri:f0dffbbec6ed840a50eeb67367cfa4d5, -, -, -)
+    entity(niiri:9ec8ea566b57711897fba57f996a1086,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0068" %% xsd:string,
-        prov:location = 'niiri:729e387de0d5316ccf723a049f2cd632',
+        prov:location = 'niiri:58cf359b5a18f021a7a3bd5c19ef0be5',
         prov:value = "13.0064306259155" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13137270324883" %% xsd:float,
         nidm_pValueUncorrected: = "0.000869955985260296" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999919" %% xsd:float,
         nidm_qValueFDR: = "0.146787157394689" %% xsd:float])
-    entity(niiri:729e387de0d5316ccf723a049f2cd632,
+    entity(niiri:58cf359b5a18f021a7a3bd5c19ef0be5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0068" %% xsd:string,
         nidm_coordinateVector: = "[-8,-4,24]" %% xsd:string])
-    wasDerivedFrom(niiri:f672ee780ba0dc20dc0aa8808e3c2090, niiri:36a1ff3bd64efa589db6c3a56ccf9d25, -, -, -)
-    entity(niiri:133da124dca5a66efd13ce67c41fded3,
+    wasDerivedFrom(niiri:9ec8ea566b57711897fba57f996a1086, niiri:67c3a7b5cc3c3fe392535195f3bad2ad, -, -, -)
+    entity(niiri:1f4eaccd991e6c5607a658d417756ce7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0069" %% xsd:string,
-        prov:location = 'niiri:1eb746ff728a0d069a40542bb5f7a689',
+        prov:location = 'niiri:8ce66f9f243d621349fcc33e8c2d721a',
         prov:value = "12.968074798584" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12687033926247" %% xsd:float,
         nidm_pValueUncorrected: = "0.00088338914171493" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999942" %% xsd:float,
         nidm_qValueFDR: = "0.147244283960254" %% xsd:float])
-    entity(niiri:1eb746ff728a0d069a40542bb5f7a689,
+    entity(niiri:8ce66f9f243d621349fcc33e8c2d721a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0069" %% xsd:string,
         nidm_coordinateVector: = "[8,-36,40]" %% xsd:string])
-    wasDerivedFrom(niiri:133da124dca5a66efd13ce67c41fded3, niiri:1c0a11fe168926616610d5836c36d35f, -, -, -)
-    entity(niiri:9801cb1bbda1a53d0101f519d9d19df1,
+    wasDerivedFrom(niiri:1f4eaccd991e6c5607a658d417756ce7, niiri:db97ffa2bd8c5823f405fd68ff718eee, -, -, -)
+    entity(niiri:4f3a8969ea371259f73c3af05071826e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0070" %% xsd:string,
-        prov:location = 'niiri:f1edc34f43382229a619f2254f87a59c',
+        prov:location = 'niiri:003e8ab6a677f803afc9b92a6b175ac5',
         prov:value = "12.9628992080688" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12626207199886" %% xsd:float,
         nidm_pValueUncorrected: = "0.000885218504765861" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999944" %% xsd:float,
         nidm_qValueFDR: = "0.147244283960254" %% xsd:float])
-    entity(niiri:f1edc34f43382229a619f2254f87a59c,
+    entity(niiri:003e8ab6a677f803afc9b92a6b175ac5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0070" %% xsd:string,
         nidm_coordinateVector: = "[24,38,0]" %% xsd:string])
-    wasDerivedFrom(niiri:9801cb1bbda1a53d0101f519d9d19df1, niiri:aa0d58d5cc7671539d09308038edb0f1, -, -, -)
-    entity(niiri:04821e6510237840cbf335fef76d5cdc,
+    wasDerivedFrom(niiri:4f3a8969ea371259f73c3af05071826e, niiri:2d47c7ce748aeebd84bed25e87007425, -, -, -)
+    entity(niiri:9243f6f83efb0d3dc889ef170a12cf0d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0071" %% xsd:string,
-        prov:location = 'niiri:1f4eb737906c00c0031d9ee2356ab46d',
+        prov:location = 'niiri:f51e48907d119eede302de1a4d7e24f3',
         prov:value = "12.9482192993164" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12453584528173" %% xsd:float,
         nidm_pValueUncorrected: = "0.000890429112242686" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999951" %% xsd:float,
         nidm_qValueFDR: = "0.14749076092896" %% xsd:float])
-    entity(niiri:1f4eb737906c00c0031d9ee2356ab46d,
+    entity(niiri:f51e48907d119eede302de1a4d7e24f3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0071" %% xsd:string,
         nidm_coordinateVector: = "[26,-50,46]" %% xsd:string])
-    wasDerivedFrom(niiri:04821e6510237840cbf335fef76d5cdc, niiri:fc71e9e9a2574cbd9d5094f50275b3c2, -, -, -)
-    entity(niiri:febde3f603b3693a20767813beb5bd71,
+    wasDerivedFrom(niiri:9243f6f83efb0d3dc889ef170a12cf0d, niiri:8b7c26257640b1664a72209e6721cdcd, -, -, -)
+    entity(niiri:3119a0747a8bd932e29ee104af2fd79d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0072" %% xsd:string,
-        prov:location = 'niiri:aa6eef7396e2ed67c9ab5d0bb298088e',
+        prov:location = 'niiri:b07e614a86690f51810792a90d026dca',
         prov:value = "12.9151954650879" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12064737190897" %% xsd:float,
         nidm_pValueUncorrected: = "0.000902269894699104" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999964" %% xsd:float,
         nidm_qValueFDR: = "0.147598889605401" %% xsd:float])
-    entity(niiri:aa6eef7396e2ed67c9ab5d0bb298088e,
+    entity(niiri:b07e614a86690f51810792a90d026dca,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0072" %% xsd:string,
         nidm_coordinateVector: = "[-30,-86,8]" %% xsd:string])
-    wasDerivedFrom(niiri:febde3f603b3693a20767813beb5bd71, niiri:c23970716bccffb656edae94cc34e353, -, -, -)
-    entity(niiri:b52c3eeba29b97da2b661dd4df58cef0,
+    wasDerivedFrom(niiri:3119a0747a8bd932e29ee104af2fd79d, niiri:4e2a5af599e4e60cf34c225aefbe86cb, -, -, -)
+    entity(niiri:45f9a9e4768213692db2f621365dc39f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0073" %% xsd:string,
-        prov:location = 'niiri:dacf1036163cfbe9703b73ef87a5b977',
+        prov:location = 'niiri:50267042cb4910a066fa7dfaf7912429',
         prov:value = "12.8661985397339" %% xsd:float,
         nidm_equivalentZStatistic: = "3.11486488202419" %% xsd:float,
         nidm_pValueUncorrected: = "0.00092014594111034" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999977" %% xsd:float,
         nidm_qValueFDR: = "0.147847736781403" %% xsd:float])
-    entity(niiri:dacf1036163cfbe9703b73ef87a5b977,
+    entity(niiri:50267042cb4910a066fa7dfaf7912429,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0073" %% xsd:string,
         nidm_coordinateVector: = "[22,-24,38]" %% xsd:string])
-    wasDerivedFrom(niiri:b52c3eeba29b97da2b661dd4df58cef0, niiri:8e2363110cdebe114cbe95493b19fa9d, -, -, -)
-    entity(niiri:9c19f778bd965a28a5a95c2a44273e2f,
+    wasDerivedFrom(niiri:45f9a9e4768213692db2f621365dc39f, niiri:3a69dd386e787d840309add4c3d8288a, -, -, -)
+    entity(niiri:f94d885513d5d6734a3639abe4f3725b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0074" %% xsd:string,
-        prov:location = 'niiri:3342cfcb637deb366202637575b9bf6e',
+        prov:location = 'niiri:61719937b537968c16c46c150415c5ba',
         prov:value = "12.8156299591064" %% xsd:float,
         nidm_equivalentZStatistic: = "3.10888025138563" %% xsd:float,
         nidm_pValueUncorrected: = "0.000938989080538355" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999985" %% xsd:float,
         nidm_qValueFDR: = "0.148123448926347" %% xsd:float])
-    entity(niiri:3342cfcb637deb366202637575b9bf6e,
+    entity(niiri:61719937b537968c16c46c150415c5ba,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0074" %% xsd:string,
         nidm_coordinateVector: = "[48,50,2]" %% xsd:string])
-    wasDerivedFrom(niiri:9c19f778bd965a28a5a95c2a44273e2f, niiri:eb4122935f1afa2c8b532875de5f0ef9, -, -, -)
-    entity(niiri:ad2e6a4a1bd4b49e04b2f5ce6f700bf1,
+    wasDerivedFrom(niiri:f94d885513d5d6734a3639abe4f3725b, niiri:6026278153ba92cecad8e5b03e166074, -, -, -)
+    entity(niiri:268ed018d417f3b43e857d7cfac12e22,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0075" %% xsd:string,
-        prov:location = 'niiri:51217ecd4042ac5a689d5913af7f97c4',
+        prov:location = 'niiri:3a8f96ab4b6f12aa57b699f8a24600c0',
         prov:value = "12.7734069824219" %% xsd:float,
         nidm_equivalentZStatistic: = "3.10387025917553" %% xsd:float,
         nidm_pValueUncorrected: = "0.000955035352381506" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999999" %% xsd:float,
         nidm_qValueFDR: = "0.149144835108449" %% xsd:float])
-    entity(niiri:51217ecd4042ac5a689d5913af7f97c4,
+    entity(niiri:3a8f96ab4b6f12aa57b699f8a24600c0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0075" %% xsd:string,
         nidm_coordinateVector: = "[-48,-68,20]" %% xsd:string])
-    wasDerivedFrom(niiri:ad2e6a4a1bd4b49e04b2f5ce6f700bf1, niiri:25018fb0acd6d245a4f445c35c5f92eb, -, -, -)
-    entity(niiri:40ede6bfbdf28e2cb70db26b715172d6,
+    wasDerivedFrom(niiri:268ed018d417f3b43e857d7cfac12e22, niiri:5df20a4fb89cbcd4160591f81dc70a0d, -, -, -)
+    entity(niiri:7afce934f02bb8824bcb0dbd9907f2bb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0076" %% xsd:string,
-        prov:location = 'niiri:32049f907c1ff3c54deff6f919d2ee46',
+        prov:location = 'niiri:7b2ba98983ea251b4cdb9f4c8145b2d2',
         prov:value = "12.7362623214722" %% xsd:float,
         nidm_equivalentZStatistic: = "3.0994529756118" %% xsd:float,
         nidm_pValueUncorrected: = "0.000969391758882221" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999993" %% xsd:float,
         nidm_qValueFDR: = "0.150376120259304" %% xsd:float])
-    entity(niiri:32049f907c1ff3c54deff6f919d2ee46,
+    entity(niiri:7b2ba98983ea251b4cdb9f4c8145b2d2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0076" %% xsd:string,
         nidm_coordinateVector: = "[24,-22,36]" %% xsd:string])
-    wasDerivedFrom(niiri:40ede6bfbdf28e2cb70db26b715172d6, niiri:ccd2969f60f8b0222713472b0a037361, -, -, -)
+    wasDerivedFrom(niiri:7afce934f02bb8824bcb0dbd9907f2bb, niiri:32dc10b2a989e36bb73d9c695b9ace8f, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_non_sphericity/nidm.provn
+++ b/spmexport/ex_spm_non_sphericity/nidm.provn
@@ -1,0 +1,2258 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:25ee938ddb1a1359b5dbfc8ddbffdf98,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:9360978694c62922ec5ea1a313b72c46,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:7a90abf761d31fac1a65bd4bda03a81a,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:7a90abf761d31fac1a65bd4bda03a81a, niiri:9360978694c62922ec5ea1a313b72c46, -)
+  wasGeneratedBy(niiri:25ee938ddb1a1359b5dbfc8ddbffdf98, niiri:7a90abf761d31fac1a65bd4bda03a81a, 2016-01-11T10:11:35)
+  bundle niiri:25ee938ddb1a1359b5dbfc8ddbffdf98
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_UnstructuredCorrelationStructure <http://purl.obolibrary.org/obo/STATO_0000405>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_FStatistic <http://purl.obolibrary.org/obo/STATO_0000282>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastExplainedMeanSquareMap <http://purl.org/nidash/nidm#NIDM_0000163>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+    prefix nidm_SupraThresholdCluster <http://purl.org/nidash/nidm#NIDM_0000070>
+    prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
+    prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+    prefix nidm_qValueFDR <http://purl.org/nidash/nidm#NIDM_0000119>
+    prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
+    prefix nidm_Peak <http://purl.org/nidash/nidm#NIDM_0000062>
+    prefix nidm_equivalentZStatistic <http://purl.org/nidash/nidm#NIDM_0000092>
+    prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
+    prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
+
+    agent(niiri:cbb4e09f0c239d9fc253f426daea95ec,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:04394321c13e24105925122a5ea9615c,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:3279b88b6e6cd5ec2237720417dd3d48,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "false" %% xsd:boolean])
+    entity(niiri:186f3712419791aaf7a04a3d1b8bd722,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:b17ee10e3431226e0e680dfd4966a939',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]" %% xsd:string])
+    entity(niiri:b17ee10e3431226e0e680dfd4966a939,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:ce59f39b89684ad9fbc37e749e8dc23d,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_UnstructuredCorrelationStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "false" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:a4e3f64a7d5dde02404b02a2e482b25c,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:a4e3f64a7d5dde02404b02a2e482b25c, niiri:cbb4e09f0c239d9fc253f426daea95ec, -)
+    used(niiri:a4e3f64a7d5dde02404b02a2e482b25c, niiri:186f3712419791aaf7a04a3d1b8bd722, -)
+    used(niiri:a4e3f64a7d5dde02404b02a2e482b25c, niiri:3279b88b6e6cd5ec2237720417dd3d48, -)
+    used(niiri:a4e3f64a7d5dde02404b02a2e482b25c, niiri:ce59f39b89684ad9fbc37e749e8dc23d, -)
+    entity(niiri:1d1c92ca0bfb701909eb307868358b1a,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
+    entity(niiri:7b426f12cc92d11d7f4d5eb771c95217,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e" %% xsd:string])
+    wasDerivedFrom(niiri:1d1c92ca0bfb701909eb307868358b1a, niiri:7b426f12cc92d11d7f4d5eb771c95217, -, -, -)
+    wasGeneratedBy(niiri:1d1c92ca0bfb701909eb307868358b1a, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
+    entity(niiri:785bae8edf8ea0f5eae2802088ac85b1,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "0.0511472336947918" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        crypto:sha512 = "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc" %% xsd:string])
+    wasGeneratedBy(niiri:785bae8edf8ea0f5eae2802088ac85b1, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
+    entity(niiri:9f2d3c6c9d93cbbc83d0629664f66005,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c'])
+    entity(niiri:1273bdcdc1d1987029f9da1d84d22ea2,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f" %% xsd:string])
+    wasDerivedFrom(niiri:9f2d3c6c9d93cbbc83d0629664f66005, niiri:1273bdcdc1d1987029f9da1d84d22ea2, -, -, -)
+    wasGeneratedBy(niiri:9f2d3c6c9d93cbbc83d0629664f66005, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
+    entity(niiri:baf9cccb8eba46b7c5f41863dda48579,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c'])
+    entity(niiri:87c6aec787414fb9d08ddd2e2f2c9b55,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978" %% xsd:string])
+    wasDerivedFrom(niiri:baf9cccb8eba46b7c5f41863dda48579, niiri:87c6aec787414fb9d08ddd2e2f2c9b55, -, -, -)
+    wasGeneratedBy(niiri:baf9cccb8eba46b7c5f41863dda48579, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
+    entity(niiri:b178295856d95973727b2b358956335e,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c'])
+    entity(niiri:1263d9ada22b54fa429647fa22af73f9,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a" %% xsd:string])
+    wasDerivedFrom(niiri:b178295856d95973727b2b358956335e, niiri:1263d9ada22b54fa429647fa22af73f9, -, -, -)
+    wasGeneratedBy(niiri:b178295856d95973727b2b358956335e, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
+    entity(niiri:0c8cae8f7fd81853bcc8700ee2f1bb91,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        crypto:sha512 = "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48" %% xsd:string])
+    entity(niiri:3c4935283c58d44dba5a403a5d3b5832,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868" %% xsd:string])
+    wasDerivedFrom(niiri:0c8cae8f7fd81853bcc8700ee2f1bb91, niiri:3c4935283c58d44dba5a403a5d3b5832, -, -, -)
+    wasGeneratedBy(niiri:0c8cae8f7fd81853bcc8700ee2f1bb91, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
+    entity(niiri:0a2a8817aa6793a351bd0a7021236cd0,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        crypto:sha512 = "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381" %% xsd:string])
+    entity(niiri:3a2ab399f71d1f0e06d2a38d3de41f29,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8" %% xsd:string])
+    wasDerivedFrom(niiri:0a2a8817aa6793a351bd0a7021236cd0, niiri:3a2ab399f71d1f0e06d2a38d3de41f29, -, -, -)
+    wasGeneratedBy(niiri:0a2a8817aa6793a351bd0a7021236cd0, niiri:a4e3f64a7d5dde02404b02a2e482b25c, -)
+    entity(niiri:df230f4ff3b58783fe139f385597465e,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_FStatistic:',
+        nidm_contrastName: = "Average effect of condition" %% xsd:string,
+        prov:label = "Contrast: Average effect of condition" %% xsd:string,
+        prov:value = "[1, 1, 1]" %% xsd:string])
+    activity(niiri:2ff41e5681a1c005622be9b68da73a06,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:cbb4e09f0c239d9fc253f426daea95ec, -)
+    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:1d1c92ca0bfb701909eb307868358b1a, -)
+    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:0c8cae8f7fd81853bcc8700ee2f1bb91, -)
+    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:186f3712419791aaf7a04a3d1b8bd722, -)
+    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:df230f4ff3b58783fe139f385597465e, -)
+    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:9f2d3c6c9d93cbbc83d0629664f66005, -)
+    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:baf9cccb8eba46b7c5f41863dda48579, -)
+    used(niiri:2ff41e5681a1c005622be9b68da73a06, niiri:b178295856d95973727b2b358956335e, -)
+    entity(niiri:50609b22ae1142a0b21014e830b41cae,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "FStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "FStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: Average effect of condition" %% xsd:string,
+        nidm_statisticType: = 'stato_FStatistic:',
+        nidm_contrastName: = "Average effect of condition" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "39" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        crypto:sha512 = "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960" %% xsd:string])
+    entity(niiri:c59df51d9201082e5f25f11b2f13807f,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmF_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762" %% xsd:string])
+    wasDerivedFrom(niiri:50609b22ae1142a0b21014e830b41cae, niiri:c59df51d9201082e5f25f11b2f13807f, -, -, -)
+    wasGeneratedBy(niiri:50609b22ae1142a0b21014e830b41cae, niiri:2ff41e5681a1c005622be9b68da73a06, -)
+    entity(niiri:2416820ce6beaa983e426560e9ec33ec,
+        [prov:type = 'nidm_ContrastExplainedMeanSquareMap:',
+        prov:location = "ContrastExplainedMeanSquare.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastExplainedMeanSquare.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Explained Mean Square Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        crypto:sha512 = "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a" %% xsd:string])
+    wasGeneratedBy(niiri:2416820ce6beaa983e426560e9ec33ec, niiri:2ff41e5681a1c005622be9b68da73a06, -)
+    entity(niiri:d16264948a1baffc5b788ff82a41433f,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
+        prov:value = "0.000999500201896764" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:d6d3c2e8396eddb36c52c8ebf1691170',
+        nidm_equivalentThreshold: = 'niiri:59cbe87bfe988562f71c7863fcee3540'])
+    entity(niiri:d6d3c2e8396eddb36c52c8ebf1691170,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "12.6602184255263" %% xsd:float])
+    entity(niiri:59cbe87bfe988562f71c7863fcee3540,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.999999999999997" %% xsd:float])
+    entity(niiri:689643975c6d062da3f861f197ffb911,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:979cfefce98a2d163c991361d12cbf64',
+        nidm_equivalentThreshold: = 'niiri:5a949293e4972919cdd1902557e60273'])
+    entity(niiri:979cfefce98a2d163c991361d12cbf64,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:5a949293e4972919cdd1902557e60273,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:932bf207ec1906155b85201be9afc0ed,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:356327ce3d3e8895d849bb23327e10f5,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:6be0e67690536755101ed426c4c5cfe1,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:cbb4e09f0c239d9fc253f426daea95ec, -)
+    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:d16264948a1baffc5b788ff82a41433f, -)
+    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:689643975c6d062da3f861f197ffb911, -)
+    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:50609b22ae1142a0b21014e830b41cae, -)
+    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:0a2a8817aa6793a351bd0a7021236cd0, -)
+    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:1d1c92ca0bfb701909eb307868358b1a, -)
+    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:932bf207ec1906155b85201be9afc0ed, -)
+    used(niiri:6be0e67690536755101ed426c4c5cfe1, niiri:356327ce3d3e8895d849bb23327e10f5, -)
+    entity(niiri:6009f6fd85ea333f9b78564cda2aa83c,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        nidm_searchVolumeInVoxels: = "167222" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1337776" %% xsd:float,
+        nidm_reselSizeInVoxels: = "68.5679161280351" %% xsd:float,
+        nidm_searchVolumeInResels: = "2244.24204044145" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[5, 56.1858858382816, 782.552337179563, 2244.24204044145]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.09364449471869, 4.06742111213816, 4.11805068781302]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.18728898943738, 8.13484222427633, 8.23610137562605]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "5.40031514302336" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "33.3078455926716" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "37.9092455175785" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "99" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "57" %% xsd:int,
+        crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
+    wasGeneratedBy(niiri:6009f6fd85ea333f9b78564cda2aa83c, niiri:6be0e67690536755101ed426c4c5cfe1, -)
+    entity(niiri:950be147189508776d90eb2c4280326c,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "71" %% xsd:int,
+        nidm_pValue: = "9.36073596413678e-09" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:404ea6617dcd902e2957d9a6b74f7ab3',
+        nidm_hasMaximumIntensityProjection: = 'niiri:a77ea9285b48403a7689ae0b730f7230',
+        nidm_inCoordinateSpace: = 'niiri:04394321c13e24105925122a5ea9615c',
+        crypto:sha512 = "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006" %% xsd:string])
+    entity(niiri:404ea6617dcd902e2957d9a6b74f7ab3,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:a77ea9285b48403a7689ae0b730f7230,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:950be147189508776d90eb2c4280326c, niiri:6be0e67690536755101ed426c4c5cfe1, -)
+    entity(niiri:ec71581037e524c5fbd95f85fa55b157,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "64" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.933381144039647" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00186515164019167" %% xsd:float,
+        nidm_pValueFWER: = "0.060233823286733" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "1" %% xsd:int])
+    wasDerivedFrom(niiri:ec71581037e524c5fbd95f85fa55b157, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:ddc3a6b40532cc9e86f19a4aa6cba853,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "139" %% xsd:int,
+        nidm_clusterSizeInResels: = "2.02718717221111" %% xsd:float,
+        nidm_pValueUncorrected: = "2.6469154891926e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.000881242002104266" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "2" %% xsd:int])
+    wasDerivedFrom(niiri:ddc3a6b40532cc9e86f19a4aa6cba853, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:c1738200f1bc478c78cb4aab2cda0cb1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "99" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.44382395718633" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000223613862913789" %% xsd:float,
+        nidm_pValueFWER: = "0.00742042768591067" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "3" %% xsd:int])
+    wasDerivedFrom(niiri:c1738200f1bc478c78cb4aab2cda0cb1, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:91205f3f0676956d1f1039643e3fcd9d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "100" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.45840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00021132818538256" %% xsd:float,
+        nidm_pValueFWER: = "0.00701417162859297" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "4" %% xsd:int])
+    wasDerivedFrom(niiri:91205f3f0676956d1f1039643e3fcd9d, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:a689a0799152fcf397ed6264dff6b7df,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "41" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.597947295400399" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00937054756605333" %% xsd:float,
+        nidm_pValueFWER: = "0.26810099909693" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "5" %% xsd:int])
+    wasDerivedFrom(niiri:a689a0799152fcf397ed6264dff6b7df, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:4f3977b902ab860fce265438ec1666b5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "42" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.612531375776019" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00868796710659031" %% xsd:float,
+        nidm_pValueFWER: = "0.251270468559567" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "6" %% xsd:int])
+    wasDerivedFrom(niiri:4f3977b902ab860fce265438ec1666b5, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:e8270a828c6a9c6a7e1a7f948de88a7e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "27" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.393770170141726" %% xsd:float,
+        nidm_pValueUncorrected: = "0.02915927403888" %% xsd:float,
+        nidm_pValueFWER: = "0.621383930767395" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "7" %% xsd:int])
+    wasDerivedFrom(niiri:e8270a828c6a9c6a7e1a7f948de88a7e, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:cda674baaa255a631b19d42763c0930c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "57" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.831292581410311" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00297536918873803" %% xsd:float,
+        nidm_pValueFWER: = "0.0943507032156397" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "8" %% xsd:int])
+    wasDerivedFrom(niiri:cda674baaa255a631b19d42763c0930c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:b9beda96f738803fb567cd0d0d5ac126,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "33" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.481274652395443" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0175801280664628" %% xsd:float,
+        nidm_pValueFWER: = "0.443203909376631" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "9" %% xsd:int])
+    wasDerivedFrom(niiri:b9beda96f738803fb567cd0d0d5ac126, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:24686319b3c7b6b6793dbf6e90029199,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0875044822537169" %% xsd:float,
+        nidm_pValueUncorrected: = "0.273373266352505" %% xsd:float,
+        nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "10" %% xsd:int])
+    wasDerivedFrom(niiri:24686319b3c7b6b6793dbf6e90029199, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:ef45eced4ec473fc374602efe1d44af2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.161523634652226" %% xsd:float,
+        nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "11" %% xsd:int])
+    wasDerivedFrom(niiri:ef45eced4ec473fc374602efe1d44af2, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:1a8d727934cbec38f1fdcc84430d7857,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "26" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.379186089766107" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0318362117547758" %% xsd:float,
+        nidm_pValueFWER: = "0.653681229272869" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "12" %% xsd:int])
+    wasDerivedFrom(niiri:1a8d727934cbec38f1fdcc84430d7857, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:0ea4cdb2fb21bb5f5f9588416f8a0986,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160424884131814" %% xsd:float,
+        nidm_pValueUncorrected: = "0.143315972308448" %% xsd:float,
+        nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "13" %% xsd:int])
+    wasDerivedFrom(niiri:0ea4cdb2fb21bb5f5f9588416f8a0986, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:e96a0a75cfbda16324a620530f8ac979,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "16" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.233345286009912" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0825813905071932" %% xsd:float,
+        nidm_pValueFWER: = "0.936111008142629" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "14" %% xsd:int])
+    wasDerivedFrom(niiri:e96a0a75cfbda16324a620530f8ac979, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:bc4b7adbe33f91a695fde03bf4b200ed,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "14" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.204177125258673" %% xsd:float,
+        nidm_pValueUncorrected: = "0.10212573718427" %% xsd:float,
+        nidm_pValueFWER: = "0.966679694237215" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "15" %% xsd:int])
+    wasDerivedFrom(niiri:bc4b7adbe33f91a695fde03bf4b200ed, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:71a412f82e6ea8cb947b5be72c8efcff,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "35" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.510442813146682" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0149558617235747" %% xsd:float,
+        nidm_pValueFWER: = "0.392344720913691" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "16" %% xsd:int])
+    wasDerivedFrom(niiri:71a412f82e6ea8cb947b5be72c8efcff, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:93e18b25ba3aeb399e6fd41cb9dfca97,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "32" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.466690572019824" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0190834833796118" %% xsd:float,
+        nidm_pValueFWER: = "0.470398116431399" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "17" %% xsd:int])
+    wasDerivedFrom(niiri:93e18b25ba3aeb399e6fd41cb9dfca97, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:3d33e1d8e7da5c593e7ad094c154132a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "46" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.670867697278497" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00645728092420274" %% xsd:float,
+        nidm_pValueFWER: = "0.193521561130372" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "18" %% xsd:int])
+    wasDerivedFrom(niiri:3d33e1d8e7da5c593e7ad094c154132a, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "15" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.218761205634292" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0917266976854565" %% xsd:float,
+        nidm_pValueFWER: = "0.952887583051913" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "19" %% xsd:int])
+    wasDerivedFrom(niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:7c11ea6d552baec493b21ecdef64c785,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "20" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.29168160751239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0553545237190288" %% xsd:float,
+        nidm_pValueFWER: = "0.841775430461368" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "20" %% xsd:int])
+    wasDerivedFrom(niiri:7c11ea6d552baec493b21ecdef64c785, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:56fa7a2fed0946da7dd3299da637b245,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160424884131814" %% xsd:float,
+        nidm_pValueUncorrected: = "0.143315972308448" %% xsd:float,
+        nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "21" %% xsd:int])
+    wasDerivedFrom(niiri:56fa7a2fed0946da7dd3299da637b245, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:c74b1ddb4c9a5395bf0b4d826708ce5a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "32" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.466690572019824" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0190834833796118" %% xsd:float,
+        nidm_pValueFWER: = "0.470398116431399" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "22" %% xsd:int])
+    wasDerivedFrom(niiri:c74b1ddb4c9a5395bf0b4d826708ce5a, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:10bec2b1f4f72ee8eedb38e17e1faab3,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.058336321502478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.371675909431407" %% xsd:float,
+        nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "23" %% xsd:int])
+    wasDerivedFrom(niiri:10bec2b1f4f72ee8eedb38e17e1faab3, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:f725bd9a5656b07d43f8eba6c3be2858,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160424884131814" %% xsd:float,
+        nidm_pValueUncorrected: = "0.143315972308448" %% xsd:float,
+        nidm_pValueFWER: = "0.991549640351899" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "24" %% xsd:int])
+    wasDerivedFrom(niiri:f725bd9a5656b07d43f8eba6c3be2858, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:83f438c66d3cf32344b7255377c7499d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0729204018780975" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317117336021626" %% xsd:float,
+        nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "25" %% xsd:int])
+    wasDerivedFrom(niiri:83f438c66d3cf32344b7255377c7499d, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:cc9360b64b21e281dcfb851074b574b6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "21" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.306265687888009" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0503036857692116" %% xsd:float,
+        nidm_pValueFWER: = "0.812786836270519" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "26" %% xsd:int])
+    wasDerivedFrom(niiri:cc9360b64b21e281dcfb851074b574b6, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:4728de35ba855317aeef4e0a7b91801c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "25" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.364602009390487" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0347983287867789" %% xsd:float,
+        nidm_pValueFWER: = "0.686218175845877" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "27" %% xsd:int])
+    wasDerivedFrom(niiri:4728de35ba855317aeef4e0a7b91801c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:f435923c3d5e3915c4aa5159c5bbc4a0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.116672643004956" %% xsd:float,
+        nidm_pValueUncorrected: = "0.20781578719113" %% xsd:float,
+        nidm_pValueFWER: = "0.999014041359979" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "28" %% xsd:int])
+    wasDerivedFrom(niiri:f435923c3d5e3915c4aa5159c5bbc4a0, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:b39b9cce118cf858149cdd53ebcda7bd,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.175008964507434" %% xsd:float,
+        nidm_pValueUncorrected: = "0.127616241080866" %% xsd:float,
+        nidm_pValueFWER: = "0.985744636441848" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "29" %% xsd:int])
+    wasDerivedFrom(niiri:b39b9cce118cf858149cdd53ebcda7bd, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:97e0a9bea1289493ad46d8a4c2b75485,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "30" %% xsd:int])
+    wasDerivedFrom(niiri:97e0a9bea1289493ad46d8a4c2b75485, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:e9e94038b5b1dbcf9f8a4d4208e34928,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.161523634652226" %% xsd:float,
+        nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "31" %% xsd:int])
+    wasDerivedFrom(niiri:e9e94038b5b1dbcf9f8a4d4208e34928, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:0857328371989db393f2fc4d7d5346bd,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.058336321502478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.371675909431407" %% xsd:float,
+        nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "32" %% xsd:int])
+    wasDerivedFrom(niiri:0857328371989db393f2fc4d7d5346bd, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:7e693a4a3e70d39b916aa2a95911a3c8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0875044822537169" %% xsd:float,
+        nidm_pValueUncorrected: = "0.273373266352505" %% xsd:float,
+        nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "33" %% xsd:int])
+    wasDerivedFrom(niiri:7e693a4a3e70d39b916aa2a95911a3c8, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:d8dc459a110e4898c23019ee42154713,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0729204018780975" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317117336021626" %% xsd:float,
+        nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "34" %% xsd:int])
+    wasDerivedFrom(niiri:d8dc459a110e4898c23019ee42154713, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:cd795f902776ad9170549b8fde8996ba,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.161523634652226" %% xsd:float,
+        nidm_pValueFWER: = "0.995392197803255" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "35" %% xsd:int])
+    wasDerivedFrom(niiri:cd795f902776ad9170549b8fde8996ba, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:ed1df7c28737883d905ca0a8f2093992,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102088562629336" %% xsd:float,
+        nidm_pValueUncorrected: = "0.237571474546961" %% xsd:float,
+        nidm_pValueFWER: = "0.99963404273418" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "36" %% xsd:int])
+    wasDerivedFrom(niiri:ed1df7c28737883d905ca0a8f2093992, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:ca7bfed8d8dbca676ba25fca93d29e2c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.116672643004956" %% xsd:float,
+        nidm_pValueUncorrected: = "0.20781578719113" %% xsd:float,
+        nidm_pValueFWER: = "0.999014041359979" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "37" %% xsd:int])
+    wasDerivedFrom(niiri:ca7bfed8d8dbca676ba25fca93d29e2c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:1dcd9b5514190f867e3e9b0b57227395,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.175008964507434" %% xsd:float,
+        nidm_pValueUncorrected: = "0.127616241080866" %% xsd:float,
+        nidm_pValueFWER: = "0.985744636441848" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "38" %% xsd:int])
+    wasDerivedFrom(niiri:1dcd9b5514190f867e3e9b0b57227395, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:79097d11179e49abc9f2bdf5ba7bb932,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0729204018780975" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317117336021626" %% xsd:float,
+        nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "39" %% xsd:int])
+    wasDerivedFrom(niiri:79097d11179e49abc9f2bdf5ba7bb932, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:d339d6251d3c159dbe2427fd1bcc1fc1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0729204018780975" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317117336021626" %% xsd:float,
+        nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "40" %% xsd:int])
+    wasDerivedFrom(niiri:d339d6251d3c159dbe2427fd1bcc1fc1, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:b0978b4f683201d3539ace75681c8b65,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0437522411268585" %% xsd:float,
+        nidm_pValueUncorrected: = "0.441752016334617" %% xsd:float,
+        nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "41" %% xsd:int])
+    wasDerivedFrom(niiri:b0978b4f683201d3539ace75681c8b65, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:133c074788eed1fa9d50d9e4608e3c1c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0875044822537169" %% xsd:float,
+        nidm_pValueUncorrected: = "0.273373266352505" %% xsd:float,
+        nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "42" %% xsd:int])
+    wasDerivedFrom(niiri:133c074788eed1fa9d50d9e4608e3c1c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:93bdd51f373f8659382785eb36932971,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "9" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.131256723380575" %% xsd:float,
+        nidm_pValueUncorrected: = "0.182785449876348" %% xsd:float,
+        nidm_pValueFWER: = "0.997730485940405" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "43" %% xsd:int])
+    wasDerivedFrom(niiri:93bdd51f373f8659382785eb36932971, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:522536a75466fe7c0e757947afe21547,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0437522411268585" %% xsd:float,
+        nidm_pValueUncorrected: = "0.441752016334617" %% xsd:float,
+        nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "44" %% xsd:int])
+    wasDerivedFrom(niiri:522536a75466fe7c0e757947afe21547, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:acdb22704e8e3566aa17ca0ccdff7a03,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0437522411268585" %% xsd:float,
+        nidm_pValueUncorrected: = "0.441752016334617" %% xsd:float,
+        nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "45" %% xsd:int])
+    wasDerivedFrom(niiri:acdb22704e8e3566aa17ca0ccdff7a03, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:e1cde03f80af40c7004f16340827c9a6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "46" %% xsd:int])
+    wasDerivedFrom(niiri:e1cde03f80af40c7004f16340827c9a6, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:1a861a102938105fb0e599c28c89f0df,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.058336321502478" %% xsd:float,
+        nidm_pValueUncorrected: = "0.371675909431407" %% xsd:float,
+        nidm_pValueFWER: = "0.999995797049595" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "47" %% xsd:int])
+    wasDerivedFrom(niiri:1a861a102938105fb0e599c28c89f0df, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:28c829a636fe7679be2b8fe3fc083d99,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0437522411268585" %% xsd:float,
+        nidm_pValueUncorrected: = "0.441752016334617" %% xsd:float,
+        nidm_pValueFWER: = "0.999999592737522" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "48" %% xsd:int])
+    wasDerivedFrom(niiri:28c829a636fe7679be2b8fe3fc083d99, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:4bb1f06cdf753bfe2cb9742585fc5f63,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0729204018780975" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317117336021626" %% xsd:float,
+        nidm_pValueFWER: = "0.999974131777239" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "49" %% xsd:int])
+    wasDerivedFrom(niiri:4bb1f06cdf753bfe2cb9742585fc5f63, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:cca6dc1b6e22a99533fb4839e0e808cf,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "50" %% xsd:int])
+    wasDerivedFrom(niiri:cca6dc1b6e22a99533fb4839e0e808cf, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:894db077f6ce41dde7580196422f5b65,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "51" %% xsd:int])
+    wasDerivedFrom(niiri:894db077f6ce41dde7580196422f5b65, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:e8143c5b2cddc4ad2f401f2b27a4cab2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "52" %% xsd:int])
+    wasDerivedFrom(niiri:e8143c5b2cddc4ad2f401f2b27a4cab2, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:09cd915bf2b2b51b32d56249f304bbce,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "53" %% xsd:int])
+    wasDerivedFrom(niiri:09cd915bf2b2b51b32d56249f304bbce, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:bf2d35b880b3d0657d2a03298074406e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0875044822537169" %% xsd:float,
+        nidm_pValueUncorrected: = "0.273373266352505" %% xsd:float,
+        nidm_pValueFWER: = "0.999888943840686" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "54" %% xsd:int])
+    wasDerivedFrom(niiri:bf2d35b880b3d0657d2a03298074406e, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:56bc4504cec954daf4a701610ddf59b3,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "55" %% xsd:int])
+    wasDerivedFrom(niiri:56bc4504cec954daf4a701610ddf59b3, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:baa1270c4a9c0f72989c973b2fbb309d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "56" %% xsd:int])
+    wasDerivedFrom(niiri:baa1270c4a9c0f72989c973b2fbb309d, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:39b258c34ddafd00d7dff6d208f62918,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "57" %% xsd:int])
+    wasDerivedFrom(niiri:39b258c34ddafd00d7dff6d208f62918, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:ea112296db729b94dfce05991c3d6989,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.029168160751239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.536068820289802" %% xsd:float,
+        nidm_pValueFWER: = "0.999999982398778" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "58" %% xsd:int])
+    wasDerivedFrom(niiri:ea112296db729b94dfce05991c3d6989, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:a41eeb9ba04d7788ba686542607ff1cc,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "59" %% xsd:int])
+    wasDerivedFrom(niiri:a41eeb9ba04d7788ba686542607ff1cc, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:9c7b81143edac28cf680878e9177494c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "60" %% xsd:int])
+    wasDerivedFrom(niiri:9c7b81143edac28cf680878e9177494c, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:e854403c8636e3e481bc993eb6180f44,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "61" %% xsd:int])
+    wasDerivedFrom(niiri:e854403c8636e3e481bc993eb6180f44, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:7f3ebf5e2a10fd569c91dd091c7af147,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "62" %% xsd:int])
+    wasDerivedFrom(niiri:7f3ebf5e2a10fd569c91dd091c7af147, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:b36c20212016b9bc7a603f3e83aca676,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.029168160751239" %% xsd:float,
+        nidm_pValueUncorrected: = "0.536068820289802" %% xsd:float,
+        nidm_pValueFWER: = "0.999999982398778" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "63" %% xsd:int])
+    wasDerivedFrom(niiri:b36c20212016b9bc7a603f3e83aca676, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:05115f2e683a3386f641d5816019de27,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "64" %% xsd:int])
+    wasDerivedFrom(niiri:05115f2e683a3386f641d5816019de27, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:1ee8276c32c1e03b7e0b4b1717c44a57,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "65" %% xsd:int])
+    wasDerivedFrom(niiri:1ee8276c32c1e03b7e0b4b1717c44a57, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:aa58a012c4a942174e0325d4c0b944fd,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "66" %% xsd:int])
+    wasDerivedFrom(niiri:aa58a012c4a942174e0325d4c0b944fd, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:69b1d9ea8525a6a583365384e39cf9e8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "67" %% xsd:int])
+    wasDerivedFrom(niiri:69b1d9ea8525a6a583365384e39cf9e8, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:f6d9af16709f321130aa58504e6604c5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "68" %% xsd:int])
+    wasDerivedFrom(niiri:f6d9af16709f321130aa58504e6604c5, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:be347b3d17b0cf1b2b8f3ad6860ae399,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "69" %% xsd:int])
+    wasDerivedFrom(niiri:be347b3d17b0cf1b2b8f3ad6860ae399, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:fb10f43ffe914843271a8cdefab5f898,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "70" %% xsd:int])
+    wasDerivedFrom(niiri:fb10f43ffe914843271a8cdefab5f898, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:ac129c99f1ae280d6d0a6f24c04b617a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0145840803756195" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675180100901307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999828904" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "71" %% xsd:int])
+    wasDerivedFrom(niiri:ac129c99f1ae280d6d0a6f24c04b617a, niiri:950be147189508776d90eb2c4280326c, -, -, -)
+    entity(niiri:0259aad92a78e6c87148ce920416a4eb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0001" %% xsd:string,
+        prov:location = 'niiri:dd5db5be9e69824ffb62949c8582d5be',
+        prov:value = "39.0658683776855" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.04009751746769" %% xsd:float,
+        nidm_pValueUncorrected: = "2.3264734660966e-07" %% xsd:float,
+        nidm_pValueFWER: = "0.0389037590875805" %% xsd:float,
+        nidm_qValueFDR: = "0.0302216629065993" %% xsd:float])
+    entity(niiri:dd5db5be9e69824ffb62949c8582d5be,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0001" %% xsd:string,
+        nidm_coordinateVector: = "[-2,-90,28]" %% xsd:string])
+    wasDerivedFrom(niiri:0259aad92a78e6c87148ce920416a4eb, niiri:ec71581037e524c5fbd95f85fa55b157, -, -, -)
+    entity(niiri:7e799bbd6f335fd540a4021e61075cf8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0002" %% xsd:string,
+        prov:location = 'niiri:d3f6be55abbd687279e07d932188a32e',
+        prov:value = "36.2393341064453" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.89725160225159" %% xsd:float,
+        nidm_pValueUncorrected: = "4.85931842320042e-07" %% xsd:float,
+        nidm_pValueFWER: = "0.071761896035709" %% xsd:float,
+        nidm_qValueFDR: = "0.0302216629065993" %% xsd:float])
+    entity(niiri:d3f6be55abbd687279e07d932188a32e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0002" %% xsd:string,
+        nidm_coordinateVector: = "[-42,-64,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:7e799bbd6f335fd540a4021e61075cf8, niiri:ddc3a6b40532cc9e86f19a4aa6cba853, -, -, -)
+    entity(niiri:0818768d40973c28e4e870de99f7a12e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0003" %% xsd:string,
+        prov:location = 'niiri:e10e6b887d937b13d419913e96b50eb4',
+        prov:value = "17.9251842498779" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.64201416072196" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000135256594276711" %% xsd:float,
+        nidm_pValueFWER: = "0.999417997648594" %% xsd:float,
+        nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
+    entity(niiri:e10e6b887d937b13d419913e96b50eb4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0003" %% xsd:string,
+        nidm_coordinateVector: = "[-40,-52,-10]" %% xsd:string])
+    wasDerivedFrom(niiri:0818768d40973c28e4e870de99f7a12e, niiri:ddc3a6b40532cc9e86f19a4aa6cba853, -, -, -)
+    entity(niiri:2e69720344eeade04945a9294efe1c46,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0004" %% xsd:string,
+        prov:location = 'niiri:43f273420f486c1569872beaefa26851',
+        prov:value = "13.454288482666" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.18324713734782" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000728166268399777" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999996872" %% xsd:float,
+        nidm_qValueFDR: = "0.140840039531724" %% xsd:float])
+    entity(niiri:43f273420f486c1569872beaefa26851,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0004" %% xsd:string,
+        nidm_coordinateVector: = "[-38,-70,0]" %% xsd:string])
+    wasDerivedFrom(niiri:2e69720344eeade04945a9294efe1c46, niiri:ddc3a6b40532cc9e86f19a4aa6cba853, -, -, -)
+    entity(niiri:0b61d4f645e8030fa41b599c3b7220dd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0005" %% xsd:string,
+        prov:location = 'niiri:a9b1c3d0f5af3d460c038461141f2a06',
+        prov:value = "29.4676361083984" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.51162164706026" %% xsd:float,
+        nidm_pValueUncorrected: = "3.21669348379849e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.305525019896507" %% xsd:float,
+        nidm_qValueFDR: = "0.0356596612461515" %% xsd:float])
+    entity(niiri:a9b1c3d0f5af3d460c038461141f2a06,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0005" %% xsd:string,
+        nidm_coordinateVector: = "[16,-88,24]" %% xsd:string])
+    wasDerivedFrom(niiri:0b61d4f645e8030fa41b599c3b7220dd, niiri:c1738200f1bc478c78cb4aab2cda0cb1, -, -, -)
+    entity(niiri:211afdee4625abd8fd61f5e2da4e7851,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0006" %% xsd:string,
+        prov:location = 'niiri:21d2bcb65d9792fab52c653d5e34433a',
+        prov:value = "28.5631580352783" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.45459114773779" %% xsd:float,
+        nidm_pValueUncorrected: = "4.20266075706888e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.365688847752494" %% xsd:float,
+        nidm_qValueFDR: = "0.0376032685416481" %% xsd:float])
+    entity(niiri:21d2bcb65d9792fab52c653d5e34433a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0006" %% xsd:string,
+        nidm_coordinateVector: = "[28,-72,26]" %% xsd:string])
+    wasDerivedFrom(niiri:211afdee4625abd8fd61f5e2da4e7851, niiri:91205f3f0676956d1f1039643e3fcd9d, -, -, -)
+    entity(niiri:36f1bebef6aafa905f0a57417a9a9409,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0007" %% xsd:string,
+        prov:location = 'niiri:d149b750b624172908054300ba57fa0d',
+        prov:value = "26.9945106506348" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.35204306383375" %% xsd:float,
+        nidm_pValueUncorrected: = "6.7437380493196e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.489729172437052" %% xsd:float,
+        nidm_qValueFDR: = "0.0406203661092224" %% xsd:float])
+    entity(niiri:d149b750b624172908054300ba57fa0d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0007" %% xsd:string,
+        nidm_coordinateVector: = "[-32,20,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:36f1bebef6aafa905f0a57417a9a9409, niiri:a689a0799152fcf397ed6264dff6b7df, -, -, -)
+    entity(niiri:2b42ff26513d8bb2fad2bee3fac979bd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0008" %% xsd:string,
+        prov:location = 'niiri:00172712096fe22fbb4c6cb0abae056c',
+        prov:value = "26.8606586456299" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.34306775687574" %% xsd:float,
+        nidm_pValueUncorrected: = "7.02533878071954e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.501353785238145" %% xsd:float,
+        nidm_qValueFDR: = "0.0406203661092224" %% xsd:float])
+    entity(niiri:00172712096fe22fbb4c6cb0abae056c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0008" %% xsd:string,
+        nidm_coordinateVector: = "[-8,50,32]" %% xsd:string])
+    wasDerivedFrom(niiri:2b42ff26513d8bb2fad2bee3fac979bd, niiri:4f3977b902ab860fce265438ec1666b5, -, -, -)
+    entity(niiri:570e544597bcf68c47263d141cd82ca4,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0009" %% xsd:string,
+        prov:location = 'niiri:4488b6dfe10aa9fffe9d9fa5f038987f',
+        prov:value = "25.8067512512207" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.27109313660164" %% xsd:float,
+        nidm_pValueUncorrected: = "9.72585724245967e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.597019202761311" %% xsd:float,
+        nidm_qValueFDR: = "0.0439563569939673" %% xsd:float])
+    entity(niiri:4488b6dfe10aa9fffe9d9fa5f038987f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0009" %% xsd:string,
+        nidm_coordinateVector: = "[-34,8,58]" %% xsd:string])
+    wasDerivedFrom(niiri:570e544597bcf68c47263d141cd82ca4, niiri:e8270a828c6a9c6a7e1a7f948de88a7e, -, -, -)
+    entity(niiri:be4c08d3fca48f05de0ae62f8b673305,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0010" %% xsd:string,
+        prov:location = 'niiri:43ecbb57ee775f4cbb1dd4af236cfbff',
+        prov:value = "25.0769119262695" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.21983658750018" %% xsd:float,
+        nidm_pValueUncorrected: = "1.22239732009977e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.665677647955296" %% xsd:float,
+        nidm_qValueFDR: = "0.0444376030498989" %% xsd:float])
+    entity(niiri:43ecbb57ee775f4cbb1dd4af236cfbff,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0010" %% xsd:string,
+        nidm_coordinateVector: = "[32,-86,0]" %% xsd:string])
+    wasDerivedFrom(niiri:be4c08d3fca48f05de0ae62f8b673305, niiri:cda674baaa255a631b19d42763c0930c, -, -, -)
+    entity(niiri:340ff54b0274dd2288512da30ba70b15,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0011" %% xsd:string,
+        prov:location = 'niiri:9b59dfd3cd6fe92f527a2d11dc8e5ad5',
+        prov:value = "24.5828113555908" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.18444689049798" %% xsd:float,
+        nidm_pValueUncorrected: = "1.42930633414418e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.711939170732988" %% xsd:float,
+        nidm_qValueFDR: = "0.04475687830922" %% xsd:float])
+    entity(niiri:9b59dfd3cd6fe92f527a2d11dc8e5ad5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0011" %% xsd:string,
+        nidm_coordinateVector: = "[66,-32,30]" %% xsd:string])
+    wasDerivedFrom(niiri:340ff54b0274dd2288512da30ba70b15, niiri:b9beda96f738803fb567cd0d0d5ac126, -, -, -)
+    entity(niiri:bfd29eeffd577f81b1028084dd3cafbb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0012" %% xsd:string,
+        prov:location = 'niiri:afdc90796927d6b5b5d8e26a0c89d918',
+        prov:value = "14.2693071365356" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.27451594161643" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000529215834762176" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999209483" %% xsd:float,
+        nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
+    entity(niiri:afdc90796927d6b5b5d8e26a0c89d918,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0012" %% xsd:string,
+        nidm_coordinateVector: = "[60,-38,28]" %% xsd:string])
+    wasDerivedFrom(niiri:bfd29eeffd577f81b1028084dd3cafbb, niiri:b9beda96f738803fb567cd0d0d5ac126, -, -, -)
+    entity(niiri:3de1d3b3fd47f85802886f79af4dc678,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0013" %% xsd:string,
+        prov:location = 'niiri:533d4d268893416ecb4d1151faad2ef6',
+        prov:value = "23.3039436340332" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.09011898331566" %% xsd:float,
+        nidm_pValueUncorrected: = "2.15575975488491e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.823947459995523" %% xsd:float,
+        nidm_qValueFDR: = "0.0478656864369739" %% xsd:float])
+    entity(niiri:533d4d268893416ecb4d1151faad2ef6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0013" %% xsd:string,
+        nidm_coordinateVector: = "[28,30,52]" %% xsd:string])
+    wasDerivedFrom(niiri:3de1d3b3fd47f85802886f79af4dc678, niiri:24686319b3c7b6b6793dbf6e90029199, -, -, -)
+    entity(niiri:4c793b1434ab014669b8e4ce2cf2139b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0014" %% xsd:string,
+        prov:location = 'niiri:f6d485f30b70a6db61c96e28aa7f2753',
+        prov:value = "22.6157932281494" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.03763886298215" %% xsd:float,
+        nidm_pValueUncorrected: = "2.69959426782984e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.87538446987651" %% xsd:float,
+        nidm_qValueFDR: = "0.0515719459796674" %% xsd:float])
+    entity(niiri:f6d485f30b70a6db61c96e28aa7f2753,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0014" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-34,6]" %% xsd:string])
+    wasDerivedFrom(niiri:4c793b1434ab014669b8e4ce2cf2139b, niiri:ef45eced4ec473fc374602efe1d44af2, -, -, -)
+    entity(niiri:f9a42b90df039166ca0e5fa02d3d604f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0015" %% xsd:string,
+        prov:location = 'niiri:55a6eaf2f3b34f1854c5cc88fea7e153',
+        prov:value = "21.8558578491211" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.97819185113407" %% xsd:float,
+        nidm_pValueUncorrected: = "3.47206660495925e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.921823721412592" %% xsd:float,
+        nidm_qValueFDR: = "0.053734847831518" %% xsd:float])
+    entity(niiri:55a6eaf2f3b34f1854c5cc88fea7e153,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0015" %% xsd:string,
+        nidm_coordinateVector: = "[-28,0,30]" %% xsd:string])
+    wasDerivedFrom(niiri:f9a42b90df039166ca0e5fa02d3d604f, niiri:1a8d727934cbec38f1fdcc84430d7857, -, -, -)
+    entity(niiri:de93eaf377bd0a9992922d03e47c7423,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0016" %% xsd:string,
+        prov:location = 'niiri:b0a8a5b4d1ad632e303792bb14434ab1',
+        prov:value = "21.8296661376953" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.97611404363788" %% xsd:float,
+        nidm_pValueUncorrected: = "3.50252708366527e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.923209894114283" %% xsd:float,
+        nidm_qValueFDR: = "0.053734847831518" %% xsd:float])
+    entity(niiri:b0a8a5b4d1ad632e303792bb14434ab1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0016" %% xsd:string,
+        nidm_coordinateVector: = "[8,34,10]" %% xsd:string])
+    wasDerivedFrom(niiri:de93eaf377bd0a9992922d03e47c7423, niiri:0ea4cdb2fb21bb5f5f9588416f8a0986, -, -, -)
+    entity(niiri:e354a84565e5c296d9efa7317a911cfe,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0017" %% xsd:string,
+        prov:location = 'niiri:6cd3c9ec2c82b8b60104f15adb91982c',
+        prov:value = "21.7287845611572" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.96809263472704" %% xsd:float,
+        nidm_pValueUncorrected: = "3.6225086553876e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.928411428313329" %% xsd:float,
+        nidm_qValueFDR: = "0.0540587737624357" %% xsd:float])
+    entity(niiri:6cd3c9ec2c82b8b60104f15adb91982c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0017" %% xsd:string,
+        nidm_coordinateVector: = "[46,-56,10]" %% xsd:string])
+    wasDerivedFrom(niiri:e354a84565e5c296d9efa7317a911cfe, niiri:e96a0a75cfbda16324a620530f8ac979, -, -, -)
+    entity(niiri:08e6714e83b23af817c91a38ea817a9d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0018" %% xsd:string,
+        prov:location = 'niiri:18511209fae629ef4fc05e9115d24b3d',
+        prov:value = "14.2801656723022" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.27570591680179" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000526991241768693" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999156251" %% xsd:float,
+        nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
+    entity(niiri:18511209fae629ef4fc05e9115d24b3d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0018" %% xsd:string,
+        nidm_coordinateVector: = "[48,-48,16]" %% xsd:string])
+    wasDerivedFrom(niiri:08e6714e83b23af817c91a38ea817a9d, niiri:e96a0a75cfbda16324a620530f8ac979, -, -, -)
+    entity(niiri:27a4396719d910dc755a3ae8f5919b75,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0019" %% xsd:string,
+        prov:location = 'niiri:11308bc9db92e428a2f7e9a8d4420c7f',
+        prov:value = "21.4629364013672" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.9468129149843" %% xsd:float,
+        nidm_pValueUncorrected: = "3.95991966499754e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.941069307565192" %% xsd:float,
+        nidm_qValueFDR: = "0.0555984329583215" %% xsd:float])
+    entity(niiri:11308bc9db92e428a2f7e9a8d4420c7f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0019" %% xsd:string,
+        nidm_coordinateVector: = "[46,-62,-10]" %% xsd:string])
+    wasDerivedFrom(niiri:27a4396719d910dc755a3ae8f5919b75, niiri:bc4b7adbe33f91a695fde03bf4b200ed, -, -, -)
+    entity(niiri:cc9face0d8fe5a7de8a150a20acca2d8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0020" %% xsd:string,
+        prov:location = 'niiri:73a9a071ca8380ed9df7a551dfd73dfa',
+        prov:value = "21.4269542694092" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.94391683979485" %% xsd:float,
+        nidm_pValueUncorrected: = "4.00807329147268e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.942665676683549" %% xsd:float,
+        nidm_qValueFDR: = "0.0555984329583215" %% xsd:float])
+    entity(niiri:73a9a071ca8380ed9df7a551dfd73dfa,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0020" %% xsd:string,
+        nidm_coordinateVector: = "[-8,-32,36]" %% xsd:string])
+    wasDerivedFrom(niiri:cc9face0d8fe5a7de8a150a20acca2d8, niiri:71a412f82e6ea8cb947b5be72c8efcff, -, -, -)
+    entity(niiri:5af15d290c54073ba4518037ca306358,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0021" %% xsd:string,
+        prov:location = 'niiri:924073fc7007784464acebdf52dfccca',
+        prov:value = "20.0413494110107" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.82938429557992" %% xsd:float,
+        nidm_pValueUncorrected: = "6.42321325474704e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.984364018223445" %% xsd:float,
+        nidm_qValueFDR: = "0.0674959642175569" %% xsd:float])
+    entity(niiri:924073fc7007784464acebdf52dfccca,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0021" %% xsd:string,
+        nidm_coordinateVector: = "[-34,-84,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:5af15d290c54073ba4518037ca306358, niiri:93e18b25ba3aeb399e6fd41cb9dfca97, -, -, -)
+    entity(niiri:ea651b661b6bfe3969159c6f0ec70642,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0022" %% xsd:string,
+        prov:location = 'niiri:6150a0cc589ec407bbf5b278e34fe8c0',
+        prov:value = "19.5813789367676" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.79000141974546" %% xsd:float,
+        nidm_pValueUncorrected: = "7.53232118573255e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.991038394814884" %% xsd:float,
+        nidm_qValueFDR: = "0.0718990170223714" %% xsd:float])
+    entity(niiri:6150a0cc589ec407bbf5b278e34fe8c0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0022" %% xsd:string,
+        nidm_coordinateVector: = "[-50,2,40]" %% xsd:string])
+    wasDerivedFrom(niiri:ea651b661b6bfe3969159c6f0ec70642, niiri:3d33e1d8e7da5c593e7ad094c154132a, -, -, -)
+    entity(niiri:8c7a07db4f3345bbb5e3dec281596f82,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0023" %% xsd:string,
+        prov:location = 'niiri:8801d1d1f53291499c55fe97c82abf06',
+        prov:value = "16.7666301727295" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.53217184854778" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00020608070787731" %% xsd:float,
+        nidm_pValueFWER: = "0.99996648470095" %% xsd:float,
+        nidm_qValueFDR: = "0.0942608471449251" %% xsd:float])
+    entity(niiri:8801d1d1f53291499c55fe97c82abf06,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0023" %% xsd:string,
+        nidm_coordinateVector: = "[-52,-6,46]" %% xsd:string])
+    wasDerivedFrom(niiri:8c7a07db4f3345bbb5e3dec281596f82, niiri:3d33e1d8e7da5c593e7ad094c154132a, -, -, -)
+    entity(niiri:0d7a35acc2e01b8de53dab1cd6885030,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0024" %% xsd:string,
+        prov:location = 'niiri:5ca0f95ce3edb5b98b519299dce96767',
+        prov:value = "19.3040504455566" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.76590943131268" %% xsd:float,
+        nidm_pValueUncorrected: = "8.2971971291701e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.993825462793153" %% xsd:float,
+        nidm_qValueFDR: = "0.0737314974355366" %% xsd:float])
+    entity(niiri:5ca0f95ce3edb5b98b519299dce96767,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0024" %% xsd:string,
+        nidm_coordinateVector: = "[24,-46,32]" %% xsd:string])
+    wasDerivedFrom(niiri:0d7a35acc2e01b8de53dab1cd6885030, niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4, -, -, -)
+    entity(niiri:0ea3ba62f32a9ee428c5ea4b5cef35cb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0025" %% xsd:string,
+        prov:location = 'niiri:140460982182cf8d062436969406364b',
+        prov:value = "19.1409015655518" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.75161143600874" %% xsd:float,
+        nidm_pValueUncorrected: = "8.7850813353163e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.995110302012489" %% xsd:float,
+        nidm_qValueFDR: = "0.0738147834753255" %% xsd:float])
+    entity(niiri:140460982182cf8d062436969406364b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0025" %% xsd:string,
+        nidm_coordinateVector: = "[6,16,50]" %% xsd:string])
+    wasDerivedFrom(niiri:0ea3ba62f32a9ee428c5ea4b5cef35cb, niiri:7c11ea6d552baec493b21ecdef64c785, -, -, -)
+    entity(niiri:c9ac5ab5461375e94e4d7324a6bedc98,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0026" %% xsd:string,
+        prov:location = 'niiri:c7cab9ce4ae0697e1f4eb6ec314ebc4d',
+        prov:value = "19.098669052124" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.74789498829157" %% xsd:float,
+        nidm_pValueUncorrected: = "8.91624398706714e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.995405100064856" %% xsd:float,
+        nidm_qValueFDR: = "0.0738147834753255" %% xsd:float])
+    entity(niiri:c7cab9ce4ae0697e1f4eb6ec314ebc4d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0026" %% xsd:string,
+        nidm_coordinateVector: = "[-4,-24,6]" %% xsd:string])
+    wasDerivedFrom(niiri:c9ac5ab5461375e94e4d7324a6bedc98, niiri:56fa7a2fed0946da7dd3299da637b245, -, -, -)
+    entity(niiri:d787aaae02f2d49ff3e8f709b3e0ffe2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0027" %% xsd:string,
+        prov:location = 'niiri:27e6b2cc327f93c6462c9e5686d7c493',
+        prov:value = "19.0145893096924" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.7404771295496" %% xsd:float,
+        nidm_pValueUncorrected: = "9.1835629583259e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.995949293325196" %% xsd:float,
+        nidm_qValueFDR: = "0.0741915113542509" %% xsd:float])
+    entity(niiri:27e6b2cc327f93c6462c9e5686d7c493,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0027" %% xsd:string,
+        nidm_coordinateVector: = "[-4,0,54]" %% xsd:string])
+    wasDerivedFrom(niiri:d787aaae02f2d49ff3e8f709b3e0ffe2, niiri:c74b1ddb4c9a5395bf0b4d826708ce5a, -, -, -)
+    entity(niiri:9db9efc1edd783d8cbdaf22ba831fdaf,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0028" %% xsd:string,
+        prov:location = 'niiri:1c5529d2dc429e1471abb89100522dbc',
+        prov:value = "18.8265838623047" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.72379883766124" %% xsd:float,
+        nidm_pValueUncorrected: = "9.81236582245915e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.996978299202392" %% xsd:float,
+        nidm_qValueFDR: = "0.0777669728451003" %% xsd:float])
+    entity(niiri:1c5529d2dc429e1471abb89100522dbc,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0028" %% xsd:string,
+        nidm_coordinateVector: = "[42,-28,30]" %% xsd:string])
+    wasDerivedFrom(niiri:9db9efc1edd783d8cbdaf22ba831fdaf, niiri:10bec2b1f4f72ee8eedb38e17e1faab3, -, -, -)
+    entity(niiri:a25f9de80ac191e47f1660393e75473f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0029" %% xsd:string,
+        prov:location = 'niiri:4fa2fadc00e657efdd63b3a39309c84a',
+        prov:value = "18.5199432373047" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.69631988620818" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000109373660980738" %% xsd:float,
+        nidm_pValueFWER: = "0.998191254166604" %% xsd:float,
+        nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
+    entity(niiri:4fa2fadc00e657efdd63b3a39309c84a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0029" %% xsd:string,
+        nidm_coordinateVector: = "[52,-12,44]" %% xsd:string])
+    wasDerivedFrom(niiri:a25f9de80ac191e47f1660393e75473f, niiri:f725bd9a5656b07d43f8eba6c3be2858, -, -, -)
+    entity(niiri:f484fb8e47371d4dd3f5ee9736deeca9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0030" %% xsd:string,
+        prov:location = 'niiri:33fd7ada9f41a7443fa610a81c719475',
+        prov:value = "18.516544342041" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.69601335434539" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000109505728679404" %% xsd:float,
+        nidm_pValueFWER: = "0.998201975106935" %% xsd:float,
+        nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
+    entity(niiri:33fd7ada9f41a7443fa610a81c719475,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0030" %% xsd:string,
+        nidm_coordinateVector: = "[-40,-28,30]" %% xsd:string])
+    wasDerivedFrom(niiri:f484fb8e47371d4dd3f5ee9736deeca9, niiri:83f438c66d3cf32344b7255377c7499d, -, -, -)
+    entity(niiri:8582459cfedf8c404f54867fe9956065,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0031" %% xsd:string,
+        prov:location = 'niiri:7574fcc563cda88fe39a2f517cefd40a',
+        prov:value = "18.4609222412109" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.69099090519778" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000111691062804176" %% xsd:float,
+        nidm_pValueFWER: = "0.998370011058266" %% xsd:float,
+        nidm_qValueFDR: = "0.0808726894914066" %% xsd:float])
+    entity(niiri:7574fcc563cda88fe39a2f517cefd40a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0031" %% xsd:string,
+        nidm_coordinateVector: = "[32,22,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:8582459cfedf8c404f54867fe9956065, niiri:cc9360b64b21e281dcfb851074b574b6, -, -, -)
+    entity(niiri:ba6bc791d8adb783ff5181c1594590b6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0032" %% xsd:string,
+        prov:location = 'niiri:2398781ef2e524c6173a32e0bb244b23',
+        prov:value = "17.9312534332275" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.64257521175179" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00013496203699781" %% xsd:float,
+        nidm_pValueFWER: = "0.99941063068466" %% xsd:float,
+        nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
+    entity(niiri:2398781ef2e524c6173a32e0bb244b23,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0032" %% xsd:string,
+        nidm_coordinateVector: = "[64,-4,10]" %% xsd:string])
+    wasDerivedFrom(niiri:ba6bc791d8adb783ff5181c1594590b6, niiri:4728de35ba855317aeef4e0a7b91801c, -, -, -)
+    entity(niiri:74387d11b1e18aa01c68936614d323d2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0033" %% xsd:string,
+        prov:location = 'niiri:719551878f20f48ff5a59d8a7a9c8229',
+        prov:value = "17.8439044952393" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.63448648232359" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000139267429951739" %% xsd:float,
+        nidm_pValueFWER: = "0.999509275806277" %% xsd:float,
+        nidm_qValueFDR: = "0.0834774193267073" %% xsd:float])
+    entity(niiri:719551878f20f48ff5a59d8a7a9c8229,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0033" %% xsd:string,
+        nidm_coordinateVector: = "[-22,-72,34]" %% xsd:string])
+    wasDerivedFrom(niiri:74387d11b1e18aa01c68936614d323d2, niiri:f435923c3d5e3915c4aa5159c5bbc4a0, -, -, -)
+    entity(niiri:f515406c4386dbba20e09dfc286cad01,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0034" %% xsd:string,
+        prov:location = 'niiri:53dfe63ffbecb2b80528e9f6b0729406',
+        prov:value = "17.552827835083" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.60731294050443" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000154692216466135" %% xsd:float,
+        nidm_pValueFWER: = "0.999742486133075" %% xsd:float,
+        nidm_qValueFDR: = "0.0862331427095326" %% xsd:float])
+    entity(niiri:53dfe63ffbecb2b80528e9f6b0729406,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0034" %% xsd:string,
+        nidm_coordinateVector: = "[-6,-44,40]" %% xsd:string])
+    wasDerivedFrom(niiri:f515406c4386dbba20e09dfc286cad01, niiri:b39b9cce118cf858149cdd53ebcda7bd, -, -, -)
+    entity(niiri:1b3fb965c01205049ccc6b0cbe41747e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0035" %% xsd:string,
+        prov:location = 'niiri:f27eb00800ba18fb1542d4dada966f33',
+        prov:value = "17.2906818389893" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.58254613965863" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000170130746602659" %% xsd:float,
+        nidm_pValueFWER: = "0.99986271355264" %% xsd:float,
+        nidm_qValueFDR: = "0.0895859395735557" %% xsd:float])
+    entity(niiri:f27eb00800ba18fb1542d4dada966f33,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0035" %% xsd:string,
+        nidm_coordinateVector: = "[-34,-38,-34]" %% xsd:string])
+    wasDerivedFrom(niiri:1b3fb965c01205049ccc6b0cbe41747e, niiri:97e0a9bea1289493ad46d8a4c2b75485, -, -, -)
+    entity(niiri:1db1dcb7ac31be92db03ea6f49276709,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0036" %% xsd:string,
+        prov:location = 'niiri:c2aa93c26b662b0231d80c11fa4a9ef6',
+        prov:value = "17.1612319946289" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.57021115022413" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000178346794309836" %% xsd:float,
+        nidm_pValueFWER: = "0.999901168620001" %% xsd:float,
+        nidm_qValueFDR: = "0.0903823255084056" %% xsd:float])
+    entity(niiri:c2aa93c26b662b0231d80c11fa4a9ef6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0036" %% xsd:string,
+        nidm_coordinateVector: = "[-46,-16,20]" %% xsd:string])
+    wasDerivedFrom(niiri:1db1dcb7ac31be92db03ea6f49276709, niiri:e9e94038b5b1dbcf9f8a4d4208e34928, -, -, -)
+    entity(niiri:e52b244ba436c001a08d0e1a0f3fc101,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0037" %% xsd:string,
+        prov:location = 'niiri:8379336830251a7cbd5eb4a5b2b7e6c0',
+        prov:value = "17.0075950622559" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.55547987606237" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000188644912021529" %% xsd:float,
+        nidm_pValueFWER: = "0.999934173907998" %% xsd:float,
+        nidm_qValueFDR: = "0.0920555845860752" %% xsd:float])
+    entity(niiri:8379336830251a7cbd5eb4a5b2b7e6c0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0037" %% xsd:string,
+        nidm_coordinateVector: = "[24,32,2]" %% xsd:string])
+    wasDerivedFrom(niiri:e52b244ba436c001a08d0e1a0f3fc101, niiri:0857328371989db393f2fc4d7d5346bd, -, -, -)
+    entity(niiri:58c50def173085b4eacf834a8b4704ff,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0038" %% xsd:string,
+        prov:location = 'niiri:0b671ab6136c76ed072d17a2c0f74a10',
+        prov:value = "16.5308303833008" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.50911812032442" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000224797592033421" %% xsd:float,
+        nidm_pValueFWER: = "0.999983487413756" %% xsd:float,
+        nidm_qValueFDR: = "0.0959555780965771" %% xsd:float])
+    entity(niiri:0b671ab6136c76ed072d17a2c0f74a10,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0038" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-90,16]" %% xsd:string])
+    wasDerivedFrom(niiri:58c50def173085b4eacf834a8b4704ff, niiri:7e693a4a3e70d39b916aa2a95911a3c8, -, -, -)
+    entity(niiri:29090a193cda0ed62625301b681522a5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0039" %% xsd:string,
+        prov:location = 'niiri:baefd951dc2ab5a50c39cd840ad1f17e',
+        prov:value = "16.5225524902344" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.50830432871627" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0002254864217901" %% xsd:float,
+        nidm_pValueFWER: = "0.999983907066973" %% xsd:float,
+        nidm_qValueFDR: = "0.0959555780965771" %% xsd:float])
+    entity(niiri:baefd951dc2ab5a50c39cd840ad1f17e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0039" %% xsd:string,
+        nidm_coordinateVector: = "[-28,-4,16]" %% xsd:string])
+    wasDerivedFrom(niiri:29090a193cda0ed62625301b681522a5, niiri:d8dc459a110e4898c23019ee42154713, -, -, -)
+    entity(niiri:b7d5268eabb9490b67684ed7ceb301c9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0040" %% xsd:string,
+        prov:location = 'niiri:9375ad74a7d7acce22a9a6dc5fa1d47d',
+        prov:value = "16.1374092102051" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.47009871338807" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00026013355917065" %% xsd:float,
+        nidm_pValueFWER: = "0.999995475747835" %% xsd:float,
+        nidm_qValueFDR: = "0.101886915515055" %% xsd:float])
+    entity(niiri:9375ad74a7d7acce22a9a6dc5fa1d47d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0040" %% xsd:string,
+        nidm_coordinateVector: = "[12,60,20]" %% xsd:string])
+    wasDerivedFrom(niiri:b7d5268eabb9490b67684ed7ceb301c9, niiri:cd795f902776ad9170549b8fde8996ba, -, -, -)
+    entity(niiri:9db92d56d94d661dd685256f317dbe48,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0041" %% xsd:string,
+        prov:location = 'niiri:e35f3a6956a4d9893c3760d30968fce5',
+        prov:value = "15.9136981964111" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.44759277757755" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000282803055741021" %% xsd:float,
+        nidm_pValueFWER: = "0.999997977474125" %% xsd:float,
+        nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
+    entity(niiri:e35f3a6956a4d9893c3760d30968fce5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0041" %% xsd:string,
+        nidm_coordinateVector: = "[4,-84,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:9db92d56d94d661dd685256f317dbe48, niiri:ed1df7c28737883d905ca0a8f2093992, -, -, -)
+    entity(niiri:95049e965261ae17e6141f440c65aade,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0042" %% xsd:string,
+        prov:location = 'niiri:8907a4706c52ef0acbd6db140d02de82',
+        prov:value = "15.8536109924316" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.44150764421068" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000289241063091916" %% xsd:float,
+        nidm_pValueFWER: = "0.999998385530387" %% xsd:float,
+        nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
+    entity(niiri:8907a4706c52ef0acbd6db140d02de82,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0042" %% xsd:string,
+        nidm_coordinateVector: = "[62,-18,22]" %% xsd:string])
+    wasDerivedFrom(niiri:95049e965261ae17e6141f440c65aade, niiri:ca7bfed8d8dbca676ba25fca93d29e2c, -, -, -)
+    entity(niiri:bc2dfd54c7c011e3626f64ebd840c082,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0043" %% xsd:string,
+        prov:location = 'niiri:8d0fe36db64dfbb57c50be778e56fc0b',
+        prov:value = "15.8288412094116" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.43899416081302" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000291939913913408" %% xsd:float,
+        nidm_pValueFWER: = "0.999998530446399" %% xsd:float,
+        nidm_qValueFDR: = "0.105222982133496" %% xsd:float])
+    entity(niiri:8d0fe36db64dfbb57c50be778e56fc0b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0043" %% xsd:string,
+        nidm_coordinateVector: = "[28,-58,44]" %% xsd:string])
+    wasDerivedFrom(niiri:bc2dfd54c7c011e3626f64ebd840c082, niiri:1dcd9b5514190f867e3e9b0b57227395, -, -, -)
+    entity(niiri:b861ffa726f69dca943d1bc1e39e3f21,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0044" %% xsd:string,
+        prov:location = 'niiri:358c40d8401882be55ffa3aa51e8c703',
+        prov:value = "15.7273988723755" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.42866974555038" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000303273553249328" %% xsd:float,
+        nidm_pValueFWER: = "0.999999007347173" %% xsd:float,
+        nidm_qValueFDR: = "0.106558197028572" %% xsd:float])
+    entity(niiri:358c40d8401882be55ffa3aa51e8c703,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0044" %% xsd:string,
+        nidm_coordinateVector: = "[38,44,0]" %% xsd:string])
+    wasDerivedFrom(niiri:b861ffa726f69dca943d1bc1e39e3f21, niiri:79097d11179e49abc9f2bdf5ba7bb932, -, -, -)
+    entity(niiri:48b5c01001fb7600fbd4531a0e1761c4,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0045" %% xsd:string,
+        prov:location = 'niiri:ae647fef7b776cfa997ad53eb4b2fc5b',
+        prov:value = "15.4726600646973" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.40252319694713" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000333833435672726" %% xsd:float,
+        nidm_pValueFWER: = "0.999999648429928" %% xsd:float,
+        nidm_qValueFDR: = "0.109105594368073" %% xsd:float])
+    entity(niiri:ae647fef7b776cfa997ad53eb4b2fc5b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0045" %% xsd:string,
+        nidm_coordinateVector: = "[40,-6,-6]" %% xsd:string])
+    wasDerivedFrom(niiri:48b5c01001fb7600fbd4531a0e1761c4, niiri:d339d6251d3c159dbe2427fd1bcc1fc1, -, -, -)
+    entity(niiri:c46952610583f569f9152387a8bc54d9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0046" %% xsd:string,
+        prov:location = 'niiri:cd6aeb3993ad5aeb4e69f7fde5b6d7dc',
+        prov:value = "15.3332357406616" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.38807697766079" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00035192253822891" %% xsd:float,
+        nidm_pValueFWER: = "0.999999807374102" %% xsd:float,
+        nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
+    entity(niiri:cd6aeb3993ad5aeb4e69f7fde5b6d7dc,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0046" %% xsd:string,
+        nidm_coordinateVector: = "[32,14,58]" %% xsd:string])
+    wasDerivedFrom(niiri:c46952610583f569f9152387a8bc54d9, niiri:b0978b4f683201d3539ace75681c8b65, -, -, -)
+    entity(niiri:549a9bbee50f3775d812947136680afd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0047" %% xsd:string,
+        prov:location = 'niiri:eb0736b11222caa828e4419e72562692',
+        prov:value = "15.3172578811646" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.38641524500992" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000354060730342054" %% xsd:float,
+        nidm_pValueFWER: = "0.99999982049151" %% xsd:float,
+        nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
+    entity(niiri:eb0736b11222caa828e4419e72562692,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0047" %% xsd:string,
+        nidm_coordinateVector: = "[4,-86,4]" %% xsd:string])
+    wasDerivedFrom(niiri:549a9bbee50f3775d812947136680afd, niiri:133c074788eed1fa9d50d9e4608e3c1c, -, -, -)
+    entity(niiri:a70159564d5e15398a8e6af937070b21,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0048" %% xsd:string,
+        prov:location = 'niiri:0cd5c4445b3ca0198be2f8b0ac1c5ff7',
+        prov:value = "15.3137311935425" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.38604828864924" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000354534526388783" %% xsd:float,
+        nidm_pValueFWER: = "0.999999823272138" %% xsd:float,
+        nidm_qValueFDR: = "0.110729615236961" %% xsd:float])
+    entity(niiri:0cd5c4445b3ca0198be2f8b0ac1c5ff7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0048" %% xsd:string,
+        nidm_coordinateVector: = "[62,-36,46]" %% xsd:string])
+    wasDerivedFrom(niiri:a70159564d5e15398a8e6af937070b21, niiri:93bdd51f373f8659382785eb36932971, -, -, -)
+    entity(niiri:d7e71a37d659eb3e8ffc416baa8d822a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0049" %% xsd:string,
+        prov:location = 'niiri:2e67727cc0cfd1e78600ff3d8e948bb7',
+        prov:value = "15.1916456222534" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.37330635701462" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000371356333789152" %% xsd:float,
+        nidm_pValueFWER: = "0.999999898084819" %% xsd:float,
+        nidm_qValueFDR: = "0.113182641774622" %% xsd:float])
+    entity(niiri:2e67727cc0cfd1e78600ff3d8e948bb7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0049" %% xsd:string,
+        nidm_coordinateVector: = "[-24,18,58]" %% xsd:string])
+    wasDerivedFrom(niiri:d7e71a37d659eb3e8ffc416baa8d822a, niiri:522536a75466fe7c0e757947afe21547, -, -, -)
+    entity(niiri:03f8d483a6d2c4d5e2df0d2834d90bc1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0050" %% xsd:string,
+        prov:location = 'niiri:017fc7f20be266bd229d46d23c92c88e',
+        prov:value = "15.0888338088989" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.36251708484568" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000386176732959709" %% xsd:float,
+        nidm_pValueFWER: = "0.999999936876428" %% xsd:float,
+        nidm_qValueFDR: = "0.114724188214818" %% xsd:float])
+    entity(niiri:017fc7f20be266bd229d46d23c92c88e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0050" %% xsd:string,
+        nidm_coordinateVector: = "[8,-22,-44]" %% xsd:string])
+    wasDerivedFrom(niiri:03f8d483a6d2c4d5e2df0d2834d90bc1, niiri:acdb22704e8e3566aa17ca0ccdff7a03, -, -, -)
+    entity(niiri:7065d45e419e04080dbcbe72642fe102,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0051" %% xsd:string,
+        prov:location = 'niiri:64d776bee75666af4e2b1252a3fd0002',
+        prov:value = "14.8200588226318" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.33405240591422" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000427952650791097" %% xsd:float,
+        nidm_pValueFWER: = "0.999999983180231" %% xsd:float,
+        nidm_qValueFDR: = "0.119307804764224" %% xsd:float])
+    entity(niiri:64d776bee75666af4e2b1252a3fd0002,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0051" %% xsd:string,
+        nidm_coordinateVector: = "[38,34,22]" %% xsd:string])
+    wasDerivedFrom(niiri:7065d45e419e04080dbcbe72642fe102, niiri:e1cde03f80af40c7004f16340827c9a6, -, -, -)
+    entity(niiri:f232f46f47a241ff82eee6a194ff86ad,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0052" %% xsd:string,
+        prov:location = 'niiri:b744cd533ab253d9b8023ced422dcd4e',
+        prov:value = "14.696608543396" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.32085065286489" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000448717729613968" %% xsd:float,
+        nidm_pValueFWER: = "0.9999999911592" %% xsd:float,
+        nidm_qValueFDR: = "0.121223400645327" %% xsd:float])
+    entity(niiri:b744cd533ab253d9b8023ced422dcd4e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0052" %% xsd:string,
+        nidm_coordinateVector: = "[0,-26,-28]" %% xsd:string])
+    wasDerivedFrom(niiri:f232f46f47a241ff82eee6a194ff86ad, niiri:1a861a102938105fb0e599c28c89f0df, -, -, -)
+    entity(niiri:d07297142ea27f1aadd2a2d0fc18eaa5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0053" %% xsd:string,
+        prov:location = 'niiri:3df6f0cc55b55ccf745b4ed025159201',
+        prov:value = "14.2414035797119" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.27145497586776" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00053497811978398" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999933201" %% xsd:float,
+        nidm_qValueFDR: = "0.128281884148943" %% xsd:float])
+    entity(niiri:3df6f0cc55b55ccf745b4ed025159201,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0053" %% xsd:string,
+        nidm_coordinateVector: = "[40,-50,-22]" %% xsd:string])
+    wasDerivedFrom(niiri:d07297142ea27f1aadd2a2d0fc18eaa5, niiri:28c829a636fe7679be2b8fe3fc083d99, -, -, -)
+    entity(niiri:04eb8dd4e9ab8ac46c751092d04da10d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0054" %% xsd:string,
+        prov:location = 'niiri:ff9d4a014bd4e0dc8a92264c7b200ed9',
+        prov:value = "14.0012445449829" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.24492687341108" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000587403942481801" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999852106" %% xsd:float,
+        nidm_qValueFDR: = "0.131447065854217" %% xsd:float])
+    entity(niiri:ff9d4a014bd4e0dc8a92264c7b200ed9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0054" %% xsd:string,
+        nidm_coordinateVector: = "[8,52,32]" %% xsd:string])
+    wasDerivedFrom(niiri:04eb8dd4e9ab8ac46c751092d04da10d, niiri:4bb1f06cdf753bfe2cb9742585fc5f63, -, -, -)
+    entity(niiri:d80002080097776aa38277bc80033aa3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0055" %% xsd:string,
+        prov:location = 'niiri:ce74cab636a5f2efe71e98f6ae695f3c',
+        prov:value = "13.9842071533203" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.2430323166614" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000591323980175695" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999867649" %% xsd:float,
+        nidm_qValueFDR: = "0.131695068372973" %% xsd:float])
+    entity(niiri:ce74cab636a5f2efe71e98f6ae695f3c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0055" %% xsd:string,
+        nidm_coordinateVector: = "[-14,-48,-24]" %% xsd:string])
+    wasDerivedFrom(niiri:d80002080097776aa38277bc80033aa3, niiri:cca6dc1b6e22a99533fb4839e0e808cf, -, -, -)
+    entity(niiri:d4c1b62bf34355cc27a8c18d2fe4f53b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0056" %% xsd:string,
+        prov:location = 'niiri:ea5c28625592b62bd93bf315cb8d38f1',
+        prov:value = "13.9203996658325" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.23592192136056" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000606252725692924" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999913111" %% xsd:float,
+        nidm_qValueFDR: = "0.13226466740541" %% xsd:float])
+    entity(niiri:ea5c28625592b62bd93bf315cb8d38f1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0056" %% xsd:string,
+        nidm_coordinateVector: = "[20,0,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:d4c1b62bf34355cc27a8c18d2fe4f53b, niiri:894db077f6ce41dde7580196422f5b65, -, -, -)
+    entity(niiri:22da22dab16541f8e410ae72c92290f3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0057" %% xsd:string,
+        prov:location = 'niiri:183de3503fa5b331b636ff710340ee17',
+        prov:value = "13.8925752639771" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.23281385809669" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000612887021428588" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999927857" %% xsd:float,
+        nidm_qValueFDR: = "0.13226466740541" %% xsd:float])
+    entity(niiri:183de3503fa5b331b636ff710340ee17,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0057" %% xsd:string,
+        nidm_coordinateVector: = "[40,-14,60]" %% xsd:string])
+    wasDerivedFrom(niiri:22da22dab16541f8e410ae72c92290f3, niiri:e8143c5b2cddc4ad2f401f2b27a4cab2, -, -, -)
+    entity(niiri:ed8e5afdf4dfba0fb8266ec7bb6e05ea,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0058" %% xsd:string,
+        prov:location = 'niiri:bb26c37ea84abd4f8e5aab60783b1ef4',
+        prov:value = "13.8641185760498" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.22963046726961" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000619751563460058" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999940447" %% xsd:float,
+        nidm_qValueFDR: = "0.132333123904287" %% xsd:float])
+    entity(niiri:bb26c37ea84abd4f8e5aab60783b1ef4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0058" %% xsd:string,
+        nidm_coordinateVector: = "[-36,10,24]" %% xsd:string])
+    wasDerivedFrom(niiri:ed8e5afdf4dfba0fb8266ec7bb6e05ea, niiri:09cd915bf2b2b51b32d56249f304bbce, -, -, -)
+    entity(niiri:8999f6eb178b306d0ec123f3b221f83e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0059" %% xsd:string,
+        prov:location = 'niiri:2fbd5acd6bb5ef2ba1473f87c213d4aa',
+        prov:value = "13.7912406921387" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.22145599369965" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000637705235827735" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999963824" %% xsd:float,
+        nidm_qValueFDR: = "0.133173984174016" %% xsd:float])
+    entity(niiri:2fbd5acd6bb5ef2ba1473f87c213d4aa,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0059" %% xsd:string,
+        nidm_coordinateVector: = "[30,-78,14]" %% xsd:string])
+    wasDerivedFrom(niiri:8999f6eb178b306d0ec123f3b221f83e, niiri:bf2d35b880b3d0657d2a03298074406e, -, -, -)
+    entity(niiri:089d2f5ca65585c3d01817a9bdbf214f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0060" %% xsd:string,
+        prov:location = 'niiri:b64d2f396f19bac0e190ab99328b9677',
+        prov:value = "13.629490852356" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.20320002112963" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000679547746644249" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999988489" %% xsd:float,
+        nidm_qValueFDR: = "0.136764826883915" %% xsd:float])
+    entity(niiri:b64d2f396f19bac0e190ab99328b9677,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0060" %% xsd:string,
+        nidm_coordinateVector: = "[18,-78,12]" %% xsd:string])
+    wasDerivedFrom(niiri:089d2f5ca65585c3d01817a9bdbf214f, niiri:56bc4504cec954daf4a701610ddf59b3, -, -, -)
+    entity(niiri:e1eec1e6fba3322a1a6483846b8a91d8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0061" %% xsd:string,
+        prov:location = 'niiri:dc2ecabdf71bb61760c0219ad76cb53e',
+        prov:value = "13.5061225891113" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.18916981007524" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000713410180681495" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999995369" %% xsd:float,
+        nidm_qValueFDR: = "0.139253735873803" %% xsd:float])
+    entity(niiri:dc2ecabdf71bb61760c0219ad76cb53e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0061" %% xsd:string,
+        nidm_coordinateVector: = "[46,8,-16]" %% xsd:string])
+    wasDerivedFrom(niiri:e1eec1e6fba3322a1a6483846b8a91d8, niiri:baa1270c4a9c0f72989c973b2fbb309d, -, -, -)
+    entity(niiri:d434f3bdadeaac5eb9b817cb94e825e9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0062" %% xsd:string,
+        prov:location = 'niiri:3a03e910b24e3e930f0b6b6c9e5c737b',
+        prov:value = "13.4754667282104" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.1856690050705" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000722098618250455" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999996325" %% xsd:float,
+        nidm_qValueFDR: = "0.1402954623971" %% xsd:float])
+    entity(niiri:3a03e910b24e3e930f0b6b6c9e5c737b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0062" %% xsd:string,
+        nidm_coordinateVector: = "[58,-40,50]" %% xsd:string])
+    wasDerivedFrom(niiri:d434f3bdadeaac5eb9b817cb94e825e9, niiri:39b258c34ddafd00d7dff6d208f62918, -, -, -)
+    entity(niiri:73253ea75fa4c291c1dccb3b8aadedf9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0063" %% xsd:string,
+        prov:location = 'niiri:843cc3a9443e428c80dd3e5419ef67ec',
+        prov:value = "13.4480972290039" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.18253860543696" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000729950259848011" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999997016" %% xsd:float,
+        nidm_qValueFDR: = "0.140840039531724" %% xsd:float])
+    entity(niiri:843cc3a9443e428c80dd3e5419ef67ec,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0063" %% xsd:string,
+        nidm_coordinateVector: = "[46,-66,32]" %% xsd:string])
+    wasDerivedFrom(niiri:73253ea75fa4c291c1dccb3b8aadedf9, niiri:ea112296db729b94dfce05991c3d6989, -, -, -)
+    entity(niiri:0250c5bfb4ece9672c03eeceb0f7b02f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0064" %% xsd:string,
+        prov:location = 'niiri:3c2b90faeb19728391b223147a6272ef',
+        prov:value = "13.2857608795166" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.16387572537233" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000778416284459293" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999163" %% xsd:float,
+        nidm_qValueFDR: = "0.14332751949213" %% xsd:float])
+    entity(niiri:3c2b90faeb19728391b223147a6272ef,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0064" %% xsd:string,
+        nidm_coordinateVector: = "[2,-76,8]" %% xsd:string])
+    wasDerivedFrom(niiri:0250c5bfb4ece9672c03eeceb0f7b02f, niiri:a41eeb9ba04d7788ba686542607ff1cc, -, -, -)
+    entity(niiri:9efe1a64a6e8c8950d8b7cab41638bf4,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0065" %% xsd:string,
+        prov:location = 'niiri:6cd33ece9349946e05442ff70eafc454',
+        prov:value = "13.2286987304688" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.15727638472708" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000796251631906664" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999472" %% xsd:float,
+        nidm_qValueFDR: = "0.143821550671959" %% xsd:float])
+    entity(niiri:6cd33ece9349946e05442ff70eafc454,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0065" %% xsd:string,
+        nidm_coordinateVector: = "[14,-24,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:9efe1a64a6e8c8950d8b7cab41638bf4, niiri:9c7b81143edac28cf680878e9177494c, -, -, -)
+    entity(niiri:6a326f32141b8c0a3055d65d9f6a8649,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0066" %% xsd:string,
+        prov:location = 'niiri:b5b1c97968ad3124f2e761ecead8345e',
+        prov:value = "13.0621271133423" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.13789355719639" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00085083330089919" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999869" %% xsd:float,
+        nidm_qValueFDR: = "0.146648454262555" %% xsd:float])
+    entity(niiri:b5b1c97968ad3124f2e761ecead8345e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0066" %% xsd:string,
+        nidm_coordinateVector: = "[-36,0,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:6a326f32141b8c0a3055d65d9f6a8649, niiri:e854403c8636e3e481bc993eb6180f44, -, -, -)
+    entity(niiri:cd1be6a68508e7a4ef251e742d0b5209,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0067" %% xsd:string,
+        prov:location = 'niiri:7e8c996c334e2b3e54960324857470e1',
+        prov:value = "13.0451946258545" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.13591325616981" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000856599341067521" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999886" %% xsd:float,
+        nidm_qValueFDR: = "0.146787157394689" %% xsd:float])
+    entity(niiri:7e8c996c334e2b3e54960324857470e1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0067" %% xsd:string,
+        nidm_coordinateVector: = "[12,6,62]" %% xsd:string])
+    wasDerivedFrom(niiri:cd1be6a68508e7a4ef251e742d0b5209, niiri:7f3ebf5e2a10fd569c91dd091c7af147, -, -, -)
+    entity(niiri:4df08c0c2756eb1b10566b4b6f695464,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0068" %% xsd:string,
+        prov:location = 'niiri:8fe3ed1f49a1014532022d8ff15e4b33',
+        prov:value = "13.0064306259155" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.13137270324883" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000869955985260296" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999919" %% xsd:float,
+        nidm_qValueFDR: = "0.146787157394689" %% xsd:float])
+    entity(niiri:8fe3ed1f49a1014532022d8ff15e4b33,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0068" %% xsd:string,
+        nidm_coordinateVector: = "[-8,-4,24]" %% xsd:string])
+    wasDerivedFrom(niiri:4df08c0c2756eb1b10566b4b6f695464, niiri:b36c20212016b9bc7a603f3e83aca676, -, -, -)
+    entity(niiri:f493daa250a5ea19aa9efa8d626c010a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0069" %% xsd:string,
+        prov:location = 'niiri:a6c74b8d30fbdf526011335c2d35ae6a',
+        prov:value = "12.968074798584" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.12687033926247" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00088338914171493" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999942" %% xsd:float,
+        nidm_qValueFDR: = "0.147244283960254" %% xsd:float])
+    entity(niiri:a6c74b8d30fbdf526011335c2d35ae6a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0069" %% xsd:string,
+        nidm_coordinateVector: = "[8,-36,40]" %% xsd:string])
+    wasDerivedFrom(niiri:f493daa250a5ea19aa9efa8d626c010a, niiri:05115f2e683a3386f641d5816019de27, -, -, -)
+    entity(niiri:8be7214c24c5b037d7fba75f4e6093e0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0070" %% xsd:string,
+        prov:location = 'niiri:2b0b836ebf6d584148281ed6f01ff393',
+        prov:value = "12.9628992080688" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.12626207199886" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000885218504765861" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999944" %% xsd:float,
+        nidm_qValueFDR: = "0.147244283960254" %% xsd:float])
+    entity(niiri:2b0b836ebf6d584148281ed6f01ff393,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0070" %% xsd:string,
+        nidm_coordinateVector: = "[24,38,0]" %% xsd:string])
+    wasDerivedFrom(niiri:8be7214c24c5b037d7fba75f4e6093e0, niiri:1ee8276c32c1e03b7e0b4b1717c44a57, -, -, -)
+    entity(niiri:3fb670bc4bf41b489875540e653fafdd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0071" %% xsd:string,
+        prov:location = 'niiri:60bbc4af8445689f911587e2015c11e0',
+        prov:value = "12.9482192993164" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.12453584528173" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000890429112242686" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999951" %% xsd:float,
+        nidm_qValueFDR: = "0.14749076092896" %% xsd:float])
+    entity(niiri:60bbc4af8445689f911587e2015c11e0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0071" %% xsd:string,
+        nidm_coordinateVector: = "[26,-50,46]" %% xsd:string])
+    wasDerivedFrom(niiri:3fb670bc4bf41b489875540e653fafdd, niiri:aa58a012c4a942174e0325d4c0b944fd, -, -, -)
+    entity(niiri:82c6fba725d300ee5b57d9b99b507dd1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0072" %% xsd:string,
+        prov:location = 'niiri:26c578b46a7a236fd0e9ec4b50b4b8a5',
+        prov:value = "12.9151954650879" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.12064737190897" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000902269894699104" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999964" %% xsd:float,
+        nidm_qValueFDR: = "0.147598889605401" %% xsd:float])
+    entity(niiri:26c578b46a7a236fd0e9ec4b50b4b8a5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0072" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-86,8]" %% xsd:string])
+    wasDerivedFrom(niiri:82c6fba725d300ee5b57d9b99b507dd1, niiri:69b1d9ea8525a6a583365384e39cf9e8, -, -, -)
+    entity(niiri:f6b78515f73bc27f172ee4971b59d62c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0073" %% xsd:string,
+        prov:location = 'niiri:df70ae256a22280944b76c315708af2e',
+        prov:value = "12.8661985397339" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.11486488202419" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00092014594111034" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999977" %% xsd:float,
+        nidm_qValueFDR: = "0.147847736781403" %% xsd:float])
+    entity(niiri:df70ae256a22280944b76c315708af2e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0073" %% xsd:string,
+        nidm_coordinateVector: = "[22,-24,38]" %% xsd:string])
+    wasDerivedFrom(niiri:f6b78515f73bc27f172ee4971b59d62c, niiri:f6d9af16709f321130aa58504e6604c5, -, -, -)
+    entity(niiri:7da556aa1244db607c1e49d0f196cfa5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0074" %% xsd:string,
+        prov:location = 'niiri:bc4dcce56afafebd60de994b46b169af',
+        prov:value = "12.8156299591064" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.10888025138563" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000938989080538355" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999985" %% xsd:float,
+        nidm_qValueFDR: = "0.148123448926347" %% xsd:float])
+    entity(niiri:bc4dcce56afafebd60de994b46b169af,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0074" %% xsd:string,
+        nidm_coordinateVector: = "[48,50,2]" %% xsd:string])
+    wasDerivedFrom(niiri:7da556aa1244db607c1e49d0f196cfa5, niiri:be347b3d17b0cf1b2b8f3ad6860ae399, -, -, -)
+    entity(niiri:23689147c9f9a1cfc3640674405fb6af,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0075" %% xsd:string,
+        prov:location = 'niiri:856080bfa95af62a2310e7f77d678b86',
+        prov:value = "12.7734069824219" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.10387025917553" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000955035352381506" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999999999" %% xsd:float,
+        nidm_qValueFDR: = "0.149144835108449" %% xsd:float])
+    entity(niiri:856080bfa95af62a2310e7f77d678b86,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0075" %% xsd:string,
+        nidm_coordinateVector: = "[-48,-68,20]" %% xsd:string])
+    wasDerivedFrom(niiri:23689147c9f9a1cfc3640674405fb6af, niiri:fb10f43ffe914843271a8cdefab5f898, -, -, -)
+    entity(niiri:7dccdae3f638e89023329e9d2f66c954,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0076" %% xsd:string,
+        prov:location = 'niiri:aec1651baeec9ebce473514a2520d9ac',
+        prov:value = "12.7362623214722" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.0994529756118" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000969391758882221" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999993" %% xsd:float,
+        nidm_qValueFDR: = "0.150376120259304" %% xsd:float])
+    entity(niiri:aec1651baeec9ebce473514a2520d9ac,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0076" %% xsd:string,
+        nidm_coordinateVector: = "[24,-22,36]" %% xsd:string])
+    wasDerivedFrom(niiri:7dccdae3f638e89023329e9d2f66c954, niiri:ac129c99f1ae280d6d0a6f24c04b617a, -, -, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_non_sphericity/nidm.ttl
+++ b/spmexport/ex_spm_non_sphericity/nidm.ttl
@@ -1,0 +1,2628 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:25ee938ddb1a1359b5dbfc8ddbffdf98
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:9360978694c62922ec5ea1a313b72c46
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:7a90abf761d31fac1a65bd4bda03a81a
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:7a90abf761d31fac1a65bd4bda03a81a prov:wasAssociatedWith niiri:9360978694c62922ec5ea1a313b72c46 .
+
+_:blank5 a prov:Generation .
+
+niiri:25ee938ddb1a1359b5dbfc8ddbffdf98 prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:11:35"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_UnstructuredCorrelationStructure: <http://purl.obolibrary.org/obo/STATO_0000405> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_FStatistic: <http://purl.obolibrary.org/obo/STATO_0000282> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastExplainedMeanSquareMap: <http://purl.org/nidash/nidm#NIDM_0000163> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070> .
+@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
+@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .
+@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .
+@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082> .
+@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .
+@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092> .
+@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
+@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
+
+niiri:cbb4e09f0c239d9fc253f426daea95ec
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:04394321c13e24105925122a5ea9615c
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:3279b88b6e6cd5ec2237720417dd3d48
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "false"^^xsd:boolean .
+
+niiri:186f3712419791aaf7a04a3d1b8bd722
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:b17ee10e3431226e0e680dfd4966a939 ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]"^^xsd:string .
+
+niiri:b17ee10e3431226e0e680dfd4966a939
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:ce59f39b89684ad9fbc37e749e8dc23d
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_UnstructuredCorrelationStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "false"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:a4e3f64a7d5dde02404b02a2e482b25c
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:a4e3f64a7d5dde02404b02a2e482b25c prov:wasAssociatedWith niiri:cbb4e09f0c239d9fc253f426daea95ec .
+
+niiri:a4e3f64a7d5dde02404b02a2e482b25c prov:used niiri:186f3712419791aaf7a04a3d1b8bd722 .
+
+niiri:a4e3f64a7d5dde02404b02a2e482b25c prov:used niiri:3279b88b6e6cd5ec2237720417dd3d48 .
+
+niiri:a4e3f64a7d5dde02404b02a2e482b25c prov:used niiri:ce59f39b89684ad9fbc37e749e8dc23d .
+
+niiri:1d1c92ca0bfb701909eb307868358b1a
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
+
+niiri:7b426f12cc92d11d7f4d5eb771c95217
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e"^^xsd:string .
+
+niiri:1d1c92ca0bfb701909eb307868358b1a prov:wasDerivedFrom niiri:7b426f12cc92d11d7f4d5eb771c95217 .
+
+niiri:1d1c92ca0bfb701909eb307868358b1a prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+
+niiri:785bae8edf8ea0f5eae2802088ac85b1
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "0.0511472336947918"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    crypto:sha512 "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc"^^xsd:string .
+
+niiri:785bae8edf8ea0f5eae2802088ac85b1 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+
+niiri:9f2d3c6c9d93cbbc83d0629664f66005
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c .
+
+niiri:1273bdcdc1d1987029f9da1d84d22ea2
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f"^^xsd:string .
+
+niiri:9f2d3c6c9d93cbbc83d0629664f66005 prov:wasDerivedFrom niiri:1273bdcdc1d1987029f9da1d84d22ea2 .
+
+niiri:9f2d3c6c9d93cbbc83d0629664f66005 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+
+niiri:baf9cccb8eba46b7c5f41863dda48579
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c .
+
+niiri:87c6aec787414fb9d08ddd2e2f2c9b55
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978"^^xsd:string .
+
+niiri:baf9cccb8eba46b7c5f41863dda48579 prov:wasDerivedFrom niiri:87c6aec787414fb9d08ddd2e2f2c9b55 .
+
+niiri:baf9cccb8eba46b7c5f41863dda48579 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+
+niiri:b178295856d95973727b2b358956335e
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c .
+
+niiri:1263d9ada22b54fa429647fa22af73f9
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a"^^xsd:string .
+
+niiri:b178295856d95973727b2b358956335e prov:wasDerivedFrom niiri:1263d9ada22b54fa429647fa22af73f9 .
+
+niiri:b178295856d95973727b2b358956335e prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+
+niiri:0c8cae8f7fd81853bcc8700ee2f1bb91
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    crypto:sha512 "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48"^^xsd:string .
+
+niiri:3c4935283c58d44dba5a403a5d3b5832
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868"^^xsd:string .
+
+niiri:0c8cae8f7fd81853bcc8700ee2f1bb91 prov:wasDerivedFrom niiri:3c4935283c58d44dba5a403a5d3b5832 .
+
+niiri:0c8cae8f7fd81853bcc8700ee2f1bb91 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+
+niiri:0a2a8817aa6793a351bd0a7021236cd0
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    crypto:sha512 "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381"^^xsd:string .
+
+niiri:3a2ab399f71d1f0e06d2a38d3de41f29
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8"^^xsd:string .
+
+niiri:0a2a8817aa6793a351bd0a7021236cd0 prov:wasDerivedFrom niiri:3a2ab399f71d1f0e06d2a38d3de41f29 .
+
+niiri:0a2a8817aa6793a351bd0a7021236cd0 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+
+niiri:df230f4ff3b58783fe139f385597465e
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_FStatistic: ;
+    nidm_contrastName: "Average effect of condition"^^xsd:string ;
+    rdfs:label "Contrast: Average effect of condition" ;
+    prov:value "[1, 1, 1]"^^xsd:string .
+
+niiri:2ff41e5681a1c005622be9b68da73a06
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:2ff41e5681a1c005622be9b68da73a06 prov:wasAssociatedWith niiri:cbb4e09f0c239d9fc253f426daea95ec .
+
+niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:1d1c92ca0bfb701909eb307868358b1a .
+
+niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:0c8cae8f7fd81853bcc8700ee2f1bb91 .
+
+niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:186f3712419791aaf7a04a3d1b8bd722 .
+
+niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:df230f4ff3b58783fe139f385597465e .
+
+niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:9f2d3c6c9d93cbbc83d0629664f66005 .
+
+niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:baf9cccb8eba46b7c5f41863dda48579 .
+
+niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:b178295856d95973727b2b358956335e .
+
+niiri:50609b22ae1142a0b21014e830b41cae
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: Average effect of condition" ;
+    nidm_statisticType: stato_FStatistic: ;
+    nidm_contrastName: "Average effect of condition"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "39"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    crypto:sha512 "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960"^^xsd:string .
+
+niiri:c59df51d9201082e5f25f11b2f13807f
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmF_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762"^^xsd:string .
+
+niiri:50609b22ae1142a0b21014e830b41cae prov:wasDerivedFrom niiri:c59df51d9201082e5f25f11b2f13807f .
+
+niiri:50609b22ae1142a0b21014e830b41cae prov:wasGeneratedBy niiri:2ff41e5681a1c005622be9b68da73a06 .
+
+niiri:2416820ce6beaa983e426560e9ec33ec
+    a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
+    prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Explained Mean Square Map" ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    crypto:sha512 "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a"^^xsd:string .
+
+niiri:2416820ce6beaa983e426560e9ec33ec prov:wasGeneratedBy niiri:2ff41e5681a1c005622be9b68da73a06 .
+
+niiri:d16264948a1baffc5b788ff82a41433f
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    prov:value "0.000999500201896764"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:d6d3c2e8396eddb36c52c8ebf1691170 ;
+    nidm_equivalentThreshold: niiri:59cbe87bfe988562f71c7863fcee3540 .
+
+niiri:d6d3c2e8396eddb36c52c8ebf1691170
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "12.6602184255263"^^xsd:float .
+
+niiri:59cbe87bfe988562f71c7863fcee3540
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.999999999999997"^^xsd:float .
+
+niiri:689643975c6d062da3f861f197ffb911
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:979cfefce98a2d163c991361d12cbf64 ;
+    nidm_equivalentThreshold: niiri:5a949293e4972919cdd1902557e60273 .
+
+niiri:979cfefce98a2d163c991361d12cbf64
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:5a949293e4972919cdd1902557e60273
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:932bf207ec1906155b85201be9afc0ed
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:356327ce3d3e8895d849bb23327e10f5
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:6be0e67690536755101ed426c4c5cfe1
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:6be0e67690536755101ed426c4c5cfe1 prov:wasAssociatedWith niiri:cbb4e09f0c239d9fc253f426daea95ec .
+
+niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:d16264948a1baffc5b788ff82a41433f .
+
+niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:689643975c6d062da3f861f197ffb911 .
+
+niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:50609b22ae1142a0b21014e830b41cae .
+
+niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:0a2a8817aa6793a351bd0a7021236cd0 .
+
+niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:1d1c92ca0bfb701909eb307868358b1a .
+
+niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:932bf207ec1906155b85201be9afc0ed .
+
+niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:356327ce3d3e8895d849bb23327e10f5 .
+
+niiri:6009f6fd85ea333f9b78564cda2aa83c
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_searchVolumeInVoxels: "167222"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1337776"^^xsd:float ;
+    nidm_reselSizeInVoxels: "68.5679161280351"^^xsd:float ;
+    nidm_searchVolumeInResels: "2244.24204044145"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[5, 56.1858858382816, 782.552337179563, 2244.24204044145]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.09364449471869, 4.06742111213816, 4.11805068781302]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.18728898943738, 8.13484222427633, 8.23610137562605]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "5.40031514302336"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "33.3078455926716"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "37.9092455175785"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "99"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "57"^^xsd:int ;
+    crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
+
+niiri:6009f6fd85ea333f9b78564cda2aa83c prov:wasGeneratedBy niiri:6be0e67690536755101ed426c4c5cfe1 .
+
+niiri:950be147189508776d90eb2c4280326c
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "71"^^xsd:int ;
+    nidm_pValue: "9.36073596413678e-09"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:404ea6617dcd902e2957d9a6b74f7ab3 ;
+    nidm_hasMaximumIntensityProjection: niiri:a77ea9285b48403a7689ae0b730f7230 ;
+    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    crypto:sha512 "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006"^^xsd:string .
+
+niiri:404ea6617dcd902e2957d9a6b74f7ab3
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:a77ea9285b48403a7689ae0b730f7230
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:950be147189508776d90eb2c4280326c prov:wasGeneratedBy niiri:6be0e67690536755101ed426c4c5cfe1 .
+
+niiri:ec71581037e524c5fbd95f85fa55b157
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0001" ;
+    nidm_clusterSizeInVoxels: "64"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.933381144039647"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00186515164019167"^^xsd:float ;
+    nidm_pValueFWER: "0.060233823286733"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "1"^^xsd:int .
+
+niiri:ec71581037e524c5fbd95f85fa55b157 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:ddc3a6b40532cc9e86f19a4aa6cba853
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0002" ;
+    nidm_clusterSizeInVoxels: "139"^^xsd:int ;
+    nidm_clusterSizeInResels: "2.02718717221111"^^xsd:float ;
+    nidm_pValueUncorrected: "2.6469154891926e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.000881242002104266"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "2"^^xsd:int .
+
+niiri:ddc3a6b40532cc9e86f19a4aa6cba853 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:c1738200f1bc478c78cb4aab2cda0cb1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0003" ;
+    nidm_clusterSizeInVoxels: "99"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.44382395718633"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000223613862913789"^^xsd:float ;
+    nidm_pValueFWER: "0.00742042768591067"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "3"^^xsd:int .
+
+niiri:c1738200f1bc478c78cb4aab2cda0cb1 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:91205f3f0676956d1f1039643e3fcd9d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0004" ;
+    nidm_clusterSizeInVoxels: "100"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.45840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00021132818538256"^^xsd:float ;
+    nidm_pValueFWER: "0.00701417162859297"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "4"^^xsd:int .
+
+niiri:91205f3f0676956d1f1039643e3fcd9d prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:a689a0799152fcf397ed6264dff6b7df
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0005" ;
+    nidm_clusterSizeInVoxels: "41"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.597947295400399"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00937054756605333"^^xsd:float ;
+    nidm_pValueFWER: "0.26810099909693"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "5"^^xsd:int .
+
+niiri:a689a0799152fcf397ed6264dff6b7df prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:4f3977b902ab860fce265438ec1666b5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0006" ;
+    nidm_clusterSizeInVoxels: "42"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.612531375776019"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00868796710659031"^^xsd:float ;
+    nidm_pValueFWER: "0.251270468559567"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "6"^^xsd:int .
+
+niiri:4f3977b902ab860fce265438ec1666b5 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:e8270a828c6a9c6a7e1a7f948de88a7e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0007" ;
+    nidm_clusterSizeInVoxels: "27"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.393770170141726"^^xsd:float ;
+    nidm_pValueUncorrected: "0.02915927403888"^^xsd:float ;
+    nidm_pValueFWER: "0.621383930767395"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "7"^^xsd:int .
+
+niiri:e8270a828c6a9c6a7e1a7f948de88a7e prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:cda674baaa255a631b19d42763c0930c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0008" ;
+    nidm_clusterSizeInVoxels: "57"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.831292581410311"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00297536918873803"^^xsd:float ;
+    nidm_pValueFWER: "0.0943507032156397"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "8"^^xsd:int .
+
+niiri:cda674baaa255a631b19d42763c0930c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:b9beda96f738803fb567cd0d0d5ac126
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0009" ;
+    nidm_clusterSizeInVoxels: "33"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.481274652395443"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0175801280664628"^^xsd:float ;
+    nidm_pValueFWER: "0.443203909376631"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "9"^^xsd:int .
+
+niiri:b9beda96f738803fb567cd0d0d5ac126 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:24686319b3c7b6b6793dbf6e90029199
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0010" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0875044822537169"^^xsd:float ;
+    nidm_pValueUncorrected: "0.273373266352505"^^xsd:float ;
+    nidm_pValueFWER: "0.999888943840686"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "10"^^xsd:int .
+
+niiri:24686319b3c7b6b6793dbf6e90029199 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:ef45eced4ec473fc374602efe1d44af2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0011" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.161523634652226"^^xsd:float ;
+    nidm_pValueFWER: "0.995392197803255"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "11"^^xsd:int .
+
+niiri:ef45eced4ec473fc374602efe1d44af2 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:1a8d727934cbec38f1fdcc84430d7857
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0012" ;
+    nidm_clusterSizeInVoxels: "26"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.379186089766107"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0318362117547758"^^xsd:float ;
+    nidm_pValueFWER: "0.653681229272869"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "12"^^xsd:int .
+
+niiri:1a8d727934cbec38f1fdcc84430d7857 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:0ea4cdb2fb21bb5f5f9588416f8a0986
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0013" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160424884131814"^^xsd:float ;
+    nidm_pValueUncorrected: "0.143315972308448"^^xsd:float ;
+    nidm_pValueFWER: "0.991549640351899"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "13"^^xsd:int .
+
+niiri:0ea4cdb2fb21bb5f5f9588416f8a0986 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:e96a0a75cfbda16324a620530f8ac979
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0014" ;
+    nidm_clusterSizeInVoxels: "16"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.233345286009912"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0825813905071932"^^xsd:float ;
+    nidm_pValueFWER: "0.936111008142629"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "14"^^xsd:int .
+
+niiri:e96a0a75cfbda16324a620530f8ac979 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:bc4b7adbe33f91a695fde03bf4b200ed
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0015" ;
+    nidm_clusterSizeInVoxels: "14"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.204177125258673"^^xsd:float ;
+    nidm_pValueUncorrected: "0.10212573718427"^^xsd:float ;
+    nidm_pValueFWER: "0.966679694237215"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "15"^^xsd:int .
+
+niiri:bc4b7adbe33f91a695fde03bf4b200ed prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:71a412f82e6ea8cb947b5be72c8efcff
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0016" ;
+    nidm_clusterSizeInVoxels: "35"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.510442813146682"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0149558617235747"^^xsd:float ;
+    nidm_pValueFWER: "0.392344720913691"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "16"^^xsd:int .
+
+niiri:71a412f82e6ea8cb947b5be72c8efcff prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:93e18b25ba3aeb399e6fd41cb9dfca97
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0017" ;
+    nidm_clusterSizeInVoxels: "32"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.466690572019824"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0190834833796118"^^xsd:float ;
+    nidm_pValueFWER: "0.470398116431399"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "17"^^xsd:int .
+
+niiri:93e18b25ba3aeb399e6fd41cb9dfca97 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:3d33e1d8e7da5c593e7ad094c154132a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0018" ;
+    nidm_clusterSizeInVoxels: "46"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.670867697278497"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00645728092420274"^^xsd:float ;
+    nidm_pValueFWER: "0.193521561130372"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "18"^^xsd:int .
+
+niiri:3d33e1d8e7da5c593e7ad094c154132a prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0019" ;
+    nidm_clusterSizeInVoxels: "15"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.218761205634292"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0917266976854565"^^xsd:float ;
+    nidm_pValueFWER: "0.952887583051913"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "19"^^xsd:int .
+
+niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:7c11ea6d552baec493b21ecdef64c785
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0020" ;
+    nidm_clusterSizeInVoxels: "20"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.29168160751239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0553545237190288"^^xsd:float ;
+    nidm_pValueFWER: "0.841775430461368"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "20"^^xsd:int .
+
+niiri:7c11ea6d552baec493b21ecdef64c785 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:56fa7a2fed0946da7dd3299da637b245
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0021" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160424884131814"^^xsd:float ;
+    nidm_pValueUncorrected: "0.143315972308448"^^xsd:float ;
+    nidm_pValueFWER: "0.991549640351899"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "21"^^xsd:int .
+
+niiri:56fa7a2fed0946da7dd3299da637b245 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:c74b1ddb4c9a5395bf0b4d826708ce5a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0022" ;
+    nidm_clusterSizeInVoxels: "32"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.466690572019824"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0190834833796118"^^xsd:float ;
+    nidm_pValueFWER: "0.470398116431399"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "22"^^xsd:int .
+
+niiri:c74b1ddb4c9a5395bf0b4d826708ce5a prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:10bec2b1f4f72ee8eedb38e17e1faab3
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0023" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.058336321502478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.371675909431407"^^xsd:float ;
+    nidm_pValueFWER: "0.999995797049595"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "23"^^xsd:int .
+
+niiri:10bec2b1f4f72ee8eedb38e17e1faab3 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:f725bd9a5656b07d43f8eba6c3be2858
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0024" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160424884131814"^^xsd:float ;
+    nidm_pValueUncorrected: "0.143315972308448"^^xsd:float ;
+    nidm_pValueFWER: "0.991549640351899"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "24"^^xsd:int .
+
+niiri:f725bd9a5656b07d43f8eba6c3be2858 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:83f438c66d3cf32344b7255377c7499d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0025" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0729204018780975"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317117336021626"^^xsd:float ;
+    nidm_pValueFWER: "0.999974131777239"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "25"^^xsd:int .
+
+niiri:83f438c66d3cf32344b7255377c7499d prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:cc9360b64b21e281dcfb851074b574b6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0026" ;
+    nidm_clusterSizeInVoxels: "21"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.306265687888009"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0503036857692116"^^xsd:float ;
+    nidm_pValueFWER: "0.812786836270519"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "26"^^xsd:int .
+
+niiri:cc9360b64b21e281dcfb851074b574b6 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:4728de35ba855317aeef4e0a7b91801c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0027" ;
+    nidm_clusterSizeInVoxels: "25"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.364602009390487"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0347983287867789"^^xsd:float ;
+    nidm_pValueFWER: "0.686218175845877"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "27"^^xsd:int .
+
+niiri:4728de35ba855317aeef4e0a7b91801c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:f435923c3d5e3915c4aa5159c5bbc4a0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0028" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.116672643004956"^^xsd:float ;
+    nidm_pValueUncorrected: "0.20781578719113"^^xsd:float ;
+    nidm_pValueFWER: "0.999014041359979"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "28"^^xsd:int .
+
+niiri:f435923c3d5e3915c4aa5159c5bbc4a0 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:b39b9cce118cf858149cdd53ebcda7bd
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0029" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.175008964507434"^^xsd:float ;
+    nidm_pValueUncorrected: "0.127616241080866"^^xsd:float ;
+    nidm_pValueFWER: "0.985744636441848"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "29"^^xsd:int .
+
+niiri:b39b9cce118cf858149cdd53ebcda7bd prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:97e0a9bea1289493ad46d8a4c2b75485
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0030" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "30"^^xsd:int .
+
+niiri:97e0a9bea1289493ad46d8a4c2b75485 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:e9e94038b5b1dbcf9f8a4d4208e34928
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0031" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.161523634652226"^^xsd:float ;
+    nidm_pValueFWER: "0.995392197803255"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "31"^^xsd:int .
+
+niiri:e9e94038b5b1dbcf9f8a4d4208e34928 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:0857328371989db393f2fc4d7d5346bd
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0032" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.058336321502478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.371675909431407"^^xsd:float ;
+    nidm_pValueFWER: "0.999995797049595"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "32"^^xsd:int .
+
+niiri:0857328371989db393f2fc4d7d5346bd prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:7e693a4a3e70d39b916aa2a95911a3c8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0033" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0875044822537169"^^xsd:float ;
+    nidm_pValueUncorrected: "0.273373266352505"^^xsd:float ;
+    nidm_pValueFWER: "0.999888943840686"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "33"^^xsd:int .
+
+niiri:7e693a4a3e70d39b916aa2a95911a3c8 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:d8dc459a110e4898c23019ee42154713
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0034" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0729204018780975"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317117336021626"^^xsd:float ;
+    nidm_pValueFWER: "0.999974131777239"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "34"^^xsd:int .
+
+niiri:d8dc459a110e4898c23019ee42154713 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:cd795f902776ad9170549b8fde8996ba
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0035" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.161523634652226"^^xsd:float ;
+    nidm_pValueFWER: "0.995392197803255"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "35"^^xsd:int .
+
+niiri:cd795f902776ad9170549b8fde8996ba prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:ed1df7c28737883d905ca0a8f2093992
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0036" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102088562629336"^^xsd:float ;
+    nidm_pValueUncorrected: "0.237571474546961"^^xsd:float ;
+    nidm_pValueFWER: "0.99963404273418"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "36"^^xsd:int .
+
+niiri:ed1df7c28737883d905ca0a8f2093992 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:ca7bfed8d8dbca676ba25fca93d29e2c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0037" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.116672643004956"^^xsd:float ;
+    nidm_pValueUncorrected: "0.20781578719113"^^xsd:float ;
+    nidm_pValueFWER: "0.999014041359979"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "37"^^xsd:int .
+
+niiri:ca7bfed8d8dbca676ba25fca93d29e2c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:1dcd9b5514190f867e3e9b0b57227395
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0038" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.175008964507434"^^xsd:float ;
+    nidm_pValueUncorrected: "0.127616241080866"^^xsd:float ;
+    nidm_pValueFWER: "0.985744636441848"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "38"^^xsd:int .
+
+niiri:1dcd9b5514190f867e3e9b0b57227395 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:79097d11179e49abc9f2bdf5ba7bb932
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0039" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0729204018780975"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317117336021626"^^xsd:float ;
+    nidm_pValueFWER: "0.999974131777239"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "39"^^xsd:int .
+
+niiri:79097d11179e49abc9f2bdf5ba7bb932 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:d339d6251d3c159dbe2427fd1bcc1fc1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0040" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0729204018780975"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317117336021626"^^xsd:float ;
+    nidm_pValueFWER: "0.999974131777239"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "40"^^xsd:int .
+
+niiri:d339d6251d3c159dbe2427fd1bcc1fc1 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:b0978b4f683201d3539ace75681c8b65
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0041" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0437522411268585"^^xsd:float ;
+    nidm_pValueUncorrected: "0.441752016334617"^^xsd:float ;
+    nidm_pValueFWER: "0.999999592737522"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "41"^^xsd:int .
+
+niiri:b0978b4f683201d3539ace75681c8b65 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:133c074788eed1fa9d50d9e4608e3c1c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0042" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0875044822537169"^^xsd:float ;
+    nidm_pValueUncorrected: "0.273373266352505"^^xsd:float ;
+    nidm_pValueFWER: "0.999888943840686"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "42"^^xsd:int .
+
+niiri:133c074788eed1fa9d50d9e4608e3c1c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:93bdd51f373f8659382785eb36932971
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0043" ;
+    nidm_clusterSizeInVoxels: "9"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.131256723380575"^^xsd:float ;
+    nidm_pValueUncorrected: "0.182785449876348"^^xsd:float ;
+    nidm_pValueFWER: "0.997730485940405"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "43"^^xsd:int .
+
+niiri:93bdd51f373f8659382785eb36932971 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:522536a75466fe7c0e757947afe21547
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0044" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0437522411268585"^^xsd:float ;
+    nidm_pValueUncorrected: "0.441752016334617"^^xsd:float ;
+    nidm_pValueFWER: "0.999999592737522"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "44"^^xsd:int .
+
+niiri:522536a75466fe7c0e757947afe21547 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:acdb22704e8e3566aa17ca0ccdff7a03
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0045" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0437522411268585"^^xsd:float ;
+    nidm_pValueUncorrected: "0.441752016334617"^^xsd:float ;
+    nidm_pValueFWER: "0.999999592737522"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "45"^^xsd:int .
+
+niiri:acdb22704e8e3566aa17ca0ccdff7a03 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:e1cde03f80af40c7004f16340827c9a6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0046" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "46"^^xsd:int .
+
+niiri:e1cde03f80af40c7004f16340827c9a6 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:1a861a102938105fb0e599c28c89f0df
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0047" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.058336321502478"^^xsd:float ;
+    nidm_pValueUncorrected: "0.371675909431407"^^xsd:float ;
+    nidm_pValueFWER: "0.999995797049595"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "47"^^xsd:int .
+
+niiri:1a861a102938105fb0e599c28c89f0df prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:28c829a636fe7679be2b8fe3fc083d99
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0048" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0437522411268585"^^xsd:float ;
+    nidm_pValueUncorrected: "0.441752016334617"^^xsd:float ;
+    nidm_pValueFWER: "0.999999592737522"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "48"^^xsd:int .
+
+niiri:28c829a636fe7679be2b8fe3fc083d99 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:4bb1f06cdf753bfe2cb9742585fc5f63
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0049" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0729204018780975"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317117336021626"^^xsd:float ;
+    nidm_pValueFWER: "0.999974131777239"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "49"^^xsd:int .
+
+niiri:4bb1f06cdf753bfe2cb9742585fc5f63 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:cca6dc1b6e22a99533fb4839e0e808cf
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0050" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "50"^^xsd:int .
+
+niiri:cca6dc1b6e22a99533fb4839e0e808cf prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:894db077f6ce41dde7580196422f5b65
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0051" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "51"^^xsd:int .
+
+niiri:894db077f6ce41dde7580196422f5b65 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:e8143c5b2cddc4ad2f401f2b27a4cab2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0052" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "52"^^xsd:int .
+
+niiri:e8143c5b2cddc4ad2f401f2b27a4cab2 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:09cd915bf2b2b51b32d56249f304bbce
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0053" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "53"^^xsd:int .
+
+niiri:09cd915bf2b2b51b32d56249f304bbce prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:bf2d35b880b3d0657d2a03298074406e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0054" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0875044822537169"^^xsd:float ;
+    nidm_pValueUncorrected: "0.273373266352505"^^xsd:float ;
+    nidm_pValueFWER: "0.999888943840686"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "54"^^xsd:int .
+
+niiri:bf2d35b880b3d0657d2a03298074406e prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:56bc4504cec954daf4a701610ddf59b3
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0055" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "55"^^xsd:int .
+
+niiri:56bc4504cec954daf4a701610ddf59b3 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:baa1270c4a9c0f72989c973b2fbb309d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0056" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "56"^^xsd:int .
+
+niiri:baa1270c4a9c0f72989c973b2fbb309d prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:39b258c34ddafd00d7dff6d208f62918
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0057" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "57"^^xsd:int .
+
+niiri:39b258c34ddafd00d7dff6d208f62918 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:ea112296db729b94dfce05991c3d6989
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0058" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.029168160751239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.536068820289802"^^xsd:float ;
+    nidm_pValueFWER: "0.999999982398778"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "58"^^xsd:int .
+
+niiri:ea112296db729b94dfce05991c3d6989 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:a41eeb9ba04d7788ba686542607ff1cc
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0059" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "59"^^xsd:int .
+
+niiri:a41eeb9ba04d7788ba686542607ff1cc prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:9c7b81143edac28cf680878e9177494c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0060" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "60"^^xsd:int .
+
+niiri:9c7b81143edac28cf680878e9177494c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:e854403c8636e3e481bc993eb6180f44
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0061" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "61"^^xsd:int .
+
+niiri:e854403c8636e3e481bc993eb6180f44 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:7f3ebf5e2a10fd569c91dd091c7af147
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0062" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "62"^^xsd:int .
+
+niiri:7f3ebf5e2a10fd569c91dd091c7af147 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:b36c20212016b9bc7a603f3e83aca676
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0063" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.029168160751239"^^xsd:float ;
+    nidm_pValueUncorrected: "0.536068820289802"^^xsd:float ;
+    nidm_pValueFWER: "0.999999982398778"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "63"^^xsd:int .
+
+niiri:b36c20212016b9bc7a603f3e83aca676 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:05115f2e683a3386f641d5816019de27
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0064" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "64"^^xsd:int .
+
+niiri:05115f2e683a3386f641d5816019de27 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:1ee8276c32c1e03b7e0b4b1717c44a57
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0065" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "65"^^xsd:int .
+
+niiri:1ee8276c32c1e03b7e0b4b1717c44a57 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:aa58a012c4a942174e0325d4c0b944fd
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0066" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "66"^^xsd:int .
+
+niiri:aa58a012c4a942174e0325d4c0b944fd prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:69b1d9ea8525a6a583365384e39cf9e8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0067" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "67"^^xsd:int .
+
+niiri:69b1d9ea8525a6a583365384e39cf9e8 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:f6d9af16709f321130aa58504e6604c5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0068" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "68"^^xsd:int .
+
+niiri:f6d9af16709f321130aa58504e6604c5 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:be347b3d17b0cf1b2b8f3ad6860ae399
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0069" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "69"^^xsd:int .
+
+niiri:be347b3d17b0cf1b2b8f3ad6860ae399 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:fb10f43ffe914843271a8cdefab5f898
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0070" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "70"^^xsd:int .
+
+niiri:fb10f43ffe914843271a8cdefab5f898 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:ac129c99f1ae280d6d0a6f24c04b617a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0071" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0145840803756195"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675180100901307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999828904"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "71"^^xsd:int .
+
+niiri:ac129c99f1ae280d6d0a6f24c04b617a prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+
+niiri:0259aad92a78e6c87148ce920416a4eb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0001" ;
+    prov:atLocation niiri:dd5db5be9e69824ffb62949c8582d5be ;
+    prov:value "39.0658683776855"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.04009751746769"^^xsd:float ;
+    nidm_pValueUncorrected: "2.3264734660966e-07"^^xsd:float ;
+    nidm_pValueFWER: "0.0389037590875805"^^xsd:float ;
+    nidm_qValueFDR: "0.0302216629065993"^^xsd:float .
+
+niiri:dd5db5be9e69824ffb62949c8582d5be
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0001" ;
+    nidm_coordinateVector: "[-2,-90,28]"^^xsd:string .
+
+niiri:0259aad92a78e6c87148ce920416a4eb prov:wasDerivedFrom niiri:ec71581037e524c5fbd95f85fa55b157 .
+
+niiri:7e799bbd6f335fd540a4021e61075cf8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0002" ;
+    prov:atLocation niiri:d3f6be55abbd687279e07d932188a32e ;
+    prov:value "36.2393341064453"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.89725160225159"^^xsd:float ;
+    nidm_pValueUncorrected: "4.85931842320042e-07"^^xsd:float ;
+    nidm_pValueFWER: "0.071761896035709"^^xsd:float ;
+    nidm_qValueFDR: "0.0302216629065993"^^xsd:float .
+
+niiri:d3f6be55abbd687279e07d932188a32e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0002" ;
+    nidm_coordinateVector: "[-42,-64,-8]"^^xsd:string .
+
+niiri:7e799bbd6f335fd540a4021e61075cf8 prov:wasDerivedFrom niiri:ddc3a6b40532cc9e86f19a4aa6cba853 .
+
+niiri:0818768d40973c28e4e870de99f7a12e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0003" ;
+    prov:atLocation niiri:e10e6b887d937b13d419913e96b50eb4 ;
+    prov:value "17.9251842498779"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.64201416072196"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000135256594276711"^^xsd:float ;
+    nidm_pValueFWER: "0.999417997648594"^^xsd:float ;
+    nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
+
+niiri:e10e6b887d937b13d419913e96b50eb4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0003" ;
+    nidm_coordinateVector: "[-40,-52,-10]"^^xsd:string .
+
+niiri:0818768d40973c28e4e870de99f7a12e prov:wasDerivedFrom niiri:ddc3a6b40532cc9e86f19a4aa6cba853 .
+
+niiri:2e69720344eeade04945a9294efe1c46
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0004" ;
+    prov:atLocation niiri:43f273420f486c1569872beaefa26851 ;
+    prov:value "13.454288482666"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.18324713734782"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000728166268399777"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999996872"^^xsd:float ;
+    nidm_qValueFDR: "0.140840039531724"^^xsd:float .
+
+niiri:43f273420f486c1569872beaefa26851
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0004" ;
+    nidm_coordinateVector: "[-38,-70,0]"^^xsd:string .
+
+niiri:2e69720344eeade04945a9294efe1c46 prov:wasDerivedFrom niiri:ddc3a6b40532cc9e86f19a4aa6cba853 .
+
+niiri:0b61d4f645e8030fa41b599c3b7220dd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0005" ;
+    prov:atLocation niiri:a9b1c3d0f5af3d460c038461141f2a06 ;
+    prov:value "29.4676361083984"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.51162164706026"^^xsd:float ;
+    nidm_pValueUncorrected: "3.21669348379849e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.305525019896507"^^xsd:float ;
+    nidm_qValueFDR: "0.0356596612461515"^^xsd:float .
+
+niiri:a9b1c3d0f5af3d460c038461141f2a06
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0005" ;
+    nidm_coordinateVector: "[16,-88,24]"^^xsd:string .
+
+niiri:0b61d4f645e8030fa41b599c3b7220dd prov:wasDerivedFrom niiri:c1738200f1bc478c78cb4aab2cda0cb1 .
+
+niiri:211afdee4625abd8fd61f5e2da4e7851
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0006" ;
+    prov:atLocation niiri:21d2bcb65d9792fab52c653d5e34433a ;
+    prov:value "28.5631580352783"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.45459114773779"^^xsd:float ;
+    nidm_pValueUncorrected: "4.20266075706888e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.365688847752494"^^xsd:float ;
+    nidm_qValueFDR: "0.0376032685416481"^^xsd:float .
+
+niiri:21d2bcb65d9792fab52c653d5e34433a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0006" ;
+    nidm_coordinateVector: "[28,-72,26]"^^xsd:string .
+
+niiri:211afdee4625abd8fd61f5e2da4e7851 prov:wasDerivedFrom niiri:91205f3f0676956d1f1039643e3fcd9d .
+
+niiri:36f1bebef6aafa905f0a57417a9a9409
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0007" ;
+    prov:atLocation niiri:d149b750b624172908054300ba57fa0d ;
+    prov:value "26.9945106506348"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.35204306383375"^^xsd:float ;
+    nidm_pValueUncorrected: "6.7437380493196e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.489729172437052"^^xsd:float ;
+    nidm_qValueFDR: "0.0406203661092224"^^xsd:float .
+
+niiri:d149b750b624172908054300ba57fa0d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0007" ;
+    nidm_coordinateVector: "[-32,20,-4]"^^xsd:string .
+
+niiri:36f1bebef6aafa905f0a57417a9a9409 prov:wasDerivedFrom niiri:a689a0799152fcf397ed6264dff6b7df .
+
+niiri:2b42ff26513d8bb2fad2bee3fac979bd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0008" ;
+    prov:atLocation niiri:00172712096fe22fbb4c6cb0abae056c ;
+    prov:value "26.8606586456299"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.34306775687574"^^xsd:float ;
+    nidm_pValueUncorrected: "7.02533878071954e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.501353785238145"^^xsd:float ;
+    nidm_qValueFDR: "0.0406203661092224"^^xsd:float .
+
+niiri:00172712096fe22fbb4c6cb0abae056c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0008" ;
+    nidm_coordinateVector: "[-8,50,32]"^^xsd:string .
+
+niiri:2b42ff26513d8bb2fad2bee3fac979bd prov:wasDerivedFrom niiri:4f3977b902ab860fce265438ec1666b5 .
+
+niiri:570e544597bcf68c47263d141cd82ca4
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0009" ;
+    prov:atLocation niiri:4488b6dfe10aa9fffe9d9fa5f038987f ;
+    prov:value "25.8067512512207"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.27109313660164"^^xsd:float ;
+    nidm_pValueUncorrected: "9.72585724245967e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.597019202761311"^^xsd:float ;
+    nidm_qValueFDR: "0.0439563569939673"^^xsd:float .
+
+niiri:4488b6dfe10aa9fffe9d9fa5f038987f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0009" ;
+    nidm_coordinateVector: "[-34,8,58]"^^xsd:string .
+
+niiri:570e544597bcf68c47263d141cd82ca4 prov:wasDerivedFrom niiri:e8270a828c6a9c6a7e1a7f948de88a7e .
+
+niiri:be4c08d3fca48f05de0ae62f8b673305
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0010" ;
+    prov:atLocation niiri:43ecbb57ee775f4cbb1dd4af236cfbff ;
+    prov:value "25.0769119262695"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.21983658750018"^^xsd:float ;
+    nidm_pValueUncorrected: "1.22239732009977e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.665677647955296"^^xsd:float ;
+    nidm_qValueFDR: "0.0444376030498989"^^xsd:float .
+
+niiri:43ecbb57ee775f4cbb1dd4af236cfbff
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0010" ;
+    nidm_coordinateVector: "[32,-86,0]"^^xsd:string .
+
+niiri:be4c08d3fca48f05de0ae62f8b673305 prov:wasDerivedFrom niiri:cda674baaa255a631b19d42763c0930c .
+
+niiri:340ff54b0274dd2288512da30ba70b15
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0011" ;
+    prov:atLocation niiri:9b59dfd3cd6fe92f527a2d11dc8e5ad5 ;
+    prov:value "24.5828113555908"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.18444689049798"^^xsd:float ;
+    nidm_pValueUncorrected: "1.42930633414418e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.711939170732988"^^xsd:float ;
+    nidm_qValueFDR: "0.04475687830922"^^xsd:float .
+
+niiri:9b59dfd3cd6fe92f527a2d11dc8e5ad5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0011" ;
+    nidm_coordinateVector: "[66,-32,30]"^^xsd:string .
+
+niiri:340ff54b0274dd2288512da30ba70b15 prov:wasDerivedFrom niiri:b9beda96f738803fb567cd0d0d5ac126 .
+
+niiri:bfd29eeffd577f81b1028084dd3cafbb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0012" ;
+    prov:atLocation niiri:afdc90796927d6b5b5d8e26a0c89d918 ;
+    prov:value "14.2693071365356"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.27451594161643"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000529215834762176"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999209483"^^xsd:float ;
+    nidm_qValueFDR: "0.128281884148943"^^xsd:float .
+
+niiri:afdc90796927d6b5b5d8e26a0c89d918
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0012" ;
+    nidm_coordinateVector: "[60,-38,28]"^^xsd:string .
+
+niiri:bfd29eeffd577f81b1028084dd3cafbb prov:wasDerivedFrom niiri:b9beda96f738803fb567cd0d0d5ac126 .
+
+niiri:3de1d3b3fd47f85802886f79af4dc678
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0013" ;
+    prov:atLocation niiri:533d4d268893416ecb4d1151faad2ef6 ;
+    prov:value "23.3039436340332"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.09011898331566"^^xsd:float ;
+    nidm_pValueUncorrected: "2.15575975488491e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.823947459995523"^^xsd:float ;
+    nidm_qValueFDR: "0.0478656864369739"^^xsd:float .
+
+niiri:533d4d268893416ecb4d1151faad2ef6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0013" ;
+    nidm_coordinateVector: "[28,30,52]"^^xsd:string .
+
+niiri:3de1d3b3fd47f85802886f79af4dc678 prov:wasDerivedFrom niiri:24686319b3c7b6b6793dbf6e90029199 .
+
+niiri:4c793b1434ab014669b8e4ce2cf2139b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0014" ;
+    prov:atLocation niiri:f6d485f30b70a6db61c96e28aa7f2753 ;
+    prov:value "22.6157932281494"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.03763886298215"^^xsd:float ;
+    nidm_pValueUncorrected: "2.69959426782984e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.87538446987651"^^xsd:float ;
+    nidm_qValueFDR: "0.0515719459796674"^^xsd:float .
+
+niiri:f6d485f30b70a6db61c96e28aa7f2753
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0014" ;
+    nidm_coordinateVector: "[-30,-34,6]"^^xsd:string .
+
+niiri:4c793b1434ab014669b8e4ce2cf2139b prov:wasDerivedFrom niiri:ef45eced4ec473fc374602efe1d44af2 .
+
+niiri:f9a42b90df039166ca0e5fa02d3d604f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0015" ;
+    prov:atLocation niiri:55a6eaf2f3b34f1854c5cc88fea7e153 ;
+    prov:value "21.8558578491211"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.97819185113407"^^xsd:float ;
+    nidm_pValueUncorrected: "3.47206660495925e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.921823721412592"^^xsd:float ;
+    nidm_qValueFDR: "0.053734847831518"^^xsd:float .
+
+niiri:55a6eaf2f3b34f1854c5cc88fea7e153
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0015" ;
+    nidm_coordinateVector: "[-28,0,30]"^^xsd:string .
+
+niiri:f9a42b90df039166ca0e5fa02d3d604f prov:wasDerivedFrom niiri:1a8d727934cbec38f1fdcc84430d7857 .
+
+niiri:de93eaf377bd0a9992922d03e47c7423
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0016" ;
+    prov:atLocation niiri:b0a8a5b4d1ad632e303792bb14434ab1 ;
+    prov:value "21.8296661376953"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.97611404363788"^^xsd:float ;
+    nidm_pValueUncorrected: "3.50252708366527e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.923209894114283"^^xsd:float ;
+    nidm_qValueFDR: "0.053734847831518"^^xsd:float .
+
+niiri:b0a8a5b4d1ad632e303792bb14434ab1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0016" ;
+    nidm_coordinateVector: "[8,34,10]"^^xsd:string .
+
+niiri:de93eaf377bd0a9992922d03e47c7423 prov:wasDerivedFrom niiri:0ea4cdb2fb21bb5f5f9588416f8a0986 .
+
+niiri:e354a84565e5c296d9efa7317a911cfe
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0017" ;
+    prov:atLocation niiri:6cd3c9ec2c82b8b60104f15adb91982c ;
+    prov:value "21.7287845611572"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.96809263472704"^^xsd:float ;
+    nidm_pValueUncorrected: "3.6225086553876e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.928411428313329"^^xsd:float ;
+    nidm_qValueFDR: "0.0540587737624357"^^xsd:float .
+
+niiri:6cd3c9ec2c82b8b60104f15adb91982c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0017" ;
+    nidm_coordinateVector: "[46,-56,10]"^^xsd:string .
+
+niiri:e354a84565e5c296d9efa7317a911cfe prov:wasDerivedFrom niiri:e96a0a75cfbda16324a620530f8ac979 .
+
+niiri:08e6714e83b23af817c91a38ea817a9d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0018" ;
+    prov:atLocation niiri:18511209fae629ef4fc05e9115d24b3d ;
+    prov:value "14.2801656723022"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.27570591680179"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000526991241768693"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999156251"^^xsd:float ;
+    nidm_qValueFDR: "0.128281884148943"^^xsd:float .
+
+niiri:18511209fae629ef4fc05e9115d24b3d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0018" ;
+    nidm_coordinateVector: "[48,-48,16]"^^xsd:string .
+
+niiri:08e6714e83b23af817c91a38ea817a9d prov:wasDerivedFrom niiri:e96a0a75cfbda16324a620530f8ac979 .
+
+niiri:27a4396719d910dc755a3ae8f5919b75
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0019" ;
+    prov:atLocation niiri:11308bc9db92e428a2f7e9a8d4420c7f ;
+    prov:value "21.4629364013672"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.9468129149843"^^xsd:float ;
+    nidm_pValueUncorrected: "3.95991966499754e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.941069307565192"^^xsd:float ;
+    nidm_qValueFDR: "0.0555984329583215"^^xsd:float .
+
+niiri:11308bc9db92e428a2f7e9a8d4420c7f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0019" ;
+    nidm_coordinateVector: "[46,-62,-10]"^^xsd:string .
+
+niiri:27a4396719d910dc755a3ae8f5919b75 prov:wasDerivedFrom niiri:bc4b7adbe33f91a695fde03bf4b200ed .
+
+niiri:cc9face0d8fe5a7de8a150a20acca2d8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0020" ;
+    prov:atLocation niiri:73a9a071ca8380ed9df7a551dfd73dfa ;
+    prov:value "21.4269542694092"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.94391683979485"^^xsd:float ;
+    nidm_pValueUncorrected: "4.00807329147268e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.942665676683549"^^xsd:float ;
+    nidm_qValueFDR: "0.0555984329583215"^^xsd:float .
+
+niiri:73a9a071ca8380ed9df7a551dfd73dfa
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0020" ;
+    nidm_coordinateVector: "[-8,-32,36]"^^xsd:string .
+
+niiri:cc9face0d8fe5a7de8a150a20acca2d8 prov:wasDerivedFrom niiri:71a412f82e6ea8cb947b5be72c8efcff .
+
+niiri:5af15d290c54073ba4518037ca306358
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0021" ;
+    prov:atLocation niiri:924073fc7007784464acebdf52dfccca ;
+    prov:value "20.0413494110107"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.82938429557992"^^xsd:float ;
+    nidm_pValueUncorrected: "6.42321325474704e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.984364018223445"^^xsd:float ;
+    nidm_qValueFDR: "0.0674959642175569"^^xsd:float .
+
+niiri:924073fc7007784464acebdf52dfccca
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0021" ;
+    nidm_coordinateVector: "[-34,-84,-4]"^^xsd:string .
+
+niiri:5af15d290c54073ba4518037ca306358 prov:wasDerivedFrom niiri:93e18b25ba3aeb399e6fd41cb9dfca97 .
+
+niiri:ea651b661b6bfe3969159c6f0ec70642
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0022" ;
+    prov:atLocation niiri:6150a0cc589ec407bbf5b278e34fe8c0 ;
+    prov:value "19.5813789367676"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.79000141974546"^^xsd:float ;
+    nidm_pValueUncorrected: "7.53232118573255e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.991038394814884"^^xsd:float ;
+    nidm_qValueFDR: "0.0718990170223714"^^xsd:float .
+
+niiri:6150a0cc589ec407bbf5b278e34fe8c0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0022" ;
+    nidm_coordinateVector: "[-50,2,40]"^^xsd:string .
+
+niiri:ea651b661b6bfe3969159c6f0ec70642 prov:wasDerivedFrom niiri:3d33e1d8e7da5c593e7ad094c154132a .
+
+niiri:8c7a07db4f3345bbb5e3dec281596f82
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0023" ;
+    prov:atLocation niiri:8801d1d1f53291499c55fe97c82abf06 ;
+    prov:value "16.7666301727295"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.53217184854778"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00020608070787731"^^xsd:float ;
+    nidm_pValueFWER: "0.99996648470095"^^xsd:float ;
+    nidm_qValueFDR: "0.0942608471449251"^^xsd:float .
+
+niiri:8801d1d1f53291499c55fe97c82abf06
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0023" ;
+    nidm_coordinateVector: "[-52,-6,46]"^^xsd:string .
+
+niiri:8c7a07db4f3345bbb5e3dec281596f82 prov:wasDerivedFrom niiri:3d33e1d8e7da5c593e7ad094c154132a .
+
+niiri:0d7a35acc2e01b8de53dab1cd6885030
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0024" ;
+    prov:atLocation niiri:5ca0f95ce3edb5b98b519299dce96767 ;
+    prov:value "19.3040504455566"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.76590943131268"^^xsd:float ;
+    nidm_pValueUncorrected: "8.2971971291701e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.993825462793153"^^xsd:float ;
+    nidm_qValueFDR: "0.0737314974355366"^^xsd:float .
+
+niiri:5ca0f95ce3edb5b98b519299dce96767
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0024" ;
+    nidm_coordinateVector: "[24,-46,32]"^^xsd:string .
+
+niiri:0d7a35acc2e01b8de53dab1cd6885030 prov:wasDerivedFrom niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4 .
+
+niiri:0ea3ba62f32a9ee428c5ea4b5cef35cb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0025" ;
+    prov:atLocation niiri:140460982182cf8d062436969406364b ;
+    prov:value "19.1409015655518"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.75161143600874"^^xsd:float ;
+    nidm_pValueUncorrected: "8.7850813353163e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.995110302012489"^^xsd:float ;
+    nidm_qValueFDR: "0.0738147834753255"^^xsd:float .
+
+niiri:140460982182cf8d062436969406364b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0025" ;
+    nidm_coordinateVector: "[6,16,50]"^^xsd:string .
+
+niiri:0ea3ba62f32a9ee428c5ea4b5cef35cb prov:wasDerivedFrom niiri:7c11ea6d552baec493b21ecdef64c785 .
+
+niiri:c9ac5ab5461375e94e4d7324a6bedc98
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0026" ;
+    prov:atLocation niiri:c7cab9ce4ae0697e1f4eb6ec314ebc4d ;
+    prov:value "19.098669052124"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.74789498829157"^^xsd:float ;
+    nidm_pValueUncorrected: "8.91624398706714e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.995405100064856"^^xsd:float ;
+    nidm_qValueFDR: "0.0738147834753255"^^xsd:float .
+
+niiri:c7cab9ce4ae0697e1f4eb6ec314ebc4d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0026" ;
+    nidm_coordinateVector: "[-4,-24,6]"^^xsd:string .
+
+niiri:c9ac5ab5461375e94e4d7324a6bedc98 prov:wasDerivedFrom niiri:56fa7a2fed0946da7dd3299da637b245 .
+
+niiri:d787aaae02f2d49ff3e8f709b3e0ffe2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0027" ;
+    prov:atLocation niiri:27e6b2cc327f93c6462c9e5686d7c493 ;
+    prov:value "19.0145893096924"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.7404771295496"^^xsd:float ;
+    nidm_pValueUncorrected: "9.1835629583259e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.995949293325196"^^xsd:float ;
+    nidm_qValueFDR: "0.0741915113542509"^^xsd:float .
+
+niiri:27e6b2cc327f93c6462c9e5686d7c493
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0027" ;
+    nidm_coordinateVector: "[-4,0,54]"^^xsd:string .
+
+niiri:d787aaae02f2d49ff3e8f709b3e0ffe2 prov:wasDerivedFrom niiri:c74b1ddb4c9a5395bf0b4d826708ce5a .
+
+niiri:9db9efc1edd783d8cbdaf22ba831fdaf
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0028" ;
+    prov:atLocation niiri:1c5529d2dc429e1471abb89100522dbc ;
+    prov:value "18.8265838623047"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.72379883766124"^^xsd:float ;
+    nidm_pValueUncorrected: "9.81236582245915e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.996978299202392"^^xsd:float ;
+    nidm_qValueFDR: "0.0777669728451003"^^xsd:float .
+
+niiri:1c5529d2dc429e1471abb89100522dbc
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0028" ;
+    nidm_coordinateVector: "[42,-28,30]"^^xsd:string .
+
+niiri:9db9efc1edd783d8cbdaf22ba831fdaf prov:wasDerivedFrom niiri:10bec2b1f4f72ee8eedb38e17e1faab3 .
+
+niiri:a25f9de80ac191e47f1660393e75473f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0029" ;
+    prov:atLocation niiri:4fa2fadc00e657efdd63b3a39309c84a ;
+    prov:value "18.5199432373047"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.69631988620818"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000109373660980738"^^xsd:float ;
+    nidm_pValueFWER: "0.998191254166604"^^xsd:float ;
+    nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
+
+niiri:4fa2fadc00e657efdd63b3a39309c84a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0029" ;
+    nidm_coordinateVector: "[52,-12,44]"^^xsd:string .
+
+niiri:a25f9de80ac191e47f1660393e75473f prov:wasDerivedFrom niiri:f725bd9a5656b07d43f8eba6c3be2858 .
+
+niiri:f484fb8e47371d4dd3f5ee9736deeca9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0030" ;
+    prov:atLocation niiri:33fd7ada9f41a7443fa610a81c719475 ;
+    prov:value "18.516544342041"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.69601335434539"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000109505728679404"^^xsd:float ;
+    nidm_pValueFWER: "0.998201975106935"^^xsd:float ;
+    nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
+
+niiri:33fd7ada9f41a7443fa610a81c719475
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0030" ;
+    nidm_coordinateVector: "[-40,-28,30]"^^xsd:string .
+
+niiri:f484fb8e47371d4dd3f5ee9736deeca9 prov:wasDerivedFrom niiri:83f438c66d3cf32344b7255377c7499d .
+
+niiri:8582459cfedf8c404f54867fe9956065
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0031" ;
+    prov:atLocation niiri:7574fcc563cda88fe39a2f517cefd40a ;
+    prov:value "18.4609222412109"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.69099090519778"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000111691062804176"^^xsd:float ;
+    nidm_pValueFWER: "0.998370011058266"^^xsd:float ;
+    nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
+
+niiri:7574fcc563cda88fe39a2f517cefd40a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0031" ;
+    nidm_coordinateVector: "[32,22,-8]"^^xsd:string .
+
+niiri:8582459cfedf8c404f54867fe9956065 prov:wasDerivedFrom niiri:cc9360b64b21e281dcfb851074b574b6 .
+
+niiri:ba6bc791d8adb783ff5181c1594590b6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0032" ;
+    prov:atLocation niiri:2398781ef2e524c6173a32e0bb244b23 ;
+    prov:value "17.9312534332275"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.64257521175179"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00013496203699781"^^xsd:float ;
+    nidm_pValueFWER: "0.99941063068466"^^xsd:float ;
+    nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
+
+niiri:2398781ef2e524c6173a32e0bb244b23
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0032" ;
+    nidm_coordinateVector: "[64,-4,10]"^^xsd:string .
+
+niiri:ba6bc791d8adb783ff5181c1594590b6 prov:wasDerivedFrom niiri:4728de35ba855317aeef4e0a7b91801c .
+
+niiri:74387d11b1e18aa01c68936614d323d2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0033" ;
+    prov:atLocation niiri:719551878f20f48ff5a59d8a7a9c8229 ;
+    prov:value "17.8439044952393"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.63448648232359"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000139267429951739"^^xsd:float ;
+    nidm_pValueFWER: "0.999509275806277"^^xsd:float ;
+    nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
+
+niiri:719551878f20f48ff5a59d8a7a9c8229
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0033" ;
+    nidm_coordinateVector: "[-22,-72,34]"^^xsd:string .
+
+niiri:74387d11b1e18aa01c68936614d323d2 prov:wasDerivedFrom niiri:f435923c3d5e3915c4aa5159c5bbc4a0 .
+
+niiri:f515406c4386dbba20e09dfc286cad01
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0034" ;
+    prov:atLocation niiri:53dfe63ffbecb2b80528e9f6b0729406 ;
+    prov:value "17.552827835083"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.60731294050443"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000154692216466135"^^xsd:float ;
+    nidm_pValueFWER: "0.999742486133075"^^xsd:float ;
+    nidm_qValueFDR: "0.0862331427095326"^^xsd:float .
+
+niiri:53dfe63ffbecb2b80528e9f6b0729406
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0034" ;
+    nidm_coordinateVector: "[-6,-44,40]"^^xsd:string .
+
+niiri:f515406c4386dbba20e09dfc286cad01 prov:wasDerivedFrom niiri:b39b9cce118cf858149cdd53ebcda7bd .
+
+niiri:1b3fb965c01205049ccc6b0cbe41747e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0035" ;
+    prov:atLocation niiri:f27eb00800ba18fb1542d4dada966f33 ;
+    prov:value "17.2906818389893"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.58254613965863"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000170130746602659"^^xsd:float ;
+    nidm_pValueFWER: "0.99986271355264"^^xsd:float ;
+    nidm_qValueFDR: "0.0895859395735557"^^xsd:float .
+
+niiri:f27eb00800ba18fb1542d4dada966f33
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0035" ;
+    nidm_coordinateVector: "[-34,-38,-34]"^^xsd:string .
+
+niiri:1b3fb965c01205049ccc6b0cbe41747e prov:wasDerivedFrom niiri:97e0a9bea1289493ad46d8a4c2b75485 .
+
+niiri:1db1dcb7ac31be92db03ea6f49276709
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0036" ;
+    prov:atLocation niiri:c2aa93c26b662b0231d80c11fa4a9ef6 ;
+    prov:value "17.1612319946289"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.57021115022413"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000178346794309836"^^xsd:float ;
+    nidm_pValueFWER: "0.999901168620001"^^xsd:float ;
+    nidm_qValueFDR: "0.0903823255084056"^^xsd:float .
+
+niiri:c2aa93c26b662b0231d80c11fa4a9ef6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0036" ;
+    nidm_coordinateVector: "[-46,-16,20]"^^xsd:string .
+
+niiri:1db1dcb7ac31be92db03ea6f49276709 prov:wasDerivedFrom niiri:e9e94038b5b1dbcf9f8a4d4208e34928 .
+
+niiri:e52b244ba436c001a08d0e1a0f3fc101
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0037" ;
+    prov:atLocation niiri:8379336830251a7cbd5eb4a5b2b7e6c0 ;
+    prov:value "17.0075950622559"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.55547987606237"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000188644912021529"^^xsd:float ;
+    nidm_pValueFWER: "0.999934173907998"^^xsd:float ;
+    nidm_qValueFDR: "0.0920555845860752"^^xsd:float .
+
+niiri:8379336830251a7cbd5eb4a5b2b7e6c0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0037" ;
+    nidm_coordinateVector: "[24,32,2]"^^xsd:string .
+
+niiri:e52b244ba436c001a08d0e1a0f3fc101 prov:wasDerivedFrom niiri:0857328371989db393f2fc4d7d5346bd .
+
+niiri:58c50def173085b4eacf834a8b4704ff
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0038" ;
+    prov:atLocation niiri:0b671ab6136c76ed072d17a2c0f74a10 ;
+    prov:value "16.5308303833008"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.50911812032442"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000224797592033421"^^xsd:float ;
+    nidm_pValueFWER: "0.999983487413756"^^xsd:float ;
+    nidm_qValueFDR: "0.0959555780965771"^^xsd:float .
+
+niiri:0b671ab6136c76ed072d17a2c0f74a10
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0038" ;
+    nidm_coordinateVector: "[-26,-90,16]"^^xsd:string .
+
+niiri:58c50def173085b4eacf834a8b4704ff prov:wasDerivedFrom niiri:7e693a4a3e70d39b916aa2a95911a3c8 .
+
+niiri:29090a193cda0ed62625301b681522a5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0039" ;
+    prov:atLocation niiri:baefd951dc2ab5a50c39cd840ad1f17e ;
+    prov:value "16.5225524902344"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.50830432871627"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0002254864217901"^^xsd:float ;
+    nidm_pValueFWER: "0.999983907066973"^^xsd:float ;
+    nidm_qValueFDR: "0.0959555780965771"^^xsd:float .
+
+niiri:baefd951dc2ab5a50c39cd840ad1f17e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0039" ;
+    nidm_coordinateVector: "[-28,-4,16]"^^xsd:string .
+
+niiri:29090a193cda0ed62625301b681522a5 prov:wasDerivedFrom niiri:d8dc459a110e4898c23019ee42154713 .
+
+niiri:b7d5268eabb9490b67684ed7ceb301c9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0040" ;
+    prov:atLocation niiri:9375ad74a7d7acce22a9a6dc5fa1d47d ;
+    prov:value "16.1374092102051"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.47009871338807"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00026013355917065"^^xsd:float ;
+    nidm_pValueFWER: "0.999995475747835"^^xsd:float ;
+    nidm_qValueFDR: "0.101886915515055"^^xsd:float .
+
+niiri:9375ad74a7d7acce22a9a6dc5fa1d47d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0040" ;
+    nidm_coordinateVector: "[12,60,20]"^^xsd:string .
+
+niiri:b7d5268eabb9490b67684ed7ceb301c9 prov:wasDerivedFrom niiri:cd795f902776ad9170549b8fde8996ba .
+
+niiri:9db92d56d94d661dd685256f317dbe48
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0041" ;
+    prov:atLocation niiri:e35f3a6956a4d9893c3760d30968fce5 ;
+    prov:value "15.9136981964111"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.44759277757755"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000282803055741021"^^xsd:float ;
+    nidm_pValueFWER: "0.999997977474125"^^xsd:float ;
+    nidm_qValueFDR: "0.105222982133496"^^xsd:float .
+
+niiri:e35f3a6956a4d9893c3760d30968fce5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0041" ;
+    nidm_coordinateVector: "[4,-84,-4]"^^xsd:string .
+
+niiri:9db92d56d94d661dd685256f317dbe48 prov:wasDerivedFrom niiri:ed1df7c28737883d905ca0a8f2093992 .
+
+niiri:95049e965261ae17e6141f440c65aade
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0042" ;
+    prov:atLocation niiri:8907a4706c52ef0acbd6db140d02de82 ;
+    prov:value "15.8536109924316"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.44150764421068"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000289241063091916"^^xsd:float ;
+    nidm_pValueFWER: "0.999998385530387"^^xsd:float ;
+    nidm_qValueFDR: "0.105222982133496"^^xsd:float .
+
+niiri:8907a4706c52ef0acbd6db140d02de82
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0042" ;
+    nidm_coordinateVector: "[62,-18,22]"^^xsd:string .
+
+niiri:95049e965261ae17e6141f440c65aade prov:wasDerivedFrom niiri:ca7bfed8d8dbca676ba25fca93d29e2c .
+
+niiri:bc2dfd54c7c011e3626f64ebd840c082
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0043" ;
+    prov:atLocation niiri:8d0fe36db64dfbb57c50be778e56fc0b ;
+    prov:value "15.8288412094116"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.43899416081302"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000291939913913408"^^xsd:float ;
+    nidm_pValueFWER: "0.999998530446399"^^xsd:float ;
+    nidm_qValueFDR: "0.105222982133496"^^xsd:float .
+
+niiri:8d0fe36db64dfbb57c50be778e56fc0b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0043" ;
+    nidm_coordinateVector: "[28,-58,44]"^^xsd:string .
+
+niiri:bc2dfd54c7c011e3626f64ebd840c082 prov:wasDerivedFrom niiri:1dcd9b5514190f867e3e9b0b57227395 .
+
+niiri:b861ffa726f69dca943d1bc1e39e3f21
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0044" ;
+    prov:atLocation niiri:358c40d8401882be55ffa3aa51e8c703 ;
+    prov:value "15.7273988723755"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.42866974555038"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000303273553249328"^^xsd:float ;
+    nidm_pValueFWER: "0.999999007347173"^^xsd:float ;
+    nidm_qValueFDR: "0.106558197028572"^^xsd:float .
+
+niiri:358c40d8401882be55ffa3aa51e8c703
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0044" ;
+    nidm_coordinateVector: "[38,44,0]"^^xsd:string .
+
+niiri:b861ffa726f69dca943d1bc1e39e3f21 prov:wasDerivedFrom niiri:79097d11179e49abc9f2bdf5ba7bb932 .
+
+niiri:48b5c01001fb7600fbd4531a0e1761c4
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0045" ;
+    prov:atLocation niiri:ae647fef7b776cfa997ad53eb4b2fc5b ;
+    prov:value "15.4726600646973"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.40252319694713"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000333833435672726"^^xsd:float ;
+    nidm_pValueFWER: "0.999999648429928"^^xsd:float ;
+    nidm_qValueFDR: "0.109105594368073"^^xsd:float .
+
+niiri:ae647fef7b776cfa997ad53eb4b2fc5b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0045" ;
+    nidm_coordinateVector: "[40,-6,-6]"^^xsd:string .
+
+niiri:48b5c01001fb7600fbd4531a0e1761c4 prov:wasDerivedFrom niiri:d339d6251d3c159dbe2427fd1bcc1fc1 .
+
+niiri:c46952610583f569f9152387a8bc54d9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0046" ;
+    prov:atLocation niiri:cd6aeb3993ad5aeb4e69f7fde5b6d7dc ;
+    prov:value "15.3332357406616"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.38807697766079"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00035192253822891"^^xsd:float ;
+    nidm_pValueFWER: "0.999999807374102"^^xsd:float ;
+    nidm_qValueFDR: "0.110729615236961"^^xsd:float .
+
+niiri:cd6aeb3993ad5aeb4e69f7fde5b6d7dc
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0046" ;
+    nidm_coordinateVector: "[32,14,58]"^^xsd:string .
+
+niiri:c46952610583f569f9152387a8bc54d9 prov:wasDerivedFrom niiri:b0978b4f683201d3539ace75681c8b65 .
+
+niiri:549a9bbee50f3775d812947136680afd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0047" ;
+    prov:atLocation niiri:eb0736b11222caa828e4419e72562692 ;
+    prov:value "15.3172578811646"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.38641524500992"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000354060730342054"^^xsd:float ;
+    nidm_pValueFWER: "0.99999982049151"^^xsd:float ;
+    nidm_qValueFDR: "0.110729615236961"^^xsd:float .
+
+niiri:eb0736b11222caa828e4419e72562692
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0047" ;
+    nidm_coordinateVector: "[4,-86,4]"^^xsd:string .
+
+niiri:549a9bbee50f3775d812947136680afd prov:wasDerivedFrom niiri:133c074788eed1fa9d50d9e4608e3c1c .
+
+niiri:a70159564d5e15398a8e6af937070b21
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0048" ;
+    prov:atLocation niiri:0cd5c4445b3ca0198be2f8b0ac1c5ff7 ;
+    prov:value "15.3137311935425"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.38604828864924"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000354534526388783"^^xsd:float ;
+    nidm_pValueFWER: "0.999999823272138"^^xsd:float ;
+    nidm_qValueFDR: "0.110729615236961"^^xsd:float .
+
+niiri:0cd5c4445b3ca0198be2f8b0ac1c5ff7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0048" ;
+    nidm_coordinateVector: "[62,-36,46]"^^xsd:string .
+
+niiri:a70159564d5e15398a8e6af937070b21 prov:wasDerivedFrom niiri:93bdd51f373f8659382785eb36932971 .
+
+niiri:d7e71a37d659eb3e8ffc416baa8d822a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0049" ;
+    prov:atLocation niiri:2e67727cc0cfd1e78600ff3d8e948bb7 ;
+    prov:value "15.1916456222534"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.37330635701462"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000371356333789152"^^xsd:float ;
+    nidm_pValueFWER: "0.999999898084819"^^xsd:float ;
+    nidm_qValueFDR: "0.113182641774622"^^xsd:float .
+
+niiri:2e67727cc0cfd1e78600ff3d8e948bb7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0049" ;
+    nidm_coordinateVector: "[-24,18,58]"^^xsd:string .
+
+niiri:d7e71a37d659eb3e8ffc416baa8d822a prov:wasDerivedFrom niiri:522536a75466fe7c0e757947afe21547 .
+
+niiri:03f8d483a6d2c4d5e2df0d2834d90bc1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0050" ;
+    prov:atLocation niiri:017fc7f20be266bd229d46d23c92c88e ;
+    prov:value "15.0888338088989"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.36251708484568"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000386176732959709"^^xsd:float ;
+    nidm_pValueFWER: "0.999999936876428"^^xsd:float ;
+    nidm_qValueFDR: "0.114724188214818"^^xsd:float .
+
+niiri:017fc7f20be266bd229d46d23c92c88e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0050" ;
+    nidm_coordinateVector: "[8,-22,-44]"^^xsd:string .
+
+niiri:03f8d483a6d2c4d5e2df0d2834d90bc1 prov:wasDerivedFrom niiri:acdb22704e8e3566aa17ca0ccdff7a03 .
+
+niiri:7065d45e419e04080dbcbe72642fe102
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0051" ;
+    prov:atLocation niiri:64d776bee75666af4e2b1252a3fd0002 ;
+    prov:value "14.8200588226318"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.33405240591422"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000427952650791097"^^xsd:float ;
+    nidm_pValueFWER: "0.999999983180231"^^xsd:float ;
+    nidm_qValueFDR: "0.119307804764224"^^xsd:float .
+
+niiri:64d776bee75666af4e2b1252a3fd0002
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0051" ;
+    nidm_coordinateVector: "[38,34,22]"^^xsd:string .
+
+niiri:7065d45e419e04080dbcbe72642fe102 prov:wasDerivedFrom niiri:e1cde03f80af40c7004f16340827c9a6 .
+
+niiri:f232f46f47a241ff82eee6a194ff86ad
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0052" ;
+    prov:atLocation niiri:b744cd533ab253d9b8023ced422dcd4e ;
+    prov:value "14.696608543396"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.32085065286489"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000448717729613968"^^xsd:float ;
+    nidm_pValueFWER: "0.9999999911592"^^xsd:float ;
+    nidm_qValueFDR: "0.121223400645327"^^xsd:float .
+
+niiri:b744cd533ab253d9b8023ced422dcd4e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0052" ;
+    nidm_coordinateVector: "[0,-26,-28]"^^xsd:string .
+
+niiri:f232f46f47a241ff82eee6a194ff86ad prov:wasDerivedFrom niiri:1a861a102938105fb0e599c28c89f0df .
+
+niiri:d07297142ea27f1aadd2a2d0fc18eaa5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0053" ;
+    prov:atLocation niiri:3df6f0cc55b55ccf745b4ed025159201 ;
+    prov:value "14.2414035797119"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.27145497586776"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00053497811978398"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999933201"^^xsd:float ;
+    nidm_qValueFDR: "0.128281884148943"^^xsd:float .
+
+niiri:3df6f0cc55b55ccf745b4ed025159201
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0053" ;
+    nidm_coordinateVector: "[40,-50,-22]"^^xsd:string .
+
+niiri:d07297142ea27f1aadd2a2d0fc18eaa5 prov:wasDerivedFrom niiri:28c829a636fe7679be2b8fe3fc083d99 .
+
+niiri:04eb8dd4e9ab8ac46c751092d04da10d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0054" ;
+    prov:atLocation niiri:ff9d4a014bd4e0dc8a92264c7b200ed9 ;
+    prov:value "14.0012445449829"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.24492687341108"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000587403942481801"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999852106"^^xsd:float ;
+    nidm_qValueFDR: "0.131447065854217"^^xsd:float .
+
+niiri:ff9d4a014bd4e0dc8a92264c7b200ed9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0054" ;
+    nidm_coordinateVector: "[8,52,32]"^^xsd:string .
+
+niiri:04eb8dd4e9ab8ac46c751092d04da10d prov:wasDerivedFrom niiri:4bb1f06cdf753bfe2cb9742585fc5f63 .
+
+niiri:d80002080097776aa38277bc80033aa3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0055" ;
+    prov:atLocation niiri:ce74cab636a5f2efe71e98f6ae695f3c ;
+    prov:value "13.9842071533203"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.2430323166614"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000591323980175695"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999867649"^^xsd:float ;
+    nidm_qValueFDR: "0.131695068372973"^^xsd:float .
+
+niiri:ce74cab636a5f2efe71e98f6ae695f3c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0055" ;
+    nidm_coordinateVector: "[-14,-48,-24]"^^xsd:string .
+
+niiri:d80002080097776aa38277bc80033aa3 prov:wasDerivedFrom niiri:cca6dc1b6e22a99533fb4839e0e808cf .
+
+niiri:d4c1b62bf34355cc27a8c18d2fe4f53b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0056" ;
+    prov:atLocation niiri:ea5c28625592b62bd93bf315cb8d38f1 ;
+    prov:value "13.9203996658325"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.23592192136056"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000606252725692924"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999913111"^^xsd:float ;
+    nidm_qValueFDR: "0.13226466740541"^^xsd:float .
+
+niiri:ea5c28625592b62bd93bf315cb8d38f1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0056" ;
+    nidm_coordinateVector: "[20,0,-8]"^^xsd:string .
+
+niiri:d4c1b62bf34355cc27a8c18d2fe4f53b prov:wasDerivedFrom niiri:894db077f6ce41dde7580196422f5b65 .
+
+niiri:22da22dab16541f8e410ae72c92290f3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0057" ;
+    prov:atLocation niiri:183de3503fa5b331b636ff710340ee17 ;
+    prov:value "13.8925752639771"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.23281385809669"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000612887021428588"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999927857"^^xsd:float ;
+    nidm_qValueFDR: "0.13226466740541"^^xsd:float .
+
+niiri:183de3503fa5b331b636ff710340ee17
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0057" ;
+    nidm_coordinateVector: "[40,-14,60]"^^xsd:string .
+
+niiri:22da22dab16541f8e410ae72c92290f3 prov:wasDerivedFrom niiri:e8143c5b2cddc4ad2f401f2b27a4cab2 .
+
+niiri:ed8e5afdf4dfba0fb8266ec7bb6e05ea
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0058" ;
+    prov:atLocation niiri:bb26c37ea84abd4f8e5aab60783b1ef4 ;
+    prov:value "13.8641185760498"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.22963046726961"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000619751563460058"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999940447"^^xsd:float ;
+    nidm_qValueFDR: "0.132333123904287"^^xsd:float .
+
+niiri:bb26c37ea84abd4f8e5aab60783b1ef4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0058" ;
+    nidm_coordinateVector: "[-36,10,24]"^^xsd:string .
+
+niiri:ed8e5afdf4dfba0fb8266ec7bb6e05ea prov:wasDerivedFrom niiri:09cd915bf2b2b51b32d56249f304bbce .
+
+niiri:8999f6eb178b306d0ec123f3b221f83e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0059" ;
+    prov:atLocation niiri:2fbd5acd6bb5ef2ba1473f87c213d4aa ;
+    prov:value "13.7912406921387"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.22145599369965"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000637705235827735"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999963824"^^xsd:float ;
+    nidm_qValueFDR: "0.133173984174016"^^xsd:float .
+
+niiri:2fbd5acd6bb5ef2ba1473f87c213d4aa
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0059" ;
+    nidm_coordinateVector: "[30,-78,14]"^^xsd:string .
+
+niiri:8999f6eb178b306d0ec123f3b221f83e prov:wasDerivedFrom niiri:bf2d35b880b3d0657d2a03298074406e .
+
+niiri:089d2f5ca65585c3d01817a9bdbf214f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0060" ;
+    prov:atLocation niiri:b64d2f396f19bac0e190ab99328b9677 ;
+    prov:value "13.629490852356"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.20320002112963"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000679547746644249"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999988489"^^xsd:float ;
+    nidm_qValueFDR: "0.136764826883915"^^xsd:float .
+
+niiri:b64d2f396f19bac0e190ab99328b9677
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0060" ;
+    nidm_coordinateVector: "[18,-78,12]"^^xsd:string .
+
+niiri:089d2f5ca65585c3d01817a9bdbf214f prov:wasDerivedFrom niiri:56bc4504cec954daf4a701610ddf59b3 .
+
+niiri:e1eec1e6fba3322a1a6483846b8a91d8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0061" ;
+    prov:atLocation niiri:dc2ecabdf71bb61760c0219ad76cb53e ;
+    prov:value "13.5061225891113"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.18916981007524"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000713410180681495"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999995369"^^xsd:float ;
+    nidm_qValueFDR: "0.139253735873803"^^xsd:float .
+
+niiri:dc2ecabdf71bb61760c0219ad76cb53e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0061" ;
+    nidm_coordinateVector: "[46,8,-16]"^^xsd:string .
+
+niiri:e1eec1e6fba3322a1a6483846b8a91d8 prov:wasDerivedFrom niiri:baa1270c4a9c0f72989c973b2fbb309d .
+
+niiri:d434f3bdadeaac5eb9b817cb94e825e9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0062" ;
+    prov:atLocation niiri:3a03e910b24e3e930f0b6b6c9e5c737b ;
+    prov:value "13.4754667282104"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.1856690050705"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000722098618250455"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999996325"^^xsd:float ;
+    nidm_qValueFDR: "0.1402954623971"^^xsd:float .
+
+niiri:3a03e910b24e3e930f0b6b6c9e5c737b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0062" ;
+    nidm_coordinateVector: "[58,-40,50]"^^xsd:string .
+
+niiri:d434f3bdadeaac5eb9b817cb94e825e9 prov:wasDerivedFrom niiri:39b258c34ddafd00d7dff6d208f62918 .
+
+niiri:73253ea75fa4c291c1dccb3b8aadedf9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0063" ;
+    prov:atLocation niiri:843cc3a9443e428c80dd3e5419ef67ec ;
+    prov:value "13.4480972290039"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.18253860543696"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000729950259848011"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999997016"^^xsd:float ;
+    nidm_qValueFDR: "0.140840039531724"^^xsd:float .
+
+niiri:843cc3a9443e428c80dd3e5419ef67ec
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0063" ;
+    nidm_coordinateVector: "[46,-66,32]"^^xsd:string .
+
+niiri:73253ea75fa4c291c1dccb3b8aadedf9 prov:wasDerivedFrom niiri:ea112296db729b94dfce05991c3d6989 .
+
+niiri:0250c5bfb4ece9672c03eeceb0f7b02f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0064" ;
+    prov:atLocation niiri:3c2b90faeb19728391b223147a6272ef ;
+    prov:value "13.2857608795166"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.16387572537233"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000778416284459293"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999163"^^xsd:float ;
+    nidm_qValueFDR: "0.14332751949213"^^xsd:float .
+
+niiri:3c2b90faeb19728391b223147a6272ef
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0064" ;
+    nidm_coordinateVector: "[2,-76,8]"^^xsd:string .
+
+niiri:0250c5bfb4ece9672c03eeceb0f7b02f prov:wasDerivedFrom niiri:a41eeb9ba04d7788ba686542607ff1cc .
+
+niiri:9efe1a64a6e8c8950d8b7cab41638bf4
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0065" ;
+    prov:atLocation niiri:6cd33ece9349946e05442ff70eafc454 ;
+    prov:value "13.2286987304688"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.15727638472708"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000796251631906664"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999472"^^xsd:float ;
+    nidm_qValueFDR: "0.143821550671959"^^xsd:float .
+
+niiri:6cd33ece9349946e05442ff70eafc454
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0065" ;
+    nidm_coordinateVector: "[14,-24,-2]"^^xsd:string .
+
+niiri:9efe1a64a6e8c8950d8b7cab41638bf4 prov:wasDerivedFrom niiri:9c7b81143edac28cf680878e9177494c .
+
+niiri:6a326f32141b8c0a3055d65d9f6a8649
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0066" ;
+    prov:atLocation niiri:b5b1c97968ad3124f2e761ecead8345e ;
+    prov:value "13.0621271133423"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.13789355719639"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00085083330089919"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999869"^^xsd:float ;
+    nidm_qValueFDR: "0.146648454262555"^^xsd:float .
+
+niiri:b5b1c97968ad3124f2e761ecead8345e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0066" ;
+    nidm_coordinateVector: "[-36,0,-4]"^^xsd:string .
+
+niiri:6a326f32141b8c0a3055d65d9f6a8649 prov:wasDerivedFrom niiri:e854403c8636e3e481bc993eb6180f44 .
+
+niiri:cd1be6a68508e7a4ef251e742d0b5209
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0067" ;
+    prov:atLocation niiri:7e8c996c334e2b3e54960324857470e1 ;
+    prov:value "13.0451946258545"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.13591325616981"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000856599341067521"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999886"^^xsd:float ;
+    nidm_qValueFDR: "0.146787157394689"^^xsd:float .
+
+niiri:7e8c996c334e2b3e54960324857470e1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0067" ;
+    nidm_coordinateVector: "[12,6,62]"^^xsd:string .
+
+niiri:cd1be6a68508e7a4ef251e742d0b5209 prov:wasDerivedFrom niiri:7f3ebf5e2a10fd569c91dd091c7af147 .
+
+niiri:4df08c0c2756eb1b10566b4b6f695464
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0068" ;
+    prov:atLocation niiri:8fe3ed1f49a1014532022d8ff15e4b33 ;
+    prov:value "13.0064306259155"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.13137270324883"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000869955985260296"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999919"^^xsd:float ;
+    nidm_qValueFDR: "0.146787157394689"^^xsd:float .
+
+niiri:8fe3ed1f49a1014532022d8ff15e4b33
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0068" ;
+    nidm_coordinateVector: "[-8,-4,24]"^^xsd:string .
+
+niiri:4df08c0c2756eb1b10566b4b6f695464 prov:wasDerivedFrom niiri:b36c20212016b9bc7a603f3e83aca676 .
+
+niiri:f493daa250a5ea19aa9efa8d626c010a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0069" ;
+    prov:atLocation niiri:a6c74b8d30fbdf526011335c2d35ae6a ;
+    prov:value "12.968074798584"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.12687033926247"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00088338914171493"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999942"^^xsd:float ;
+    nidm_qValueFDR: "0.147244283960254"^^xsd:float .
+
+niiri:a6c74b8d30fbdf526011335c2d35ae6a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0069" ;
+    nidm_coordinateVector: "[8,-36,40]"^^xsd:string .
+
+niiri:f493daa250a5ea19aa9efa8d626c010a prov:wasDerivedFrom niiri:05115f2e683a3386f641d5816019de27 .
+
+niiri:8be7214c24c5b037d7fba75f4e6093e0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0070" ;
+    prov:atLocation niiri:2b0b836ebf6d584148281ed6f01ff393 ;
+    prov:value "12.9628992080688"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.12626207199886"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000885218504765861"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999944"^^xsd:float ;
+    nidm_qValueFDR: "0.147244283960254"^^xsd:float .
+
+niiri:2b0b836ebf6d584148281ed6f01ff393
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0070" ;
+    nidm_coordinateVector: "[24,38,0]"^^xsd:string .
+
+niiri:8be7214c24c5b037d7fba75f4e6093e0 prov:wasDerivedFrom niiri:1ee8276c32c1e03b7e0b4b1717c44a57 .
+
+niiri:3fb670bc4bf41b489875540e653fafdd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0071" ;
+    prov:atLocation niiri:60bbc4af8445689f911587e2015c11e0 ;
+    prov:value "12.9482192993164"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.12453584528173"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000890429112242686"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999951"^^xsd:float ;
+    nidm_qValueFDR: "0.14749076092896"^^xsd:float .
+
+niiri:60bbc4af8445689f911587e2015c11e0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0071" ;
+    nidm_coordinateVector: "[26,-50,46]"^^xsd:string .
+
+niiri:3fb670bc4bf41b489875540e653fafdd prov:wasDerivedFrom niiri:aa58a012c4a942174e0325d4c0b944fd .
+
+niiri:82c6fba725d300ee5b57d9b99b507dd1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0072" ;
+    prov:atLocation niiri:26c578b46a7a236fd0e9ec4b50b4b8a5 ;
+    prov:value "12.9151954650879"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.12064737190897"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000902269894699104"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999964"^^xsd:float ;
+    nidm_qValueFDR: "0.147598889605401"^^xsd:float .
+
+niiri:26c578b46a7a236fd0e9ec4b50b4b8a5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0072" ;
+    nidm_coordinateVector: "[-30,-86,8]"^^xsd:string .
+
+niiri:82c6fba725d300ee5b57d9b99b507dd1 prov:wasDerivedFrom niiri:69b1d9ea8525a6a583365384e39cf9e8 .
+
+niiri:f6b78515f73bc27f172ee4971b59d62c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0073" ;
+    prov:atLocation niiri:df70ae256a22280944b76c315708af2e ;
+    prov:value "12.8661985397339"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.11486488202419"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00092014594111034"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999977"^^xsd:float ;
+    nidm_qValueFDR: "0.147847736781403"^^xsd:float .
+
+niiri:df70ae256a22280944b76c315708af2e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0073" ;
+    nidm_coordinateVector: "[22,-24,38]"^^xsd:string .
+
+niiri:f6b78515f73bc27f172ee4971b59d62c prov:wasDerivedFrom niiri:f6d9af16709f321130aa58504e6604c5 .
+
+niiri:7da556aa1244db607c1e49d0f196cfa5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0074" ;
+    prov:atLocation niiri:bc4dcce56afafebd60de994b46b169af ;
+    prov:value "12.8156299591064"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.10888025138563"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000938989080538355"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999985"^^xsd:float ;
+    nidm_qValueFDR: "0.148123448926347"^^xsd:float .
+
+niiri:bc4dcce56afafebd60de994b46b169af
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0074" ;
+    nidm_coordinateVector: "[48,50,2]"^^xsd:string .
+
+niiri:7da556aa1244db607c1e49d0f196cfa5 prov:wasDerivedFrom niiri:be347b3d17b0cf1b2b8f3ad6860ae399 .
+
+niiri:23689147c9f9a1cfc3640674405fb6af
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0075" ;
+    prov:atLocation niiri:856080bfa95af62a2310e7f77d678b86 ;
+    prov:value "12.7734069824219"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.10387025917553"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000955035352381506"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999999999"^^xsd:float ;
+    nidm_qValueFDR: "0.149144835108449"^^xsd:float .
+
+niiri:856080bfa95af62a2310e7f77d678b86
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0075" ;
+    nidm_coordinateVector: "[-48,-68,20]"^^xsd:string .
+
+niiri:23689147c9f9a1cfc3640674405fb6af prov:wasDerivedFrom niiri:fb10f43ffe914843271a8cdefab5f898 .
+
+niiri:7dccdae3f638e89023329e9d2f66c954
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0076" ;
+    prov:atLocation niiri:aec1651baeec9ebce473514a2520d9ac ;
+    prov:value "12.7362623214722"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.0994529756118"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000969391758882221"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
+    nidm_qValueFDR: "0.150376120259304"^^xsd:float .
+
+niiri:aec1651baeec9ebce473514a2520d9ac
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0076" ;
+    nidm_coordinateVector: "[24,-22,36]"^^xsd:string .
+
+niiri:7dccdae3f638e89023329e9d2f66c954 prov:wasDerivedFrom niiri:ac129c99f1ae280d6d0a6f24c04b617a .
+

--- a/spmexport/ex_spm_non_sphericity/nidm.ttl
+++ b/spmexport/ex_spm_non_sphericity/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:7b4cf04d3e03731e8b127b5ef008e6ba
+niiri:99dc1e7d9ba53c5c6f18c0f640fee6e0
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:b823f4f8cbc1c10feef0f31492474351
+niiri:b7874a1ae03c388637bdda802a0ec6d0
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:2df4836000438363ab93c2c037ea1c9f
+niiri:8406d28dc5a6ff3dcee923e5b77a172c
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:2df4836000438363ab93c2c037ea1c9f prov:wasAssociatedWith niiri:b823f4f8cbc1c10feef0f31492474351 .
+niiri:8406d28dc5a6ff3dcee923e5b77a172c prov:wasAssociatedWith niiri:b7874a1ae03c388637bdda802a0ec6d0 .
 
 _:blank5 a prov:Generation .
 
-niiri:7b4cf04d3e03731e8b127b5ef008e6ba prov:qualifiedGeneration _:blank5 .
+niiri:99dc1e7d9ba53c5c6f18c0f640fee6e0 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:33:49"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:44:11"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -131,12 +131,12 @@ _:blank5 prov:atTime "2016-01-11T10:33:49"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:8707d65d3a15dbf845684e80f7df9da7
+niiri:234c7e043e4aca8ed9fefeb09a8d256c
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:c91eabb6ae30ecd695a7cf4b3fcab893
+niiri:762e57d57e56c8570d19ee32ae1e75c3
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -146,27 +146,27 @@ niiri:c91eabb6ae30ecd695a7cf4b3fcab893
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:34de00e96ed7c645577a52f0e7289dc5
+niiri:6d6a8f3ee06f679449aee413b3618fcf
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean .
 
-niiri:c75f4ff351459ee32fa91d23800efb92
+niiri:9b05a6ff4dfa65e2cb2f77532ccb5456
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:3065da080a203d349041ec0f402e8e33 ;
+    dc:description niiri:bebd9964776e1393e484606bdc3b8b5c ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]"^^xsd:string .
 
-niiri:3065da080a203d349041ec0f402e8e33
+niiri:bebd9964776e1393e484606bdc3b8b5c
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:d6bb9097d5397477b9a2fe34b1e173d1
+niiri:c4151781347f6d33fd68abb19f8b2ec3
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_UnstructuredCorrelationStructure: ;
@@ -174,162 +174,162 @@ niiri:d6bb9097d5397477b9a2fe34b1e173d1
     nidm_errorVarianceHomogeneous: "false"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:48bd386fe0be968592a13062b5c43885
+niiri:d9ae952dd939b0fc1e59859df92ddc2a
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:48bd386fe0be968592a13062b5c43885 prov:wasAssociatedWith niiri:8707d65d3a15dbf845684e80f7df9da7 .
+niiri:d9ae952dd939b0fc1e59859df92ddc2a prov:wasAssociatedWith niiri:234c7e043e4aca8ed9fefeb09a8d256c .
 
-niiri:48bd386fe0be968592a13062b5c43885 prov:used niiri:c75f4ff351459ee32fa91d23800efb92 .
+niiri:d9ae952dd939b0fc1e59859df92ddc2a prov:used niiri:9b05a6ff4dfa65e2cb2f77532ccb5456 .
 
-niiri:48bd386fe0be968592a13062b5c43885 prov:used niiri:34de00e96ed7c645577a52f0e7289dc5 .
+niiri:d9ae952dd939b0fc1e59859df92ddc2a prov:used niiri:6d6a8f3ee06f679449aee413b3618fcf .
 
-niiri:48bd386fe0be968592a13062b5c43885 prov:used niiri:d6bb9097d5397477b9a2fe34b1e173d1 .
+niiri:d9ae952dd939b0fc1e59859df92ddc2a prov:used niiri:c4151781347f6d33fd68abb19f8b2ec3 .
 
-niiri:9f3d2992eab79fd14d4660154ae8238a
+niiri:4f82f60faefd085ffe16261907d905b5
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:5e1b296cb7615ea4c933955980cef164
+niiri:793decdab241256463612be93f874e2e
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e"^^xsd:string .
 
-niiri:9f3d2992eab79fd14d4660154ae8238a prov:wasDerivedFrom niiri:5e1b296cb7615ea4c933955980cef164 .
+niiri:4f82f60faefd085ffe16261907d905b5 prov:wasDerivedFrom niiri:793decdab241256463612be93f874e2e .
 
-niiri:9f3d2992eab79fd14d4660154ae8238a prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
+niiri:4f82f60faefd085ffe16261907d905b5 prov:wasGeneratedBy niiri:d9ae952dd939b0fc1e59859df92ddc2a .
 
-niiri:2907b9f1080a55bf3a3b5fde0463d565
+niiri:49b46b2346703f97e806a5849e3e5d9d
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "0.0511472336947918"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 ;
     crypto:sha512 "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc"^^xsd:string .
 
-niiri:2907b9f1080a55bf3a3b5fde0463d565 prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
+niiri:49b46b2346703f97e806a5849e3e5d9d prov:wasGeneratedBy niiri:d9ae952dd939b0fc1e59859df92ddc2a .
 
-niiri:fd2e03999ed8a414f71235a7246666d9
+niiri:8514e027e15dd49a399e30c4b202c1f3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 .
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 .
 
-niiri:ba6d197e4b83b9354b3d92dc6cdbe6e7
+niiri:142a5fc026254184050862a8debfcca8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f"^^xsd:string .
 
-niiri:fd2e03999ed8a414f71235a7246666d9 prov:wasDerivedFrom niiri:ba6d197e4b83b9354b3d92dc6cdbe6e7 .
+niiri:8514e027e15dd49a399e30c4b202c1f3 prov:wasDerivedFrom niiri:142a5fc026254184050862a8debfcca8 .
 
-niiri:fd2e03999ed8a414f71235a7246666d9 prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
+niiri:8514e027e15dd49a399e30c4b202c1f3 prov:wasGeneratedBy niiri:d9ae952dd939b0fc1e59859df92ddc2a .
 
-niiri:af828ebe888a0cdbc655a60d27afaa91
+niiri:74aaa5804ac9ac06ff6ffa92cb2b4204
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 .
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 .
 
-niiri:a4ab3adcdfcd06863c089ef11dfef36a
+niiri:db601c927922d2467db6d794e787485a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978"^^xsd:string .
 
-niiri:af828ebe888a0cdbc655a60d27afaa91 prov:wasDerivedFrom niiri:a4ab3adcdfcd06863c089ef11dfef36a .
+niiri:74aaa5804ac9ac06ff6ffa92cb2b4204 prov:wasDerivedFrom niiri:db601c927922d2467db6d794e787485a .
 
-niiri:af828ebe888a0cdbc655a60d27afaa91 prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
+niiri:74aaa5804ac9ac06ff6ffa92cb2b4204 prov:wasGeneratedBy niiri:d9ae952dd939b0fc1e59859df92ddc2a .
 
-niiri:bd9421d9a41bc778b27e2be0eda0496f
+niiri:b69ac8eaca662c7c4998f0d7ed7d5c1a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 .
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 .
 
-niiri:db047f8eefe5537016244f0bb25e3637
+niiri:4c1d5f9c25d6cc2aa583c90fb8fd5662
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a"^^xsd:string .
 
-niiri:bd9421d9a41bc778b27e2be0eda0496f prov:wasDerivedFrom niiri:db047f8eefe5537016244f0bb25e3637 .
+niiri:b69ac8eaca662c7c4998f0d7ed7d5c1a prov:wasDerivedFrom niiri:4c1d5f9c25d6cc2aa583c90fb8fd5662 .
 
-niiri:bd9421d9a41bc778b27e2be0eda0496f prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
+niiri:b69ac8eaca662c7c4998f0d7ed7d5c1a prov:wasGeneratedBy niiri:d9ae952dd939b0fc1e59859df92ddc2a .
 
-niiri:dc244080dfe10dc4223d65ff1b5587f2
+niiri:2756551f850c95c68505ddc97c07c28c
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 ;
     crypto:sha512 "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48"^^xsd:string .
 
-niiri:ade1763484de1aa955eb941d8892ffcb
+niiri:c7212c5edf8cabf87aaf95d8e4fd4b1f
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868"^^xsd:string .
 
-niiri:dc244080dfe10dc4223d65ff1b5587f2 prov:wasDerivedFrom niiri:ade1763484de1aa955eb941d8892ffcb .
+niiri:2756551f850c95c68505ddc97c07c28c prov:wasDerivedFrom niiri:c7212c5edf8cabf87aaf95d8e4fd4b1f .
 
-niiri:dc244080dfe10dc4223d65ff1b5587f2 prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
+niiri:2756551f850c95c68505ddc97c07c28c prov:wasGeneratedBy niiri:d9ae952dd939b0fc1e59859df92ddc2a .
 
-niiri:86e735169b95dc7176008fba7b0cbabd
+niiri:db3b899f360335973148454d21c7bf0b
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 ;
     crypto:sha512 "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381"^^xsd:string .
 
-niiri:a2f5143ec88d6b7200a0d1b34f1c06ab
+niiri:c126d1c14db853f6fffea497964fa3ea
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8"^^xsd:string .
 
-niiri:86e735169b95dc7176008fba7b0cbabd prov:wasDerivedFrom niiri:a2f5143ec88d6b7200a0d1b34f1c06ab .
+niiri:db3b899f360335973148454d21c7bf0b prov:wasDerivedFrom niiri:c126d1c14db853f6fffea497964fa3ea .
 
-niiri:86e735169b95dc7176008fba7b0cbabd prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
+niiri:db3b899f360335973148454d21c7bf0b prov:wasGeneratedBy niiri:d9ae952dd939b0fc1e59859df92ddc2a .
 
-niiri:99e218282e31bd12efdffa7662e50016
+niiri:36290d7c38277ec084868686167f98c6
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_FStatistic: ;
     nidm_contrastName: "Average effect of condition"^^xsd:string ;
     rdfs:label "Contrast: Average effect of condition" ;
     prov:value "[1, 1, 1]"^^xsd:string .
 
-niiri:f30c53c09afee24faac70ef520464dcc
+niiri:3c77450bfe975012c43cc1c35a7e8df9
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:f30c53c09afee24faac70ef520464dcc prov:wasAssociatedWith niiri:8707d65d3a15dbf845684e80f7df9da7 .
+niiri:3c77450bfe975012c43cc1c35a7e8df9 prov:wasAssociatedWith niiri:234c7e043e4aca8ed9fefeb09a8d256c .
 
-niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:9f3d2992eab79fd14d4660154ae8238a .
+niiri:3c77450bfe975012c43cc1c35a7e8df9 prov:used niiri:4f82f60faefd085ffe16261907d905b5 .
 
-niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:dc244080dfe10dc4223d65ff1b5587f2 .
+niiri:3c77450bfe975012c43cc1c35a7e8df9 prov:used niiri:2756551f850c95c68505ddc97c07c28c .
 
-niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:c75f4ff351459ee32fa91d23800efb92 .
+niiri:3c77450bfe975012c43cc1c35a7e8df9 prov:used niiri:9b05a6ff4dfa65e2cb2f77532ccb5456 .
 
-niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:99e218282e31bd12efdffa7662e50016 .
+niiri:3c77450bfe975012c43cc1c35a7e8df9 prov:used niiri:36290d7c38277ec084868686167f98c6 .
 
-niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:fd2e03999ed8a414f71235a7246666d9 .
+niiri:3c77450bfe975012c43cc1c35a7e8df9 prov:used niiri:8514e027e15dd49a399e30c4b202c1f3 .
 
-niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:af828ebe888a0cdbc655a60d27afaa91 .
+niiri:3c77450bfe975012c43cc1c35a7e8df9 prov:used niiri:74aaa5804ac9ac06ff6ffa92cb2b4204 .
 
-niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:bd9421d9a41bc778b27e2be0eda0496f .
+niiri:3c77450bfe975012c43cc1c35a7e8df9 prov:used niiri:b69ac8eaca662c7c4998f0d7ed7d5c1a .
 
-niiri:67b4a4f6b336096ca6b563aa31361183
+niiri:577e331ed1c3ff69dc99e6f96e20ad41
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
@@ -339,104 +339,104 @@ niiri:67b4a4f6b336096ca6b563aa31361183
     nidm_contrastName: "Average effect of condition"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "39"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 ;
     crypto:sha512 "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960"^^xsd:string .
 
-niiri:70bdd0befd9857e4ff6434527df6ac2c
+niiri:4e1d261dffd37f590ebc9108f1036f1b
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmF_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762"^^xsd:string .
 
-niiri:67b4a4f6b336096ca6b563aa31361183 prov:wasDerivedFrom niiri:70bdd0befd9857e4ff6434527df6ac2c .
+niiri:577e331ed1c3ff69dc99e6f96e20ad41 prov:wasDerivedFrom niiri:4e1d261dffd37f590ebc9108f1036f1b .
 
-niiri:67b4a4f6b336096ca6b563aa31361183 prov:wasGeneratedBy niiri:f30c53c09afee24faac70ef520464dcc .
+niiri:577e331ed1c3ff69dc99e6f96e20ad41 prov:wasGeneratedBy niiri:3c77450bfe975012c43cc1c35a7e8df9 .
 
-niiri:23c30668e6a9efa0ff2e602769536cb0
+niiri:6411aeed5f90e0dc568d5646456b0c89
     a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
     prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Explained Mean Square Map" ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 ;
     crypto:sha512 "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a"^^xsd:string .
 
-niiri:23c30668e6a9efa0ff2e602769536cb0 prov:wasGeneratedBy niiri:f30c53c09afee24faac70ef520464dcc .
+niiri:6411aeed5f90e0dc568d5646456b0c89 prov:wasGeneratedBy niiri:3c77450bfe975012c43cc1c35a7e8df9 .
 
-niiri:40440229b29f5872d53eef25ecf0f975
+niiri:5a23de0647497e69518d9ecbd7dd2993
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500201896764"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:2c452674a1f81d156e269dbe9725998a ;
-    nidm_equivalentThreshold: niiri:15ee33831544a51d39b276ac0d45c0cb .
+    nidm_equivalentThreshold: niiri:9589dc23e84a662f161ab3515e2f989b ;
+    nidm_equivalentThreshold: niiri:d19aebd9783b84a7c2479ca6e65ba6ac .
 
-niiri:2c452674a1f81d156e269dbe9725998a
+niiri:9589dc23e84a662f161ab3515e2f989b
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "12.6602184255263"^^xsd:float .
 
-niiri:15ee33831544a51d39b276ac0d45c0cb
+niiri:d19aebd9783b84a7c2479ca6e65ba6ac
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:981d4a611d50d796152b8e8eb6283194
+niiri:b7917679b11eb67ab1ab21dfde06646f
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:3455442e086debfe280887e4ef34a59a ;
-    nidm_equivalentThreshold: niiri:eec7cc036dfbc9f23b1c4ad9eede1da3 .
+    nidm_equivalentThreshold: niiri:d50e394152f7c5db5c7133e1470974d6 ;
+    nidm_equivalentThreshold: niiri:4f1457a0836d72fad4ea9d0eead06e77 .
 
-niiri:3455442e086debfe280887e4ef34a59a
+niiri:d50e394152f7c5db5c7133e1470974d6
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:eec7cc036dfbc9f23b1c4ad9eede1da3
+niiri:4f1457a0836d72fad4ea9d0eead06e77
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:ae1827b0fff51351ca6d76d580243226
+niiri:423f12bcbd6d374ee66c9f2a2e4c948f
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:00a53452216f98c5cdd45baf25410a08
+niiri:7487ab156945a06f5c7ec5c417b4ea5b
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db
+niiri:b5d284eb0075094514b80a3e61142bca
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:wasAssociatedWith niiri:8707d65d3a15dbf845684e80f7df9da7 .
+niiri:b5d284eb0075094514b80a3e61142bca prov:wasAssociatedWith niiri:234c7e043e4aca8ed9fefeb09a8d256c .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:40440229b29f5872d53eef25ecf0f975 .
+niiri:b5d284eb0075094514b80a3e61142bca prov:used niiri:5a23de0647497e69518d9ecbd7dd2993 .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:981d4a611d50d796152b8e8eb6283194 .
+niiri:b5d284eb0075094514b80a3e61142bca prov:used niiri:b7917679b11eb67ab1ab21dfde06646f .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:67b4a4f6b336096ca6b563aa31361183 .
+niiri:b5d284eb0075094514b80a3e61142bca prov:used niiri:577e331ed1c3ff69dc99e6f96e20ad41 .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:86e735169b95dc7176008fba7b0cbabd .
+niiri:b5d284eb0075094514b80a3e61142bca prov:used niiri:db3b899f360335973148454d21c7bf0b .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:9f3d2992eab79fd14d4660154ae8238a .
+niiri:b5d284eb0075094514b80a3e61142bca prov:used niiri:4f82f60faefd085ffe16261907d905b5 .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:ae1827b0fff51351ca6d76d580243226 .
+niiri:b5d284eb0075094514b80a3e61142bca prov:used niiri:423f12bcbd6d374ee66c9f2a2e4c948f .
 
-niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:00a53452216f98c5cdd45baf25410a08 .
+niiri:b5d284eb0075094514b80a3e61142bca prov:used niiri:7487ab156945a06f5c7ec5c417b4ea5b .
 
-niiri:144940fea03f1e81a40c282fefbe54f4
+niiri:6ddf1c015bd8fb5b1a30ef647d9f65e2
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 ;
     nidm_searchVolumeInVoxels: "167222"^^xsd:int ;
     nidm_searchVolumeInUnits: "1337776"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.5679161280351"^^xsd:float ;
@@ -453,9 +453,9 @@ niiri:144940fea03f1e81a40c282fefbe54f4
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "57"^^xsd:int ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:144940fea03f1e81a40c282fefbe54f4 prov:wasGeneratedBy niiri:9ea94d4c881c3057dcce3e08fa91b4db .
+niiri:6ddf1c015bd8fb5b1a30ef647d9f65e2 prov:wasGeneratedBy niiri:b5d284eb0075094514b80a3e61142bca .
 
-niiri:a79e189fef35c2ea79f265fe43ab3fd5
+niiri:3306774fd09ce4866577fe9443b964ef
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -463,26 +463,26 @@ niiri:a79e189fef35c2ea79f265fe43ab3fd5
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "71"^^xsd:int ;
     nidm_pValue: "9.36073596413678e-09"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:f36222cc921e73ce4c2371f2c0ddc287 ;
-    nidm_hasMaximumIntensityProjection: niiri:cf3dd6a7998b23db2dee0adcb3e1f4d7 ;
-    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
+    nidm_hasClusterLabelsMap: niiri:e45e235dce1fd30780f52611e0c22812 ;
+    nidm_hasMaximumIntensityProjection: niiri:a0d4a6364727910bf49b77221a804961 ;
+    nidm_inCoordinateSpace: niiri:762e57d57e56c8570d19ee32ae1e75c3 ;
     crypto:sha512 "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006"^^xsd:string .
 
-niiri:f36222cc921e73ce4c2371f2c0ddc287
+niiri:e45e235dce1fd30780f52611e0c22812
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:cf3dd6a7998b23db2dee0adcb3e1f4d7
+niiri:a0d4a6364727910bf49b77221a804961
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:a79e189fef35c2ea79f265fe43ab3fd5 prov:wasGeneratedBy niiri:9ea94d4c881c3057dcce3e08fa91b4db .
+niiri:3306774fd09ce4866577fe9443b964ef prov:wasGeneratedBy niiri:b5d284eb0075094514b80a3e61142bca .
 
-niiri:fcafd29e2d4984d5ef1a1e4525c5ba42
+niiri:4c1f276d9af9d476ea0e6263c11e3928
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "64"^^xsd:int ;
@@ -492,9 +492,9 @@ niiri:fcafd29e2d4984d5ef1a1e4525c5ba42
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:fcafd29e2d4984d5ef1a1e4525c5ba42 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:4c1f276d9af9d476ea0e6263c11e3928 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:444cc626db04f602c9c9011fa5e21c84
+niiri:6dfa7cc864f8425fe2ca83d23d9f375e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "139"^^xsd:int ;
@@ -504,9 +504,9 @@ niiri:444cc626db04f602c9c9011fa5e21c84
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:444cc626db04f602c9c9011fa5e21c84 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:6dfa7cc864f8425fe2ca83d23d9f375e prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:b1753f3aee975cc2167fd8ecc371ac5b
+niiri:e1dc5ba7de5b768eb8d9fdd13abef0cf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "99"^^xsd:int ;
@@ -516,9 +516,9 @@ niiri:b1753f3aee975cc2167fd8ecc371ac5b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:b1753f3aee975cc2167fd8ecc371ac5b prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:e1dc5ba7de5b768eb8d9fdd13abef0cf prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:e217bff071e4c58201ab9d5e50316202
+niiri:ec2dccfb1ebaaaf8d91e33c14f11f3ea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "100"^^xsd:int ;
@@ -528,9 +528,9 @@ niiri:e217bff071e4c58201ab9d5e50316202
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:e217bff071e4c58201ab9d5e50316202 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:ec2dccfb1ebaaaf8d91e33c14f11f3ea prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:293f17b4b9a3d5e7642f3136e988fb69
+niiri:122c2e266aeef305c550f167cf916f71
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -540,9 +540,9 @@ niiri:293f17b4b9a3d5e7642f3136e988fb69
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:293f17b4b9a3d5e7642f3136e988fb69 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:122c2e266aeef305c550f167cf916f71 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:f39819aeb0366241cbbae35a6427fc8b
+niiri:1f521c6f09c963d12ee383c50f6388b1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "42"^^xsd:int ;
@@ -552,9 +552,9 @@ niiri:f39819aeb0366241cbbae35a6427fc8b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:f39819aeb0366241cbbae35a6427fc8b prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:1f521c6f09c963d12ee383c50f6388b1 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:804f36b4efe7eb06f1a23107f02c9522
+niiri:27132a256d54493c9f080d2bc58b4156
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -564,9 +564,9 @@ niiri:804f36b4efe7eb06f1a23107f02c9522
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:804f36b4efe7eb06f1a23107f02c9522 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:27132a256d54493c9f080d2bc58b4156 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:808fd4e2193f0ed5ab2626fc643077ca
+niiri:7054c75c48fb30d1f27ab2bbb0333840
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "57"^^xsd:int ;
@@ -576,9 +576,9 @@ niiri:808fd4e2193f0ed5ab2626fc643077ca
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:808fd4e2193f0ed5ab2626fc643077ca prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:7054c75c48fb30d1f27ab2bbb0333840 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:2667f28dbb2bce2c8e774ae24bc32c34
+niiri:40921ed9322bcbb9736f38620e4e285a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -588,9 +588,9 @@ niiri:2667f28dbb2bce2c8e774ae24bc32c34
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:2667f28dbb2bce2c8e774ae24bc32c34 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:40921ed9322bcbb9736f38620e4e285a prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:81153168c82f38e0344a3da5990713f4
+niiri:7d90f7765940a5ab337f7643782ed47c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -600,9 +600,9 @@ niiri:81153168c82f38e0344a3da5990713f4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:81153168c82f38e0344a3da5990713f4 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:7d90f7765940a5ab337f7643782ed47c prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:51df67b679cd0aa1c10588b2540f80ff
+niiri:adb148e8a32d9f1ce4153efd0ac2dbc6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -612,9 +612,9 @@ niiri:51df67b679cd0aa1c10588b2540f80ff
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:51df67b679cd0aa1c10588b2540f80ff prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:adb148e8a32d9f1ce4153efd0ac2dbc6 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:c3859302a7f8a3aa876923fe5311fdeb
+niiri:4b83b464e56c198d5b02a944ed283f4f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -624,9 +624,9 @@ niiri:c3859302a7f8a3aa876923fe5311fdeb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:c3859302a7f8a3aa876923fe5311fdeb prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:4b83b464e56c198d5b02a944ed283f4f prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:a9683c02ec255a54e2147300ce75147c
+niiri:0c7c2733a41b8cb85ab46d0144d6798a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -636,9 +636,9 @@ niiri:a9683c02ec255a54e2147300ce75147c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:a9683c02ec255a54e2147300ce75147c prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:0c7c2733a41b8cb85ab46d0144d6798a prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:4b0d5b1cbdc197add17ddae11c60a960
+niiri:f4caac7418e57d3e43a996a7ba654c2f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -648,9 +648,9 @@ niiri:4b0d5b1cbdc197add17ddae11c60a960
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:4b0d5b1cbdc197add17ddae11c60a960 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:f4caac7418e57d3e43a996a7ba654c2f prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:074f24af2809bb5962437625180d87d8
+niiri:cd181349ed02b711f1a6828158bcf43a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -660,9 +660,9 @@ niiri:074f24af2809bb5962437625180d87d8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:074f24af2809bb5962437625180d87d8 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:cd181349ed02b711f1a6828158bcf43a prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:3950399d3cc373d8735fcf48ad86f542
+niiri:e79df66e13024ab7771ec5eb685083aa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "35"^^xsd:int ;
@@ -672,9 +672,9 @@ niiri:3950399d3cc373d8735fcf48ad86f542
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:3950399d3cc373d8735fcf48ad86f542 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:e79df66e13024ab7771ec5eb685083aa prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:bab302ab1de7ceb32ee2a4553bab718d
+niiri:196e757350d816ffa8ac1b4ae4acb7b7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -684,9 +684,9 @@ niiri:bab302ab1de7ceb32ee2a4553bab718d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:bab302ab1de7ceb32ee2a4553bab718d prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:196e757350d816ffa8ac1b4ae4acb7b7 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:14ab5f557514798d8218e39a2199e27a
+niiri:fe44f10323dac9699d3966ced3bfaa90
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "46"^^xsd:int ;
@@ -696,9 +696,9 @@ niiri:14ab5f557514798d8218e39a2199e27a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:14ab5f557514798d8218e39a2199e27a prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:fe44f10323dac9699d3966ced3bfaa90 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:bc603717c0c5d8a8779b8aa6c28564b3
+niiri:ec03a5611c90a708dd60390dcb8ecc38
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -708,9 +708,9 @@ niiri:bc603717c0c5d8a8779b8aa6c28564b3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:bc603717c0c5d8a8779b8aa6c28564b3 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:ec03a5611c90a708dd60390dcb8ecc38 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:106ee2638843f2793b5ac6735acad91e
+niiri:56e6c7924a2f68ad79e3f7a7ae002bc4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -720,9 +720,9 @@ niiri:106ee2638843f2793b5ac6735acad91e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:106ee2638843f2793b5ac6735acad91e prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:56e6c7924a2f68ad79e3f7a7ae002bc4 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:01c1ab06b5a4997e0980bcddb0f69696
+niiri:cdfaf6b796e2c2557787c484faec4633
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -732,9 +732,9 @@ niiri:01c1ab06b5a4997e0980bcddb0f69696
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:01c1ab06b5a4997e0980bcddb0f69696 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:cdfaf6b796e2c2557787c484faec4633 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:8f249184eec9591adc7a3fc1c7e37936
+niiri:f3fd301ca5fc6b876a28a4e840896ae7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -744,9 +744,9 @@ niiri:8f249184eec9591adc7a3fc1c7e37936
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:8f249184eec9591adc7a3fc1c7e37936 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:f3fd301ca5fc6b876a28a4e840896ae7 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:c7ba1e0ca7a63ee914a7fa6cddbda281
+niiri:384bbe6b71ec2ae3109307c983930490
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -756,9 +756,9 @@ niiri:c7ba1e0ca7a63ee914a7fa6cddbda281
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:c7ba1e0ca7a63ee914a7fa6cddbda281 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:384bbe6b71ec2ae3109307c983930490 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:91987e35b1d8c15af66e3327a6e4b602
+niiri:19cd545bb290d6b4b5d50c3ca0b0d8e8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -768,9 +768,9 @@ niiri:91987e35b1d8c15af66e3327a6e4b602
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:91987e35b1d8c15af66e3327a6e4b602 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:19cd545bb290d6b4b5d50c3ca0b0d8e8 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:c09f3990ca4bd168f93fa27a56eeb56c
+niiri:1e795237a34002c8edd0e85dd55bd6db
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -780,9 +780,9 @@ niiri:c09f3990ca4bd168f93fa27a56eeb56c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:c09f3990ca4bd168f93fa27a56eeb56c prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:1e795237a34002c8edd0e85dd55bd6db prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:4f39525fd234b098e759c0ffc971fd5b
+niiri:a4f5ae0b708bf7e12619874d39f89768
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -792,9 +792,9 @@ niiri:4f39525fd234b098e759c0ffc971fd5b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:4f39525fd234b098e759c0ffc971fd5b prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:a4f5ae0b708bf7e12619874d39f89768 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:66eca61ada8ceb626c8ffd13d3efa1cc
+niiri:98a7f50d7445498f6d5c6b8931b0b269
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "25"^^xsd:int ;
@@ -804,9 +804,9 @@ niiri:66eca61ada8ceb626c8ffd13d3efa1cc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:66eca61ada8ceb626c8ffd13d3efa1cc prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:98a7f50d7445498f6d5c6b8931b0b269 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:5cf9402b2b494a87640a66aec1a6fdaf
+niiri:0f673bfb48646ef7ce92732ddcd2561d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -816,9 +816,9 @@ niiri:5cf9402b2b494a87640a66aec1a6fdaf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:5cf9402b2b494a87640a66aec1a6fdaf prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:0f673bfb48646ef7ce92732ddcd2561d prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:1cd1f14fea72d133db88783e1b907b7f
+niiri:e4e7c604a0dfd11b952f2d763f8365a1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -828,9 +828,9 @@ niiri:1cd1f14fea72d133db88783e1b907b7f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:1cd1f14fea72d133db88783e1b907b7f prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:e4e7c604a0dfd11b952f2d763f8365a1 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:c3340fa012c626e62e86cdb279a4e883
+niiri:4fec6e6678455cee0511a392e629ec66
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -840,9 +840,9 @@ niiri:c3340fa012c626e62e86cdb279a4e883
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:c3340fa012c626e62e86cdb279a4e883 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:4fec6e6678455cee0511a392e629ec66 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd
+niiri:df39775c5b1f38c8f9be672ec1fd63ff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -852,9 +852,9 @@ niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:df39775c5b1f38c8f9be672ec1fd63ff prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:8b25738f634743abd67e5fd856e90f74
+niiri:d89f1264b6a74fc289ac86f3b1b14dde
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -864,9 +864,9 @@ niiri:8b25738f634743abd67e5fd856e90f74
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:8b25738f634743abd67e5fd856e90f74 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:d89f1264b6a74fc289ac86f3b1b14dde prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:1c59a22b32098831723dc21703615fd1
+niiri:6b099ac0f252fd44544d43dc12a3d6df
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -876,9 +876,9 @@ niiri:1c59a22b32098831723dc21703615fd1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:1c59a22b32098831723dc21703615fd1 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:6b099ac0f252fd44544d43dc12a3d6df prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:139b6ecf5fdad735a51b4385a24aded9
+niiri:de2e4a4014cc48ae0a2f90c80c8aa267
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -888,9 +888,9 @@ niiri:139b6ecf5fdad735a51b4385a24aded9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:139b6ecf5fdad735a51b4385a24aded9 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:de2e4a4014cc48ae0a2f90c80c8aa267 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:e6a138032615b9872d9261e35d2455f4
+niiri:0fde32a1a3d9efae8053253baac76ffc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -900,9 +900,9 @@ niiri:e6a138032615b9872d9261e35d2455f4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:e6a138032615b9872d9261e35d2455f4 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:0fde32a1a3d9efae8053253baac76ffc prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:37bc5cb5a158a9f86c496a5d1935903c
+niiri:93cac87b0b2603caa2e73e808a49aa59
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -912,9 +912,9 @@ niiri:37bc5cb5a158a9f86c496a5d1935903c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:37bc5cb5a158a9f86c496a5d1935903c prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:93cac87b0b2603caa2e73e808a49aa59 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:f86c9bb022fe2e7bb4f2a1d963869d32
+niiri:5869329bf3b962a832bb7acb7781cebd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -924,9 +924,9 @@ niiri:f86c9bb022fe2e7bb4f2a1d963869d32
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:f86c9bb022fe2e7bb4f2a1d963869d32 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:5869329bf3b962a832bb7acb7781cebd prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:cecab36bcbd915f7841bff34cd7f59a6
+niiri:10ed6be507db860ee020a597d2bcfbc3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -936,9 +936,9 @@ niiri:cecab36bcbd915f7841bff34cd7f59a6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:cecab36bcbd915f7841bff34cd7f59a6 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:10ed6be507db860ee020a597d2bcfbc3 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:752ff8a0ff1912e3b3a3cc0b0af92bac
+niiri:d4cffec5c689a35b7bf1bec1606134a5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -948,9 +948,9 @@ niiri:752ff8a0ff1912e3b3a3cc0b0af92bac
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:752ff8a0ff1912e3b3a3cc0b0af92bac prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:d4cffec5c689a35b7bf1bec1606134a5 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:bbfdc94758422f4cdfa2d461f26c652c
+niiri:2f94714c99bebff5b4831f0cfafa8496
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -960,9 +960,9 @@ niiri:bbfdc94758422f4cdfa2d461f26c652c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:bbfdc94758422f4cdfa2d461f26c652c prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:2f94714c99bebff5b4831f0cfafa8496 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:412f44bb99fe0b4ac5111c8bb0d6824f
+niiri:ca58cacd0a13b44f43d59156a4c52a6a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -972,9 +972,9 @@ niiri:412f44bb99fe0b4ac5111c8bb0d6824f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:412f44bb99fe0b4ac5111c8bb0d6824f prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:ca58cacd0a13b44f43d59156a4c52a6a prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:ae1cd8d0dfca9341507b66eafba6459d
+niiri:61377f406c900484318b0d2817a3c523
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -984,9 +984,9 @@ niiri:ae1cd8d0dfca9341507b66eafba6459d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:ae1cd8d0dfca9341507b66eafba6459d prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:61377f406c900484318b0d2817a3c523 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:089292d98902368bd347bcdfa162cfda
+niiri:307dd0ecb797aef0ce055f67fc2fa294
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -996,9 +996,9 @@ niiri:089292d98902368bd347bcdfa162cfda
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:089292d98902368bd347bcdfa162cfda prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:307dd0ecb797aef0ce055f67fc2fa294 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:716ffa34870ad39bf06d8e49c18b9bce
+niiri:e1f1160e4c3acdd85c621d64903334ab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1008,9 +1008,9 @@ niiri:716ffa34870ad39bf06d8e49c18b9bce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:716ffa34870ad39bf06d8e49c18b9bce prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:e1f1160e4c3acdd85c621d64903334ab prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:8c7ca240ed7a4d85316011dd6f1768ff
+niiri:bcd49735a6a0a30da7b9fe3278d6f064
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1020,9 +1020,9 @@ niiri:8c7ca240ed7a4d85316011dd6f1768ff
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:8c7ca240ed7a4d85316011dd6f1768ff prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:bcd49735a6a0a30da7b9fe3278d6f064 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:08593ccb1d9e49118b073d271565bd78
+niiri:290672736f8553a55089385f6b74f206
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1032,9 +1032,9 @@ niiri:08593ccb1d9e49118b073d271565bd78
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:08593ccb1d9e49118b073d271565bd78 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:290672736f8553a55089385f6b74f206 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:b52f4fded36d906e3611187b1ea82271
+niiri:5ecd1cdffe7971283f7ba38938b61b2c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1044,9 +1044,9 @@ niiri:b52f4fded36d906e3611187b1ea82271
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:b52f4fded36d906e3611187b1ea82271 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:5ecd1cdffe7971283f7ba38938b61b2c prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:900eebea134685a11022813f19903499
+niiri:e1e08c2b6ca06aabfd4b12e4367167be
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1056,9 +1056,9 @@ niiri:900eebea134685a11022813f19903499
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:900eebea134685a11022813f19903499 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:e1e08c2b6ca06aabfd4b12e4367167be prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:a20506ad4a845975db3365e7c162d818
+niiri:ef50676f067416d91bba713a2fc0321a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1068,9 +1068,9 @@ niiri:a20506ad4a845975db3365e7c162d818
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:a20506ad4a845975db3365e7c162d818 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:ef50676f067416d91bba713a2fc0321a prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:cfde284823e7c32d74bec0b81232bb7a
+niiri:947bdfd650d750aaad83d695fd5ff821
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1080,9 +1080,9 @@ niiri:cfde284823e7c32d74bec0b81232bb7a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:cfde284823e7c32d74bec0b81232bb7a prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:947bdfd650d750aaad83d695fd5ff821 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:496bec06cfc8ef95b3cbe0997c654d26
+niiri:51e987ef34cc607991dc3fcd1b06d12d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1092,9 +1092,9 @@ niiri:496bec06cfc8ef95b3cbe0997c654d26
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:496bec06cfc8ef95b3cbe0997c654d26 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:51e987ef34cc607991dc3fcd1b06d12d prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:e4bff32759970a1099e3a417cf7206b0
+niiri:9e0d3d51afc26653e6ee900965729d85
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1104,9 +1104,9 @@ niiri:e4bff32759970a1099e3a417cf7206b0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:e4bff32759970a1099e3a417cf7206b0 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:9e0d3d51afc26653e6ee900965729d85 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:40337b736645244404b84afb6772e7a9
+niiri:9d7d7cea0614241978504c478df9b65a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1116,9 +1116,9 @@ niiri:40337b736645244404b84afb6772e7a9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:40337b736645244404b84afb6772e7a9 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:9d7d7cea0614241978504c478df9b65a prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:42bc55f4f90f29daf9e12be119e1ddab
+niiri:20b5974d23f3286a95aa7fbb587ef438
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1128,9 +1128,9 @@ niiri:42bc55f4f90f29daf9e12be119e1ddab
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:42bc55f4f90f29daf9e12be119e1ddab prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:20b5974d23f3286a95aa7fbb587ef438 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:067c79f86db85b508893737af41699ce
+niiri:9a32bcfd38e5afc90a14c0c217161efa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1140,9 +1140,9 @@ niiri:067c79f86db85b508893737af41699ce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:067c79f86db85b508893737af41699ce prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:9a32bcfd38e5afc90a14c0c217161efa prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:1a35a6d628eed4f2fc8c554a4a579a19
+niiri:210435c4c0603b37239c262e4c742cd7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1152,9 +1152,9 @@ niiri:1a35a6d628eed4f2fc8c554a4a579a19
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:1a35a6d628eed4f2fc8c554a4a579a19 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:210435c4c0603b37239c262e4c742cd7 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:0e92ac2d77c091672e014daf15280170
+niiri:7c7c96862dfaf19b5ad9f27652329ae0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1164,9 +1164,9 @@ niiri:0e92ac2d77c091672e014daf15280170
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:0e92ac2d77c091672e014daf15280170 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:7c7c96862dfaf19b5ad9f27652329ae0 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:0d2b802df946de1efd390f218ef63fce
+niiri:3cb44c7fa017003278142567fd208f77
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1176,9 +1176,9 @@ niiri:0d2b802df946de1efd390f218ef63fce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:0d2b802df946de1efd390f218ef63fce prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:3cb44c7fa017003278142567fd208f77 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:627d75e08350cce3541dd568e3ddaa39
+niiri:d0db4687f221096cb9c4f8413c4f75c6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1188,9 +1188,9 @@ niiri:627d75e08350cce3541dd568e3ddaa39
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:627d75e08350cce3541dd568e3ddaa39 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:d0db4687f221096cb9c4f8413c4f75c6 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:20516921d28241951d08251e80cac5b5
+niiri:7ef8baaeb7357f28badb11366679f71c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1200,9 +1200,9 @@ niiri:20516921d28241951d08251e80cac5b5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:20516921d28241951d08251e80cac5b5 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:7ef8baaeb7357f28badb11366679f71c prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:3822c0fa262ca8cb8a67590f3eec2fe6
+niiri:cec5df2d95985851dd02c6d0db6fe243
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1212,9 +1212,9 @@ niiri:3822c0fa262ca8cb8a67590f3eec2fe6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:3822c0fa262ca8cb8a67590f3eec2fe6 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:cec5df2d95985851dd02c6d0db6fe243 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:51287994298816d649ba6908b4e3d0bb
+niiri:f0dffbbec6ed840a50eeb67367cfa4d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1224,9 +1224,9 @@ niiri:51287994298816d649ba6908b4e3d0bb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:51287994298816d649ba6908b4e3d0bb prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:f0dffbbec6ed840a50eeb67367cfa4d5 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:36a1ff3bd64efa589db6c3a56ccf9d25
+niiri:67c3a7b5cc3c3fe392535195f3bad2ad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1236,9 +1236,9 @@ niiri:36a1ff3bd64efa589db6c3a56ccf9d25
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:36a1ff3bd64efa589db6c3a56ccf9d25 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:67c3a7b5cc3c3fe392535195f3bad2ad prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:1c0a11fe168926616610d5836c36d35f
+niiri:db97ffa2bd8c5823f405fd68ff718eee
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1248,9 +1248,9 @@ niiri:1c0a11fe168926616610d5836c36d35f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:1c0a11fe168926616610d5836c36d35f prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:db97ffa2bd8c5823f405fd68ff718eee prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:aa0d58d5cc7671539d09308038edb0f1
+niiri:2d47c7ce748aeebd84bed25e87007425
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1260,9 +1260,9 @@ niiri:aa0d58d5cc7671539d09308038edb0f1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:aa0d58d5cc7671539d09308038edb0f1 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:2d47c7ce748aeebd84bed25e87007425 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:fc71e9e9a2574cbd9d5094f50275b3c2
+niiri:8b7c26257640b1664a72209e6721cdcd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1272,9 +1272,9 @@ niiri:fc71e9e9a2574cbd9d5094f50275b3c2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:fc71e9e9a2574cbd9d5094f50275b3c2 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:8b7c26257640b1664a72209e6721cdcd prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:c23970716bccffb656edae94cc34e353
+niiri:4e2a5af599e4e60cf34c225aefbe86cb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1284,9 +1284,9 @@ niiri:c23970716bccffb656edae94cc34e353
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:c23970716bccffb656edae94cc34e353 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:4e2a5af599e4e60cf34c225aefbe86cb prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:8e2363110cdebe114cbe95493b19fa9d
+niiri:3a69dd386e787d840309add4c3d8288a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1296,9 +1296,9 @@ niiri:8e2363110cdebe114cbe95493b19fa9d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:8e2363110cdebe114cbe95493b19fa9d prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:3a69dd386e787d840309add4c3d8288a prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:eb4122935f1afa2c8b532875de5f0ef9
+niiri:6026278153ba92cecad8e5b03e166074
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1308,9 +1308,9 @@ niiri:eb4122935f1afa2c8b532875de5f0ef9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:eb4122935f1afa2c8b532875de5f0ef9 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:6026278153ba92cecad8e5b03e166074 prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:25018fb0acd6d245a4f445c35c5f92eb
+niiri:5df20a4fb89cbcd4160591f81dc70a0d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1320,9 +1320,9 @@ niiri:25018fb0acd6d245a4f445c35c5f92eb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:25018fb0acd6d245a4f445c35c5f92eb prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:5df20a4fb89cbcd4160591f81dc70a0d prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:ccd2969f60f8b0222713472b0a037361
+niiri:32dc10b2a989e36bb73d9c695b9ace8f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1332,1297 +1332,1297 @@ niiri:ccd2969f60f8b0222713472b0a037361
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:ccd2969f60f8b0222713472b0a037361 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
+niiri:32dc10b2a989e36bb73d9c695b9ace8f prov:wasDerivedFrom niiri:3306774fd09ce4866577fe9443b964ef .
 
-niiri:baa4e7252d8424602eff0da2b334e0ea
+niiri:a4b5d66106f3fdd4bbb70333fc014ed9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:3dcaa7f03a6601fd8a98a0250eb396ce ;
+    prov:atLocation niiri:e6c8661d28f8dd23040b47851749cfd0 ;
     prov:value "39.0658683776855"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04009751746769"^^xsd:float ;
     nidm_pValueUncorrected: "2.3264734660966e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0389037590875805"^^xsd:float ;
     nidm_qValueFDR: "0.0302216629065993"^^xsd:float .
 
-niiri:3dcaa7f03a6601fd8a98a0250eb396ce
+niiri:e6c8661d28f8dd23040b47851749cfd0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-2,-90,28]"^^xsd:string .
 
-niiri:baa4e7252d8424602eff0da2b334e0ea prov:wasDerivedFrom niiri:fcafd29e2d4984d5ef1a1e4525c5ba42 .
+niiri:a4b5d66106f3fdd4bbb70333fc014ed9 prov:wasDerivedFrom niiri:4c1f276d9af9d476ea0e6263c11e3928 .
 
-niiri:ef00983a1ab378c0ed62a4e8080df8cf
+niiri:80b273a8f471de09518cdb5beddadab1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:a3fcc5c0311ede9dd4d7b167cd4e683f ;
+    prov:atLocation niiri:e7e7b7bf2afd8637c397bcad07b85708 ;
     prov:value "36.2393341064453"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89725160225159"^^xsd:float ;
     nidm_pValueUncorrected: "4.85931842320042e-07"^^xsd:float ;
     nidm_pValueFWER: "0.071761896035709"^^xsd:float ;
     nidm_qValueFDR: "0.0302216629065993"^^xsd:float .
 
-niiri:a3fcc5c0311ede9dd4d7b167cd4e683f
+niiri:e7e7b7bf2afd8637c397bcad07b85708
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-42,-64,-8]"^^xsd:string .
 
-niiri:ef00983a1ab378c0ed62a4e8080df8cf prov:wasDerivedFrom niiri:444cc626db04f602c9c9011fa5e21c84 .
+niiri:80b273a8f471de09518cdb5beddadab1 prov:wasDerivedFrom niiri:6dfa7cc864f8425fe2ca83d23d9f375e .
 
-niiri:915137b9c7e5154400a1f1cc8692da57
+niiri:3f7650665beafba93222678f20a6dd8c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:6b30d660a4ad3dfdee42a3cd8d2d46f0 ;
+    prov:atLocation niiri:8e42064393b892a0c8085557be17c943 ;
     prov:value "17.9251842498779"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64201416072196"^^xsd:float ;
     nidm_pValueUncorrected: "0.000135256594276711"^^xsd:float ;
     nidm_pValueFWER: "0.999417997648594"^^xsd:float ;
     nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
 
-niiri:6b30d660a4ad3dfdee42a3cd8d2d46f0
+niiri:8e42064393b892a0c8085557be17c943
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-40,-52,-10]"^^xsd:string .
 
-niiri:915137b9c7e5154400a1f1cc8692da57 prov:wasDerivedFrom niiri:444cc626db04f602c9c9011fa5e21c84 .
+niiri:3f7650665beafba93222678f20a6dd8c prov:wasDerivedFrom niiri:6dfa7cc864f8425fe2ca83d23d9f375e .
 
-niiri:e99d8d782cf7659baaf6c7a11fd75959
+niiri:4b55fa30e44c1ef889886e6cde14c762
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:deb2e3be4bbfe246eccd4c8e2cb277c9 ;
+    prov:atLocation niiri:ff21d0b06b48639a5d45597abb5c09d7 ;
     prov:value "13.454288482666"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18324713734782"^^xsd:float ;
     nidm_pValueUncorrected: "0.000728166268399777"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996872"^^xsd:float ;
     nidm_qValueFDR: "0.140840039531724"^^xsd:float .
 
-niiri:deb2e3be4bbfe246eccd4c8e2cb277c9
+niiri:ff21d0b06b48639a5d45597abb5c09d7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-38,-70,0]"^^xsd:string .
 
-niiri:e99d8d782cf7659baaf6c7a11fd75959 prov:wasDerivedFrom niiri:444cc626db04f602c9c9011fa5e21c84 .
+niiri:4b55fa30e44c1ef889886e6cde14c762 prov:wasDerivedFrom niiri:6dfa7cc864f8425fe2ca83d23d9f375e .
 
-niiri:887edacd038795695bc5935681d9ec60
+niiri:5dabdb8ba436106d06e1c8c00d3c0062
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:149ea3c3b924b56714ebbd48bd4cf7eb ;
+    prov:atLocation niiri:5cc65ad8be948f162cac2e722174df85 ;
     prov:value "29.4676361083984"^^xsd:float ;
     nidm_equivalentZStatistic: "4.51162164706026"^^xsd:float ;
     nidm_pValueUncorrected: "3.21669348379849e-06"^^xsd:float ;
     nidm_pValueFWER: "0.305525019896507"^^xsd:float ;
     nidm_qValueFDR: "0.0356596612461515"^^xsd:float .
 
-niiri:149ea3c3b924b56714ebbd48bd4cf7eb
+niiri:5cc65ad8be948f162cac2e722174df85
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[16,-88,24]"^^xsd:string .
 
-niiri:887edacd038795695bc5935681d9ec60 prov:wasDerivedFrom niiri:b1753f3aee975cc2167fd8ecc371ac5b .
+niiri:5dabdb8ba436106d06e1c8c00d3c0062 prov:wasDerivedFrom niiri:e1dc5ba7de5b768eb8d9fdd13abef0cf .
 
-niiri:966afe2baff599cc271b19f81f50e736
+niiri:2cc88f86b0896997e77e8ae4db3466fa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:de9e01b6bf2a659aa4d3377d86836307 ;
+    prov:atLocation niiri:f3c58ba1b59b55104e6a67eb2a49bfe7 ;
     prov:value "28.5631580352783"^^xsd:float ;
     nidm_equivalentZStatistic: "4.45459114773779"^^xsd:float ;
     nidm_pValueUncorrected: "4.20266075706888e-06"^^xsd:float ;
     nidm_pValueFWER: "0.365688847752494"^^xsd:float ;
     nidm_qValueFDR: "0.0376032685416481"^^xsd:float .
 
-niiri:de9e01b6bf2a659aa4d3377d86836307
+niiri:f3c58ba1b59b55104e6a67eb2a49bfe7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[28,-72,26]"^^xsd:string .
 
-niiri:966afe2baff599cc271b19f81f50e736 prov:wasDerivedFrom niiri:e217bff071e4c58201ab9d5e50316202 .
+niiri:2cc88f86b0896997e77e8ae4db3466fa prov:wasDerivedFrom niiri:ec2dccfb1ebaaaf8d91e33c14f11f3ea .
 
-niiri:25bc992eccfc2b6a6a24289f4e757203
+niiri:074e638017a74cef02a16c08d8e42006
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:e01e6d8bfc3791e75a43288c36fa1d9c ;
+    prov:atLocation niiri:01fc9cdf27d2103b7930391f8b2ea3d3 ;
     prov:value "26.9945106506348"^^xsd:float ;
     nidm_equivalentZStatistic: "4.35204306383375"^^xsd:float ;
     nidm_pValueUncorrected: "6.7437380493196e-06"^^xsd:float ;
     nidm_pValueFWER: "0.489729172437052"^^xsd:float ;
     nidm_qValueFDR: "0.0406203661092224"^^xsd:float .
 
-niiri:e01e6d8bfc3791e75a43288c36fa1d9c
+niiri:01fc9cdf27d2103b7930391f8b2ea3d3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[-32,20,-4]"^^xsd:string .
 
-niiri:25bc992eccfc2b6a6a24289f4e757203 prov:wasDerivedFrom niiri:293f17b4b9a3d5e7642f3136e988fb69 .
+niiri:074e638017a74cef02a16c08d8e42006 prov:wasDerivedFrom niiri:122c2e266aeef305c550f167cf916f71 .
 
-niiri:f9405b475d3bdca76e81a6717bca04c2
+niiri:8d7cd6dcbd82a0f5592c3c44c8dd84ff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:d382a0c6c03aa0a2f6ee3c758f66a342 ;
+    prov:atLocation niiri:252f7991c4a1845b01ddb30503d8d863 ;
     prov:value "26.8606586456299"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34306775687574"^^xsd:float ;
     nidm_pValueUncorrected: "7.02533878071954e-06"^^xsd:float ;
     nidm_pValueFWER: "0.501353785238145"^^xsd:float ;
     nidm_qValueFDR: "0.0406203661092224"^^xsd:float .
 
-niiri:d382a0c6c03aa0a2f6ee3c758f66a342
+niiri:252f7991c4a1845b01ddb30503d8d863
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-8,50,32]"^^xsd:string .
 
-niiri:f9405b475d3bdca76e81a6717bca04c2 prov:wasDerivedFrom niiri:f39819aeb0366241cbbae35a6427fc8b .
+niiri:8d7cd6dcbd82a0f5592c3c44c8dd84ff prov:wasDerivedFrom niiri:1f521c6f09c963d12ee383c50f6388b1 .
 
-niiri:5f02b40490d007ae68a92b4316e9efd9
+niiri:71fb9ba017dcd88efbdbf312b4d060d9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:dd4a0e1012831b8affc68995057a1120 ;
+    prov:atLocation niiri:6a71ac7754a9b7fbfc6bfaa02c11d530 ;
     prov:value "25.8067512512207"^^xsd:float ;
     nidm_equivalentZStatistic: "4.27109313660164"^^xsd:float ;
     nidm_pValueUncorrected: "9.72585724245967e-06"^^xsd:float ;
     nidm_pValueFWER: "0.597019202761311"^^xsd:float ;
     nidm_qValueFDR: "0.0439563569939673"^^xsd:float .
 
-niiri:dd4a0e1012831b8affc68995057a1120
+niiri:6a71ac7754a9b7fbfc6bfaa02c11d530
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-34,8,58]"^^xsd:string .
 
-niiri:5f02b40490d007ae68a92b4316e9efd9 prov:wasDerivedFrom niiri:804f36b4efe7eb06f1a23107f02c9522 .
+niiri:71fb9ba017dcd88efbdbf312b4d060d9 prov:wasDerivedFrom niiri:27132a256d54493c9f080d2bc58b4156 .
 
-niiri:9eb8c305928cd26af5d735f290a7ce8a
+niiri:c6195964f0ecba12db98dfb166219c62
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:c53ceb2c4d2e390230752c97501ffbd1 ;
+    prov:atLocation niiri:c5898b1fb96ddd15f3391d41ff541d6a ;
     prov:value "25.0769119262695"^^xsd:float ;
     nidm_equivalentZStatistic: "4.21983658750018"^^xsd:float ;
     nidm_pValueUncorrected: "1.22239732009977e-05"^^xsd:float ;
     nidm_pValueFWER: "0.665677647955296"^^xsd:float ;
     nidm_qValueFDR: "0.0444376030498989"^^xsd:float .
 
-niiri:c53ceb2c4d2e390230752c97501ffbd1
+niiri:c5898b1fb96ddd15f3391d41ff541d6a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[32,-86,0]"^^xsd:string .
 
-niiri:9eb8c305928cd26af5d735f290a7ce8a prov:wasDerivedFrom niiri:808fd4e2193f0ed5ab2626fc643077ca .
+niiri:c6195964f0ecba12db98dfb166219c62 prov:wasDerivedFrom niiri:7054c75c48fb30d1f27ab2bbb0333840 .
 
-niiri:11109932f0e2675cb40f05a3edc02ba0
+niiri:ce340d21c8afc601ee08ecb7a457da25
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:03754f6422c542b58050fa515c5326b7 ;
+    prov:atLocation niiri:8488d4cb4456e28be487f199b4d97608 ;
     prov:value "24.5828113555908"^^xsd:float ;
     nidm_equivalentZStatistic: "4.18444689049798"^^xsd:float ;
     nidm_pValueUncorrected: "1.42930633414418e-05"^^xsd:float ;
     nidm_pValueFWER: "0.711939170732988"^^xsd:float ;
     nidm_qValueFDR: "0.04475687830922"^^xsd:float .
 
-niiri:03754f6422c542b58050fa515c5326b7
+niiri:8488d4cb4456e28be487f199b4d97608
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[66,-32,30]"^^xsd:string .
 
-niiri:11109932f0e2675cb40f05a3edc02ba0 prov:wasDerivedFrom niiri:2667f28dbb2bce2c8e774ae24bc32c34 .
+niiri:ce340d21c8afc601ee08ecb7a457da25 prov:wasDerivedFrom niiri:40921ed9322bcbb9736f38620e4e285a .
 
-niiri:4fefff5985067f520ab89234bd477dd4
+niiri:f03ec4c103041b877b9cae5a2d180a74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:35dc6728bd9b0380bd0c34c5ef999f15 ;
+    prov:atLocation niiri:7e06c1af22bc9c2b12f6cc76c8c7f66e ;
     prov:value "14.2693071365356"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27451594161643"^^xsd:float ;
     nidm_pValueUncorrected: "0.000529215834762176"^^xsd:float ;
     nidm_pValueFWER: "0.999999999209483"^^xsd:float ;
     nidm_qValueFDR: "0.128281884148943"^^xsd:float .
 
-niiri:35dc6728bd9b0380bd0c34c5ef999f15
+niiri:7e06c1af22bc9c2b12f6cc76c8c7f66e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[60,-38,28]"^^xsd:string .
 
-niiri:4fefff5985067f520ab89234bd477dd4 prov:wasDerivedFrom niiri:2667f28dbb2bce2c8e774ae24bc32c34 .
+niiri:f03ec4c103041b877b9cae5a2d180a74 prov:wasDerivedFrom niiri:40921ed9322bcbb9736f38620e4e285a .
 
-niiri:0a247f47177e119fa9edf6e9f6f98b5e
+niiri:380064f5294cac972c58e3ea6c97bd61
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:3717dcf5b4b7f3fadfa70b271f5a347b ;
+    prov:atLocation niiri:f539c472e21c00876796de97ec02e302 ;
     prov:value "23.3039436340332"^^xsd:float ;
     nidm_equivalentZStatistic: "4.09011898331566"^^xsd:float ;
     nidm_pValueUncorrected: "2.15575975488491e-05"^^xsd:float ;
     nidm_pValueFWER: "0.823947459995523"^^xsd:float ;
     nidm_qValueFDR: "0.0478656864369739"^^xsd:float .
 
-niiri:3717dcf5b4b7f3fadfa70b271f5a347b
+niiri:f539c472e21c00876796de97ec02e302
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[28,30,52]"^^xsd:string .
 
-niiri:0a247f47177e119fa9edf6e9f6f98b5e prov:wasDerivedFrom niiri:81153168c82f38e0344a3da5990713f4 .
+niiri:380064f5294cac972c58e3ea6c97bd61 prov:wasDerivedFrom niiri:7d90f7765940a5ab337f7643782ed47c .
 
-niiri:07aa292e8e64264cf6b16262dd9b0461
+niiri:73a8b070f80bf9bc91a66c26d61eccd7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:17d984ec4e21314566bdf4644fb07af0 ;
+    prov:atLocation niiri:bb014a1ef20c2696675ef76b2e0ee76f ;
     prov:value "22.6157932281494"^^xsd:float ;
     nidm_equivalentZStatistic: "4.03763886298215"^^xsd:float ;
     nidm_pValueUncorrected: "2.69959426782984e-05"^^xsd:float ;
     nidm_pValueFWER: "0.87538446987651"^^xsd:float ;
     nidm_qValueFDR: "0.0515719459796674"^^xsd:float .
 
-niiri:17d984ec4e21314566bdf4644fb07af0
+niiri:bb014a1ef20c2696675ef76b2e0ee76f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-30,-34,6]"^^xsd:string .
 
-niiri:07aa292e8e64264cf6b16262dd9b0461 prov:wasDerivedFrom niiri:51df67b679cd0aa1c10588b2540f80ff .
+niiri:73a8b070f80bf9bc91a66c26d61eccd7 prov:wasDerivedFrom niiri:adb148e8a32d9f1ce4153efd0ac2dbc6 .
 
-niiri:c09425629406f190de8edebf54022f2d
+niiri:89f052acead95535f656ffcba48e3b7d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:cd4e978cbe4323a391c6fa96ba73890b ;
+    prov:atLocation niiri:971a1775ef89417b195708fdf276dbdd ;
     prov:value "21.8558578491211"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97819185113407"^^xsd:float ;
     nidm_pValueUncorrected: "3.47206660495925e-05"^^xsd:float ;
     nidm_pValueFWER: "0.921823721412592"^^xsd:float ;
     nidm_qValueFDR: "0.053734847831518"^^xsd:float .
 
-niiri:cd4e978cbe4323a391c6fa96ba73890b
+niiri:971a1775ef89417b195708fdf276dbdd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-28,0,30]"^^xsd:string .
 
-niiri:c09425629406f190de8edebf54022f2d prov:wasDerivedFrom niiri:c3859302a7f8a3aa876923fe5311fdeb .
+niiri:89f052acead95535f656ffcba48e3b7d prov:wasDerivedFrom niiri:4b83b464e56c198d5b02a944ed283f4f .
 
-niiri:00455682ca694ef095f7439ab81ebd12
+niiri:a461f7f85b7c93e0257a2abe934b8cd1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:a61981cb739588894bbdc415c7c87afe ;
+    prov:atLocation niiri:ee07dc885b0177dec74aed7571cb797c ;
     prov:value "21.8296661376953"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97611404363788"^^xsd:float ;
     nidm_pValueUncorrected: "3.50252708366527e-05"^^xsd:float ;
     nidm_pValueFWER: "0.923209894114283"^^xsd:float ;
     nidm_qValueFDR: "0.053734847831518"^^xsd:float .
 
-niiri:a61981cb739588894bbdc415c7c87afe
+niiri:ee07dc885b0177dec74aed7571cb797c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[8,34,10]"^^xsd:string .
 
-niiri:00455682ca694ef095f7439ab81ebd12 prov:wasDerivedFrom niiri:a9683c02ec255a54e2147300ce75147c .
+niiri:a461f7f85b7c93e0257a2abe934b8cd1 prov:wasDerivedFrom niiri:0c7c2733a41b8cb85ab46d0144d6798a .
 
-niiri:5cc633c2d1685a757beeaecee1a48008
+niiri:1ac086531bc098af131e9714a3b83b12
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:b7a12cc701147c2a30416bd9e767f926 ;
+    prov:atLocation niiri:ebdc7b10afb6bea822ede76d7fdbb5a5 ;
     prov:value "21.7287845611572"^^xsd:float ;
     nidm_equivalentZStatistic: "3.96809263472704"^^xsd:float ;
     nidm_pValueUncorrected: "3.6225086553876e-05"^^xsd:float ;
     nidm_pValueFWER: "0.928411428313329"^^xsd:float ;
     nidm_qValueFDR: "0.0540587737624357"^^xsd:float .
 
-niiri:b7a12cc701147c2a30416bd9e767f926
+niiri:ebdc7b10afb6bea822ede76d7fdbb5a5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[46,-56,10]"^^xsd:string .
 
-niiri:5cc633c2d1685a757beeaecee1a48008 prov:wasDerivedFrom niiri:4b0d5b1cbdc197add17ddae11c60a960 .
+niiri:1ac086531bc098af131e9714a3b83b12 prov:wasDerivedFrom niiri:f4caac7418e57d3e43a996a7ba654c2f .
 
-niiri:bc5fb74855b827b626fd1eebefaa6d4d
+niiri:bf746b5c92e282960a90d715da3e9348
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:352d0e5787411f3cc15519e7582cf21f ;
+    prov:atLocation niiri:dfde90eec39f9b1b9a3c0f23d4a02625 ;
     prov:value "14.2801656723022"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27570591680179"^^xsd:float ;
     nidm_pValueUncorrected: "0.000526991241768693"^^xsd:float ;
     nidm_pValueFWER: "0.999999999156251"^^xsd:float ;
     nidm_qValueFDR: "0.128281884148943"^^xsd:float .
 
-niiri:352d0e5787411f3cc15519e7582cf21f
+niiri:dfde90eec39f9b1b9a3c0f23d4a02625
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[48,-48,16]"^^xsd:string .
 
-niiri:bc5fb74855b827b626fd1eebefaa6d4d prov:wasDerivedFrom niiri:4b0d5b1cbdc197add17ddae11c60a960 .
+niiri:bf746b5c92e282960a90d715da3e9348 prov:wasDerivedFrom niiri:f4caac7418e57d3e43a996a7ba654c2f .
 
-niiri:90dc79d65e7f32dfb01b08b18c3ce762
+niiri:a447b0cecc50da0ea88347128197c345
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:33a1d7fed96c259799c80dc81ed84ff7 ;
+    prov:atLocation niiri:088da6b8de973e2cae4da24790c12a93 ;
     prov:value "21.4629364013672"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9468129149843"^^xsd:float ;
     nidm_pValueUncorrected: "3.95991966499754e-05"^^xsd:float ;
     nidm_pValueFWER: "0.941069307565192"^^xsd:float ;
     nidm_qValueFDR: "0.0555984329583215"^^xsd:float .
 
-niiri:33a1d7fed96c259799c80dc81ed84ff7
+niiri:088da6b8de973e2cae4da24790c12a93
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[46,-62,-10]"^^xsd:string .
 
-niiri:90dc79d65e7f32dfb01b08b18c3ce762 prov:wasDerivedFrom niiri:074f24af2809bb5962437625180d87d8 .
+niiri:a447b0cecc50da0ea88347128197c345 prov:wasDerivedFrom niiri:cd181349ed02b711f1a6828158bcf43a .
 
-niiri:865765b8e81628e180cd32d69ff2a873
+niiri:ae5abe12c74c45cfd3926ba1612ffba2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:572e00e92909efbb8dbfa749a8192c13 ;
+    prov:atLocation niiri:197ad10ce797561392405a298e974d2f ;
     prov:value "21.4269542694092"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94391683979485"^^xsd:float ;
     nidm_pValueUncorrected: "4.00807329147268e-05"^^xsd:float ;
     nidm_pValueFWER: "0.942665676683549"^^xsd:float ;
     nidm_qValueFDR: "0.0555984329583215"^^xsd:float .
 
-niiri:572e00e92909efbb8dbfa749a8192c13
+niiri:197ad10ce797561392405a298e974d2f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-8,-32,36]"^^xsd:string .
 
-niiri:865765b8e81628e180cd32d69ff2a873 prov:wasDerivedFrom niiri:3950399d3cc373d8735fcf48ad86f542 .
+niiri:ae5abe12c74c45cfd3926ba1612ffba2 prov:wasDerivedFrom niiri:e79df66e13024ab7771ec5eb685083aa .
 
-niiri:016b2fb8ca4f729da187a0f0b71608cc
+niiri:1f2ba07ccc62e5275dd063020505b5a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:98776a828aca5a643515928e94c4cdc1 ;
+    prov:atLocation niiri:e20b66260ee51af0dcd93cc998bd40e3 ;
     prov:value "20.0413494110107"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82938429557992"^^xsd:float ;
     nidm_pValueUncorrected: "6.42321325474704e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984364018223445"^^xsd:float ;
     nidm_qValueFDR: "0.0674959642175569"^^xsd:float .
 
-niiri:98776a828aca5a643515928e94c4cdc1
+niiri:e20b66260ee51af0dcd93cc998bd40e3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-34,-84,-4]"^^xsd:string .
 
-niiri:016b2fb8ca4f729da187a0f0b71608cc prov:wasDerivedFrom niiri:bab302ab1de7ceb32ee2a4553bab718d .
+niiri:1f2ba07ccc62e5275dd063020505b5a0 prov:wasDerivedFrom niiri:196e757350d816ffa8ac1b4ae4acb7b7 .
 
-niiri:ca802812c6d952e6eb53d6a2598748c3
+niiri:ce16f70f7779546dfadce90aa2b616c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:305b4d132dad573dd2e91152abf41d15 ;
+    prov:atLocation niiri:f567e22563c6428fe26c5d6d093f4f90 ;
     prov:value "19.5813789367676"^^xsd:float ;
     nidm_equivalentZStatistic: "3.79000141974546"^^xsd:float ;
     nidm_pValueUncorrected: "7.53232118573255e-05"^^xsd:float ;
     nidm_pValueFWER: "0.991038394814884"^^xsd:float ;
     nidm_qValueFDR: "0.0718990170223714"^^xsd:float .
 
-niiri:305b4d132dad573dd2e91152abf41d15
+niiri:f567e22563c6428fe26c5d6d093f4f90
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-50,2,40]"^^xsd:string .
 
-niiri:ca802812c6d952e6eb53d6a2598748c3 prov:wasDerivedFrom niiri:14ab5f557514798d8218e39a2199e27a .
+niiri:ce16f70f7779546dfadce90aa2b616c4 prov:wasDerivedFrom niiri:fe44f10323dac9699d3966ced3bfaa90 .
 
-niiri:2cd7edd94889650191f6f242b9a4c176
+niiri:ac087026e1fae344bef102ebc6369217
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:0d995ab3826e8df7675b6f8b8f4c2673 ;
+    prov:atLocation niiri:65fc106af51b8b5701b029fa54f23b6b ;
     prov:value "16.7666301727295"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53217184854778"^^xsd:float ;
     nidm_pValueUncorrected: "0.00020608070787731"^^xsd:float ;
     nidm_pValueFWER: "0.99996648470095"^^xsd:float ;
     nidm_qValueFDR: "0.0942608471449251"^^xsd:float .
 
-niiri:0d995ab3826e8df7675b6f8b8f4c2673
+niiri:65fc106af51b8b5701b029fa54f23b6b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-52,-6,46]"^^xsd:string .
 
-niiri:2cd7edd94889650191f6f242b9a4c176 prov:wasDerivedFrom niiri:14ab5f557514798d8218e39a2199e27a .
+niiri:ac087026e1fae344bef102ebc6369217 prov:wasDerivedFrom niiri:fe44f10323dac9699d3966ced3bfaa90 .
 
-niiri:390e65b5876e189721e8386b64e468ba
+niiri:635b0e02961f2a78b72796a9c2e17324
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:8e65f05088e65ca40cdab4f7b8c45feb ;
+    prov:atLocation niiri:b46abfb5190d694712f1f4c11de9d701 ;
     prov:value "19.3040504455566"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76590943131268"^^xsd:float ;
     nidm_pValueUncorrected: "8.2971971291701e-05"^^xsd:float ;
     nidm_pValueFWER: "0.993825462793153"^^xsd:float ;
     nidm_qValueFDR: "0.0737314974355366"^^xsd:float .
 
-niiri:8e65f05088e65ca40cdab4f7b8c45feb
+niiri:b46abfb5190d694712f1f4c11de9d701
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[24,-46,32]"^^xsd:string .
 
-niiri:390e65b5876e189721e8386b64e468ba prov:wasDerivedFrom niiri:bc603717c0c5d8a8779b8aa6c28564b3 .
+niiri:635b0e02961f2a78b72796a9c2e17324 prov:wasDerivedFrom niiri:ec03a5611c90a708dd60390dcb8ecc38 .
 
-niiri:613f7d1a72653a094215c0c7838598d6
+niiri:9ec9ec5e398bddae9b7e40ae59725d63
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:261bf2d0efecb03152c6e1cdf2df18c0 ;
+    prov:atLocation niiri:4a185ebc5f4d1de8ede7b1068b95bee7 ;
     prov:value "19.1409015655518"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75161143600874"^^xsd:float ;
     nidm_pValueUncorrected: "8.7850813353163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995110302012489"^^xsd:float ;
     nidm_qValueFDR: "0.0738147834753255"^^xsd:float .
 
-niiri:261bf2d0efecb03152c6e1cdf2df18c0
+niiri:4a185ebc5f4d1de8ede7b1068b95bee7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[6,16,50]"^^xsd:string .
 
-niiri:613f7d1a72653a094215c0c7838598d6 prov:wasDerivedFrom niiri:106ee2638843f2793b5ac6735acad91e .
+niiri:9ec9ec5e398bddae9b7e40ae59725d63 prov:wasDerivedFrom niiri:56e6c7924a2f68ad79e3f7a7ae002bc4 .
 
-niiri:dbe73b14c812ef0bb874edaf583e9d7c
+niiri:a9c8d878bf0f79a4e19e5fcba292c1d0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:64529db73025d3ebe03ab8490a2c7588 ;
+    prov:atLocation niiri:02c035a9817a3caa54dd18a13e2035f0 ;
     prov:value "19.098669052124"^^xsd:float ;
     nidm_equivalentZStatistic: "3.74789498829157"^^xsd:float ;
     nidm_pValueUncorrected: "8.91624398706714e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995405100064856"^^xsd:float ;
     nidm_qValueFDR: "0.0738147834753255"^^xsd:float .
 
-niiri:64529db73025d3ebe03ab8490a2c7588
+niiri:02c035a9817a3caa54dd18a13e2035f0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-4,-24,6]"^^xsd:string .
 
-niiri:dbe73b14c812ef0bb874edaf583e9d7c prov:wasDerivedFrom niiri:01c1ab06b5a4997e0980bcddb0f69696 .
+niiri:a9c8d878bf0f79a4e19e5fcba292c1d0 prov:wasDerivedFrom niiri:cdfaf6b796e2c2557787c484faec4633 .
 
-niiri:d74cbd45e77a6bd61d201389470b3f9d
+niiri:06f5e32a866b81a387b9af05e7bb4dd0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:2a23dfb2262a16b99ed1460c9726d32d ;
+    prov:atLocation niiri:37aa56db8b87ee90b242d01a374785c7 ;
     prov:value "19.0145893096924"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7404771295496"^^xsd:float ;
     nidm_pValueUncorrected: "9.1835629583259e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995949293325196"^^xsd:float ;
     nidm_qValueFDR: "0.0741915113542509"^^xsd:float .
 
-niiri:2a23dfb2262a16b99ed1460c9726d32d
+niiri:37aa56db8b87ee90b242d01a374785c7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-4,0,54]"^^xsd:string .
 
-niiri:d74cbd45e77a6bd61d201389470b3f9d prov:wasDerivedFrom niiri:8f249184eec9591adc7a3fc1c7e37936 .
+niiri:06f5e32a866b81a387b9af05e7bb4dd0 prov:wasDerivedFrom niiri:f3fd301ca5fc6b876a28a4e840896ae7 .
 
-niiri:4bb899cd9f06bf6ba2fefa26066f1718
+niiri:1ee6d6112a6b6d3536ce8264fcb7b4c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:84e6c234c35fdc2fa131ca05716bd905 ;
+    prov:atLocation niiri:2fd08c9a53a8e9fb7b04c521a2a1cd17 ;
     prov:value "18.8265838623047"^^xsd:float ;
     nidm_equivalentZStatistic: "3.72379883766124"^^xsd:float ;
     nidm_pValueUncorrected: "9.81236582245915e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996978299202392"^^xsd:float ;
     nidm_qValueFDR: "0.0777669728451003"^^xsd:float .
 
-niiri:84e6c234c35fdc2fa131ca05716bd905
+niiri:2fd08c9a53a8e9fb7b04c521a2a1cd17
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[42,-28,30]"^^xsd:string .
 
-niiri:4bb899cd9f06bf6ba2fefa26066f1718 prov:wasDerivedFrom niiri:c7ba1e0ca7a63ee914a7fa6cddbda281 .
+niiri:1ee6d6112a6b6d3536ce8264fcb7b4c2 prov:wasDerivedFrom niiri:384bbe6b71ec2ae3109307c983930490 .
 
-niiri:2fcf4f5e0a9409e59f9b3a198af722a2
+niiri:d16c30636db69b3fdadc372725e795b3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:dfeeafe9412e26a98688ac2eb5eedc76 ;
+    prov:atLocation niiri:83dd62bd96860aa2272e2459d7254fbf ;
     prov:value "18.5199432373047"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69631988620818"^^xsd:float ;
     nidm_pValueUncorrected: "0.000109373660980738"^^xsd:float ;
     nidm_pValueFWER: "0.998191254166604"^^xsd:float ;
     nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
 
-niiri:dfeeafe9412e26a98688ac2eb5eedc76
+niiri:83dd62bd96860aa2272e2459d7254fbf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[52,-12,44]"^^xsd:string .
 
-niiri:2fcf4f5e0a9409e59f9b3a198af722a2 prov:wasDerivedFrom niiri:91987e35b1d8c15af66e3327a6e4b602 .
+niiri:d16c30636db69b3fdadc372725e795b3 prov:wasDerivedFrom niiri:19cd545bb290d6b4b5d50c3ca0b0d8e8 .
 
-niiri:01dc6fc72b88495c5e6c08fc0cc0bc35
+niiri:dd3ea80bed9326c0c1e5f9d969330df1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:a785670f070730f0b5dad30427a1e8f7 ;
+    prov:atLocation niiri:f1bd534575da07c1a675a049095b255b ;
     prov:value "18.516544342041"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69601335434539"^^xsd:float ;
     nidm_pValueUncorrected: "0.000109505728679404"^^xsd:float ;
     nidm_pValueFWER: "0.998201975106935"^^xsd:float ;
     nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
 
-niiri:a785670f070730f0b5dad30427a1e8f7
+niiri:f1bd534575da07c1a675a049095b255b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-40,-28,30]"^^xsd:string .
 
-niiri:01dc6fc72b88495c5e6c08fc0cc0bc35 prov:wasDerivedFrom niiri:c09f3990ca4bd168f93fa27a56eeb56c .
+niiri:dd3ea80bed9326c0c1e5f9d969330df1 prov:wasDerivedFrom niiri:1e795237a34002c8edd0e85dd55bd6db .
 
-niiri:cf74bac84d8f51cb7fb8a579dd4b736b
+niiri:7e2b0e69ab0d6650bcdb2ff672f6931b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:62e6d759392d4c5a22e393f530aba130 ;
+    prov:atLocation niiri:fe5c4a2eb46fc779cf97d7894da36e0f ;
     prov:value "18.4609222412109"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69099090519778"^^xsd:float ;
     nidm_pValueUncorrected: "0.000111691062804176"^^xsd:float ;
     nidm_pValueFWER: "0.998370011058266"^^xsd:float ;
     nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
 
-niiri:62e6d759392d4c5a22e393f530aba130
+niiri:fe5c4a2eb46fc779cf97d7894da36e0f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[32,22,-8]"^^xsd:string .
 
-niiri:cf74bac84d8f51cb7fb8a579dd4b736b prov:wasDerivedFrom niiri:4f39525fd234b098e759c0ffc971fd5b .
+niiri:7e2b0e69ab0d6650bcdb2ff672f6931b prov:wasDerivedFrom niiri:a4f5ae0b708bf7e12619874d39f89768 .
 
-niiri:39ca307d31c5892250f913783b4db62c
+niiri:517f5bd6e8d2babbc82e5c44d3c343a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:d6626578cce8299da3656ac371463365 ;
+    prov:atLocation niiri:bb394618dc108a4c0f8a031886a63a5f ;
     prov:value "17.9312534332275"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64257521175179"^^xsd:float ;
     nidm_pValueUncorrected: "0.00013496203699781"^^xsd:float ;
     nidm_pValueFWER: "0.99941063068466"^^xsd:float ;
     nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
 
-niiri:d6626578cce8299da3656ac371463365
+niiri:bb394618dc108a4c0f8a031886a63a5f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[64,-4,10]"^^xsd:string .
 
-niiri:39ca307d31c5892250f913783b4db62c prov:wasDerivedFrom niiri:66eca61ada8ceb626c8ffd13d3efa1cc .
+niiri:517f5bd6e8d2babbc82e5c44d3c343a0 prov:wasDerivedFrom niiri:98a7f50d7445498f6d5c6b8931b0b269 .
 
-niiri:1f3bee85e377a2130e061374ce19f6ab
+niiri:f2d996e53248a5f49b8f38bd51dd3713
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:a706a639a6105ecabcfe5a088abd9d25 ;
+    prov:atLocation niiri:bac756dc194de6c4d757026e3fff1c1f ;
     prov:value "17.8439044952393"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63448648232359"^^xsd:float ;
     nidm_pValueUncorrected: "0.000139267429951739"^^xsd:float ;
     nidm_pValueFWER: "0.999509275806277"^^xsd:float ;
     nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
 
-niiri:a706a639a6105ecabcfe5a088abd9d25
+niiri:bac756dc194de6c4d757026e3fff1c1f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-22,-72,34]"^^xsd:string .
 
-niiri:1f3bee85e377a2130e061374ce19f6ab prov:wasDerivedFrom niiri:5cf9402b2b494a87640a66aec1a6fdaf .
+niiri:f2d996e53248a5f49b8f38bd51dd3713 prov:wasDerivedFrom niiri:0f673bfb48646ef7ce92732ddcd2561d .
 
-niiri:7f7625524d177fe4781c28633ad04fb0
+niiri:6f930a9d11797b87f44c2badce80aec6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:dde299cfdeb368ced964fe7a498cc703 ;
+    prov:atLocation niiri:d0c138010f71ad70be1e51fe2d839397 ;
     prov:value "17.552827835083"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60731294050443"^^xsd:float ;
     nidm_pValueUncorrected: "0.000154692216466135"^^xsd:float ;
     nidm_pValueFWER: "0.999742486133075"^^xsd:float ;
     nidm_qValueFDR: "0.0862331427095326"^^xsd:float .
 
-niiri:dde299cfdeb368ced964fe7a498cc703
+niiri:d0c138010f71ad70be1e51fe2d839397
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-6,-44,40]"^^xsd:string .
 
-niiri:7f7625524d177fe4781c28633ad04fb0 prov:wasDerivedFrom niiri:1cd1f14fea72d133db88783e1b907b7f .
+niiri:6f930a9d11797b87f44c2badce80aec6 prov:wasDerivedFrom niiri:e4e7c604a0dfd11b952f2d763f8365a1 .
 
-niiri:ea8dfff70bef204151c3aa37de438b0f
+niiri:327a241b1d9f4509ded23784092fa3b7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:d703077133d717f4a9d9411fe4c791a6 ;
+    prov:atLocation niiri:9054a9c70fe461e9d187a84b5dd0908f ;
     prov:value "17.2906818389893"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58254613965863"^^xsd:float ;
     nidm_pValueUncorrected: "0.000170130746602659"^^xsd:float ;
     nidm_pValueFWER: "0.99986271355264"^^xsd:float ;
     nidm_qValueFDR: "0.0895859395735557"^^xsd:float .
 
-niiri:d703077133d717f4a9d9411fe4c791a6
+niiri:9054a9c70fe461e9d187a84b5dd0908f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-34,-38,-34]"^^xsd:string .
 
-niiri:ea8dfff70bef204151c3aa37de438b0f prov:wasDerivedFrom niiri:c3340fa012c626e62e86cdb279a4e883 .
+niiri:327a241b1d9f4509ded23784092fa3b7 prov:wasDerivedFrom niiri:4fec6e6678455cee0511a392e629ec66 .
 
-niiri:1f8b76bc5a6e0e44d52dc38f77dfb573
+niiri:41b9df925c1027d8561ada2ee95218ca
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:52d6deef40815f931bff80e4a0c0e30e ;
+    prov:atLocation niiri:f774990d88d82217c54c2bfadc119a0c ;
     prov:value "17.1612319946289"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57021115022413"^^xsd:float ;
     nidm_pValueUncorrected: "0.000178346794309836"^^xsd:float ;
     nidm_pValueFWER: "0.999901168620001"^^xsd:float ;
     nidm_qValueFDR: "0.0903823255084056"^^xsd:float .
 
-niiri:52d6deef40815f931bff80e4a0c0e30e
+niiri:f774990d88d82217c54c2bfadc119a0c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-46,-16,20]"^^xsd:string .
 
-niiri:1f8b76bc5a6e0e44d52dc38f77dfb573 prov:wasDerivedFrom niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd .
+niiri:41b9df925c1027d8561ada2ee95218ca prov:wasDerivedFrom niiri:df39775c5b1f38c8f9be672ec1fd63ff .
 
-niiri:ebb56262d90fa761f5c469bbcf6709b0
+niiri:80957271b12bb9a1c487565b2838bb66
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:bd5feebad73f603c2c5027f05c096a98 ;
+    prov:atLocation niiri:ff6c352882928d5baedf221a22bda6d2 ;
     prov:value "17.0075950622559"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55547987606237"^^xsd:float ;
     nidm_pValueUncorrected: "0.000188644912021529"^^xsd:float ;
     nidm_pValueFWER: "0.999934173907998"^^xsd:float ;
     nidm_qValueFDR: "0.0920555845860752"^^xsd:float .
 
-niiri:bd5feebad73f603c2c5027f05c096a98
+niiri:ff6c352882928d5baedf221a22bda6d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[24,32,2]"^^xsd:string .
 
-niiri:ebb56262d90fa761f5c469bbcf6709b0 prov:wasDerivedFrom niiri:8b25738f634743abd67e5fd856e90f74 .
+niiri:80957271b12bb9a1c487565b2838bb66 prov:wasDerivedFrom niiri:d89f1264b6a74fc289ac86f3b1b14dde .
 
-niiri:66c1ec432c1811911fdd6cd83f434d1b
+niiri:57a55f1ccdf43052d26c74811ccaab55
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:e5c4443633b94c1fa86927c7c92b220e ;
+    prov:atLocation niiri:950617618298bf3334ffddbd55a7a1cc ;
     prov:value "16.5308303833008"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50911812032442"^^xsd:float ;
     nidm_pValueUncorrected: "0.000224797592033421"^^xsd:float ;
     nidm_pValueFWER: "0.999983487413756"^^xsd:float ;
     nidm_qValueFDR: "0.0959555780965771"^^xsd:float .
 
-niiri:e5c4443633b94c1fa86927c7c92b220e
+niiri:950617618298bf3334ffddbd55a7a1cc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-26,-90,16]"^^xsd:string .
 
-niiri:66c1ec432c1811911fdd6cd83f434d1b prov:wasDerivedFrom niiri:1c59a22b32098831723dc21703615fd1 .
+niiri:57a55f1ccdf43052d26c74811ccaab55 prov:wasDerivedFrom niiri:6b099ac0f252fd44544d43dc12a3d6df .
 
-niiri:5f67ac778b6bca3e423969c609840ac8
+niiri:9c8c48700682cf318494852b869a0c02
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:a555880be249de2c84bc634ee280dbd7 ;
+    prov:atLocation niiri:a06e98a6f7670fca9ff5bf0157004bb3 ;
     prov:value "16.5225524902344"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50830432871627"^^xsd:float ;
     nidm_pValueUncorrected: "0.0002254864217901"^^xsd:float ;
     nidm_pValueFWER: "0.999983907066973"^^xsd:float ;
     nidm_qValueFDR: "0.0959555780965771"^^xsd:float .
 
-niiri:a555880be249de2c84bc634ee280dbd7
+niiri:a06e98a6f7670fca9ff5bf0157004bb3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-28,-4,16]"^^xsd:string .
 
-niiri:5f67ac778b6bca3e423969c609840ac8 prov:wasDerivedFrom niiri:139b6ecf5fdad735a51b4385a24aded9 .
+niiri:9c8c48700682cf318494852b869a0c02 prov:wasDerivedFrom niiri:de2e4a4014cc48ae0a2f90c80c8aa267 .
 
-niiri:5acb0f78fc88ddc60b2b62de835c1f34
+niiri:cc9b8d795bbac958aaf9b43fbd529026
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:eb3468c7ba505890d9c51ddfff00f74f ;
+    prov:atLocation niiri:2b50c69d0b92059509b14d9acfd238e9 ;
     prov:value "16.1374092102051"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47009871338807"^^xsd:float ;
     nidm_pValueUncorrected: "0.00026013355917065"^^xsd:float ;
     nidm_pValueFWER: "0.999995475747835"^^xsd:float ;
     nidm_qValueFDR: "0.101886915515055"^^xsd:float .
 
-niiri:eb3468c7ba505890d9c51ddfff00f74f
+niiri:2b50c69d0b92059509b14d9acfd238e9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[12,60,20]"^^xsd:string .
 
-niiri:5acb0f78fc88ddc60b2b62de835c1f34 prov:wasDerivedFrom niiri:e6a138032615b9872d9261e35d2455f4 .
+niiri:cc9b8d795bbac958aaf9b43fbd529026 prov:wasDerivedFrom niiri:0fde32a1a3d9efae8053253baac76ffc .
 
-niiri:0da938bd32e898d2174c988f1eaf4581
+niiri:9caf9d8c07b2f7bfff509850711f496c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:4a0acfe4d96a811a5bbd2fea220ee9f8 ;
+    prov:atLocation niiri:054f48629a0bfc1fc6f90348fd2784fb ;
     prov:value "15.9136981964111"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44759277757755"^^xsd:float ;
     nidm_pValueUncorrected: "0.000282803055741021"^^xsd:float ;
     nidm_pValueFWER: "0.999997977474125"^^xsd:float ;
     nidm_qValueFDR: "0.105222982133496"^^xsd:float .
 
-niiri:4a0acfe4d96a811a5bbd2fea220ee9f8
+niiri:054f48629a0bfc1fc6f90348fd2784fb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[4,-84,-4]"^^xsd:string .
 
-niiri:0da938bd32e898d2174c988f1eaf4581 prov:wasDerivedFrom niiri:37bc5cb5a158a9f86c496a5d1935903c .
+niiri:9caf9d8c07b2f7bfff509850711f496c prov:wasDerivedFrom niiri:93cac87b0b2603caa2e73e808a49aa59 .
 
-niiri:8c6a5d705c064da10637a02bbcea89bb
+niiri:f8ee304b70c41fce6525bce376facf90
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:a7922d8059c11028e4ec965953a381f4 ;
+    prov:atLocation niiri:0991de2b116957894edf7f933f355265 ;
     prov:value "15.8536109924316"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44150764421068"^^xsd:float ;
     nidm_pValueUncorrected: "0.000289241063091916"^^xsd:float ;
     nidm_pValueFWER: "0.999998385530387"^^xsd:float ;
     nidm_qValueFDR: "0.105222982133496"^^xsd:float .
 
-niiri:a7922d8059c11028e4ec965953a381f4
+niiri:0991de2b116957894edf7f933f355265
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[62,-18,22]"^^xsd:string .
 
-niiri:8c6a5d705c064da10637a02bbcea89bb prov:wasDerivedFrom niiri:f86c9bb022fe2e7bb4f2a1d963869d32 .
+niiri:f8ee304b70c41fce6525bce376facf90 prov:wasDerivedFrom niiri:5869329bf3b962a832bb7acb7781cebd .
 
-niiri:cf7dcc23115c0b40b60445223ba951c9
+niiri:b7d0e95b32356b2041707271fcfca84e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:f42b18360ea8f8af980f3d406996a6b7 ;
+    prov:atLocation niiri:0b435d3e5fef1995961220d7e0a8de62 ;
     prov:value "15.8288412094116"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43899416081302"^^xsd:float ;
     nidm_pValueUncorrected: "0.000291939913913408"^^xsd:float ;
     nidm_pValueFWER: "0.999998530446399"^^xsd:float ;
     nidm_qValueFDR: "0.105222982133496"^^xsd:float .
 
-niiri:f42b18360ea8f8af980f3d406996a6b7
+niiri:0b435d3e5fef1995961220d7e0a8de62
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[28,-58,44]"^^xsd:string .
 
-niiri:cf7dcc23115c0b40b60445223ba951c9 prov:wasDerivedFrom niiri:cecab36bcbd915f7841bff34cd7f59a6 .
+niiri:b7d0e95b32356b2041707271fcfca84e prov:wasDerivedFrom niiri:10ed6be507db860ee020a597d2bcfbc3 .
 
-niiri:c7e7aa913113f6519557c66a5087a3a8
+niiri:d57aa193b6ac9bb96b274e5259bb5ae7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:b8359b6165a7f498d646c290e8cd1c6c ;
+    prov:atLocation niiri:0678547c45e4ded802195d443e1b4adb ;
     prov:value "15.7273988723755"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42866974555038"^^xsd:float ;
     nidm_pValueUncorrected: "0.000303273553249328"^^xsd:float ;
     nidm_pValueFWER: "0.999999007347173"^^xsd:float ;
     nidm_qValueFDR: "0.106558197028572"^^xsd:float .
 
-niiri:b8359b6165a7f498d646c290e8cd1c6c
+niiri:0678547c45e4ded802195d443e1b4adb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[38,44,0]"^^xsd:string .
 
-niiri:c7e7aa913113f6519557c66a5087a3a8 prov:wasDerivedFrom niiri:752ff8a0ff1912e3b3a3cc0b0af92bac .
+niiri:d57aa193b6ac9bb96b274e5259bb5ae7 prov:wasDerivedFrom niiri:d4cffec5c689a35b7bf1bec1606134a5 .
 
-niiri:84d2dd552da32536ba619bf257b99a8e
+niiri:c7422a129ab7f2a919babb4fa7c89159
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:a8431b89c9e7b5310335b9441226ea8e ;
+    prov:atLocation niiri:29d5f4d8321f3255dc444a6bd52bd9a1 ;
     prov:value "15.4726600646973"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40252319694713"^^xsd:float ;
     nidm_pValueUncorrected: "0.000333833435672726"^^xsd:float ;
     nidm_pValueFWER: "0.999999648429928"^^xsd:float ;
     nidm_qValueFDR: "0.109105594368073"^^xsd:float .
 
-niiri:a8431b89c9e7b5310335b9441226ea8e
+niiri:29d5f4d8321f3255dc444a6bd52bd9a1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[40,-6,-6]"^^xsd:string .
 
-niiri:84d2dd552da32536ba619bf257b99a8e prov:wasDerivedFrom niiri:bbfdc94758422f4cdfa2d461f26c652c .
+niiri:c7422a129ab7f2a919babb4fa7c89159 prov:wasDerivedFrom niiri:2f94714c99bebff5b4831f0cfafa8496 .
 
-niiri:ac77b7c2f4ff41e88896e4ba87eadac1
+niiri:762a5a8c225478c6703d3b26ca737450
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:c99f7fc58da7232a1f42538844fca3ae ;
+    prov:atLocation niiri:8375751b34f073f3570bda0fc5b04a2d ;
     prov:value "15.3332357406616"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38807697766079"^^xsd:float ;
     nidm_pValueUncorrected: "0.00035192253822891"^^xsd:float ;
     nidm_pValueFWER: "0.999999807374102"^^xsd:float ;
     nidm_qValueFDR: "0.110729615236961"^^xsd:float .
 
-niiri:c99f7fc58da7232a1f42538844fca3ae
+niiri:8375751b34f073f3570bda0fc5b04a2d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[32,14,58]"^^xsd:string .
 
-niiri:ac77b7c2f4ff41e88896e4ba87eadac1 prov:wasDerivedFrom niiri:412f44bb99fe0b4ac5111c8bb0d6824f .
+niiri:762a5a8c225478c6703d3b26ca737450 prov:wasDerivedFrom niiri:ca58cacd0a13b44f43d59156a4c52a6a .
 
-niiri:fd0d7457e6ffb07f08eca126631606af
+niiri:e4fbf72406459fb025e130aa2aca989d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:d5fba9940a2400106183302f6016bc4b ;
+    prov:atLocation niiri:8330ad3bc2d7bb7815f7ea6b52f22b4e ;
     prov:value "15.3172578811646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38641524500992"^^xsd:float ;
     nidm_pValueUncorrected: "0.000354060730342054"^^xsd:float ;
     nidm_pValueFWER: "0.99999982049151"^^xsd:float ;
     nidm_qValueFDR: "0.110729615236961"^^xsd:float .
 
-niiri:d5fba9940a2400106183302f6016bc4b
+niiri:8330ad3bc2d7bb7815f7ea6b52f22b4e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[4,-86,4]"^^xsd:string .
 
-niiri:fd0d7457e6ffb07f08eca126631606af prov:wasDerivedFrom niiri:ae1cd8d0dfca9341507b66eafba6459d .
+niiri:e4fbf72406459fb025e130aa2aca989d prov:wasDerivedFrom niiri:61377f406c900484318b0d2817a3c523 .
 
-niiri:49269ead5464f020f20ecbdb76e9e6fa
+niiri:0d880252d15ec80597ff6a66d3ce357d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:de463eb97f5bdebf8c7c86e1b3c0390b ;
+    prov:atLocation niiri:b58a47985494e5da2d970330b8999204 ;
     prov:value "15.3137311935425"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38604828864924"^^xsd:float ;
     nidm_pValueUncorrected: "0.000354534526388783"^^xsd:float ;
     nidm_pValueFWER: "0.999999823272138"^^xsd:float ;
     nidm_qValueFDR: "0.110729615236961"^^xsd:float .
 
-niiri:de463eb97f5bdebf8c7c86e1b3c0390b
+niiri:b58a47985494e5da2d970330b8999204
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[62,-36,46]"^^xsd:string .
 
-niiri:49269ead5464f020f20ecbdb76e9e6fa prov:wasDerivedFrom niiri:089292d98902368bd347bcdfa162cfda .
+niiri:0d880252d15ec80597ff6a66d3ce357d prov:wasDerivedFrom niiri:307dd0ecb797aef0ce055f67fc2fa294 .
 
-niiri:7e757cfd5d9ab4dc7b7ed7c707af0b92
+niiri:cd398237ebe4e31d44e2353895ac40a5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:f64c41b60e15a328c7edf5b31cc35bb6 ;
+    prov:atLocation niiri:1e6c367b3ff399bd1b032ff38c100b12 ;
     prov:value "15.1916456222534"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37330635701462"^^xsd:float ;
     nidm_pValueUncorrected: "0.000371356333789152"^^xsd:float ;
     nidm_pValueFWER: "0.999999898084819"^^xsd:float ;
     nidm_qValueFDR: "0.113182641774622"^^xsd:float .
 
-niiri:f64c41b60e15a328c7edf5b31cc35bb6
+niiri:1e6c367b3ff399bd1b032ff38c100b12
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[-24,18,58]"^^xsd:string .
 
-niiri:7e757cfd5d9ab4dc7b7ed7c707af0b92 prov:wasDerivedFrom niiri:716ffa34870ad39bf06d8e49c18b9bce .
+niiri:cd398237ebe4e31d44e2353895ac40a5 prov:wasDerivedFrom niiri:e1f1160e4c3acdd85c621d64903334ab .
 
-niiri:1187cc9f9751060cd5bdbcc8bc4b20ce
+niiri:dd807d68bb7b271fd59c4bb70c811249
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:fe5b4275099b74097635eb9f7b4bc414 ;
+    prov:atLocation niiri:56d93aaec0edfdfc89387314b3e56566 ;
     prov:value "15.0888338088989"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36251708484568"^^xsd:float ;
     nidm_pValueUncorrected: "0.000386176732959709"^^xsd:float ;
     nidm_pValueFWER: "0.999999936876428"^^xsd:float ;
     nidm_qValueFDR: "0.114724188214818"^^xsd:float .
 
-niiri:fe5b4275099b74097635eb9f7b4bc414
+niiri:56d93aaec0edfdfc89387314b3e56566
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[8,-22,-44]"^^xsd:string .
 
-niiri:1187cc9f9751060cd5bdbcc8bc4b20ce prov:wasDerivedFrom niiri:8c7ca240ed7a4d85316011dd6f1768ff .
+niiri:dd807d68bb7b271fd59c4bb70c811249 prov:wasDerivedFrom niiri:bcd49735a6a0a30da7b9fe3278d6f064 .
 
-niiri:aa80010f717675a3a90dd7af1d9b1867
+niiri:6853db33c1053711f824bd586141fabe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:8a342a7e8ab4849998a118155ae4e602 ;
+    prov:atLocation niiri:54059f59333fed994723eddb0e55b65b ;
     prov:value "14.8200588226318"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33405240591422"^^xsd:float ;
     nidm_pValueUncorrected: "0.000427952650791097"^^xsd:float ;
     nidm_pValueFWER: "0.999999983180231"^^xsd:float ;
     nidm_qValueFDR: "0.119307804764224"^^xsd:float .
 
-niiri:8a342a7e8ab4849998a118155ae4e602
+niiri:54059f59333fed994723eddb0e55b65b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[38,34,22]"^^xsd:string .
 
-niiri:aa80010f717675a3a90dd7af1d9b1867 prov:wasDerivedFrom niiri:08593ccb1d9e49118b073d271565bd78 .
+niiri:6853db33c1053711f824bd586141fabe prov:wasDerivedFrom niiri:290672736f8553a55089385f6b74f206 .
 
-niiri:ba5d10a86acf3f4093c769c8fa361c7c
+niiri:b1e8f19541d681f48c5129bb66dcf335
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:efbdced299f9a874e778dd97925cd80e ;
+    prov:atLocation niiri:f06fe90d336d6fbe71a1db3b413c7d3c ;
     prov:value "14.696608543396"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32085065286489"^^xsd:float ;
     nidm_pValueUncorrected: "0.000448717729613968"^^xsd:float ;
     nidm_pValueFWER: "0.9999999911592"^^xsd:float ;
     nidm_qValueFDR: "0.121223400645327"^^xsd:float .
 
-niiri:efbdced299f9a874e778dd97925cd80e
+niiri:f06fe90d336d6fbe71a1db3b413c7d3c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[0,-26,-28]"^^xsd:string .
 
-niiri:ba5d10a86acf3f4093c769c8fa361c7c prov:wasDerivedFrom niiri:b52f4fded36d906e3611187b1ea82271 .
+niiri:b1e8f19541d681f48c5129bb66dcf335 prov:wasDerivedFrom niiri:5ecd1cdffe7971283f7ba38938b61b2c .
 
-niiri:10055d39115bd79bb71ae44a1b641f14
+niiri:65eaa4cbcb457da0734c9ff7d3a21b4a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:f1ba673212538f0ac2d79c06bd68cf16 ;
+    prov:atLocation niiri:c4a7634f1b2d594c6140cd5bc8cd1af9 ;
     prov:value "14.2414035797119"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27145497586776"^^xsd:float ;
     nidm_pValueUncorrected: "0.00053497811978398"^^xsd:float ;
     nidm_pValueFWER: "0.99999999933201"^^xsd:float ;
     nidm_qValueFDR: "0.128281884148943"^^xsd:float .
 
-niiri:f1ba673212538f0ac2d79c06bd68cf16
+niiri:c4a7634f1b2d594c6140cd5bc8cd1af9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[40,-50,-22]"^^xsd:string .
 
-niiri:10055d39115bd79bb71ae44a1b641f14 prov:wasDerivedFrom niiri:900eebea134685a11022813f19903499 .
+niiri:65eaa4cbcb457da0734c9ff7d3a21b4a prov:wasDerivedFrom niiri:e1e08c2b6ca06aabfd4b12e4367167be .
 
-niiri:024cfe8a8af184572999a9d180792536
+niiri:680883c3efa292a156e1ca9912880f20
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:8bd27ef17ea505784747393676c66e61 ;
+    prov:atLocation niiri:f318aaee15be61d5b8484fc4ad854618 ;
     prov:value "14.0012445449829"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24492687341108"^^xsd:float ;
     nidm_pValueUncorrected: "0.000587403942481801"^^xsd:float ;
     nidm_pValueFWER: "0.999999999852106"^^xsd:float ;
     nidm_qValueFDR: "0.131447065854217"^^xsd:float .
 
-niiri:8bd27ef17ea505784747393676c66e61
+niiri:f318aaee15be61d5b8484fc4ad854618
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[8,52,32]"^^xsd:string .
 
-niiri:024cfe8a8af184572999a9d180792536 prov:wasDerivedFrom niiri:a20506ad4a845975db3365e7c162d818 .
+niiri:680883c3efa292a156e1ca9912880f20 prov:wasDerivedFrom niiri:ef50676f067416d91bba713a2fc0321a .
 
-niiri:7a1112a488de76696afff578ff73b63a
+niiri:3886b26bb74aeadfd7fd0758d5ac87fa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:c3e118566488fbb275af41e9caa2d23e ;
+    prov:atLocation niiri:aed32c56cb51ebf9a918441830579843 ;
     prov:value "13.9842071533203"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2430323166614"^^xsd:float ;
     nidm_pValueUncorrected: "0.000591323980175695"^^xsd:float ;
     nidm_pValueFWER: "0.999999999867649"^^xsd:float ;
     nidm_qValueFDR: "0.131695068372973"^^xsd:float .
 
-niiri:c3e118566488fbb275af41e9caa2d23e
+niiri:aed32c56cb51ebf9a918441830579843
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-14,-48,-24]"^^xsd:string .
 
-niiri:7a1112a488de76696afff578ff73b63a prov:wasDerivedFrom niiri:cfde284823e7c32d74bec0b81232bb7a .
+niiri:3886b26bb74aeadfd7fd0758d5ac87fa prov:wasDerivedFrom niiri:947bdfd650d750aaad83d695fd5ff821 .
 
-niiri:d17f027d268c7f08e9841c1c575cf23e
+niiri:a85de1f634e031040b045156e50b8663
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:ae9a839905051fcbf3c519761251289d ;
+    prov:atLocation niiri:3e2bc5e98bf9e6fab0870d2c4bdf5d34 ;
     prov:value "13.9203996658325"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23592192136056"^^xsd:float ;
     nidm_pValueUncorrected: "0.000606252725692924"^^xsd:float ;
     nidm_pValueFWER: "0.999999999913111"^^xsd:float ;
     nidm_qValueFDR: "0.13226466740541"^^xsd:float .
 
-niiri:ae9a839905051fcbf3c519761251289d
+niiri:3e2bc5e98bf9e6fab0870d2c4bdf5d34
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[20,0,-8]"^^xsd:string .
 
-niiri:d17f027d268c7f08e9841c1c575cf23e prov:wasDerivedFrom niiri:496bec06cfc8ef95b3cbe0997c654d26 .
+niiri:a85de1f634e031040b045156e50b8663 prov:wasDerivedFrom niiri:51e987ef34cc607991dc3fcd1b06d12d .
 
-niiri:9a81d2292183627c111fac27998c2da6
+niiri:c9c453badd84eb33004fcf72af23bf1b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:84fa347a32d4bf011d58a0338bec2648 ;
+    prov:atLocation niiri:cfec8710cf8e7ba581e0267ad4b2319e ;
     prov:value "13.8925752639771"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23281385809669"^^xsd:float ;
     nidm_pValueUncorrected: "0.000612887021428588"^^xsd:float ;
     nidm_pValueFWER: "0.999999999927857"^^xsd:float ;
     nidm_qValueFDR: "0.13226466740541"^^xsd:float .
 
-niiri:84fa347a32d4bf011d58a0338bec2648
+niiri:cfec8710cf8e7ba581e0267ad4b2319e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[40,-14,60]"^^xsd:string .
 
-niiri:9a81d2292183627c111fac27998c2da6 prov:wasDerivedFrom niiri:e4bff32759970a1099e3a417cf7206b0 .
+niiri:c9c453badd84eb33004fcf72af23bf1b prov:wasDerivedFrom niiri:9e0d3d51afc26653e6ee900965729d85 .
 
-niiri:8b4c54efdd01e22033ec948028b376c6
+niiri:8fb7990e2a3094e39c98804faf3476c6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:cec9885ccb4c5eddad3e16791941394f ;
+    prov:atLocation niiri:a32e14841e7c0ca58935af8a10051a91 ;
     prov:value "13.8641185760498"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22963046726961"^^xsd:float ;
     nidm_pValueUncorrected: "0.000619751563460058"^^xsd:float ;
     nidm_pValueFWER: "0.999999999940447"^^xsd:float ;
     nidm_qValueFDR: "0.132333123904287"^^xsd:float .
 
-niiri:cec9885ccb4c5eddad3e16791941394f
+niiri:a32e14841e7c0ca58935af8a10051a91
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-36,10,24]"^^xsd:string .
 
-niiri:8b4c54efdd01e22033ec948028b376c6 prov:wasDerivedFrom niiri:40337b736645244404b84afb6772e7a9 .
+niiri:8fb7990e2a3094e39c98804faf3476c6 prov:wasDerivedFrom niiri:9d7d7cea0614241978504c478df9b65a .
 
-niiri:dc9b5b7925435de1e123f050c0f32db2
+niiri:e27123a684d62fdc9d18f0a3d92960cf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:abc2ee78bd07cda0b6ddcacbac427081 ;
+    prov:atLocation niiri:44105d28c46d8cf49561d64d83b7f67e ;
     prov:value "13.7912406921387"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22145599369965"^^xsd:float ;
     nidm_pValueUncorrected: "0.000637705235827735"^^xsd:float ;
     nidm_pValueFWER: "0.999999999963824"^^xsd:float ;
     nidm_qValueFDR: "0.133173984174016"^^xsd:float .
 
-niiri:abc2ee78bd07cda0b6ddcacbac427081
+niiri:44105d28c46d8cf49561d64d83b7f67e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[30,-78,14]"^^xsd:string .
 
-niiri:dc9b5b7925435de1e123f050c0f32db2 prov:wasDerivedFrom niiri:42bc55f4f90f29daf9e12be119e1ddab .
+niiri:e27123a684d62fdc9d18f0a3d92960cf prov:wasDerivedFrom niiri:20b5974d23f3286a95aa7fbb587ef438 .
 
-niiri:98a17ff5e5165fb8c24152b264b38518
+niiri:fe8bc9afc41b8b24738b1ecc268430b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:4ff470161927caacc784743cebf1ff5c ;
+    prov:atLocation niiri:4ad634e819e7502cb6e973e21f01dcb5 ;
     prov:value "13.629490852356"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20320002112963"^^xsd:float ;
     nidm_pValueUncorrected: "0.000679547746644249"^^xsd:float ;
     nidm_pValueFWER: "0.999999999988489"^^xsd:float ;
     nidm_qValueFDR: "0.136764826883915"^^xsd:float .
 
-niiri:4ff470161927caacc784743cebf1ff5c
+niiri:4ad634e819e7502cb6e973e21f01dcb5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[18,-78,12]"^^xsd:string .
 
-niiri:98a17ff5e5165fb8c24152b264b38518 prov:wasDerivedFrom niiri:067c79f86db85b508893737af41699ce .
+niiri:fe8bc9afc41b8b24738b1ecc268430b0 prov:wasDerivedFrom niiri:9a32bcfd38e5afc90a14c0c217161efa .
 
-niiri:457b57ff4d2f772e5a87d72e416d55f7
+niiri:ae7ee486258f0dae48d5e8bf50ad8f9a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:642bfe0fc88a3e08454fca298ff2547d ;
+    prov:atLocation niiri:4bbc0d3a18913695fb71f3e69866cdac ;
     prov:value "13.5061225891113"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18916981007524"^^xsd:float ;
     nidm_pValueUncorrected: "0.000713410180681495"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995369"^^xsd:float ;
     nidm_qValueFDR: "0.139253735873803"^^xsd:float .
 
-niiri:642bfe0fc88a3e08454fca298ff2547d
+niiri:4bbc0d3a18913695fb71f3e69866cdac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[46,8,-16]"^^xsd:string .
 
-niiri:457b57ff4d2f772e5a87d72e416d55f7 prov:wasDerivedFrom niiri:1a35a6d628eed4f2fc8c554a4a579a19 .
+niiri:ae7ee486258f0dae48d5e8bf50ad8f9a prov:wasDerivedFrom niiri:210435c4c0603b37239c262e4c742cd7 .
 
-niiri:983d2f990b97c775c7da5a27177fc0f6
+niiri:6d75431b8cc59654b1625ba7727b2c99
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:b7b5b47e2538aa1f088bf22667e716bc ;
+    prov:atLocation niiri:e074496b841b67475a31a93f47d65ce3 ;
     prov:value "13.4754667282104"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1856690050705"^^xsd:float ;
     nidm_pValueUncorrected: "0.000722098618250455"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996325"^^xsd:float ;
     nidm_qValueFDR: "0.1402954623971"^^xsd:float .
 
-niiri:b7b5b47e2538aa1f088bf22667e716bc
+niiri:e074496b841b67475a31a93f47d65ce3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[58,-40,50]"^^xsd:string .
 
-niiri:983d2f990b97c775c7da5a27177fc0f6 prov:wasDerivedFrom niiri:0e92ac2d77c091672e014daf15280170 .
+niiri:6d75431b8cc59654b1625ba7727b2c99 prov:wasDerivedFrom niiri:7c7c96862dfaf19b5ad9f27652329ae0 .
 
-niiri:0d84f12f1eecf02fd70239d18b674632
+niiri:f0af53a4324f48d47ab9a0666034d93c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:b200c3101378d90c3289227f2f311490 ;
+    prov:atLocation niiri:620f27d7626b16337913220c7107c4a5 ;
     prov:value "13.4480972290039"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18253860543696"^^xsd:float ;
     nidm_pValueUncorrected: "0.000729950259848011"^^xsd:float ;
     nidm_pValueFWER: "0.999999999997016"^^xsd:float ;
     nidm_qValueFDR: "0.140840039531724"^^xsd:float .
 
-niiri:b200c3101378d90c3289227f2f311490
+niiri:620f27d7626b16337913220c7107c4a5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[46,-66,32]"^^xsd:string .
 
-niiri:0d84f12f1eecf02fd70239d18b674632 prov:wasDerivedFrom niiri:0d2b802df946de1efd390f218ef63fce .
+niiri:f0af53a4324f48d47ab9a0666034d93c prov:wasDerivedFrom niiri:3cb44c7fa017003278142567fd208f77 .
 
-niiri:1106844ff3c3aa841e131a1c8b3cee03
+niiri:cef34ffd29ba805c930823965884c6ae
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:2c69785e6a1162eaef0e8d5fb846e6be ;
+    prov:atLocation niiri:44bfba582c9b94d11f800bc7e4460a5e ;
     prov:value "13.2857608795166"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16387572537233"^^xsd:float ;
     nidm_pValueUncorrected: "0.000778416284459293"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999163"^^xsd:float ;
     nidm_qValueFDR: "0.14332751949213"^^xsd:float .
 
-niiri:2c69785e6a1162eaef0e8d5fb846e6be
+niiri:44bfba582c9b94d11f800bc7e4460a5e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[2,-76,8]"^^xsd:string .
 
-niiri:1106844ff3c3aa841e131a1c8b3cee03 prov:wasDerivedFrom niiri:627d75e08350cce3541dd568e3ddaa39 .
+niiri:cef34ffd29ba805c930823965884c6ae prov:wasDerivedFrom niiri:d0db4687f221096cb9c4f8413c4f75c6 .
 
-niiri:8f5c2c4423ccd494ee5e86fe3deb293e
+niiri:1aa2f72fc93fb6973ae744cebc511ef4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:611027fbd0882487ef894fa5a6a8e4e5 ;
+    prov:atLocation niiri:f91f42faf168af767e942f38ff2367c2 ;
     prov:value "13.2286987304688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15727638472708"^^xsd:float ;
     nidm_pValueUncorrected: "0.000796251631906664"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999472"^^xsd:float ;
     nidm_qValueFDR: "0.143821550671959"^^xsd:float .
 
-niiri:611027fbd0882487ef894fa5a6a8e4e5
+niiri:f91f42faf168af767e942f38ff2367c2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[14,-24,-2]"^^xsd:string .
 
-niiri:8f5c2c4423ccd494ee5e86fe3deb293e prov:wasDerivedFrom niiri:20516921d28241951d08251e80cac5b5 .
+niiri:1aa2f72fc93fb6973ae744cebc511ef4 prov:wasDerivedFrom niiri:7ef8baaeb7357f28badb11366679f71c .
 
-niiri:ec7eede0d453f71f84e10d81d45a185d
+niiri:442356249320781048907ca9e1850c5a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:4bd2715c430b33d70e84b77b850d16be ;
+    prov:atLocation niiri:7a37cc3e0a15fcfdece2cd392b603adc ;
     prov:value "13.0621271133423"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13789355719639"^^xsd:float ;
     nidm_pValueUncorrected: "0.00085083330089919"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999869"^^xsd:float ;
     nidm_qValueFDR: "0.146648454262555"^^xsd:float .
 
-niiri:4bd2715c430b33d70e84b77b850d16be
+niiri:7a37cc3e0a15fcfdece2cd392b603adc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-36,0,-4]"^^xsd:string .
 
-niiri:ec7eede0d453f71f84e10d81d45a185d prov:wasDerivedFrom niiri:3822c0fa262ca8cb8a67590f3eec2fe6 .
+niiri:442356249320781048907ca9e1850c5a prov:wasDerivedFrom niiri:cec5df2d95985851dd02c6d0db6fe243 .
 
-niiri:4ee980646f678b94fcd5772eb72db1d4
+niiri:82f53a0a6c8b368ff5c21bd17bdf95fe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:34b06f9fb053f163bc7a00ce986a8123 ;
+    prov:atLocation niiri:4f84af5759966f61ee9c71d98847736a ;
     prov:value "13.0451946258545"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13591325616981"^^xsd:float ;
     nidm_pValueUncorrected: "0.000856599341067521"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999886"^^xsd:float ;
     nidm_qValueFDR: "0.146787157394689"^^xsd:float .
 
-niiri:34b06f9fb053f163bc7a00ce986a8123
+niiri:4f84af5759966f61ee9c71d98847736a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[12,6,62]"^^xsd:string .
 
-niiri:4ee980646f678b94fcd5772eb72db1d4 prov:wasDerivedFrom niiri:51287994298816d649ba6908b4e3d0bb .
+niiri:82f53a0a6c8b368ff5c21bd17bdf95fe prov:wasDerivedFrom niiri:f0dffbbec6ed840a50eeb67367cfa4d5 .
 
-niiri:f672ee780ba0dc20dc0aa8808e3c2090
+niiri:9ec8ea566b57711897fba57f996a1086
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:729e387de0d5316ccf723a049f2cd632 ;
+    prov:atLocation niiri:58cf359b5a18f021a7a3bd5c19ef0be5 ;
     prov:value "13.0064306259155"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13137270324883"^^xsd:float ;
     nidm_pValueUncorrected: "0.000869955985260296"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999919"^^xsd:float ;
     nidm_qValueFDR: "0.146787157394689"^^xsd:float .
 
-niiri:729e387de0d5316ccf723a049f2cd632
+niiri:58cf359b5a18f021a7a3bd5c19ef0be5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[-8,-4,24]"^^xsd:string .
 
-niiri:f672ee780ba0dc20dc0aa8808e3c2090 prov:wasDerivedFrom niiri:36a1ff3bd64efa589db6c3a56ccf9d25 .
+niiri:9ec8ea566b57711897fba57f996a1086 prov:wasDerivedFrom niiri:67c3a7b5cc3c3fe392535195f3bad2ad .
 
-niiri:133da124dca5a66efd13ce67c41fded3
+niiri:1f4eaccd991e6c5607a658d417756ce7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:1eb746ff728a0d069a40542bb5f7a689 ;
+    prov:atLocation niiri:8ce66f9f243d621349fcc33e8c2d721a ;
     prov:value "12.968074798584"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12687033926247"^^xsd:float ;
     nidm_pValueUncorrected: "0.00088338914171493"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999942"^^xsd:float ;
     nidm_qValueFDR: "0.147244283960254"^^xsd:float .
 
-niiri:1eb746ff728a0d069a40542bb5f7a689
+niiri:8ce66f9f243d621349fcc33e8c2d721a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[8,-36,40]"^^xsd:string .
 
-niiri:133da124dca5a66efd13ce67c41fded3 prov:wasDerivedFrom niiri:1c0a11fe168926616610d5836c36d35f .
+niiri:1f4eaccd991e6c5607a658d417756ce7 prov:wasDerivedFrom niiri:db97ffa2bd8c5823f405fd68ff718eee .
 
-niiri:9801cb1bbda1a53d0101f519d9d19df1
+niiri:4f3a8969ea371259f73c3af05071826e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:f1edc34f43382229a619f2254f87a59c ;
+    prov:atLocation niiri:003e8ab6a677f803afc9b92a6b175ac5 ;
     prov:value "12.9628992080688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12626207199886"^^xsd:float ;
     nidm_pValueUncorrected: "0.000885218504765861"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999944"^^xsd:float ;
     nidm_qValueFDR: "0.147244283960254"^^xsd:float .
 
-niiri:f1edc34f43382229a619f2254f87a59c
+niiri:003e8ab6a677f803afc9b92a6b175ac5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[24,38,0]"^^xsd:string .
 
-niiri:9801cb1bbda1a53d0101f519d9d19df1 prov:wasDerivedFrom niiri:aa0d58d5cc7671539d09308038edb0f1 .
+niiri:4f3a8969ea371259f73c3af05071826e prov:wasDerivedFrom niiri:2d47c7ce748aeebd84bed25e87007425 .
 
-niiri:04821e6510237840cbf335fef76d5cdc
+niiri:9243f6f83efb0d3dc889ef170a12cf0d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:1f4eb737906c00c0031d9ee2356ab46d ;
+    prov:atLocation niiri:f51e48907d119eede302de1a4d7e24f3 ;
     prov:value "12.9482192993164"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12453584528173"^^xsd:float ;
     nidm_pValueUncorrected: "0.000890429112242686"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999951"^^xsd:float ;
     nidm_qValueFDR: "0.14749076092896"^^xsd:float .
 
-niiri:1f4eb737906c00c0031d9ee2356ab46d
+niiri:f51e48907d119eede302de1a4d7e24f3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[26,-50,46]"^^xsd:string .
 
-niiri:04821e6510237840cbf335fef76d5cdc prov:wasDerivedFrom niiri:fc71e9e9a2574cbd9d5094f50275b3c2 .
+niiri:9243f6f83efb0d3dc889ef170a12cf0d prov:wasDerivedFrom niiri:8b7c26257640b1664a72209e6721cdcd .
 
-niiri:febde3f603b3693a20767813beb5bd71
+niiri:3119a0747a8bd932e29ee104af2fd79d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:aa6eef7396e2ed67c9ab5d0bb298088e ;
+    prov:atLocation niiri:b07e614a86690f51810792a90d026dca ;
     prov:value "12.9151954650879"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12064737190897"^^xsd:float ;
     nidm_pValueUncorrected: "0.000902269894699104"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999964"^^xsd:float ;
     nidm_qValueFDR: "0.147598889605401"^^xsd:float .
 
-niiri:aa6eef7396e2ed67c9ab5d0bb298088e
+niiri:b07e614a86690f51810792a90d026dca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-30,-86,8]"^^xsd:string .
 
-niiri:febde3f603b3693a20767813beb5bd71 prov:wasDerivedFrom niiri:c23970716bccffb656edae94cc34e353 .
+niiri:3119a0747a8bd932e29ee104af2fd79d prov:wasDerivedFrom niiri:4e2a5af599e4e60cf34c225aefbe86cb .
 
-niiri:b52c3eeba29b97da2b661dd4df58cef0
+niiri:45f9a9e4768213692db2f621365dc39f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:dacf1036163cfbe9703b73ef87a5b977 ;
+    prov:atLocation niiri:50267042cb4910a066fa7dfaf7912429 ;
     prov:value "12.8661985397339"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11486488202419"^^xsd:float ;
     nidm_pValueUncorrected: "0.00092014594111034"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999977"^^xsd:float ;
     nidm_qValueFDR: "0.147847736781403"^^xsd:float .
 
-niiri:dacf1036163cfbe9703b73ef87a5b977
+niiri:50267042cb4910a066fa7dfaf7912429
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[22,-24,38]"^^xsd:string .
 
-niiri:b52c3eeba29b97da2b661dd4df58cef0 prov:wasDerivedFrom niiri:8e2363110cdebe114cbe95493b19fa9d .
+niiri:45f9a9e4768213692db2f621365dc39f prov:wasDerivedFrom niiri:3a69dd386e787d840309add4c3d8288a .
 
-niiri:9c19f778bd965a28a5a95c2a44273e2f
+niiri:f94d885513d5d6734a3639abe4f3725b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:3342cfcb637deb366202637575b9bf6e ;
+    prov:atLocation niiri:61719937b537968c16c46c150415c5ba ;
     prov:value "12.8156299591064"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10888025138563"^^xsd:float ;
     nidm_pValueUncorrected: "0.000938989080538355"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999985"^^xsd:float ;
     nidm_qValueFDR: "0.148123448926347"^^xsd:float .
 
-niiri:3342cfcb637deb366202637575b9bf6e
+niiri:61719937b537968c16c46c150415c5ba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[48,50,2]"^^xsd:string .
 
-niiri:9c19f778bd965a28a5a95c2a44273e2f prov:wasDerivedFrom niiri:eb4122935f1afa2c8b532875de5f0ef9 .
+niiri:f94d885513d5d6734a3639abe4f3725b prov:wasDerivedFrom niiri:6026278153ba92cecad8e5b03e166074 .
 
-niiri:ad2e6a4a1bd4b49e04b2f5ce6f700bf1
+niiri:268ed018d417f3b43e857d7cfac12e22
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:51217ecd4042ac5a689d5913af7f97c4 ;
+    prov:atLocation niiri:3a8f96ab4b6f12aa57b699f8a24600c0 ;
     prov:value "12.7734069824219"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10387025917553"^^xsd:float ;
     nidm_pValueUncorrected: "0.000955035352381506"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.149144835108449"^^xsd:float .
 
-niiri:51217ecd4042ac5a689d5913af7f97c4
+niiri:3a8f96ab4b6f12aa57b699f8a24600c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-48,-68,20]"^^xsd:string .
 
-niiri:ad2e6a4a1bd4b49e04b2f5ce6f700bf1 prov:wasDerivedFrom niiri:25018fb0acd6d245a4f445c35c5f92eb .
+niiri:268ed018d417f3b43e857d7cfac12e22 prov:wasDerivedFrom niiri:5df20a4fb89cbcd4160591f81dc70a0d .
 
-niiri:40ede6bfbdf28e2cb70db26b715172d6
+niiri:7afce934f02bb8824bcb0dbd9907f2bb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:32049f907c1ff3c54deff6f919d2ee46 ;
+    prov:atLocation niiri:7b2ba98983ea251b4cdb9f4c8145b2d2 ;
     prov:value "12.7362623214722"^^xsd:float ;
     nidm_equivalentZStatistic: "3.0994529756118"^^xsd:float ;
     nidm_pValueUncorrected: "0.000969391758882221"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.150376120259304"^^xsd:float .
 
-niiri:32049f907c1ff3c54deff6f919d2ee46
+niiri:7b2ba98983ea251b4cdb9f4c8145b2d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[24,-22,36]"^^xsd:string .
 
-niiri:40ede6bfbdf28e2cb70db26b715172d6 prov:wasDerivedFrom niiri:ccd2969f60f8b0222713472b0a037361 .
+niiri:7afce934f02bb8824bcb0dbd9907f2bb prov:wasDerivedFrom niiri:32dc10b2a989e36bb73d9c695b9ace8f .
 

--- a/spmexport/ex_spm_non_sphericity/nidm.ttl
+++ b/spmexport/ex_spm_non_sphericity/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:25ee938ddb1a1359b5dbfc8ddbffdf98
+niiri:7b4cf04d3e03731e8b127b5ef008e6ba
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:9360978694c62922ec5ea1a313b72c46
+niiri:b823f4f8cbc1c10feef0f31492474351
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:7a90abf761d31fac1a65bd4bda03a81a
+niiri:2df4836000438363ab93c2c037ea1c9f
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:7a90abf761d31fac1a65bd4bda03a81a prov:wasAssociatedWith niiri:9360978694c62922ec5ea1a313b72c46 .
+niiri:2df4836000438363ab93c2c037ea1c9f prov:wasAssociatedWith niiri:b823f4f8cbc1c10feef0f31492474351 .
 
 _:blank5 a prov:Generation .
 
-niiri:25ee938ddb1a1359b5dbfc8ddbffdf98 prov:qualifiedGeneration _:blank5 .
+niiri:7b4cf04d3e03731e8b127b5ef008e6ba prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:11:35"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:33:49"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -131,12 +131,12 @@ _:blank5 prov:atTime "2016-01-11T10:11:35"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:cbb4e09f0c239d9fc253f426daea95ec
+niiri:8707d65d3a15dbf845684e80f7df9da7
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:04394321c13e24105925122a5ea9615c
+niiri:c91eabb6ae30ecd695a7cf4b3fcab893
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -146,27 +146,27 @@ niiri:04394321c13e24105925122a5ea9615c
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:3279b88b6e6cd5ec2237720417dd3d48
+niiri:34de00e96ed7c645577a52f0e7289dc5
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean .
 
-niiri:186f3712419791aaf7a04a3d1b8bd722
+niiri:c75f4ff351459ee32fa91d23800efb92
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:b17ee10e3431226e0e680dfd4966a939 ;
+    dc:description niiri:3065da080a203d349041ec0f402e8e33 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]"^^xsd:string .
 
-niiri:b17ee10e3431226e0e680dfd4966a939
+niiri:3065da080a203d349041ec0f402e8e33
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:ce59f39b89684ad9fbc37e749e8dc23d
+niiri:d6bb9097d5397477b9a2fe34b1e173d1
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_UnstructuredCorrelationStructure: ;
@@ -174,162 +174,162 @@ niiri:ce59f39b89684ad9fbc37e749e8dc23d
     nidm_errorVarianceHomogeneous: "false"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:a4e3f64a7d5dde02404b02a2e482b25c
+niiri:48bd386fe0be968592a13062b5c43885
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:a4e3f64a7d5dde02404b02a2e482b25c prov:wasAssociatedWith niiri:cbb4e09f0c239d9fc253f426daea95ec .
+niiri:48bd386fe0be968592a13062b5c43885 prov:wasAssociatedWith niiri:8707d65d3a15dbf845684e80f7df9da7 .
 
-niiri:a4e3f64a7d5dde02404b02a2e482b25c prov:used niiri:186f3712419791aaf7a04a3d1b8bd722 .
+niiri:48bd386fe0be968592a13062b5c43885 prov:used niiri:c75f4ff351459ee32fa91d23800efb92 .
 
-niiri:a4e3f64a7d5dde02404b02a2e482b25c prov:used niiri:3279b88b6e6cd5ec2237720417dd3d48 .
+niiri:48bd386fe0be968592a13062b5c43885 prov:used niiri:34de00e96ed7c645577a52f0e7289dc5 .
 
-niiri:a4e3f64a7d5dde02404b02a2e482b25c prov:used niiri:ce59f39b89684ad9fbc37e749e8dc23d .
+niiri:48bd386fe0be968592a13062b5c43885 prov:used niiri:d6bb9097d5397477b9a2fe34b1e173d1 .
 
-niiri:1d1c92ca0bfb701909eb307868358b1a
+niiri:9f3d2992eab79fd14d4660154ae8238a
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:7b426f12cc92d11d7f4d5eb771c95217
+niiri:5e1b296cb7615ea4c933955980cef164
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e"^^xsd:string .
 
-niiri:1d1c92ca0bfb701909eb307868358b1a prov:wasDerivedFrom niiri:7b426f12cc92d11d7f4d5eb771c95217 .
+niiri:9f3d2992eab79fd14d4660154ae8238a prov:wasDerivedFrom niiri:5e1b296cb7615ea4c933955980cef164 .
 
-niiri:1d1c92ca0bfb701909eb307868358b1a prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+niiri:9f3d2992eab79fd14d4660154ae8238a prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
 
-niiri:785bae8edf8ea0f5eae2802088ac85b1
+niiri:2907b9f1080a55bf3a3b5fde0463d565
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "0.0511472336947918"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
     crypto:sha512 "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc"^^xsd:string .
 
-niiri:785bae8edf8ea0f5eae2802088ac85b1 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+niiri:2907b9f1080a55bf3a3b5fde0463d565 prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
 
-niiri:9f2d3c6c9d93cbbc83d0629664f66005
+niiri:fd2e03999ed8a414f71235a7246666d9
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c .
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 .
 
-niiri:1273bdcdc1d1987029f9da1d84d22ea2
+niiri:ba6d197e4b83b9354b3d92dc6cdbe6e7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f"^^xsd:string .
 
-niiri:9f2d3c6c9d93cbbc83d0629664f66005 prov:wasDerivedFrom niiri:1273bdcdc1d1987029f9da1d84d22ea2 .
+niiri:fd2e03999ed8a414f71235a7246666d9 prov:wasDerivedFrom niiri:ba6d197e4b83b9354b3d92dc6cdbe6e7 .
 
-niiri:9f2d3c6c9d93cbbc83d0629664f66005 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+niiri:fd2e03999ed8a414f71235a7246666d9 prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
 
-niiri:baf9cccb8eba46b7c5f41863dda48579
+niiri:af828ebe888a0cdbc655a60d27afaa91
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c .
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 .
 
-niiri:87c6aec787414fb9d08ddd2e2f2c9b55
+niiri:a4ab3adcdfcd06863c089ef11dfef36a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978"^^xsd:string .
 
-niiri:baf9cccb8eba46b7c5f41863dda48579 prov:wasDerivedFrom niiri:87c6aec787414fb9d08ddd2e2f2c9b55 .
+niiri:af828ebe888a0cdbc655a60d27afaa91 prov:wasDerivedFrom niiri:a4ab3adcdfcd06863c089ef11dfef36a .
 
-niiri:baf9cccb8eba46b7c5f41863dda48579 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+niiri:af828ebe888a0cdbc655a60d27afaa91 prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
 
-niiri:b178295856d95973727b2b358956335e
+niiri:bd9421d9a41bc778b27e2be0eda0496f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c .
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 .
 
-niiri:1263d9ada22b54fa429647fa22af73f9
+niiri:db047f8eefe5537016244f0bb25e3637
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a"^^xsd:string .
 
-niiri:b178295856d95973727b2b358956335e prov:wasDerivedFrom niiri:1263d9ada22b54fa429647fa22af73f9 .
+niiri:bd9421d9a41bc778b27e2be0eda0496f prov:wasDerivedFrom niiri:db047f8eefe5537016244f0bb25e3637 .
 
-niiri:b178295856d95973727b2b358956335e prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+niiri:bd9421d9a41bc778b27e2be0eda0496f prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
 
-niiri:0c8cae8f7fd81853bcc8700ee2f1bb91
+niiri:dc244080dfe10dc4223d65ff1b5587f2
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
     crypto:sha512 "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48"^^xsd:string .
 
-niiri:3c4935283c58d44dba5a403a5d3b5832
+niiri:ade1763484de1aa955eb941d8892ffcb
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868"^^xsd:string .
 
-niiri:0c8cae8f7fd81853bcc8700ee2f1bb91 prov:wasDerivedFrom niiri:3c4935283c58d44dba5a403a5d3b5832 .
+niiri:dc244080dfe10dc4223d65ff1b5587f2 prov:wasDerivedFrom niiri:ade1763484de1aa955eb941d8892ffcb .
 
-niiri:0c8cae8f7fd81853bcc8700ee2f1bb91 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+niiri:dc244080dfe10dc4223d65ff1b5587f2 prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
 
-niiri:0a2a8817aa6793a351bd0a7021236cd0
+niiri:86e735169b95dc7176008fba7b0cbabd
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
     crypto:sha512 "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381"^^xsd:string .
 
-niiri:3a2ab399f71d1f0e06d2a38d3de41f29
+niiri:a2f5143ec88d6b7200a0d1b34f1c06ab
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8"^^xsd:string .
 
-niiri:0a2a8817aa6793a351bd0a7021236cd0 prov:wasDerivedFrom niiri:3a2ab399f71d1f0e06d2a38d3de41f29 .
+niiri:86e735169b95dc7176008fba7b0cbabd prov:wasDerivedFrom niiri:a2f5143ec88d6b7200a0d1b34f1c06ab .
 
-niiri:0a2a8817aa6793a351bd0a7021236cd0 prov:wasGeneratedBy niiri:a4e3f64a7d5dde02404b02a2e482b25c .
+niiri:86e735169b95dc7176008fba7b0cbabd prov:wasGeneratedBy niiri:48bd386fe0be968592a13062b5c43885 .
 
-niiri:df230f4ff3b58783fe139f385597465e
+niiri:99e218282e31bd12efdffa7662e50016
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_FStatistic: ;
     nidm_contrastName: "Average effect of condition"^^xsd:string ;
     rdfs:label "Contrast: Average effect of condition" ;
     prov:value "[1, 1, 1]"^^xsd:string .
 
-niiri:2ff41e5681a1c005622be9b68da73a06
+niiri:f30c53c09afee24faac70ef520464dcc
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:2ff41e5681a1c005622be9b68da73a06 prov:wasAssociatedWith niiri:cbb4e09f0c239d9fc253f426daea95ec .
+niiri:f30c53c09afee24faac70ef520464dcc prov:wasAssociatedWith niiri:8707d65d3a15dbf845684e80f7df9da7 .
 
-niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:1d1c92ca0bfb701909eb307868358b1a .
+niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:9f3d2992eab79fd14d4660154ae8238a .
 
-niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:0c8cae8f7fd81853bcc8700ee2f1bb91 .
+niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:dc244080dfe10dc4223d65ff1b5587f2 .
 
-niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:186f3712419791aaf7a04a3d1b8bd722 .
+niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:c75f4ff351459ee32fa91d23800efb92 .
 
-niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:df230f4ff3b58783fe139f385597465e .
+niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:99e218282e31bd12efdffa7662e50016 .
 
-niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:9f2d3c6c9d93cbbc83d0629664f66005 .
+niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:fd2e03999ed8a414f71235a7246666d9 .
 
-niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:baf9cccb8eba46b7c5f41863dda48579 .
+niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:af828ebe888a0cdbc655a60d27afaa91 .
 
-niiri:2ff41e5681a1c005622be9b68da73a06 prov:used niiri:b178295856d95973727b2b358956335e .
+niiri:f30c53c09afee24faac70ef520464dcc prov:used niiri:bd9421d9a41bc778b27e2be0eda0496f .
 
-niiri:50609b22ae1142a0b21014e830b41cae
+niiri:67b4a4f6b336096ca6b563aa31361183
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
@@ -339,104 +339,104 @@ niiri:50609b22ae1142a0b21014e830b41cae
     nidm_contrastName: "Average effect of condition"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "39"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
     crypto:sha512 "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960"^^xsd:string .
 
-niiri:c59df51d9201082e5f25f11b2f13807f
+niiri:70bdd0befd9857e4ff6434527df6ac2c
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmF_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762"^^xsd:string .
 
-niiri:50609b22ae1142a0b21014e830b41cae prov:wasDerivedFrom niiri:c59df51d9201082e5f25f11b2f13807f .
+niiri:67b4a4f6b336096ca6b563aa31361183 prov:wasDerivedFrom niiri:70bdd0befd9857e4ff6434527df6ac2c .
 
-niiri:50609b22ae1142a0b21014e830b41cae prov:wasGeneratedBy niiri:2ff41e5681a1c005622be9b68da73a06 .
+niiri:67b4a4f6b336096ca6b563aa31361183 prov:wasGeneratedBy niiri:f30c53c09afee24faac70ef520464dcc .
 
-niiri:2416820ce6beaa983e426560e9ec33ec
+niiri:23c30668e6a9efa0ff2e602769536cb0
     a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
     prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Explained Mean Square Map" ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
     crypto:sha512 "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a"^^xsd:string .
 
-niiri:2416820ce6beaa983e426560e9ec33ec prov:wasGeneratedBy niiri:2ff41e5681a1c005622be9b68da73a06 .
+niiri:23c30668e6a9efa0ff2e602769536cb0 prov:wasGeneratedBy niiri:f30c53c09afee24faac70ef520464dcc .
 
-niiri:d16264948a1baffc5b788ff82a41433f
+niiri:40440229b29f5872d53eef25ecf0f975
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500201896764"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:d6d3c2e8396eddb36c52c8ebf1691170 ;
-    nidm_equivalentThreshold: niiri:59cbe87bfe988562f71c7863fcee3540 .
+    nidm_equivalentThreshold: niiri:2c452674a1f81d156e269dbe9725998a ;
+    nidm_equivalentThreshold: niiri:15ee33831544a51d39b276ac0d45c0cb .
 
-niiri:d6d3c2e8396eddb36c52c8ebf1691170
+niiri:2c452674a1f81d156e269dbe9725998a
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "12.6602184255263"^^xsd:float .
 
-niiri:59cbe87bfe988562f71c7863fcee3540
+niiri:15ee33831544a51d39b276ac0d45c0cb
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:689643975c6d062da3f861f197ffb911
+niiri:981d4a611d50d796152b8e8eb6283194
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:979cfefce98a2d163c991361d12cbf64 ;
-    nidm_equivalentThreshold: niiri:5a949293e4972919cdd1902557e60273 .
+    nidm_equivalentThreshold: niiri:3455442e086debfe280887e4ef34a59a ;
+    nidm_equivalentThreshold: niiri:eec7cc036dfbc9f23b1c4ad9eede1da3 .
 
-niiri:979cfefce98a2d163c991361d12cbf64
+niiri:3455442e086debfe280887e4ef34a59a
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:5a949293e4972919cdd1902557e60273
+niiri:eec7cc036dfbc9f23b1c4ad9eede1da3
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:932bf207ec1906155b85201be9afc0ed
+niiri:ae1827b0fff51351ca6d76d580243226
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:356327ce3d3e8895d849bb23327e10f5
+niiri:00a53452216f98c5cdd45baf25410a08
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:6be0e67690536755101ed426c4c5cfe1
+niiri:9ea94d4c881c3057dcce3e08fa91b4db
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:6be0e67690536755101ed426c4c5cfe1 prov:wasAssociatedWith niiri:cbb4e09f0c239d9fc253f426daea95ec .
+niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:wasAssociatedWith niiri:8707d65d3a15dbf845684e80f7df9da7 .
 
-niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:d16264948a1baffc5b788ff82a41433f .
+niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:40440229b29f5872d53eef25ecf0f975 .
 
-niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:689643975c6d062da3f861f197ffb911 .
+niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:981d4a611d50d796152b8e8eb6283194 .
 
-niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:50609b22ae1142a0b21014e830b41cae .
+niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:67b4a4f6b336096ca6b563aa31361183 .
 
-niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:0a2a8817aa6793a351bd0a7021236cd0 .
+niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:86e735169b95dc7176008fba7b0cbabd .
 
-niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:1d1c92ca0bfb701909eb307868358b1a .
+niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:9f3d2992eab79fd14d4660154ae8238a .
 
-niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:932bf207ec1906155b85201be9afc0ed .
+niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:ae1827b0fff51351ca6d76d580243226 .
 
-niiri:6be0e67690536755101ed426c4c5cfe1 prov:used niiri:356327ce3d3e8895d849bb23327e10f5 .
+niiri:9ea94d4c881c3057dcce3e08fa91b4db prov:used niiri:00a53452216f98c5cdd45baf25410a08 .
 
-niiri:6009f6fd85ea333f9b78564cda2aa83c
+niiri:144940fea03f1e81a40c282fefbe54f4
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
     nidm_searchVolumeInVoxels: "167222"^^xsd:int ;
     nidm_searchVolumeInUnits: "1337776"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.5679161280351"^^xsd:float ;
@@ -453,9 +453,9 @@ niiri:6009f6fd85ea333f9b78564cda2aa83c
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "57"^^xsd:int ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:6009f6fd85ea333f9b78564cda2aa83c prov:wasGeneratedBy niiri:6be0e67690536755101ed426c4c5cfe1 .
+niiri:144940fea03f1e81a40c282fefbe54f4 prov:wasGeneratedBy niiri:9ea94d4c881c3057dcce3e08fa91b4db .
 
-niiri:950be147189508776d90eb2c4280326c
+niiri:a79e189fef35c2ea79f265fe43ab3fd5
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -463,26 +463,26 @@ niiri:950be147189508776d90eb2c4280326c
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "71"^^xsd:int ;
     nidm_pValue: "9.36073596413678e-09"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:404ea6617dcd902e2957d9a6b74f7ab3 ;
-    nidm_hasMaximumIntensityProjection: niiri:a77ea9285b48403a7689ae0b730f7230 ;
-    nidm_inCoordinateSpace: niiri:04394321c13e24105925122a5ea9615c ;
+    nidm_hasClusterLabelsMap: niiri:f36222cc921e73ce4c2371f2c0ddc287 ;
+    nidm_hasMaximumIntensityProjection: niiri:cf3dd6a7998b23db2dee0adcb3e1f4d7 ;
+    nidm_inCoordinateSpace: niiri:c91eabb6ae30ecd695a7cf4b3fcab893 ;
     crypto:sha512 "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006"^^xsd:string .
 
-niiri:404ea6617dcd902e2957d9a6b74f7ab3
+niiri:f36222cc921e73ce4c2371f2c0ddc287
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:a77ea9285b48403a7689ae0b730f7230
+niiri:cf3dd6a7998b23db2dee0adcb3e1f4d7
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:950be147189508776d90eb2c4280326c prov:wasGeneratedBy niiri:6be0e67690536755101ed426c4c5cfe1 .
+niiri:a79e189fef35c2ea79f265fe43ab3fd5 prov:wasGeneratedBy niiri:9ea94d4c881c3057dcce3e08fa91b4db .
 
-niiri:ec71581037e524c5fbd95f85fa55b157
+niiri:fcafd29e2d4984d5ef1a1e4525c5ba42
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "64"^^xsd:int ;
@@ -492,9 +492,9 @@ niiri:ec71581037e524c5fbd95f85fa55b157
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:ec71581037e524c5fbd95f85fa55b157 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:fcafd29e2d4984d5ef1a1e4525c5ba42 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:ddc3a6b40532cc9e86f19a4aa6cba853
+niiri:444cc626db04f602c9c9011fa5e21c84
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "139"^^xsd:int ;
@@ -504,9 +504,9 @@ niiri:ddc3a6b40532cc9e86f19a4aa6cba853
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:ddc3a6b40532cc9e86f19a4aa6cba853 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:444cc626db04f602c9c9011fa5e21c84 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:c1738200f1bc478c78cb4aab2cda0cb1
+niiri:b1753f3aee975cc2167fd8ecc371ac5b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "99"^^xsd:int ;
@@ -516,9 +516,9 @@ niiri:c1738200f1bc478c78cb4aab2cda0cb1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:c1738200f1bc478c78cb4aab2cda0cb1 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:b1753f3aee975cc2167fd8ecc371ac5b prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:91205f3f0676956d1f1039643e3fcd9d
+niiri:e217bff071e4c58201ab9d5e50316202
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "100"^^xsd:int ;
@@ -528,9 +528,9 @@ niiri:91205f3f0676956d1f1039643e3fcd9d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:91205f3f0676956d1f1039643e3fcd9d prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:e217bff071e4c58201ab9d5e50316202 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:a689a0799152fcf397ed6264dff6b7df
+niiri:293f17b4b9a3d5e7642f3136e988fb69
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -540,9 +540,9 @@ niiri:a689a0799152fcf397ed6264dff6b7df
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:a689a0799152fcf397ed6264dff6b7df prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:293f17b4b9a3d5e7642f3136e988fb69 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:4f3977b902ab860fce265438ec1666b5
+niiri:f39819aeb0366241cbbae35a6427fc8b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "42"^^xsd:int ;
@@ -552,9 +552,9 @@ niiri:4f3977b902ab860fce265438ec1666b5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:4f3977b902ab860fce265438ec1666b5 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:f39819aeb0366241cbbae35a6427fc8b prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:e8270a828c6a9c6a7e1a7f948de88a7e
+niiri:804f36b4efe7eb06f1a23107f02c9522
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -564,9 +564,9 @@ niiri:e8270a828c6a9c6a7e1a7f948de88a7e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:e8270a828c6a9c6a7e1a7f948de88a7e prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:804f36b4efe7eb06f1a23107f02c9522 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:cda674baaa255a631b19d42763c0930c
+niiri:808fd4e2193f0ed5ab2626fc643077ca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "57"^^xsd:int ;
@@ -576,9 +576,9 @@ niiri:cda674baaa255a631b19d42763c0930c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:cda674baaa255a631b19d42763c0930c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:808fd4e2193f0ed5ab2626fc643077ca prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:b9beda96f738803fb567cd0d0d5ac126
+niiri:2667f28dbb2bce2c8e774ae24bc32c34
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -588,9 +588,9 @@ niiri:b9beda96f738803fb567cd0d0d5ac126
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:b9beda96f738803fb567cd0d0d5ac126 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:2667f28dbb2bce2c8e774ae24bc32c34 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:24686319b3c7b6b6793dbf6e90029199
+niiri:81153168c82f38e0344a3da5990713f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -600,9 +600,9 @@ niiri:24686319b3c7b6b6793dbf6e90029199
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:24686319b3c7b6b6793dbf6e90029199 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:81153168c82f38e0344a3da5990713f4 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:ef45eced4ec473fc374602efe1d44af2
+niiri:51df67b679cd0aa1c10588b2540f80ff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -612,9 +612,9 @@ niiri:ef45eced4ec473fc374602efe1d44af2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:ef45eced4ec473fc374602efe1d44af2 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:51df67b679cd0aa1c10588b2540f80ff prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:1a8d727934cbec38f1fdcc84430d7857
+niiri:c3859302a7f8a3aa876923fe5311fdeb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -624,9 +624,9 @@ niiri:1a8d727934cbec38f1fdcc84430d7857
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:1a8d727934cbec38f1fdcc84430d7857 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:c3859302a7f8a3aa876923fe5311fdeb prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:0ea4cdb2fb21bb5f5f9588416f8a0986
+niiri:a9683c02ec255a54e2147300ce75147c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -636,9 +636,9 @@ niiri:0ea4cdb2fb21bb5f5f9588416f8a0986
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:0ea4cdb2fb21bb5f5f9588416f8a0986 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:a9683c02ec255a54e2147300ce75147c prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:e96a0a75cfbda16324a620530f8ac979
+niiri:4b0d5b1cbdc197add17ddae11c60a960
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -648,9 +648,9 @@ niiri:e96a0a75cfbda16324a620530f8ac979
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:e96a0a75cfbda16324a620530f8ac979 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:4b0d5b1cbdc197add17ddae11c60a960 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:bc4b7adbe33f91a695fde03bf4b200ed
+niiri:074f24af2809bb5962437625180d87d8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -660,9 +660,9 @@ niiri:bc4b7adbe33f91a695fde03bf4b200ed
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:bc4b7adbe33f91a695fde03bf4b200ed prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:074f24af2809bb5962437625180d87d8 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:71a412f82e6ea8cb947b5be72c8efcff
+niiri:3950399d3cc373d8735fcf48ad86f542
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "35"^^xsd:int ;
@@ -672,9 +672,9 @@ niiri:71a412f82e6ea8cb947b5be72c8efcff
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:71a412f82e6ea8cb947b5be72c8efcff prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:3950399d3cc373d8735fcf48ad86f542 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:93e18b25ba3aeb399e6fd41cb9dfca97
+niiri:bab302ab1de7ceb32ee2a4553bab718d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -684,9 +684,9 @@ niiri:93e18b25ba3aeb399e6fd41cb9dfca97
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:93e18b25ba3aeb399e6fd41cb9dfca97 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:bab302ab1de7ceb32ee2a4553bab718d prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:3d33e1d8e7da5c593e7ad094c154132a
+niiri:14ab5f557514798d8218e39a2199e27a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "46"^^xsd:int ;
@@ -696,9 +696,9 @@ niiri:3d33e1d8e7da5c593e7ad094c154132a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:3d33e1d8e7da5c593e7ad094c154132a prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:14ab5f557514798d8218e39a2199e27a prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4
+niiri:bc603717c0c5d8a8779b8aa6c28564b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -708,9 +708,9 @@ niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:bc603717c0c5d8a8779b8aa6c28564b3 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:7c11ea6d552baec493b21ecdef64c785
+niiri:106ee2638843f2793b5ac6735acad91e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -720,9 +720,9 @@ niiri:7c11ea6d552baec493b21ecdef64c785
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:7c11ea6d552baec493b21ecdef64c785 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:106ee2638843f2793b5ac6735acad91e prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:56fa7a2fed0946da7dd3299da637b245
+niiri:01c1ab06b5a4997e0980bcddb0f69696
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -732,9 +732,9 @@ niiri:56fa7a2fed0946da7dd3299da637b245
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:56fa7a2fed0946da7dd3299da637b245 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:01c1ab06b5a4997e0980bcddb0f69696 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:c74b1ddb4c9a5395bf0b4d826708ce5a
+niiri:8f249184eec9591adc7a3fc1c7e37936
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -744,9 +744,9 @@ niiri:c74b1ddb4c9a5395bf0b4d826708ce5a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:c74b1ddb4c9a5395bf0b4d826708ce5a prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:8f249184eec9591adc7a3fc1c7e37936 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:10bec2b1f4f72ee8eedb38e17e1faab3
+niiri:c7ba1e0ca7a63ee914a7fa6cddbda281
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -756,9 +756,9 @@ niiri:10bec2b1f4f72ee8eedb38e17e1faab3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:10bec2b1f4f72ee8eedb38e17e1faab3 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:c7ba1e0ca7a63ee914a7fa6cddbda281 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:f725bd9a5656b07d43f8eba6c3be2858
+niiri:91987e35b1d8c15af66e3327a6e4b602
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -768,9 +768,9 @@ niiri:f725bd9a5656b07d43f8eba6c3be2858
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:f725bd9a5656b07d43f8eba6c3be2858 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:91987e35b1d8c15af66e3327a6e4b602 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:83f438c66d3cf32344b7255377c7499d
+niiri:c09f3990ca4bd168f93fa27a56eeb56c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -780,9 +780,9 @@ niiri:83f438c66d3cf32344b7255377c7499d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:83f438c66d3cf32344b7255377c7499d prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:c09f3990ca4bd168f93fa27a56eeb56c prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:cc9360b64b21e281dcfb851074b574b6
+niiri:4f39525fd234b098e759c0ffc971fd5b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -792,9 +792,9 @@ niiri:cc9360b64b21e281dcfb851074b574b6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:cc9360b64b21e281dcfb851074b574b6 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:4f39525fd234b098e759c0ffc971fd5b prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:4728de35ba855317aeef4e0a7b91801c
+niiri:66eca61ada8ceb626c8ffd13d3efa1cc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "25"^^xsd:int ;
@@ -804,9 +804,9 @@ niiri:4728de35ba855317aeef4e0a7b91801c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:4728de35ba855317aeef4e0a7b91801c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:66eca61ada8ceb626c8ffd13d3efa1cc prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:f435923c3d5e3915c4aa5159c5bbc4a0
+niiri:5cf9402b2b494a87640a66aec1a6fdaf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -816,9 +816,9 @@ niiri:f435923c3d5e3915c4aa5159c5bbc4a0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:f435923c3d5e3915c4aa5159c5bbc4a0 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:5cf9402b2b494a87640a66aec1a6fdaf prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:b39b9cce118cf858149cdd53ebcda7bd
+niiri:1cd1f14fea72d133db88783e1b907b7f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -828,9 +828,9 @@ niiri:b39b9cce118cf858149cdd53ebcda7bd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:b39b9cce118cf858149cdd53ebcda7bd prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:1cd1f14fea72d133db88783e1b907b7f prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:97e0a9bea1289493ad46d8a4c2b75485
+niiri:c3340fa012c626e62e86cdb279a4e883
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -840,9 +840,9 @@ niiri:97e0a9bea1289493ad46d8a4c2b75485
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:97e0a9bea1289493ad46d8a4c2b75485 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:c3340fa012c626e62e86cdb279a4e883 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:e9e94038b5b1dbcf9f8a4d4208e34928
+niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -852,9 +852,9 @@ niiri:e9e94038b5b1dbcf9f8a4d4208e34928
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:e9e94038b5b1dbcf9f8a4d4208e34928 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:0857328371989db393f2fc4d7d5346bd
+niiri:8b25738f634743abd67e5fd856e90f74
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -864,9 +864,9 @@ niiri:0857328371989db393f2fc4d7d5346bd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:0857328371989db393f2fc4d7d5346bd prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:8b25738f634743abd67e5fd856e90f74 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:7e693a4a3e70d39b916aa2a95911a3c8
+niiri:1c59a22b32098831723dc21703615fd1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -876,9 +876,9 @@ niiri:7e693a4a3e70d39b916aa2a95911a3c8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:7e693a4a3e70d39b916aa2a95911a3c8 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:1c59a22b32098831723dc21703615fd1 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:d8dc459a110e4898c23019ee42154713
+niiri:139b6ecf5fdad735a51b4385a24aded9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -888,9 +888,9 @@ niiri:d8dc459a110e4898c23019ee42154713
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:d8dc459a110e4898c23019ee42154713 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:139b6ecf5fdad735a51b4385a24aded9 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:cd795f902776ad9170549b8fde8996ba
+niiri:e6a138032615b9872d9261e35d2455f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -900,9 +900,9 @@ niiri:cd795f902776ad9170549b8fde8996ba
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:cd795f902776ad9170549b8fde8996ba prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:e6a138032615b9872d9261e35d2455f4 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:ed1df7c28737883d905ca0a8f2093992
+niiri:37bc5cb5a158a9f86c496a5d1935903c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -912,9 +912,9 @@ niiri:ed1df7c28737883d905ca0a8f2093992
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:ed1df7c28737883d905ca0a8f2093992 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:37bc5cb5a158a9f86c496a5d1935903c prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:ca7bfed8d8dbca676ba25fca93d29e2c
+niiri:f86c9bb022fe2e7bb4f2a1d963869d32
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -924,9 +924,9 @@ niiri:ca7bfed8d8dbca676ba25fca93d29e2c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:ca7bfed8d8dbca676ba25fca93d29e2c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:f86c9bb022fe2e7bb4f2a1d963869d32 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:1dcd9b5514190f867e3e9b0b57227395
+niiri:cecab36bcbd915f7841bff34cd7f59a6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -936,9 +936,9 @@ niiri:1dcd9b5514190f867e3e9b0b57227395
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:1dcd9b5514190f867e3e9b0b57227395 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:cecab36bcbd915f7841bff34cd7f59a6 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:79097d11179e49abc9f2bdf5ba7bb932
+niiri:752ff8a0ff1912e3b3a3cc0b0af92bac
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -948,9 +948,9 @@ niiri:79097d11179e49abc9f2bdf5ba7bb932
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:79097d11179e49abc9f2bdf5ba7bb932 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:752ff8a0ff1912e3b3a3cc0b0af92bac prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:d339d6251d3c159dbe2427fd1bcc1fc1
+niiri:bbfdc94758422f4cdfa2d461f26c652c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -960,9 +960,9 @@ niiri:d339d6251d3c159dbe2427fd1bcc1fc1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:d339d6251d3c159dbe2427fd1bcc1fc1 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:bbfdc94758422f4cdfa2d461f26c652c prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:b0978b4f683201d3539ace75681c8b65
+niiri:412f44bb99fe0b4ac5111c8bb0d6824f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -972,9 +972,9 @@ niiri:b0978b4f683201d3539ace75681c8b65
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:b0978b4f683201d3539ace75681c8b65 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:412f44bb99fe0b4ac5111c8bb0d6824f prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:133c074788eed1fa9d50d9e4608e3c1c
+niiri:ae1cd8d0dfca9341507b66eafba6459d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -984,9 +984,9 @@ niiri:133c074788eed1fa9d50d9e4608e3c1c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:133c074788eed1fa9d50d9e4608e3c1c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:ae1cd8d0dfca9341507b66eafba6459d prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:93bdd51f373f8659382785eb36932971
+niiri:089292d98902368bd347bcdfa162cfda
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -996,9 +996,9 @@ niiri:93bdd51f373f8659382785eb36932971
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:93bdd51f373f8659382785eb36932971 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:089292d98902368bd347bcdfa162cfda prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:522536a75466fe7c0e757947afe21547
+niiri:716ffa34870ad39bf06d8e49c18b9bce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1008,9 +1008,9 @@ niiri:522536a75466fe7c0e757947afe21547
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:522536a75466fe7c0e757947afe21547 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:716ffa34870ad39bf06d8e49c18b9bce prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:acdb22704e8e3566aa17ca0ccdff7a03
+niiri:8c7ca240ed7a4d85316011dd6f1768ff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1020,9 +1020,9 @@ niiri:acdb22704e8e3566aa17ca0ccdff7a03
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:acdb22704e8e3566aa17ca0ccdff7a03 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:8c7ca240ed7a4d85316011dd6f1768ff prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:e1cde03f80af40c7004f16340827c9a6
+niiri:08593ccb1d9e49118b073d271565bd78
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1032,9 +1032,9 @@ niiri:e1cde03f80af40c7004f16340827c9a6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:e1cde03f80af40c7004f16340827c9a6 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:08593ccb1d9e49118b073d271565bd78 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:1a861a102938105fb0e599c28c89f0df
+niiri:b52f4fded36d906e3611187b1ea82271
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1044,9 +1044,9 @@ niiri:1a861a102938105fb0e599c28c89f0df
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:1a861a102938105fb0e599c28c89f0df prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:b52f4fded36d906e3611187b1ea82271 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:28c829a636fe7679be2b8fe3fc083d99
+niiri:900eebea134685a11022813f19903499
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1056,9 +1056,9 @@ niiri:28c829a636fe7679be2b8fe3fc083d99
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:28c829a636fe7679be2b8fe3fc083d99 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:900eebea134685a11022813f19903499 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:4bb1f06cdf753bfe2cb9742585fc5f63
+niiri:a20506ad4a845975db3365e7c162d818
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1068,9 +1068,9 @@ niiri:4bb1f06cdf753bfe2cb9742585fc5f63
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:4bb1f06cdf753bfe2cb9742585fc5f63 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:a20506ad4a845975db3365e7c162d818 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:cca6dc1b6e22a99533fb4839e0e808cf
+niiri:cfde284823e7c32d74bec0b81232bb7a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1080,9 +1080,9 @@ niiri:cca6dc1b6e22a99533fb4839e0e808cf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:cca6dc1b6e22a99533fb4839e0e808cf prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:cfde284823e7c32d74bec0b81232bb7a prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:894db077f6ce41dde7580196422f5b65
+niiri:496bec06cfc8ef95b3cbe0997c654d26
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1092,9 +1092,9 @@ niiri:894db077f6ce41dde7580196422f5b65
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:894db077f6ce41dde7580196422f5b65 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:496bec06cfc8ef95b3cbe0997c654d26 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:e8143c5b2cddc4ad2f401f2b27a4cab2
+niiri:e4bff32759970a1099e3a417cf7206b0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1104,9 +1104,9 @@ niiri:e8143c5b2cddc4ad2f401f2b27a4cab2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:e8143c5b2cddc4ad2f401f2b27a4cab2 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:e4bff32759970a1099e3a417cf7206b0 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:09cd915bf2b2b51b32d56249f304bbce
+niiri:40337b736645244404b84afb6772e7a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1116,9 +1116,9 @@ niiri:09cd915bf2b2b51b32d56249f304bbce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:09cd915bf2b2b51b32d56249f304bbce prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:40337b736645244404b84afb6772e7a9 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:bf2d35b880b3d0657d2a03298074406e
+niiri:42bc55f4f90f29daf9e12be119e1ddab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1128,9 +1128,9 @@ niiri:bf2d35b880b3d0657d2a03298074406e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:bf2d35b880b3d0657d2a03298074406e prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:42bc55f4f90f29daf9e12be119e1ddab prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:56bc4504cec954daf4a701610ddf59b3
+niiri:067c79f86db85b508893737af41699ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1140,9 +1140,9 @@ niiri:56bc4504cec954daf4a701610ddf59b3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:56bc4504cec954daf4a701610ddf59b3 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:067c79f86db85b508893737af41699ce prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:baa1270c4a9c0f72989c973b2fbb309d
+niiri:1a35a6d628eed4f2fc8c554a4a579a19
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1152,9 +1152,9 @@ niiri:baa1270c4a9c0f72989c973b2fbb309d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:baa1270c4a9c0f72989c973b2fbb309d prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:1a35a6d628eed4f2fc8c554a4a579a19 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:39b258c34ddafd00d7dff6d208f62918
+niiri:0e92ac2d77c091672e014daf15280170
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1164,9 +1164,9 @@ niiri:39b258c34ddafd00d7dff6d208f62918
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:39b258c34ddafd00d7dff6d208f62918 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:0e92ac2d77c091672e014daf15280170 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:ea112296db729b94dfce05991c3d6989
+niiri:0d2b802df946de1efd390f218ef63fce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1176,9 +1176,9 @@ niiri:ea112296db729b94dfce05991c3d6989
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:ea112296db729b94dfce05991c3d6989 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:0d2b802df946de1efd390f218ef63fce prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:a41eeb9ba04d7788ba686542607ff1cc
+niiri:627d75e08350cce3541dd568e3ddaa39
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1188,9 +1188,9 @@ niiri:a41eeb9ba04d7788ba686542607ff1cc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:a41eeb9ba04d7788ba686542607ff1cc prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:627d75e08350cce3541dd568e3ddaa39 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:9c7b81143edac28cf680878e9177494c
+niiri:20516921d28241951d08251e80cac5b5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1200,9 +1200,9 @@ niiri:9c7b81143edac28cf680878e9177494c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:9c7b81143edac28cf680878e9177494c prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:20516921d28241951d08251e80cac5b5 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:e854403c8636e3e481bc993eb6180f44
+niiri:3822c0fa262ca8cb8a67590f3eec2fe6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1212,9 +1212,9 @@ niiri:e854403c8636e3e481bc993eb6180f44
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:e854403c8636e3e481bc993eb6180f44 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:3822c0fa262ca8cb8a67590f3eec2fe6 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:7f3ebf5e2a10fd569c91dd091c7af147
+niiri:51287994298816d649ba6908b4e3d0bb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1224,9 +1224,9 @@ niiri:7f3ebf5e2a10fd569c91dd091c7af147
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:7f3ebf5e2a10fd569c91dd091c7af147 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:51287994298816d649ba6908b4e3d0bb prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:b36c20212016b9bc7a603f3e83aca676
+niiri:36a1ff3bd64efa589db6c3a56ccf9d25
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1236,9 +1236,9 @@ niiri:b36c20212016b9bc7a603f3e83aca676
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:b36c20212016b9bc7a603f3e83aca676 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:36a1ff3bd64efa589db6c3a56ccf9d25 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:05115f2e683a3386f641d5816019de27
+niiri:1c0a11fe168926616610d5836c36d35f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1248,9 +1248,9 @@ niiri:05115f2e683a3386f641d5816019de27
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:05115f2e683a3386f641d5816019de27 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:1c0a11fe168926616610d5836c36d35f prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:1ee8276c32c1e03b7e0b4b1717c44a57
+niiri:aa0d58d5cc7671539d09308038edb0f1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1260,9 +1260,9 @@ niiri:1ee8276c32c1e03b7e0b4b1717c44a57
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:1ee8276c32c1e03b7e0b4b1717c44a57 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:aa0d58d5cc7671539d09308038edb0f1 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:aa58a012c4a942174e0325d4c0b944fd
+niiri:fc71e9e9a2574cbd9d5094f50275b3c2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1272,9 +1272,9 @@ niiri:aa58a012c4a942174e0325d4c0b944fd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:aa58a012c4a942174e0325d4c0b944fd prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:fc71e9e9a2574cbd9d5094f50275b3c2 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:69b1d9ea8525a6a583365384e39cf9e8
+niiri:c23970716bccffb656edae94cc34e353
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1284,9 +1284,9 @@ niiri:69b1d9ea8525a6a583365384e39cf9e8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:69b1d9ea8525a6a583365384e39cf9e8 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:c23970716bccffb656edae94cc34e353 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:f6d9af16709f321130aa58504e6604c5
+niiri:8e2363110cdebe114cbe95493b19fa9d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1296,9 +1296,9 @@ niiri:f6d9af16709f321130aa58504e6604c5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:f6d9af16709f321130aa58504e6604c5 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:8e2363110cdebe114cbe95493b19fa9d prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:be347b3d17b0cf1b2b8f3ad6860ae399
+niiri:eb4122935f1afa2c8b532875de5f0ef9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1308,9 +1308,9 @@ niiri:be347b3d17b0cf1b2b8f3ad6860ae399
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:be347b3d17b0cf1b2b8f3ad6860ae399 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:eb4122935f1afa2c8b532875de5f0ef9 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:fb10f43ffe914843271a8cdefab5f898
+niiri:25018fb0acd6d245a4f445c35c5f92eb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1320,9 +1320,9 @@ niiri:fb10f43ffe914843271a8cdefab5f898
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:fb10f43ffe914843271a8cdefab5f898 prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:25018fb0acd6d245a4f445c35c5f92eb prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:ac129c99f1ae280d6d0a6f24c04b617a
+niiri:ccd2969f60f8b0222713472b0a037361
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1332,1297 +1332,1297 @@ niiri:ac129c99f1ae280d6d0a6f24c04b617a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:ac129c99f1ae280d6d0a6f24c04b617a prov:wasDerivedFrom niiri:950be147189508776d90eb2c4280326c .
+niiri:ccd2969f60f8b0222713472b0a037361 prov:wasDerivedFrom niiri:a79e189fef35c2ea79f265fe43ab3fd5 .
 
-niiri:0259aad92a78e6c87148ce920416a4eb
+niiri:baa4e7252d8424602eff0da2b334e0ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:dd5db5be9e69824ffb62949c8582d5be ;
+    prov:atLocation niiri:3dcaa7f03a6601fd8a98a0250eb396ce ;
     prov:value "39.0658683776855"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04009751746769"^^xsd:float ;
     nidm_pValueUncorrected: "2.3264734660966e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0389037590875805"^^xsd:float ;
     nidm_qValueFDR: "0.0302216629065993"^^xsd:float .
 
-niiri:dd5db5be9e69824ffb62949c8582d5be
+niiri:3dcaa7f03a6601fd8a98a0250eb396ce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-2,-90,28]"^^xsd:string .
 
-niiri:0259aad92a78e6c87148ce920416a4eb prov:wasDerivedFrom niiri:ec71581037e524c5fbd95f85fa55b157 .
+niiri:baa4e7252d8424602eff0da2b334e0ea prov:wasDerivedFrom niiri:fcafd29e2d4984d5ef1a1e4525c5ba42 .
 
-niiri:7e799bbd6f335fd540a4021e61075cf8
+niiri:ef00983a1ab378c0ed62a4e8080df8cf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:d3f6be55abbd687279e07d932188a32e ;
+    prov:atLocation niiri:a3fcc5c0311ede9dd4d7b167cd4e683f ;
     prov:value "36.2393341064453"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89725160225159"^^xsd:float ;
     nidm_pValueUncorrected: "4.85931842320042e-07"^^xsd:float ;
     nidm_pValueFWER: "0.071761896035709"^^xsd:float ;
     nidm_qValueFDR: "0.0302216629065993"^^xsd:float .
 
-niiri:d3f6be55abbd687279e07d932188a32e
+niiri:a3fcc5c0311ede9dd4d7b167cd4e683f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-42,-64,-8]"^^xsd:string .
 
-niiri:7e799bbd6f335fd540a4021e61075cf8 prov:wasDerivedFrom niiri:ddc3a6b40532cc9e86f19a4aa6cba853 .
+niiri:ef00983a1ab378c0ed62a4e8080df8cf prov:wasDerivedFrom niiri:444cc626db04f602c9c9011fa5e21c84 .
 
-niiri:0818768d40973c28e4e870de99f7a12e
+niiri:915137b9c7e5154400a1f1cc8692da57
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:e10e6b887d937b13d419913e96b50eb4 ;
+    prov:atLocation niiri:6b30d660a4ad3dfdee42a3cd8d2d46f0 ;
     prov:value "17.9251842498779"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64201416072196"^^xsd:float ;
     nidm_pValueUncorrected: "0.000135256594276711"^^xsd:float ;
     nidm_pValueFWER: "0.999417997648594"^^xsd:float ;
     nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
 
-niiri:e10e6b887d937b13d419913e96b50eb4
+niiri:6b30d660a4ad3dfdee42a3cd8d2d46f0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-40,-52,-10]"^^xsd:string .
 
-niiri:0818768d40973c28e4e870de99f7a12e prov:wasDerivedFrom niiri:ddc3a6b40532cc9e86f19a4aa6cba853 .
+niiri:915137b9c7e5154400a1f1cc8692da57 prov:wasDerivedFrom niiri:444cc626db04f602c9c9011fa5e21c84 .
 
-niiri:2e69720344eeade04945a9294efe1c46
+niiri:e99d8d782cf7659baaf6c7a11fd75959
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:43f273420f486c1569872beaefa26851 ;
+    prov:atLocation niiri:deb2e3be4bbfe246eccd4c8e2cb277c9 ;
     prov:value "13.454288482666"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18324713734782"^^xsd:float ;
     nidm_pValueUncorrected: "0.000728166268399777"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996872"^^xsd:float ;
     nidm_qValueFDR: "0.140840039531724"^^xsd:float .
 
-niiri:43f273420f486c1569872beaefa26851
+niiri:deb2e3be4bbfe246eccd4c8e2cb277c9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-38,-70,0]"^^xsd:string .
 
-niiri:2e69720344eeade04945a9294efe1c46 prov:wasDerivedFrom niiri:ddc3a6b40532cc9e86f19a4aa6cba853 .
+niiri:e99d8d782cf7659baaf6c7a11fd75959 prov:wasDerivedFrom niiri:444cc626db04f602c9c9011fa5e21c84 .
 
-niiri:0b61d4f645e8030fa41b599c3b7220dd
+niiri:887edacd038795695bc5935681d9ec60
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:a9b1c3d0f5af3d460c038461141f2a06 ;
+    prov:atLocation niiri:149ea3c3b924b56714ebbd48bd4cf7eb ;
     prov:value "29.4676361083984"^^xsd:float ;
     nidm_equivalentZStatistic: "4.51162164706026"^^xsd:float ;
     nidm_pValueUncorrected: "3.21669348379849e-06"^^xsd:float ;
     nidm_pValueFWER: "0.305525019896507"^^xsd:float ;
     nidm_qValueFDR: "0.0356596612461515"^^xsd:float .
 
-niiri:a9b1c3d0f5af3d460c038461141f2a06
+niiri:149ea3c3b924b56714ebbd48bd4cf7eb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[16,-88,24]"^^xsd:string .
 
-niiri:0b61d4f645e8030fa41b599c3b7220dd prov:wasDerivedFrom niiri:c1738200f1bc478c78cb4aab2cda0cb1 .
+niiri:887edacd038795695bc5935681d9ec60 prov:wasDerivedFrom niiri:b1753f3aee975cc2167fd8ecc371ac5b .
 
-niiri:211afdee4625abd8fd61f5e2da4e7851
+niiri:966afe2baff599cc271b19f81f50e736
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:21d2bcb65d9792fab52c653d5e34433a ;
+    prov:atLocation niiri:de9e01b6bf2a659aa4d3377d86836307 ;
     prov:value "28.5631580352783"^^xsd:float ;
     nidm_equivalentZStatistic: "4.45459114773779"^^xsd:float ;
     nidm_pValueUncorrected: "4.20266075706888e-06"^^xsd:float ;
     nidm_pValueFWER: "0.365688847752494"^^xsd:float ;
     nidm_qValueFDR: "0.0376032685416481"^^xsd:float .
 
-niiri:21d2bcb65d9792fab52c653d5e34433a
+niiri:de9e01b6bf2a659aa4d3377d86836307
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[28,-72,26]"^^xsd:string .
 
-niiri:211afdee4625abd8fd61f5e2da4e7851 prov:wasDerivedFrom niiri:91205f3f0676956d1f1039643e3fcd9d .
+niiri:966afe2baff599cc271b19f81f50e736 prov:wasDerivedFrom niiri:e217bff071e4c58201ab9d5e50316202 .
 
-niiri:36f1bebef6aafa905f0a57417a9a9409
+niiri:25bc992eccfc2b6a6a24289f4e757203
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:d149b750b624172908054300ba57fa0d ;
+    prov:atLocation niiri:e01e6d8bfc3791e75a43288c36fa1d9c ;
     prov:value "26.9945106506348"^^xsd:float ;
     nidm_equivalentZStatistic: "4.35204306383375"^^xsd:float ;
     nidm_pValueUncorrected: "6.7437380493196e-06"^^xsd:float ;
     nidm_pValueFWER: "0.489729172437052"^^xsd:float ;
     nidm_qValueFDR: "0.0406203661092224"^^xsd:float .
 
-niiri:d149b750b624172908054300ba57fa0d
+niiri:e01e6d8bfc3791e75a43288c36fa1d9c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[-32,20,-4]"^^xsd:string .
 
-niiri:36f1bebef6aafa905f0a57417a9a9409 prov:wasDerivedFrom niiri:a689a0799152fcf397ed6264dff6b7df .
+niiri:25bc992eccfc2b6a6a24289f4e757203 prov:wasDerivedFrom niiri:293f17b4b9a3d5e7642f3136e988fb69 .
 
-niiri:2b42ff26513d8bb2fad2bee3fac979bd
+niiri:f9405b475d3bdca76e81a6717bca04c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:00172712096fe22fbb4c6cb0abae056c ;
+    prov:atLocation niiri:d382a0c6c03aa0a2f6ee3c758f66a342 ;
     prov:value "26.8606586456299"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34306775687574"^^xsd:float ;
     nidm_pValueUncorrected: "7.02533878071954e-06"^^xsd:float ;
     nidm_pValueFWER: "0.501353785238145"^^xsd:float ;
     nidm_qValueFDR: "0.0406203661092224"^^xsd:float .
 
-niiri:00172712096fe22fbb4c6cb0abae056c
+niiri:d382a0c6c03aa0a2f6ee3c758f66a342
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-8,50,32]"^^xsd:string .
 
-niiri:2b42ff26513d8bb2fad2bee3fac979bd prov:wasDerivedFrom niiri:4f3977b902ab860fce265438ec1666b5 .
+niiri:f9405b475d3bdca76e81a6717bca04c2 prov:wasDerivedFrom niiri:f39819aeb0366241cbbae35a6427fc8b .
 
-niiri:570e544597bcf68c47263d141cd82ca4
+niiri:5f02b40490d007ae68a92b4316e9efd9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:4488b6dfe10aa9fffe9d9fa5f038987f ;
+    prov:atLocation niiri:dd4a0e1012831b8affc68995057a1120 ;
     prov:value "25.8067512512207"^^xsd:float ;
     nidm_equivalentZStatistic: "4.27109313660164"^^xsd:float ;
     nidm_pValueUncorrected: "9.72585724245967e-06"^^xsd:float ;
     nidm_pValueFWER: "0.597019202761311"^^xsd:float ;
     nidm_qValueFDR: "0.0439563569939673"^^xsd:float .
 
-niiri:4488b6dfe10aa9fffe9d9fa5f038987f
+niiri:dd4a0e1012831b8affc68995057a1120
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-34,8,58]"^^xsd:string .
 
-niiri:570e544597bcf68c47263d141cd82ca4 prov:wasDerivedFrom niiri:e8270a828c6a9c6a7e1a7f948de88a7e .
+niiri:5f02b40490d007ae68a92b4316e9efd9 prov:wasDerivedFrom niiri:804f36b4efe7eb06f1a23107f02c9522 .
 
-niiri:be4c08d3fca48f05de0ae62f8b673305
+niiri:9eb8c305928cd26af5d735f290a7ce8a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:43ecbb57ee775f4cbb1dd4af236cfbff ;
+    prov:atLocation niiri:c53ceb2c4d2e390230752c97501ffbd1 ;
     prov:value "25.0769119262695"^^xsd:float ;
     nidm_equivalentZStatistic: "4.21983658750018"^^xsd:float ;
     nidm_pValueUncorrected: "1.22239732009977e-05"^^xsd:float ;
     nidm_pValueFWER: "0.665677647955296"^^xsd:float ;
     nidm_qValueFDR: "0.0444376030498989"^^xsd:float .
 
-niiri:43ecbb57ee775f4cbb1dd4af236cfbff
+niiri:c53ceb2c4d2e390230752c97501ffbd1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[32,-86,0]"^^xsd:string .
 
-niiri:be4c08d3fca48f05de0ae62f8b673305 prov:wasDerivedFrom niiri:cda674baaa255a631b19d42763c0930c .
+niiri:9eb8c305928cd26af5d735f290a7ce8a prov:wasDerivedFrom niiri:808fd4e2193f0ed5ab2626fc643077ca .
 
-niiri:340ff54b0274dd2288512da30ba70b15
+niiri:11109932f0e2675cb40f05a3edc02ba0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:9b59dfd3cd6fe92f527a2d11dc8e5ad5 ;
+    prov:atLocation niiri:03754f6422c542b58050fa515c5326b7 ;
     prov:value "24.5828113555908"^^xsd:float ;
     nidm_equivalentZStatistic: "4.18444689049798"^^xsd:float ;
     nidm_pValueUncorrected: "1.42930633414418e-05"^^xsd:float ;
     nidm_pValueFWER: "0.711939170732988"^^xsd:float ;
     nidm_qValueFDR: "0.04475687830922"^^xsd:float .
 
-niiri:9b59dfd3cd6fe92f527a2d11dc8e5ad5
+niiri:03754f6422c542b58050fa515c5326b7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[66,-32,30]"^^xsd:string .
 
-niiri:340ff54b0274dd2288512da30ba70b15 prov:wasDerivedFrom niiri:b9beda96f738803fb567cd0d0d5ac126 .
+niiri:11109932f0e2675cb40f05a3edc02ba0 prov:wasDerivedFrom niiri:2667f28dbb2bce2c8e774ae24bc32c34 .
 
-niiri:bfd29eeffd577f81b1028084dd3cafbb
+niiri:4fefff5985067f520ab89234bd477dd4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:afdc90796927d6b5b5d8e26a0c89d918 ;
+    prov:atLocation niiri:35dc6728bd9b0380bd0c34c5ef999f15 ;
     prov:value "14.2693071365356"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27451594161643"^^xsd:float ;
     nidm_pValueUncorrected: "0.000529215834762176"^^xsd:float ;
     nidm_pValueFWER: "0.999999999209483"^^xsd:float ;
     nidm_qValueFDR: "0.128281884148943"^^xsd:float .
 
-niiri:afdc90796927d6b5b5d8e26a0c89d918
+niiri:35dc6728bd9b0380bd0c34c5ef999f15
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[60,-38,28]"^^xsd:string .
 
-niiri:bfd29eeffd577f81b1028084dd3cafbb prov:wasDerivedFrom niiri:b9beda96f738803fb567cd0d0d5ac126 .
+niiri:4fefff5985067f520ab89234bd477dd4 prov:wasDerivedFrom niiri:2667f28dbb2bce2c8e774ae24bc32c34 .
 
-niiri:3de1d3b3fd47f85802886f79af4dc678
+niiri:0a247f47177e119fa9edf6e9f6f98b5e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:533d4d268893416ecb4d1151faad2ef6 ;
+    prov:atLocation niiri:3717dcf5b4b7f3fadfa70b271f5a347b ;
     prov:value "23.3039436340332"^^xsd:float ;
     nidm_equivalentZStatistic: "4.09011898331566"^^xsd:float ;
     nidm_pValueUncorrected: "2.15575975488491e-05"^^xsd:float ;
     nidm_pValueFWER: "0.823947459995523"^^xsd:float ;
     nidm_qValueFDR: "0.0478656864369739"^^xsd:float .
 
-niiri:533d4d268893416ecb4d1151faad2ef6
+niiri:3717dcf5b4b7f3fadfa70b271f5a347b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[28,30,52]"^^xsd:string .
 
-niiri:3de1d3b3fd47f85802886f79af4dc678 prov:wasDerivedFrom niiri:24686319b3c7b6b6793dbf6e90029199 .
+niiri:0a247f47177e119fa9edf6e9f6f98b5e prov:wasDerivedFrom niiri:81153168c82f38e0344a3da5990713f4 .
 
-niiri:4c793b1434ab014669b8e4ce2cf2139b
+niiri:07aa292e8e64264cf6b16262dd9b0461
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:f6d485f30b70a6db61c96e28aa7f2753 ;
+    prov:atLocation niiri:17d984ec4e21314566bdf4644fb07af0 ;
     prov:value "22.6157932281494"^^xsd:float ;
     nidm_equivalentZStatistic: "4.03763886298215"^^xsd:float ;
     nidm_pValueUncorrected: "2.69959426782984e-05"^^xsd:float ;
     nidm_pValueFWER: "0.87538446987651"^^xsd:float ;
     nidm_qValueFDR: "0.0515719459796674"^^xsd:float .
 
-niiri:f6d485f30b70a6db61c96e28aa7f2753
+niiri:17d984ec4e21314566bdf4644fb07af0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-30,-34,6]"^^xsd:string .
 
-niiri:4c793b1434ab014669b8e4ce2cf2139b prov:wasDerivedFrom niiri:ef45eced4ec473fc374602efe1d44af2 .
+niiri:07aa292e8e64264cf6b16262dd9b0461 prov:wasDerivedFrom niiri:51df67b679cd0aa1c10588b2540f80ff .
 
-niiri:f9a42b90df039166ca0e5fa02d3d604f
+niiri:c09425629406f190de8edebf54022f2d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:55a6eaf2f3b34f1854c5cc88fea7e153 ;
+    prov:atLocation niiri:cd4e978cbe4323a391c6fa96ba73890b ;
     prov:value "21.8558578491211"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97819185113407"^^xsd:float ;
     nidm_pValueUncorrected: "3.47206660495925e-05"^^xsd:float ;
     nidm_pValueFWER: "0.921823721412592"^^xsd:float ;
     nidm_qValueFDR: "0.053734847831518"^^xsd:float .
 
-niiri:55a6eaf2f3b34f1854c5cc88fea7e153
+niiri:cd4e978cbe4323a391c6fa96ba73890b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-28,0,30]"^^xsd:string .
 
-niiri:f9a42b90df039166ca0e5fa02d3d604f prov:wasDerivedFrom niiri:1a8d727934cbec38f1fdcc84430d7857 .
+niiri:c09425629406f190de8edebf54022f2d prov:wasDerivedFrom niiri:c3859302a7f8a3aa876923fe5311fdeb .
 
-niiri:de93eaf377bd0a9992922d03e47c7423
+niiri:00455682ca694ef095f7439ab81ebd12
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:b0a8a5b4d1ad632e303792bb14434ab1 ;
+    prov:atLocation niiri:a61981cb739588894bbdc415c7c87afe ;
     prov:value "21.8296661376953"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97611404363788"^^xsd:float ;
     nidm_pValueUncorrected: "3.50252708366527e-05"^^xsd:float ;
     nidm_pValueFWER: "0.923209894114283"^^xsd:float ;
     nidm_qValueFDR: "0.053734847831518"^^xsd:float .
 
-niiri:b0a8a5b4d1ad632e303792bb14434ab1
+niiri:a61981cb739588894bbdc415c7c87afe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[8,34,10]"^^xsd:string .
 
-niiri:de93eaf377bd0a9992922d03e47c7423 prov:wasDerivedFrom niiri:0ea4cdb2fb21bb5f5f9588416f8a0986 .
+niiri:00455682ca694ef095f7439ab81ebd12 prov:wasDerivedFrom niiri:a9683c02ec255a54e2147300ce75147c .
 
-niiri:e354a84565e5c296d9efa7317a911cfe
+niiri:5cc633c2d1685a757beeaecee1a48008
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:6cd3c9ec2c82b8b60104f15adb91982c ;
+    prov:atLocation niiri:b7a12cc701147c2a30416bd9e767f926 ;
     prov:value "21.7287845611572"^^xsd:float ;
     nidm_equivalentZStatistic: "3.96809263472704"^^xsd:float ;
     nidm_pValueUncorrected: "3.6225086553876e-05"^^xsd:float ;
     nidm_pValueFWER: "0.928411428313329"^^xsd:float ;
     nidm_qValueFDR: "0.0540587737624357"^^xsd:float .
 
-niiri:6cd3c9ec2c82b8b60104f15adb91982c
+niiri:b7a12cc701147c2a30416bd9e767f926
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[46,-56,10]"^^xsd:string .
 
-niiri:e354a84565e5c296d9efa7317a911cfe prov:wasDerivedFrom niiri:e96a0a75cfbda16324a620530f8ac979 .
+niiri:5cc633c2d1685a757beeaecee1a48008 prov:wasDerivedFrom niiri:4b0d5b1cbdc197add17ddae11c60a960 .
 
-niiri:08e6714e83b23af817c91a38ea817a9d
+niiri:bc5fb74855b827b626fd1eebefaa6d4d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:18511209fae629ef4fc05e9115d24b3d ;
+    prov:atLocation niiri:352d0e5787411f3cc15519e7582cf21f ;
     prov:value "14.2801656723022"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27570591680179"^^xsd:float ;
     nidm_pValueUncorrected: "0.000526991241768693"^^xsd:float ;
     nidm_pValueFWER: "0.999999999156251"^^xsd:float ;
     nidm_qValueFDR: "0.128281884148943"^^xsd:float .
 
-niiri:18511209fae629ef4fc05e9115d24b3d
+niiri:352d0e5787411f3cc15519e7582cf21f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[48,-48,16]"^^xsd:string .
 
-niiri:08e6714e83b23af817c91a38ea817a9d prov:wasDerivedFrom niiri:e96a0a75cfbda16324a620530f8ac979 .
+niiri:bc5fb74855b827b626fd1eebefaa6d4d prov:wasDerivedFrom niiri:4b0d5b1cbdc197add17ddae11c60a960 .
 
-niiri:27a4396719d910dc755a3ae8f5919b75
+niiri:90dc79d65e7f32dfb01b08b18c3ce762
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:11308bc9db92e428a2f7e9a8d4420c7f ;
+    prov:atLocation niiri:33a1d7fed96c259799c80dc81ed84ff7 ;
     prov:value "21.4629364013672"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9468129149843"^^xsd:float ;
     nidm_pValueUncorrected: "3.95991966499754e-05"^^xsd:float ;
     nidm_pValueFWER: "0.941069307565192"^^xsd:float ;
     nidm_qValueFDR: "0.0555984329583215"^^xsd:float .
 
-niiri:11308bc9db92e428a2f7e9a8d4420c7f
+niiri:33a1d7fed96c259799c80dc81ed84ff7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[46,-62,-10]"^^xsd:string .
 
-niiri:27a4396719d910dc755a3ae8f5919b75 prov:wasDerivedFrom niiri:bc4b7adbe33f91a695fde03bf4b200ed .
+niiri:90dc79d65e7f32dfb01b08b18c3ce762 prov:wasDerivedFrom niiri:074f24af2809bb5962437625180d87d8 .
 
-niiri:cc9face0d8fe5a7de8a150a20acca2d8
+niiri:865765b8e81628e180cd32d69ff2a873
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:73a9a071ca8380ed9df7a551dfd73dfa ;
+    prov:atLocation niiri:572e00e92909efbb8dbfa749a8192c13 ;
     prov:value "21.4269542694092"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94391683979485"^^xsd:float ;
     nidm_pValueUncorrected: "4.00807329147268e-05"^^xsd:float ;
     nidm_pValueFWER: "0.942665676683549"^^xsd:float ;
     nidm_qValueFDR: "0.0555984329583215"^^xsd:float .
 
-niiri:73a9a071ca8380ed9df7a551dfd73dfa
+niiri:572e00e92909efbb8dbfa749a8192c13
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-8,-32,36]"^^xsd:string .
 
-niiri:cc9face0d8fe5a7de8a150a20acca2d8 prov:wasDerivedFrom niiri:71a412f82e6ea8cb947b5be72c8efcff .
+niiri:865765b8e81628e180cd32d69ff2a873 prov:wasDerivedFrom niiri:3950399d3cc373d8735fcf48ad86f542 .
 
-niiri:5af15d290c54073ba4518037ca306358
+niiri:016b2fb8ca4f729da187a0f0b71608cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:924073fc7007784464acebdf52dfccca ;
+    prov:atLocation niiri:98776a828aca5a643515928e94c4cdc1 ;
     prov:value "20.0413494110107"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82938429557992"^^xsd:float ;
     nidm_pValueUncorrected: "6.42321325474704e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984364018223445"^^xsd:float ;
     nidm_qValueFDR: "0.0674959642175569"^^xsd:float .
 
-niiri:924073fc7007784464acebdf52dfccca
+niiri:98776a828aca5a643515928e94c4cdc1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-34,-84,-4]"^^xsd:string .
 
-niiri:5af15d290c54073ba4518037ca306358 prov:wasDerivedFrom niiri:93e18b25ba3aeb399e6fd41cb9dfca97 .
+niiri:016b2fb8ca4f729da187a0f0b71608cc prov:wasDerivedFrom niiri:bab302ab1de7ceb32ee2a4553bab718d .
 
-niiri:ea651b661b6bfe3969159c6f0ec70642
+niiri:ca802812c6d952e6eb53d6a2598748c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:6150a0cc589ec407bbf5b278e34fe8c0 ;
+    prov:atLocation niiri:305b4d132dad573dd2e91152abf41d15 ;
     prov:value "19.5813789367676"^^xsd:float ;
     nidm_equivalentZStatistic: "3.79000141974546"^^xsd:float ;
     nidm_pValueUncorrected: "7.53232118573255e-05"^^xsd:float ;
     nidm_pValueFWER: "0.991038394814884"^^xsd:float ;
     nidm_qValueFDR: "0.0718990170223714"^^xsd:float .
 
-niiri:6150a0cc589ec407bbf5b278e34fe8c0
+niiri:305b4d132dad573dd2e91152abf41d15
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-50,2,40]"^^xsd:string .
 
-niiri:ea651b661b6bfe3969159c6f0ec70642 prov:wasDerivedFrom niiri:3d33e1d8e7da5c593e7ad094c154132a .
+niiri:ca802812c6d952e6eb53d6a2598748c3 prov:wasDerivedFrom niiri:14ab5f557514798d8218e39a2199e27a .
 
-niiri:8c7a07db4f3345bbb5e3dec281596f82
+niiri:2cd7edd94889650191f6f242b9a4c176
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:8801d1d1f53291499c55fe97c82abf06 ;
+    prov:atLocation niiri:0d995ab3826e8df7675b6f8b8f4c2673 ;
     prov:value "16.7666301727295"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53217184854778"^^xsd:float ;
     nidm_pValueUncorrected: "0.00020608070787731"^^xsd:float ;
     nidm_pValueFWER: "0.99996648470095"^^xsd:float ;
     nidm_qValueFDR: "0.0942608471449251"^^xsd:float .
 
-niiri:8801d1d1f53291499c55fe97c82abf06
+niiri:0d995ab3826e8df7675b6f8b8f4c2673
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-52,-6,46]"^^xsd:string .
 
-niiri:8c7a07db4f3345bbb5e3dec281596f82 prov:wasDerivedFrom niiri:3d33e1d8e7da5c593e7ad094c154132a .
+niiri:2cd7edd94889650191f6f242b9a4c176 prov:wasDerivedFrom niiri:14ab5f557514798d8218e39a2199e27a .
 
-niiri:0d7a35acc2e01b8de53dab1cd6885030
+niiri:390e65b5876e189721e8386b64e468ba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:5ca0f95ce3edb5b98b519299dce96767 ;
+    prov:atLocation niiri:8e65f05088e65ca40cdab4f7b8c45feb ;
     prov:value "19.3040504455566"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76590943131268"^^xsd:float ;
     nidm_pValueUncorrected: "8.2971971291701e-05"^^xsd:float ;
     nidm_pValueFWER: "0.993825462793153"^^xsd:float ;
     nidm_qValueFDR: "0.0737314974355366"^^xsd:float .
 
-niiri:5ca0f95ce3edb5b98b519299dce96767
+niiri:8e65f05088e65ca40cdab4f7b8c45feb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[24,-46,32]"^^xsd:string .
 
-niiri:0d7a35acc2e01b8de53dab1cd6885030 prov:wasDerivedFrom niiri:29aacfbb8eb7b7f0ba6ca8cc344739c4 .
+niiri:390e65b5876e189721e8386b64e468ba prov:wasDerivedFrom niiri:bc603717c0c5d8a8779b8aa6c28564b3 .
 
-niiri:0ea3ba62f32a9ee428c5ea4b5cef35cb
+niiri:613f7d1a72653a094215c0c7838598d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:140460982182cf8d062436969406364b ;
+    prov:atLocation niiri:261bf2d0efecb03152c6e1cdf2df18c0 ;
     prov:value "19.1409015655518"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75161143600874"^^xsd:float ;
     nidm_pValueUncorrected: "8.7850813353163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995110302012489"^^xsd:float ;
     nidm_qValueFDR: "0.0738147834753255"^^xsd:float .
 
-niiri:140460982182cf8d062436969406364b
+niiri:261bf2d0efecb03152c6e1cdf2df18c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[6,16,50]"^^xsd:string .
 
-niiri:0ea3ba62f32a9ee428c5ea4b5cef35cb prov:wasDerivedFrom niiri:7c11ea6d552baec493b21ecdef64c785 .
+niiri:613f7d1a72653a094215c0c7838598d6 prov:wasDerivedFrom niiri:106ee2638843f2793b5ac6735acad91e .
 
-niiri:c9ac5ab5461375e94e4d7324a6bedc98
+niiri:dbe73b14c812ef0bb874edaf583e9d7c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:c7cab9ce4ae0697e1f4eb6ec314ebc4d ;
+    prov:atLocation niiri:64529db73025d3ebe03ab8490a2c7588 ;
     prov:value "19.098669052124"^^xsd:float ;
     nidm_equivalentZStatistic: "3.74789498829157"^^xsd:float ;
     nidm_pValueUncorrected: "8.91624398706714e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995405100064856"^^xsd:float ;
     nidm_qValueFDR: "0.0738147834753255"^^xsd:float .
 
-niiri:c7cab9ce4ae0697e1f4eb6ec314ebc4d
+niiri:64529db73025d3ebe03ab8490a2c7588
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-4,-24,6]"^^xsd:string .
 
-niiri:c9ac5ab5461375e94e4d7324a6bedc98 prov:wasDerivedFrom niiri:56fa7a2fed0946da7dd3299da637b245 .
+niiri:dbe73b14c812ef0bb874edaf583e9d7c prov:wasDerivedFrom niiri:01c1ab06b5a4997e0980bcddb0f69696 .
 
-niiri:d787aaae02f2d49ff3e8f709b3e0ffe2
+niiri:d74cbd45e77a6bd61d201389470b3f9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:27e6b2cc327f93c6462c9e5686d7c493 ;
+    prov:atLocation niiri:2a23dfb2262a16b99ed1460c9726d32d ;
     prov:value "19.0145893096924"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7404771295496"^^xsd:float ;
     nidm_pValueUncorrected: "9.1835629583259e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995949293325196"^^xsd:float ;
     nidm_qValueFDR: "0.0741915113542509"^^xsd:float .
 
-niiri:27e6b2cc327f93c6462c9e5686d7c493
+niiri:2a23dfb2262a16b99ed1460c9726d32d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-4,0,54]"^^xsd:string .
 
-niiri:d787aaae02f2d49ff3e8f709b3e0ffe2 prov:wasDerivedFrom niiri:c74b1ddb4c9a5395bf0b4d826708ce5a .
+niiri:d74cbd45e77a6bd61d201389470b3f9d prov:wasDerivedFrom niiri:8f249184eec9591adc7a3fc1c7e37936 .
 
-niiri:9db9efc1edd783d8cbdaf22ba831fdaf
+niiri:4bb899cd9f06bf6ba2fefa26066f1718
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:1c5529d2dc429e1471abb89100522dbc ;
+    prov:atLocation niiri:84e6c234c35fdc2fa131ca05716bd905 ;
     prov:value "18.8265838623047"^^xsd:float ;
     nidm_equivalentZStatistic: "3.72379883766124"^^xsd:float ;
     nidm_pValueUncorrected: "9.81236582245915e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996978299202392"^^xsd:float ;
     nidm_qValueFDR: "0.0777669728451003"^^xsd:float .
 
-niiri:1c5529d2dc429e1471abb89100522dbc
+niiri:84e6c234c35fdc2fa131ca05716bd905
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[42,-28,30]"^^xsd:string .
 
-niiri:9db9efc1edd783d8cbdaf22ba831fdaf prov:wasDerivedFrom niiri:10bec2b1f4f72ee8eedb38e17e1faab3 .
+niiri:4bb899cd9f06bf6ba2fefa26066f1718 prov:wasDerivedFrom niiri:c7ba1e0ca7a63ee914a7fa6cddbda281 .
 
-niiri:a25f9de80ac191e47f1660393e75473f
+niiri:2fcf4f5e0a9409e59f9b3a198af722a2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:4fa2fadc00e657efdd63b3a39309c84a ;
+    prov:atLocation niiri:dfeeafe9412e26a98688ac2eb5eedc76 ;
     prov:value "18.5199432373047"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69631988620818"^^xsd:float ;
     nidm_pValueUncorrected: "0.000109373660980738"^^xsd:float ;
     nidm_pValueFWER: "0.998191254166604"^^xsd:float ;
     nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
 
-niiri:4fa2fadc00e657efdd63b3a39309c84a
+niiri:dfeeafe9412e26a98688ac2eb5eedc76
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[52,-12,44]"^^xsd:string .
 
-niiri:a25f9de80ac191e47f1660393e75473f prov:wasDerivedFrom niiri:f725bd9a5656b07d43f8eba6c3be2858 .
+niiri:2fcf4f5e0a9409e59f9b3a198af722a2 prov:wasDerivedFrom niiri:91987e35b1d8c15af66e3327a6e4b602 .
 
-niiri:f484fb8e47371d4dd3f5ee9736deeca9
+niiri:01dc6fc72b88495c5e6c08fc0cc0bc35
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:33fd7ada9f41a7443fa610a81c719475 ;
+    prov:atLocation niiri:a785670f070730f0b5dad30427a1e8f7 ;
     prov:value "18.516544342041"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69601335434539"^^xsd:float ;
     nidm_pValueUncorrected: "0.000109505728679404"^^xsd:float ;
     nidm_pValueFWER: "0.998201975106935"^^xsd:float ;
     nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
 
-niiri:33fd7ada9f41a7443fa610a81c719475
+niiri:a785670f070730f0b5dad30427a1e8f7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-40,-28,30]"^^xsd:string .
 
-niiri:f484fb8e47371d4dd3f5ee9736deeca9 prov:wasDerivedFrom niiri:83f438c66d3cf32344b7255377c7499d .
+niiri:01dc6fc72b88495c5e6c08fc0cc0bc35 prov:wasDerivedFrom niiri:c09f3990ca4bd168f93fa27a56eeb56c .
 
-niiri:8582459cfedf8c404f54867fe9956065
+niiri:cf74bac84d8f51cb7fb8a579dd4b736b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:7574fcc563cda88fe39a2f517cefd40a ;
+    prov:atLocation niiri:62e6d759392d4c5a22e393f530aba130 ;
     prov:value "18.4609222412109"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69099090519778"^^xsd:float ;
     nidm_pValueUncorrected: "0.000111691062804176"^^xsd:float ;
     nidm_pValueFWER: "0.998370011058266"^^xsd:float ;
     nidm_qValueFDR: "0.0808726894914066"^^xsd:float .
 
-niiri:7574fcc563cda88fe39a2f517cefd40a
+niiri:62e6d759392d4c5a22e393f530aba130
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[32,22,-8]"^^xsd:string .
 
-niiri:8582459cfedf8c404f54867fe9956065 prov:wasDerivedFrom niiri:cc9360b64b21e281dcfb851074b574b6 .
+niiri:cf74bac84d8f51cb7fb8a579dd4b736b prov:wasDerivedFrom niiri:4f39525fd234b098e759c0ffc971fd5b .
 
-niiri:ba6bc791d8adb783ff5181c1594590b6
+niiri:39ca307d31c5892250f913783b4db62c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:2398781ef2e524c6173a32e0bb244b23 ;
+    prov:atLocation niiri:d6626578cce8299da3656ac371463365 ;
     prov:value "17.9312534332275"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64257521175179"^^xsd:float ;
     nidm_pValueUncorrected: "0.00013496203699781"^^xsd:float ;
     nidm_pValueFWER: "0.99941063068466"^^xsd:float ;
     nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
 
-niiri:2398781ef2e524c6173a32e0bb244b23
+niiri:d6626578cce8299da3656ac371463365
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[64,-4,10]"^^xsd:string .
 
-niiri:ba6bc791d8adb783ff5181c1594590b6 prov:wasDerivedFrom niiri:4728de35ba855317aeef4e0a7b91801c .
+niiri:39ca307d31c5892250f913783b4db62c prov:wasDerivedFrom niiri:66eca61ada8ceb626c8ffd13d3efa1cc .
 
-niiri:74387d11b1e18aa01c68936614d323d2
+niiri:1f3bee85e377a2130e061374ce19f6ab
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:719551878f20f48ff5a59d8a7a9c8229 ;
+    prov:atLocation niiri:a706a639a6105ecabcfe5a088abd9d25 ;
     prov:value "17.8439044952393"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63448648232359"^^xsd:float ;
     nidm_pValueUncorrected: "0.000139267429951739"^^xsd:float ;
     nidm_pValueFWER: "0.999509275806277"^^xsd:float ;
     nidm_qValueFDR: "0.0834774193267073"^^xsd:float .
 
-niiri:719551878f20f48ff5a59d8a7a9c8229
+niiri:a706a639a6105ecabcfe5a088abd9d25
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-22,-72,34]"^^xsd:string .
 
-niiri:74387d11b1e18aa01c68936614d323d2 prov:wasDerivedFrom niiri:f435923c3d5e3915c4aa5159c5bbc4a0 .
+niiri:1f3bee85e377a2130e061374ce19f6ab prov:wasDerivedFrom niiri:5cf9402b2b494a87640a66aec1a6fdaf .
 
-niiri:f515406c4386dbba20e09dfc286cad01
+niiri:7f7625524d177fe4781c28633ad04fb0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:53dfe63ffbecb2b80528e9f6b0729406 ;
+    prov:atLocation niiri:dde299cfdeb368ced964fe7a498cc703 ;
     prov:value "17.552827835083"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60731294050443"^^xsd:float ;
     nidm_pValueUncorrected: "0.000154692216466135"^^xsd:float ;
     nidm_pValueFWER: "0.999742486133075"^^xsd:float ;
     nidm_qValueFDR: "0.0862331427095326"^^xsd:float .
 
-niiri:53dfe63ffbecb2b80528e9f6b0729406
+niiri:dde299cfdeb368ced964fe7a498cc703
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-6,-44,40]"^^xsd:string .
 
-niiri:f515406c4386dbba20e09dfc286cad01 prov:wasDerivedFrom niiri:b39b9cce118cf858149cdd53ebcda7bd .
+niiri:7f7625524d177fe4781c28633ad04fb0 prov:wasDerivedFrom niiri:1cd1f14fea72d133db88783e1b907b7f .
 
-niiri:1b3fb965c01205049ccc6b0cbe41747e
+niiri:ea8dfff70bef204151c3aa37de438b0f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:f27eb00800ba18fb1542d4dada966f33 ;
+    prov:atLocation niiri:d703077133d717f4a9d9411fe4c791a6 ;
     prov:value "17.2906818389893"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58254613965863"^^xsd:float ;
     nidm_pValueUncorrected: "0.000170130746602659"^^xsd:float ;
     nidm_pValueFWER: "0.99986271355264"^^xsd:float ;
     nidm_qValueFDR: "0.0895859395735557"^^xsd:float .
 
-niiri:f27eb00800ba18fb1542d4dada966f33
+niiri:d703077133d717f4a9d9411fe4c791a6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-34,-38,-34]"^^xsd:string .
 
-niiri:1b3fb965c01205049ccc6b0cbe41747e prov:wasDerivedFrom niiri:97e0a9bea1289493ad46d8a4c2b75485 .
+niiri:ea8dfff70bef204151c3aa37de438b0f prov:wasDerivedFrom niiri:c3340fa012c626e62e86cdb279a4e883 .
 
-niiri:1db1dcb7ac31be92db03ea6f49276709
+niiri:1f8b76bc5a6e0e44d52dc38f77dfb573
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:c2aa93c26b662b0231d80c11fa4a9ef6 ;
+    prov:atLocation niiri:52d6deef40815f931bff80e4a0c0e30e ;
     prov:value "17.1612319946289"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57021115022413"^^xsd:float ;
     nidm_pValueUncorrected: "0.000178346794309836"^^xsd:float ;
     nidm_pValueFWER: "0.999901168620001"^^xsd:float ;
     nidm_qValueFDR: "0.0903823255084056"^^xsd:float .
 
-niiri:c2aa93c26b662b0231d80c11fa4a9ef6
+niiri:52d6deef40815f931bff80e4a0c0e30e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-46,-16,20]"^^xsd:string .
 
-niiri:1db1dcb7ac31be92db03ea6f49276709 prov:wasDerivedFrom niiri:e9e94038b5b1dbcf9f8a4d4208e34928 .
+niiri:1f8b76bc5a6e0e44d52dc38f77dfb573 prov:wasDerivedFrom niiri:ab64ef9cfaa22101d1a0ddaad92a3bfd .
 
-niiri:e52b244ba436c001a08d0e1a0f3fc101
+niiri:ebb56262d90fa761f5c469bbcf6709b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:8379336830251a7cbd5eb4a5b2b7e6c0 ;
+    prov:atLocation niiri:bd5feebad73f603c2c5027f05c096a98 ;
     prov:value "17.0075950622559"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55547987606237"^^xsd:float ;
     nidm_pValueUncorrected: "0.000188644912021529"^^xsd:float ;
     nidm_pValueFWER: "0.999934173907998"^^xsd:float ;
     nidm_qValueFDR: "0.0920555845860752"^^xsd:float .
 
-niiri:8379336830251a7cbd5eb4a5b2b7e6c0
+niiri:bd5feebad73f603c2c5027f05c096a98
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[24,32,2]"^^xsd:string .
 
-niiri:e52b244ba436c001a08d0e1a0f3fc101 prov:wasDerivedFrom niiri:0857328371989db393f2fc4d7d5346bd .
+niiri:ebb56262d90fa761f5c469bbcf6709b0 prov:wasDerivedFrom niiri:8b25738f634743abd67e5fd856e90f74 .
 
-niiri:58c50def173085b4eacf834a8b4704ff
+niiri:66c1ec432c1811911fdd6cd83f434d1b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:0b671ab6136c76ed072d17a2c0f74a10 ;
+    prov:atLocation niiri:e5c4443633b94c1fa86927c7c92b220e ;
     prov:value "16.5308303833008"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50911812032442"^^xsd:float ;
     nidm_pValueUncorrected: "0.000224797592033421"^^xsd:float ;
     nidm_pValueFWER: "0.999983487413756"^^xsd:float ;
     nidm_qValueFDR: "0.0959555780965771"^^xsd:float .
 
-niiri:0b671ab6136c76ed072d17a2c0f74a10
+niiri:e5c4443633b94c1fa86927c7c92b220e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-26,-90,16]"^^xsd:string .
 
-niiri:58c50def173085b4eacf834a8b4704ff prov:wasDerivedFrom niiri:7e693a4a3e70d39b916aa2a95911a3c8 .
+niiri:66c1ec432c1811911fdd6cd83f434d1b prov:wasDerivedFrom niiri:1c59a22b32098831723dc21703615fd1 .
 
-niiri:29090a193cda0ed62625301b681522a5
+niiri:5f67ac778b6bca3e423969c609840ac8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:baefd951dc2ab5a50c39cd840ad1f17e ;
+    prov:atLocation niiri:a555880be249de2c84bc634ee280dbd7 ;
     prov:value "16.5225524902344"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50830432871627"^^xsd:float ;
     nidm_pValueUncorrected: "0.0002254864217901"^^xsd:float ;
     nidm_pValueFWER: "0.999983907066973"^^xsd:float ;
     nidm_qValueFDR: "0.0959555780965771"^^xsd:float .
 
-niiri:baefd951dc2ab5a50c39cd840ad1f17e
+niiri:a555880be249de2c84bc634ee280dbd7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-28,-4,16]"^^xsd:string .
 
-niiri:29090a193cda0ed62625301b681522a5 prov:wasDerivedFrom niiri:d8dc459a110e4898c23019ee42154713 .
+niiri:5f67ac778b6bca3e423969c609840ac8 prov:wasDerivedFrom niiri:139b6ecf5fdad735a51b4385a24aded9 .
 
-niiri:b7d5268eabb9490b67684ed7ceb301c9
+niiri:5acb0f78fc88ddc60b2b62de835c1f34
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:9375ad74a7d7acce22a9a6dc5fa1d47d ;
+    prov:atLocation niiri:eb3468c7ba505890d9c51ddfff00f74f ;
     prov:value "16.1374092102051"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47009871338807"^^xsd:float ;
     nidm_pValueUncorrected: "0.00026013355917065"^^xsd:float ;
     nidm_pValueFWER: "0.999995475747835"^^xsd:float ;
     nidm_qValueFDR: "0.101886915515055"^^xsd:float .
 
-niiri:9375ad74a7d7acce22a9a6dc5fa1d47d
+niiri:eb3468c7ba505890d9c51ddfff00f74f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[12,60,20]"^^xsd:string .
 
-niiri:b7d5268eabb9490b67684ed7ceb301c9 prov:wasDerivedFrom niiri:cd795f902776ad9170549b8fde8996ba .
+niiri:5acb0f78fc88ddc60b2b62de835c1f34 prov:wasDerivedFrom niiri:e6a138032615b9872d9261e35d2455f4 .
 
-niiri:9db92d56d94d661dd685256f317dbe48
+niiri:0da938bd32e898d2174c988f1eaf4581
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:e35f3a6956a4d9893c3760d30968fce5 ;
+    prov:atLocation niiri:4a0acfe4d96a811a5bbd2fea220ee9f8 ;
     prov:value "15.9136981964111"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44759277757755"^^xsd:float ;
     nidm_pValueUncorrected: "0.000282803055741021"^^xsd:float ;
     nidm_pValueFWER: "0.999997977474125"^^xsd:float ;
     nidm_qValueFDR: "0.105222982133496"^^xsd:float .
 
-niiri:e35f3a6956a4d9893c3760d30968fce5
+niiri:4a0acfe4d96a811a5bbd2fea220ee9f8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[4,-84,-4]"^^xsd:string .
 
-niiri:9db92d56d94d661dd685256f317dbe48 prov:wasDerivedFrom niiri:ed1df7c28737883d905ca0a8f2093992 .
+niiri:0da938bd32e898d2174c988f1eaf4581 prov:wasDerivedFrom niiri:37bc5cb5a158a9f86c496a5d1935903c .
 
-niiri:95049e965261ae17e6141f440c65aade
+niiri:8c6a5d705c064da10637a02bbcea89bb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:8907a4706c52ef0acbd6db140d02de82 ;
+    prov:atLocation niiri:a7922d8059c11028e4ec965953a381f4 ;
     prov:value "15.8536109924316"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44150764421068"^^xsd:float ;
     nidm_pValueUncorrected: "0.000289241063091916"^^xsd:float ;
     nidm_pValueFWER: "0.999998385530387"^^xsd:float ;
     nidm_qValueFDR: "0.105222982133496"^^xsd:float .
 
-niiri:8907a4706c52ef0acbd6db140d02de82
+niiri:a7922d8059c11028e4ec965953a381f4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[62,-18,22]"^^xsd:string .
 
-niiri:95049e965261ae17e6141f440c65aade prov:wasDerivedFrom niiri:ca7bfed8d8dbca676ba25fca93d29e2c .
+niiri:8c6a5d705c064da10637a02bbcea89bb prov:wasDerivedFrom niiri:f86c9bb022fe2e7bb4f2a1d963869d32 .
 
-niiri:bc2dfd54c7c011e3626f64ebd840c082
+niiri:cf7dcc23115c0b40b60445223ba951c9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:8d0fe36db64dfbb57c50be778e56fc0b ;
+    prov:atLocation niiri:f42b18360ea8f8af980f3d406996a6b7 ;
     prov:value "15.8288412094116"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43899416081302"^^xsd:float ;
     nidm_pValueUncorrected: "0.000291939913913408"^^xsd:float ;
     nidm_pValueFWER: "0.999998530446399"^^xsd:float ;
     nidm_qValueFDR: "0.105222982133496"^^xsd:float .
 
-niiri:8d0fe36db64dfbb57c50be778e56fc0b
+niiri:f42b18360ea8f8af980f3d406996a6b7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[28,-58,44]"^^xsd:string .
 
-niiri:bc2dfd54c7c011e3626f64ebd840c082 prov:wasDerivedFrom niiri:1dcd9b5514190f867e3e9b0b57227395 .
+niiri:cf7dcc23115c0b40b60445223ba951c9 prov:wasDerivedFrom niiri:cecab36bcbd915f7841bff34cd7f59a6 .
 
-niiri:b861ffa726f69dca943d1bc1e39e3f21
+niiri:c7e7aa913113f6519557c66a5087a3a8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:358c40d8401882be55ffa3aa51e8c703 ;
+    prov:atLocation niiri:b8359b6165a7f498d646c290e8cd1c6c ;
     prov:value "15.7273988723755"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42866974555038"^^xsd:float ;
     nidm_pValueUncorrected: "0.000303273553249328"^^xsd:float ;
     nidm_pValueFWER: "0.999999007347173"^^xsd:float ;
     nidm_qValueFDR: "0.106558197028572"^^xsd:float .
 
-niiri:358c40d8401882be55ffa3aa51e8c703
+niiri:b8359b6165a7f498d646c290e8cd1c6c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[38,44,0]"^^xsd:string .
 
-niiri:b861ffa726f69dca943d1bc1e39e3f21 prov:wasDerivedFrom niiri:79097d11179e49abc9f2bdf5ba7bb932 .
+niiri:c7e7aa913113f6519557c66a5087a3a8 prov:wasDerivedFrom niiri:752ff8a0ff1912e3b3a3cc0b0af92bac .
 
-niiri:48b5c01001fb7600fbd4531a0e1761c4
+niiri:84d2dd552da32536ba619bf257b99a8e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:ae647fef7b776cfa997ad53eb4b2fc5b ;
+    prov:atLocation niiri:a8431b89c9e7b5310335b9441226ea8e ;
     prov:value "15.4726600646973"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40252319694713"^^xsd:float ;
     nidm_pValueUncorrected: "0.000333833435672726"^^xsd:float ;
     nidm_pValueFWER: "0.999999648429928"^^xsd:float ;
     nidm_qValueFDR: "0.109105594368073"^^xsd:float .
 
-niiri:ae647fef7b776cfa997ad53eb4b2fc5b
+niiri:a8431b89c9e7b5310335b9441226ea8e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[40,-6,-6]"^^xsd:string .
 
-niiri:48b5c01001fb7600fbd4531a0e1761c4 prov:wasDerivedFrom niiri:d339d6251d3c159dbe2427fd1bcc1fc1 .
+niiri:84d2dd552da32536ba619bf257b99a8e prov:wasDerivedFrom niiri:bbfdc94758422f4cdfa2d461f26c652c .
 
-niiri:c46952610583f569f9152387a8bc54d9
+niiri:ac77b7c2f4ff41e88896e4ba87eadac1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:cd6aeb3993ad5aeb4e69f7fde5b6d7dc ;
+    prov:atLocation niiri:c99f7fc58da7232a1f42538844fca3ae ;
     prov:value "15.3332357406616"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38807697766079"^^xsd:float ;
     nidm_pValueUncorrected: "0.00035192253822891"^^xsd:float ;
     nidm_pValueFWER: "0.999999807374102"^^xsd:float ;
     nidm_qValueFDR: "0.110729615236961"^^xsd:float .
 
-niiri:cd6aeb3993ad5aeb4e69f7fde5b6d7dc
+niiri:c99f7fc58da7232a1f42538844fca3ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[32,14,58]"^^xsd:string .
 
-niiri:c46952610583f569f9152387a8bc54d9 prov:wasDerivedFrom niiri:b0978b4f683201d3539ace75681c8b65 .
+niiri:ac77b7c2f4ff41e88896e4ba87eadac1 prov:wasDerivedFrom niiri:412f44bb99fe0b4ac5111c8bb0d6824f .
 
-niiri:549a9bbee50f3775d812947136680afd
+niiri:fd0d7457e6ffb07f08eca126631606af
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:eb0736b11222caa828e4419e72562692 ;
+    prov:atLocation niiri:d5fba9940a2400106183302f6016bc4b ;
     prov:value "15.3172578811646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38641524500992"^^xsd:float ;
     nidm_pValueUncorrected: "0.000354060730342054"^^xsd:float ;
     nidm_pValueFWER: "0.99999982049151"^^xsd:float ;
     nidm_qValueFDR: "0.110729615236961"^^xsd:float .
 
-niiri:eb0736b11222caa828e4419e72562692
+niiri:d5fba9940a2400106183302f6016bc4b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[4,-86,4]"^^xsd:string .
 
-niiri:549a9bbee50f3775d812947136680afd prov:wasDerivedFrom niiri:133c074788eed1fa9d50d9e4608e3c1c .
+niiri:fd0d7457e6ffb07f08eca126631606af prov:wasDerivedFrom niiri:ae1cd8d0dfca9341507b66eafba6459d .
 
-niiri:a70159564d5e15398a8e6af937070b21
+niiri:49269ead5464f020f20ecbdb76e9e6fa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:0cd5c4445b3ca0198be2f8b0ac1c5ff7 ;
+    prov:atLocation niiri:de463eb97f5bdebf8c7c86e1b3c0390b ;
     prov:value "15.3137311935425"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38604828864924"^^xsd:float ;
     nidm_pValueUncorrected: "0.000354534526388783"^^xsd:float ;
     nidm_pValueFWER: "0.999999823272138"^^xsd:float ;
     nidm_qValueFDR: "0.110729615236961"^^xsd:float .
 
-niiri:0cd5c4445b3ca0198be2f8b0ac1c5ff7
+niiri:de463eb97f5bdebf8c7c86e1b3c0390b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[62,-36,46]"^^xsd:string .
 
-niiri:a70159564d5e15398a8e6af937070b21 prov:wasDerivedFrom niiri:93bdd51f373f8659382785eb36932971 .
+niiri:49269ead5464f020f20ecbdb76e9e6fa prov:wasDerivedFrom niiri:089292d98902368bd347bcdfa162cfda .
 
-niiri:d7e71a37d659eb3e8ffc416baa8d822a
+niiri:7e757cfd5d9ab4dc7b7ed7c707af0b92
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:2e67727cc0cfd1e78600ff3d8e948bb7 ;
+    prov:atLocation niiri:f64c41b60e15a328c7edf5b31cc35bb6 ;
     prov:value "15.1916456222534"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37330635701462"^^xsd:float ;
     nidm_pValueUncorrected: "0.000371356333789152"^^xsd:float ;
     nidm_pValueFWER: "0.999999898084819"^^xsd:float ;
     nidm_qValueFDR: "0.113182641774622"^^xsd:float .
 
-niiri:2e67727cc0cfd1e78600ff3d8e948bb7
+niiri:f64c41b60e15a328c7edf5b31cc35bb6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[-24,18,58]"^^xsd:string .
 
-niiri:d7e71a37d659eb3e8ffc416baa8d822a prov:wasDerivedFrom niiri:522536a75466fe7c0e757947afe21547 .
+niiri:7e757cfd5d9ab4dc7b7ed7c707af0b92 prov:wasDerivedFrom niiri:716ffa34870ad39bf06d8e49c18b9bce .
 
-niiri:03f8d483a6d2c4d5e2df0d2834d90bc1
+niiri:1187cc9f9751060cd5bdbcc8bc4b20ce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:017fc7f20be266bd229d46d23c92c88e ;
+    prov:atLocation niiri:fe5b4275099b74097635eb9f7b4bc414 ;
     prov:value "15.0888338088989"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36251708484568"^^xsd:float ;
     nidm_pValueUncorrected: "0.000386176732959709"^^xsd:float ;
     nidm_pValueFWER: "0.999999936876428"^^xsd:float ;
     nidm_qValueFDR: "0.114724188214818"^^xsd:float .
 
-niiri:017fc7f20be266bd229d46d23c92c88e
+niiri:fe5b4275099b74097635eb9f7b4bc414
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[8,-22,-44]"^^xsd:string .
 
-niiri:03f8d483a6d2c4d5e2df0d2834d90bc1 prov:wasDerivedFrom niiri:acdb22704e8e3566aa17ca0ccdff7a03 .
+niiri:1187cc9f9751060cd5bdbcc8bc4b20ce prov:wasDerivedFrom niiri:8c7ca240ed7a4d85316011dd6f1768ff .
 
-niiri:7065d45e419e04080dbcbe72642fe102
+niiri:aa80010f717675a3a90dd7af1d9b1867
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:64d776bee75666af4e2b1252a3fd0002 ;
+    prov:atLocation niiri:8a342a7e8ab4849998a118155ae4e602 ;
     prov:value "14.8200588226318"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33405240591422"^^xsd:float ;
     nidm_pValueUncorrected: "0.000427952650791097"^^xsd:float ;
     nidm_pValueFWER: "0.999999983180231"^^xsd:float ;
     nidm_qValueFDR: "0.119307804764224"^^xsd:float .
 
-niiri:64d776bee75666af4e2b1252a3fd0002
+niiri:8a342a7e8ab4849998a118155ae4e602
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[38,34,22]"^^xsd:string .
 
-niiri:7065d45e419e04080dbcbe72642fe102 prov:wasDerivedFrom niiri:e1cde03f80af40c7004f16340827c9a6 .
+niiri:aa80010f717675a3a90dd7af1d9b1867 prov:wasDerivedFrom niiri:08593ccb1d9e49118b073d271565bd78 .
 
-niiri:f232f46f47a241ff82eee6a194ff86ad
+niiri:ba5d10a86acf3f4093c769c8fa361c7c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:b744cd533ab253d9b8023ced422dcd4e ;
+    prov:atLocation niiri:efbdced299f9a874e778dd97925cd80e ;
     prov:value "14.696608543396"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32085065286489"^^xsd:float ;
     nidm_pValueUncorrected: "0.000448717729613968"^^xsd:float ;
     nidm_pValueFWER: "0.9999999911592"^^xsd:float ;
     nidm_qValueFDR: "0.121223400645327"^^xsd:float .
 
-niiri:b744cd533ab253d9b8023ced422dcd4e
+niiri:efbdced299f9a874e778dd97925cd80e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[0,-26,-28]"^^xsd:string .
 
-niiri:f232f46f47a241ff82eee6a194ff86ad prov:wasDerivedFrom niiri:1a861a102938105fb0e599c28c89f0df .
+niiri:ba5d10a86acf3f4093c769c8fa361c7c prov:wasDerivedFrom niiri:b52f4fded36d906e3611187b1ea82271 .
 
-niiri:d07297142ea27f1aadd2a2d0fc18eaa5
+niiri:10055d39115bd79bb71ae44a1b641f14
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:3df6f0cc55b55ccf745b4ed025159201 ;
+    prov:atLocation niiri:f1ba673212538f0ac2d79c06bd68cf16 ;
     prov:value "14.2414035797119"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27145497586776"^^xsd:float ;
     nidm_pValueUncorrected: "0.00053497811978398"^^xsd:float ;
     nidm_pValueFWER: "0.99999999933201"^^xsd:float ;
     nidm_qValueFDR: "0.128281884148943"^^xsd:float .
 
-niiri:3df6f0cc55b55ccf745b4ed025159201
+niiri:f1ba673212538f0ac2d79c06bd68cf16
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[40,-50,-22]"^^xsd:string .
 
-niiri:d07297142ea27f1aadd2a2d0fc18eaa5 prov:wasDerivedFrom niiri:28c829a636fe7679be2b8fe3fc083d99 .
+niiri:10055d39115bd79bb71ae44a1b641f14 prov:wasDerivedFrom niiri:900eebea134685a11022813f19903499 .
 
-niiri:04eb8dd4e9ab8ac46c751092d04da10d
+niiri:024cfe8a8af184572999a9d180792536
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:ff9d4a014bd4e0dc8a92264c7b200ed9 ;
+    prov:atLocation niiri:8bd27ef17ea505784747393676c66e61 ;
     prov:value "14.0012445449829"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24492687341108"^^xsd:float ;
     nidm_pValueUncorrected: "0.000587403942481801"^^xsd:float ;
     nidm_pValueFWER: "0.999999999852106"^^xsd:float ;
     nidm_qValueFDR: "0.131447065854217"^^xsd:float .
 
-niiri:ff9d4a014bd4e0dc8a92264c7b200ed9
+niiri:8bd27ef17ea505784747393676c66e61
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[8,52,32]"^^xsd:string .
 
-niiri:04eb8dd4e9ab8ac46c751092d04da10d prov:wasDerivedFrom niiri:4bb1f06cdf753bfe2cb9742585fc5f63 .
+niiri:024cfe8a8af184572999a9d180792536 prov:wasDerivedFrom niiri:a20506ad4a845975db3365e7c162d818 .
 
-niiri:d80002080097776aa38277bc80033aa3
+niiri:7a1112a488de76696afff578ff73b63a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:ce74cab636a5f2efe71e98f6ae695f3c ;
+    prov:atLocation niiri:c3e118566488fbb275af41e9caa2d23e ;
     prov:value "13.9842071533203"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2430323166614"^^xsd:float ;
     nidm_pValueUncorrected: "0.000591323980175695"^^xsd:float ;
     nidm_pValueFWER: "0.999999999867649"^^xsd:float ;
     nidm_qValueFDR: "0.131695068372973"^^xsd:float .
 
-niiri:ce74cab636a5f2efe71e98f6ae695f3c
+niiri:c3e118566488fbb275af41e9caa2d23e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-14,-48,-24]"^^xsd:string .
 
-niiri:d80002080097776aa38277bc80033aa3 prov:wasDerivedFrom niiri:cca6dc1b6e22a99533fb4839e0e808cf .
+niiri:7a1112a488de76696afff578ff73b63a prov:wasDerivedFrom niiri:cfde284823e7c32d74bec0b81232bb7a .
 
-niiri:d4c1b62bf34355cc27a8c18d2fe4f53b
+niiri:d17f027d268c7f08e9841c1c575cf23e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:ea5c28625592b62bd93bf315cb8d38f1 ;
+    prov:atLocation niiri:ae9a839905051fcbf3c519761251289d ;
     prov:value "13.9203996658325"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23592192136056"^^xsd:float ;
     nidm_pValueUncorrected: "0.000606252725692924"^^xsd:float ;
     nidm_pValueFWER: "0.999999999913111"^^xsd:float ;
     nidm_qValueFDR: "0.13226466740541"^^xsd:float .
 
-niiri:ea5c28625592b62bd93bf315cb8d38f1
+niiri:ae9a839905051fcbf3c519761251289d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[20,0,-8]"^^xsd:string .
 
-niiri:d4c1b62bf34355cc27a8c18d2fe4f53b prov:wasDerivedFrom niiri:894db077f6ce41dde7580196422f5b65 .
+niiri:d17f027d268c7f08e9841c1c575cf23e prov:wasDerivedFrom niiri:496bec06cfc8ef95b3cbe0997c654d26 .
 
-niiri:22da22dab16541f8e410ae72c92290f3
+niiri:9a81d2292183627c111fac27998c2da6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:183de3503fa5b331b636ff710340ee17 ;
+    prov:atLocation niiri:84fa347a32d4bf011d58a0338bec2648 ;
     prov:value "13.8925752639771"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23281385809669"^^xsd:float ;
     nidm_pValueUncorrected: "0.000612887021428588"^^xsd:float ;
     nidm_pValueFWER: "0.999999999927857"^^xsd:float ;
     nidm_qValueFDR: "0.13226466740541"^^xsd:float .
 
-niiri:183de3503fa5b331b636ff710340ee17
+niiri:84fa347a32d4bf011d58a0338bec2648
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[40,-14,60]"^^xsd:string .
 
-niiri:22da22dab16541f8e410ae72c92290f3 prov:wasDerivedFrom niiri:e8143c5b2cddc4ad2f401f2b27a4cab2 .
+niiri:9a81d2292183627c111fac27998c2da6 prov:wasDerivedFrom niiri:e4bff32759970a1099e3a417cf7206b0 .
 
-niiri:ed8e5afdf4dfba0fb8266ec7bb6e05ea
+niiri:8b4c54efdd01e22033ec948028b376c6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:bb26c37ea84abd4f8e5aab60783b1ef4 ;
+    prov:atLocation niiri:cec9885ccb4c5eddad3e16791941394f ;
     prov:value "13.8641185760498"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22963046726961"^^xsd:float ;
     nidm_pValueUncorrected: "0.000619751563460058"^^xsd:float ;
     nidm_pValueFWER: "0.999999999940447"^^xsd:float ;
     nidm_qValueFDR: "0.132333123904287"^^xsd:float .
 
-niiri:bb26c37ea84abd4f8e5aab60783b1ef4
+niiri:cec9885ccb4c5eddad3e16791941394f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-36,10,24]"^^xsd:string .
 
-niiri:ed8e5afdf4dfba0fb8266ec7bb6e05ea prov:wasDerivedFrom niiri:09cd915bf2b2b51b32d56249f304bbce .
+niiri:8b4c54efdd01e22033ec948028b376c6 prov:wasDerivedFrom niiri:40337b736645244404b84afb6772e7a9 .
 
-niiri:8999f6eb178b306d0ec123f3b221f83e
+niiri:dc9b5b7925435de1e123f050c0f32db2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:2fbd5acd6bb5ef2ba1473f87c213d4aa ;
+    prov:atLocation niiri:abc2ee78bd07cda0b6ddcacbac427081 ;
     prov:value "13.7912406921387"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22145599369965"^^xsd:float ;
     nidm_pValueUncorrected: "0.000637705235827735"^^xsd:float ;
     nidm_pValueFWER: "0.999999999963824"^^xsd:float ;
     nidm_qValueFDR: "0.133173984174016"^^xsd:float .
 
-niiri:2fbd5acd6bb5ef2ba1473f87c213d4aa
+niiri:abc2ee78bd07cda0b6ddcacbac427081
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[30,-78,14]"^^xsd:string .
 
-niiri:8999f6eb178b306d0ec123f3b221f83e prov:wasDerivedFrom niiri:bf2d35b880b3d0657d2a03298074406e .
+niiri:dc9b5b7925435de1e123f050c0f32db2 prov:wasDerivedFrom niiri:42bc55f4f90f29daf9e12be119e1ddab .
 
-niiri:089d2f5ca65585c3d01817a9bdbf214f
+niiri:98a17ff5e5165fb8c24152b264b38518
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:b64d2f396f19bac0e190ab99328b9677 ;
+    prov:atLocation niiri:4ff470161927caacc784743cebf1ff5c ;
     prov:value "13.629490852356"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20320002112963"^^xsd:float ;
     nidm_pValueUncorrected: "0.000679547746644249"^^xsd:float ;
     nidm_pValueFWER: "0.999999999988489"^^xsd:float ;
     nidm_qValueFDR: "0.136764826883915"^^xsd:float .
 
-niiri:b64d2f396f19bac0e190ab99328b9677
+niiri:4ff470161927caacc784743cebf1ff5c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[18,-78,12]"^^xsd:string .
 
-niiri:089d2f5ca65585c3d01817a9bdbf214f prov:wasDerivedFrom niiri:56bc4504cec954daf4a701610ddf59b3 .
+niiri:98a17ff5e5165fb8c24152b264b38518 prov:wasDerivedFrom niiri:067c79f86db85b508893737af41699ce .
 
-niiri:e1eec1e6fba3322a1a6483846b8a91d8
+niiri:457b57ff4d2f772e5a87d72e416d55f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:dc2ecabdf71bb61760c0219ad76cb53e ;
+    prov:atLocation niiri:642bfe0fc88a3e08454fca298ff2547d ;
     prov:value "13.5061225891113"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18916981007524"^^xsd:float ;
     nidm_pValueUncorrected: "0.000713410180681495"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995369"^^xsd:float ;
     nidm_qValueFDR: "0.139253735873803"^^xsd:float .
 
-niiri:dc2ecabdf71bb61760c0219ad76cb53e
+niiri:642bfe0fc88a3e08454fca298ff2547d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[46,8,-16]"^^xsd:string .
 
-niiri:e1eec1e6fba3322a1a6483846b8a91d8 prov:wasDerivedFrom niiri:baa1270c4a9c0f72989c973b2fbb309d .
+niiri:457b57ff4d2f772e5a87d72e416d55f7 prov:wasDerivedFrom niiri:1a35a6d628eed4f2fc8c554a4a579a19 .
 
-niiri:d434f3bdadeaac5eb9b817cb94e825e9
+niiri:983d2f990b97c775c7da5a27177fc0f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:3a03e910b24e3e930f0b6b6c9e5c737b ;
+    prov:atLocation niiri:b7b5b47e2538aa1f088bf22667e716bc ;
     prov:value "13.4754667282104"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1856690050705"^^xsd:float ;
     nidm_pValueUncorrected: "0.000722098618250455"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996325"^^xsd:float ;
     nidm_qValueFDR: "0.1402954623971"^^xsd:float .
 
-niiri:3a03e910b24e3e930f0b6b6c9e5c737b
+niiri:b7b5b47e2538aa1f088bf22667e716bc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[58,-40,50]"^^xsd:string .
 
-niiri:d434f3bdadeaac5eb9b817cb94e825e9 prov:wasDerivedFrom niiri:39b258c34ddafd00d7dff6d208f62918 .
+niiri:983d2f990b97c775c7da5a27177fc0f6 prov:wasDerivedFrom niiri:0e92ac2d77c091672e014daf15280170 .
 
-niiri:73253ea75fa4c291c1dccb3b8aadedf9
+niiri:0d84f12f1eecf02fd70239d18b674632
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:843cc3a9443e428c80dd3e5419ef67ec ;
+    prov:atLocation niiri:b200c3101378d90c3289227f2f311490 ;
     prov:value "13.4480972290039"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18253860543696"^^xsd:float ;
     nidm_pValueUncorrected: "0.000729950259848011"^^xsd:float ;
     nidm_pValueFWER: "0.999999999997016"^^xsd:float ;
     nidm_qValueFDR: "0.140840039531724"^^xsd:float .
 
-niiri:843cc3a9443e428c80dd3e5419ef67ec
+niiri:b200c3101378d90c3289227f2f311490
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[46,-66,32]"^^xsd:string .
 
-niiri:73253ea75fa4c291c1dccb3b8aadedf9 prov:wasDerivedFrom niiri:ea112296db729b94dfce05991c3d6989 .
+niiri:0d84f12f1eecf02fd70239d18b674632 prov:wasDerivedFrom niiri:0d2b802df946de1efd390f218ef63fce .
 
-niiri:0250c5bfb4ece9672c03eeceb0f7b02f
+niiri:1106844ff3c3aa841e131a1c8b3cee03
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:3c2b90faeb19728391b223147a6272ef ;
+    prov:atLocation niiri:2c69785e6a1162eaef0e8d5fb846e6be ;
     prov:value "13.2857608795166"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16387572537233"^^xsd:float ;
     nidm_pValueUncorrected: "0.000778416284459293"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999163"^^xsd:float ;
     nidm_qValueFDR: "0.14332751949213"^^xsd:float .
 
-niiri:3c2b90faeb19728391b223147a6272ef
+niiri:2c69785e6a1162eaef0e8d5fb846e6be
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[2,-76,8]"^^xsd:string .
 
-niiri:0250c5bfb4ece9672c03eeceb0f7b02f prov:wasDerivedFrom niiri:a41eeb9ba04d7788ba686542607ff1cc .
+niiri:1106844ff3c3aa841e131a1c8b3cee03 prov:wasDerivedFrom niiri:627d75e08350cce3541dd568e3ddaa39 .
 
-niiri:9efe1a64a6e8c8950d8b7cab41638bf4
+niiri:8f5c2c4423ccd494ee5e86fe3deb293e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:6cd33ece9349946e05442ff70eafc454 ;
+    prov:atLocation niiri:611027fbd0882487ef894fa5a6a8e4e5 ;
     prov:value "13.2286987304688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15727638472708"^^xsd:float ;
     nidm_pValueUncorrected: "0.000796251631906664"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999472"^^xsd:float ;
     nidm_qValueFDR: "0.143821550671959"^^xsd:float .
 
-niiri:6cd33ece9349946e05442ff70eafc454
+niiri:611027fbd0882487ef894fa5a6a8e4e5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[14,-24,-2]"^^xsd:string .
 
-niiri:9efe1a64a6e8c8950d8b7cab41638bf4 prov:wasDerivedFrom niiri:9c7b81143edac28cf680878e9177494c .
+niiri:8f5c2c4423ccd494ee5e86fe3deb293e prov:wasDerivedFrom niiri:20516921d28241951d08251e80cac5b5 .
 
-niiri:6a326f32141b8c0a3055d65d9f6a8649
+niiri:ec7eede0d453f71f84e10d81d45a185d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:b5b1c97968ad3124f2e761ecead8345e ;
+    prov:atLocation niiri:4bd2715c430b33d70e84b77b850d16be ;
     prov:value "13.0621271133423"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13789355719639"^^xsd:float ;
     nidm_pValueUncorrected: "0.00085083330089919"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999869"^^xsd:float ;
     nidm_qValueFDR: "0.146648454262555"^^xsd:float .
 
-niiri:b5b1c97968ad3124f2e761ecead8345e
+niiri:4bd2715c430b33d70e84b77b850d16be
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-36,0,-4]"^^xsd:string .
 
-niiri:6a326f32141b8c0a3055d65d9f6a8649 prov:wasDerivedFrom niiri:e854403c8636e3e481bc993eb6180f44 .
+niiri:ec7eede0d453f71f84e10d81d45a185d prov:wasDerivedFrom niiri:3822c0fa262ca8cb8a67590f3eec2fe6 .
 
-niiri:cd1be6a68508e7a4ef251e742d0b5209
+niiri:4ee980646f678b94fcd5772eb72db1d4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:7e8c996c334e2b3e54960324857470e1 ;
+    prov:atLocation niiri:34b06f9fb053f163bc7a00ce986a8123 ;
     prov:value "13.0451946258545"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13591325616981"^^xsd:float ;
     nidm_pValueUncorrected: "0.000856599341067521"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999886"^^xsd:float ;
     nidm_qValueFDR: "0.146787157394689"^^xsd:float .
 
-niiri:7e8c996c334e2b3e54960324857470e1
+niiri:34b06f9fb053f163bc7a00ce986a8123
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[12,6,62]"^^xsd:string .
 
-niiri:cd1be6a68508e7a4ef251e742d0b5209 prov:wasDerivedFrom niiri:7f3ebf5e2a10fd569c91dd091c7af147 .
+niiri:4ee980646f678b94fcd5772eb72db1d4 prov:wasDerivedFrom niiri:51287994298816d649ba6908b4e3d0bb .
 
-niiri:4df08c0c2756eb1b10566b4b6f695464
+niiri:f672ee780ba0dc20dc0aa8808e3c2090
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:8fe3ed1f49a1014532022d8ff15e4b33 ;
+    prov:atLocation niiri:729e387de0d5316ccf723a049f2cd632 ;
     prov:value "13.0064306259155"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13137270324883"^^xsd:float ;
     nidm_pValueUncorrected: "0.000869955985260296"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999919"^^xsd:float ;
     nidm_qValueFDR: "0.146787157394689"^^xsd:float .
 
-niiri:8fe3ed1f49a1014532022d8ff15e4b33
+niiri:729e387de0d5316ccf723a049f2cd632
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[-8,-4,24]"^^xsd:string .
 
-niiri:4df08c0c2756eb1b10566b4b6f695464 prov:wasDerivedFrom niiri:b36c20212016b9bc7a603f3e83aca676 .
+niiri:f672ee780ba0dc20dc0aa8808e3c2090 prov:wasDerivedFrom niiri:36a1ff3bd64efa589db6c3a56ccf9d25 .
 
-niiri:f493daa250a5ea19aa9efa8d626c010a
+niiri:133da124dca5a66efd13ce67c41fded3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:a6c74b8d30fbdf526011335c2d35ae6a ;
+    prov:atLocation niiri:1eb746ff728a0d069a40542bb5f7a689 ;
     prov:value "12.968074798584"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12687033926247"^^xsd:float ;
     nidm_pValueUncorrected: "0.00088338914171493"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999942"^^xsd:float ;
     nidm_qValueFDR: "0.147244283960254"^^xsd:float .
 
-niiri:a6c74b8d30fbdf526011335c2d35ae6a
+niiri:1eb746ff728a0d069a40542bb5f7a689
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[8,-36,40]"^^xsd:string .
 
-niiri:f493daa250a5ea19aa9efa8d626c010a prov:wasDerivedFrom niiri:05115f2e683a3386f641d5816019de27 .
+niiri:133da124dca5a66efd13ce67c41fded3 prov:wasDerivedFrom niiri:1c0a11fe168926616610d5836c36d35f .
 
-niiri:8be7214c24c5b037d7fba75f4e6093e0
+niiri:9801cb1bbda1a53d0101f519d9d19df1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:2b0b836ebf6d584148281ed6f01ff393 ;
+    prov:atLocation niiri:f1edc34f43382229a619f2254f87a59c ;
     prov:value "12.9628992080688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12626207199886"^^xsd:float ;
     nidm_pValueUncorrected: "0.000885218504765861"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999944"^^xsd:float ;
     nidm_qValueFDR: "0.147244283960254"^^xsd:float .
 
-niiri:2b0b836ebf6d584148281ed6f01ff393
+niiri:f1edc34f43382229a619f2254f87a59c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[24,38,0]"^^xsd:string .
 
-niiri:8be7214c24c5b037d7fba75f4e6093e0 prov:wasDerivedFrom niiri:1ee8276c32c1e03b7e0b4b1717c44a57 .
+niiri:9801cb1bbda1a53d0101f519d9d19df1 prov:wasDerivedFrom niiri:aa0d58d5cc7671539d09308038edb0f1 .
 
-niiri:3fb670bc4bf41b489875540e653fafdd
+niiri:04821e6510237840cbf335fef76d5cdc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:60bbc4af8445689f911587e2015c11e0 ;
+    prov:atLocation niiri:1f4eb737906c00c0031d9ee2356ab46d ;
     prov:value "12.9482192993164"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12453584528173"^^xsd:float ;
     nidm_pValueUncorrected: "0.000890429112242686"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999951"^^xsd:float ;
     nidm_qValueFDR: "0.14749076092896"^^xsd:float .
 
-niiri:60bbc4af8445689f911587e2015c11e0
+niiri:1f4eb737906c00c0031d9ee2356ab46d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[26,-50,46]"^^xsd:string .
 
-niiri:3fb670bc4bf41b489875540e653fafdd prov:wasDerivedFrom niiri:aa58a012c4a942174e0325d4c0b944fd .
+niiri:04821e6510237840cbf335fef76d5cdc prov:wasDerivedFrom niiri:fc71e9e9a2574cbd9d5094f50275b3c2 .
 
-niiri:82c6fba725d300ee5b57d9b99b507dd1
+niiri:febde3f603b3693a20767813beb5bd71
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:26c578b46a7a236fd0e9ec4b50b4b8a5 ;
+    prov:atLocation niiri:aa6eef7396e2ed67c9ab5d0bb298088e ;
     prov:value "12.9151954650879"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12064737190897"^^xsd:float ;
     nidm_pValueUncorrected: "0.000902269894699104"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999964"^^xsd:float ;
     nidm_qValueFDR: "0.147598889605401"^^xsd:float .
 
-niiri:26c578b46a7a236fd0e9ec4b50b4b8a5
+niiri:aa6eef7396e2ed67c9ab5d0bb298088e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-30,-86,8]"^^xsd:string .
 
-niiri:82c6fba725d300ee5b57d9b99b507dd1 prov:wasDerivedFrom niiri:69b1d9ea8525a6a583365384e39cf9e8 .
+niiri:febde3f603b3693a20767813beb5bd71 prov:wasDerivedFrom niiri:c23970716bccffb656edae94cc34e353 .
 
-niiri:f6b78515f73bc27f172ee4971b59d62c
+niiri:b52c3eeba29b97da2b661dd4df58cef0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:df70ae256a22280944b76c315708af2e ;
+    prov:atLocation niiri:dacf1036163cfbe9703b73ef87a5b977 ;
     prov:value "12.8661985397339"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11486488202419"^^xsd:float ;
     nidm_pValueUncorrected: "0.00092014594111034"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999977"^^xsd:float ;
     nidm_qValueFDR: "0.147847736781403"^^xsd:float .
 
-niiri:df70ae256a22280944b76c315708af2e
+niiri:dacf1036163cfbe9703b73ef87a5b977
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[22,-24,38]"^^xsd:string .
 
-niiri:f6b78515f73bc27f172ee4971b59d62c prov:wasDerivedFrom niiri:f6d9af16709f321130aa58504e6604c5 .
+niiri:b52c3eeba29b97da2b661dd4df58cef0 prov:wasDerivedFrom niiri:8e2363110cdebe114cbe95493b19fa9d .
 
-niiri:7da556aa1244db607c1e49d0f196cfa5
+niiri:9c19f778bd965a28a5a95c2a44273e2f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:bc4dcce56afafebd60de994b46b169af ;
+    prov:atLocation niiri:3342cfcb637deb366202637575b9bf6e ;
     prov:value "12.8156299591064"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10888025138563"^^xsd:float ;
     nidm_pValueUncorrected: "0.000938989080538355"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999985"^^xsd:float ;
     nidm_qValueFDR: "0.148123448926347"^^xsd:float .
 
-niiri:bc4dcce56afafebd60de994b46b169af
+niiri:3342cfcb637deb366202637575b9bf6e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[48,50,2]"^^xsd:string .
 
-niiri:7da556aa1244db607c1e49d0f196cfa5 prov:wasDerivedFrom niiri:be347b3d17b0cf1b2b8f3ad6860ae399 .
+niiri:9c19f778bd965a28a5a95c2a44273e2f prov:wasDerivedFrom niiri:eb4122935f1afa2c8b532875de5f0ef9 .
 
-niiri:23689147c9f9a1cfc3640674405fb6af
+niiri:ad2e6a4a1bd4b49e04b2f5ce6f700bf1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:856080bfa95af62a2310e7f77d678b86 ;
+    prov:atLocation niiri:51217ecd4042ac5a689d5913af7f97c4 ;
     prov:value "12.7734069824219"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10387025917553"^^xsd:float ;
     nidm_pValueUncorrected: "0.000955035352381506"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.149144835108449"^^xsd:float .
 
-niiri:856080bfa95af62a2310e7f77d678b86
+niiri:51217ecd4042ac5a689d5913af7f97c4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-48,-68,20]"^^xsd:string .
 
-niiri:23689147c9f9a1cfc3640674405fb6af prov:wasDerivedFrom niiri:fb10f43ffe914843271a8cdefab5f898 .
+niiri:ad2e6a4a1bd4b49e04b2f5ce6f700bf1 prov:wasDerivedFrom niiri:25018fb0acd6d245a4f445c35c5f92eb .
 
-niiri:7dccdae3f638e89023329e9d2f66c954
+niiri:40ede6bfbdf28e2cb70db26b715172d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:aec1651baeec9ebce473514a2520d9ac ;
+    prov:atLocation niiri:32049f907c1ff3c54deff6f919d2ee46 ;
     prov:value "12.7362623214722"^^xsd:float ;
     nidm_equivalentZStatistic: "3.0994529756118"^^xsd:float ;
     nidm_pValueUncorrected: "0.000969391758882221"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.150376120259304"^^xsd:float .
 
-niiri:aec1651baeec9ebce473514a2520d9ac
+niiri:32049f907c1ff3c54deff6f919d2ee46
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[24,-22,36]"^^xsd:string .
 
-niiri:7dccdae3f638e89023329e9d2f66c954 prov:wasDerivedFrom niiri:ac129c99f1ae280d6d0a6f24c04b617a .
+niiri:40ede6bfbdf28e2cb70db26b715172d6 prov:wasDerivedFrom niiri:ccd2969f60f8b0222713472b0a037361 .
 

--- a/spmexport/ex_spm_partial_conjunction/config.json
+++ b/spmexport/ex_spm_partial_conjunction/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["partial_conjunction/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_partial_conjunction/nidm.provn
+++ b/spmexport/ex_spm_partial_conjunction/nidm.provn
@@ -1,0 +1,4722 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:040b09b9b063245a4737fca3df5cdd7d,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:81951937f6ae09441f641771cfea9128,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:cc2545342f68b7d4d79cd122b1fcabbb,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:cc2545342f68b7d4d79cd122b1fcabbb, niiri:81951937f6ae09441f641771cfea9128, -)
+  wasGeneratedBy(niiri:040b09b9b063245a4737fca3df5cdd7d, niiri:cc2545342f68b7d4d79cd122b1fcabbb, 2016-01-11T10:11:58)
+  bundle niiri:040b09b9b063245a4737fca3df5cdd7d
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix spm_partialConjunctionDegree <http://purl.org/nidash/spm#SPM_0000015>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+    prefix nidm_SupraThresholdCluster <http://purl.org/nidash/nidm#NIDM_0000070>
+    prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
+    prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+    prefix nidm_qValueFDR <http://purl.org/nidash/nidm#NIDM_0000119>
+    prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
+    prefix nidm_Peak <http://purl.org/nidash/nidm#NIDM_0000062>
+    prefix nidm_equivalentZStatistic <http://purl.org/nidash/nidm#NIDM_0000092>
+    prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
+    prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
+
+    agent(niiri:ca46a12c6a6d80a84b02ee07a74d055c,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:4ddf2148145597f7f7c9369cb269b13f,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:1c3284ad8fc17300f53a85a850aa14b6,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:1a568ef0c2c5aa1a886880bbdf2d08f8,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:87e000d813ecf48e9045ac10927bd76c,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:29dae04876f55e477f52f60d27b0ce4d',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:1a568ef0c2c5aa1a886880bbdf2d08f8',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:29dae04876f55e477f52f60d27b0ce4d,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:07c328d2e12fa56c0f2874230dfc8be8,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:a36c7399032b89af037fcdfdcf2d9f29,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:a36c7399032b89af037fcdfdcf2d9f29, niiri:ca46a12c6a6d80a84b02ee07a74d055c, -)
+    used(niiri:a36c7399032b89af037fcdfdcf2d9f29, niiri:87e000d813ecf48e9045ac10927bd76c, -)
+    used(niiri:a36c7399032b89af037fcdfdcf2d9f29, niiri:1c3284ad8fc17300f53a85a850aa14b6, -)
+    used(niiri:a36c7399032b89af037fcdfdcf2d9f29, niiri:07c328d2e12fa56c0f2874230dfc8be8, -)
+    entity(niiri:297de961f206e0187be8fdda200091ee,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
+    entity(niiri:ec2656e975a6d0642c33357bfa356e4b,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
+    wasDerivedFrom(niiri:297de961f206e0187be8fdda200091ee, niiri:ec2656e975a6d0642c33357bfa356e4b, -, -, -)
+    wasGeneratedBy(niiri:297de961f206e0187be8fdda200091ee, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:a354106ee78314547a9438f2bb2dee6c,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "108.038318634033" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
+    wasGeneratedBy(niiri:a354106ee78314547a9438f2bb2dee6c, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:38c86177a556ef8eb57c8feb5a72bbe6,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
+    entity(niiri:379fb8881957a95b855265fdeb2eae08,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f" %% xsd:string])
+    wasDerivedFrom(niiri:38c86177a556ef8eb57c8feb5a72bbe6, niiri:379fb8881957a95b855265fdeb2eae08, -, -, -)
+    wasGeneratedBy(niiri:38c86177a556ef8eb57c8feb5a72bbe6, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:0640a7b36210753d2e9b544c3f195a55,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
+    entity(niiri:6b197125a990fba281a71f02c3a45aac,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
+    wasDerivedFrom(niiri:0640a7b36210753d2e9b544c3f195a55, niiri:6b197125a990fba281a71f02c3a45aac, -, -, -)
+    wasGeneratedBy(niiri:0640a7b36210753d2e9b544c3f195a55, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:2d0fff51543ffad218594440febbbc00,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
+    entity(niiri:2bcd6acc3147da711188ef3d9591491e,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb" %% xsd:string])
+    wasDerivedFrom(niiri:2d0fff51543ffad218594440febbbc00, niiri:2bcd6acc3147da711188ef3d9591491e, -, -, -)
+    wasGeneratedBy(niiri:2d0fff51543ffad218594440febbbc00, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:1e3dffce54f22bc8a196481235889e5a,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 4" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
+    entity(niiri:59d5f854810e0cf53187fca482714676,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0004.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6" %% xsd:string])
+    wasDerivedFrom(niiri:1e3dffce54f22bc8a196481235889e5a, niiri:59d5f854810e0cf53187fca482714676, -, -, -)
+    wasGeneratedBy(niiri:1e3dffce54f22bc8a196481235889e5a, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:883679c50b07b857a6c67ccde5dc3273,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 5" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
+    entity(niiri:0db23e51e95f52cb9f0539d9da712088,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0005.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff" %% xsd:string])
+    wasDerivedFrom(niiri:883679c50b07b857a6c67ccde5dc3273, niiri:0db23e51e95f52cb9f0539d9da712088, -, -, -)
+    wasGeneratedBy(niiri:883679c50b07b857a6c67ccde5dc3273, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:67e0052a2914e6b58321e390f9d4a9ea,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 6" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
+    entity(niiri:7654bad538105caaf15e55efcb04c343,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0006.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
+    wasDerivedFrom(niiri:67e0052a2914e6b58321e390f9d4a9ea, niiri:7654bad538105caaf15e55efcb04c343, -, -, -)
+    wasGeneratedBy(niiri:67e0052a2914e6b58321e390f9d4a9ea, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:a79b8d0835c3bf79e9faf32502e506b4,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8" %% xsd:string])
+    entity(niiri:28c03f1f4b9973dbb638d943ac9944e6,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81" %% xsd:string])
+    wasDerivedFrom(niiri:a79b8d0835c3bf79e9faf32502e506b4, niiri:28c03f1f4b9973dbb638d943ac9944e6, -, -, -)
+    wasGeneratedBy(niiri:a79b8d0835c3bf79e9faf32502e506b4, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:089005ddd166a56358c0d0ec21720e18,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8" %% xsd:string])
+    entity(niiri:949f5e9e8329eea5ff262f3113b92d3c,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29" %% xsd:string])
+    wasDerivedFrom(niiri:089005ddd166a56358c0d0ec21720e18, niiri:949f5e9e8329eea5ff262f3113b92d3c, -, -, -)
+    wasGeneratedBy(niiri:089005ddd166a56358c0d0ec21720e18, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
+    entity(niiri:6310b38d15cf70fcc0b18a630086f710,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        prov:label = "Contrast: mr vs plain" %% xsd:string,
+        prov:value = "[1, 1, -1, -1, 0, 0]" %% xsd:string])
+    activity(niiri:470a6da8f55eec239393f9743368624c,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation 1"])
+    wasAssociatedWith(niiri:470a6da8f55eec239393f9743368624c, niiri:ca46a12c6a6d80a84b02ee07a74d055c, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:297de961f206e0187be8fdda200091ee, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:a79b8d0835c3bf79e9faf32502e506b4, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:87e000d813ecf48e9045ac10927bd76c, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:6310b38d15cf70fcc0b18a630086f710, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:38c86177a556ef8eb57c8feb5a72bbe6, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:0640a7b36210753d2e9b544c3f195a55, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:2d0fff51543ffad218594440febbbc00, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:1e3dffce54f22bc8a196481235889e5a, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:883679c50b07b857a6c67ccde5dc3273, -)
+    used(niiri:470a6da8f55eec239393f9743368624c, niiri:67e0052a2914e6b58321e390f9d4a9ea, -)
+    entity(niiri:7512552d6509729de4464db02c1b2b85,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic_0001.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic_0001.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: mr vs plain" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "3d222abce9f360902d01cb45ffaaa3d711c699c6771f36ee61630ccc2fec2275897a15dd31b846a074e20b59337bae8b171223c15f22d8f2168a1967e85b397a" %% xsd:string])
+    entity(niiri:fb4dee4e1331d80c18561bf743daf272,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782" %% xsd:string])
+    wasDerivedFrom(niiri:7512552d6509729de4464db02c1b2b85, niiri:fb4dee4e1331d80c18561bf743daf272, -, -, -)
+    wasGeneratedBy(niiri:7512552d6509729de4464db02c1b2b85, niiri:470a6da8f55eec239393f9743368624c, -)
+    entity(niiri:b4a484110c0e0f1679fe0a5f8bdff03e,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast_0001.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast_0001.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: mr vs plain" %% xsd:string,
+        nidm_contrastName: = "mr vs plain" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5" %% xsd:string])
+    entity(niiri:1dd135affe7808067a99b5363be9574c,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28" %% xsd:string])
+    wasDerivedFrom(niiri:b4a484110c0e0f1679fe0a5f8bdff03e, niiri:1dd135affe7808067a99b5363be9574c, -, -, -)
+    wasGeneratedBy(niiri:b4a484110c0e0f1679fe0a5f8bdff03e, niiri:470a6da8f55eec239393f9743368624c, -)
+    entity(niiri:759cc611eb1badedf971eb0bbd3381ef,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError_0001.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError_0001.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b" %% xsd:string])
+    wasGeneratedBy(niiri:759cc611eb1badedf971eb0bbd3381ef, niiri:470a6da8f55eec239393f9743368624c, -)
+    entity(niiri:830506c8d8c91472fbeb134a312b9816,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
+        prov:label = "Contrast: switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
+        prov:value = "[0.953151930124911, -1.04684806987509, 1.04684806987509, -0.953151930124911, 0, 0]" %% xsd:string])
+    activity(niiri:d74adb2677a9d89623e02872d79aefab,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation 2"])
+    wasAssociatedWith(niiri:d74adb2677a9d89623e02872d79aefab, niiri:ca46a12c6a6d80a84b02ee07a74d055c, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:297de961f206e0187be8fdda200091ee, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:a79b8d0835c3bf79e9faf32502e506b4, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:87e000d813ecf48e9045ac10927bd76c, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:830506c8d8c91472fbeb134a312b9816, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:38c86177a556ef8eb57c8feb5a72bbe6, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:0640a7b36210753d2e9b544c3f195a55, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:2d0fff51543ffad218594440febbbc00, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:1e3dffce54f22bc8a196481235889e5a, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:883679c50b07b857a6c67ccde5dc3273, -)
+    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:67e0052a2914e6b58321e390f9d4a9ea, -)
+    entity(niiri:3847144ad5571b76c8855c604579438d,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic_0002.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic_0002.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "ec2f61dbf28ab2256a374dc5e3a93ba3a54e520c6bccd089dfbd07421e445b4881154433ea31e32587c1fae170daa5dc0a21f6efc328b90727d8d25bbd524e2f" %% xsd:string])
+    entity(niiri:d321a1053a1ad60011b5d0c936fced97,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0005.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "4a7d076c01440a170e048ebe9644f90193b2aaf1291f454bdc6be2cf17e11a66b1d177025f5ed77434afe780ff8dcba710ec41120246e38894f823eb0fd88621" %% xsd:string])
+    wasDerivedFrom(niiri:3847144ad5571b76c8855c604579438d, niiri:d321a1053a1ad60011b5d0c936fced97, -, -, -)
+    wasGeneratedBy(niiri:3847144ad5571b76c8855c604579438d, niiri:d74adb2677a9d89623e02872d79aefab, -)
+    entity(niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast_0002.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast_0002.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
+        nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "31a00f409f493fc214fe1f84fe2a799bb96d1e03d67f2ce5b8c5b5fdb934bb0005f1be68addb81934052af4643c3099542ea4944013e9346042a44c2ed8f3788" %% xsd:string])
+    entity(niiri:a98253404e56b8be6f3aecf1424cb0f4,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0005.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "6d92adc90c0045445b66064818fdae617474690e92e9cb332e73fa8bf27f6d1d18367c0648ffbc74196a5c2ce9f4af4186394628eed475a0e2866efe3d4eee9b" %% xsd:string])
+    wasDerivedFrom(niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc, niiri:a98253404e56b8be6f3aecf1424cb0f4, -, -, -)
+    wasGeneratedBy(niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc, niiri:d74adb2677a9d89623e02872d79aefab, -)
+    entity(niiri:ec1657f37e3b226c40848c8427be67c3,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError_0002.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError_0002.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "ac87f548f0d92f929c05476d2aacbc7e5319da6d62a5585a72d714be836b1b86962a36c6d473ae84c17cd613d683976e9fc562d6d7692cb8e942966f71e34a08" %% xsd:string])
+    wasGeneratedBy(niiri:ec1657f37e3b226c40848c8427be67c3, niiri:d74adb2677a9d89623e02872d79aefab, -)
+    entity(niiri:bcc964db0d0638d6cba59069ee9e794b,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.048771 (unc.)" %% xsd:string,
+        prov:value = "0.0487705355732563" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:d7de198640509df2418dca3bf55b09d0',
+        nidm_equivalentThreshold: = 'niiri:33a31ffbbf2d136c84bd8c001890f221'])
+    entity(niiri:d7de198640509df2418dca3bf55b09d0,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.761625168301108" %% xsd:float])
+    entity(niiri:33a31ffbbf2d136c84bd8c001890f221,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:f41b4c97497eeb8255330583a8825b93,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:22c0ec80ae0df81cd54796dadc1cfffb',
+        nidm_equivalentThreshold: = 'niiri:0b3f07f9fa7448b8eeed2625fdc5d588'])
+    entity(niiri:22c0ec80ae0df81cd54796dadc1cfffb,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:0b3f07f9fa7448b8eeed2625fdc5d588,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:a71a2dfa1ab66a64c9d2c36c5c2f03b1,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:074ce8c7927ae74cf34930d375480b95,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:f5c1c82a9559f27878c8865f0d227dde,
+        [prov:type = "spm_PartialConjunctionInference",
+        prov:label = " Partial Conjunction Inference",
+        spm_partialConjunctionDegree: = "2" %% xsd:int])
+    wasAssociatedWith(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:ca46a12c6a6d80a84b02ee07a74d055c, -)
+    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:bcc964db0d0638d6cba59069ee9e794b, -)
+    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:f41b4c97497eeb8255330583a8825b93, -)
+    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:7512552d6509729de4464db02c1b2b85, -)
+    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:3847144ad5571b76c8855c604579438d, -)
+    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:089005ddd166a56358c0d0ec21720e18, -)
+    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:297de961f206e0187be8fdda200091ee, -)
+    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:a71a2dfa1ab66a64c9d2c36c5c2f03b1, -)
+    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:074ce8c7927ae74cf34930d375480b95, -)
+    entity(niiri:992e1b6a07509a3db325ed8f8bfff412,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
+        nidm_reselSizeInVoxels: = "68.4409986586553" %% xsd:float,
+        nidm_searchVolumeInResels: = "2811.45809925534" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[5, 96.6116867805852, 900.100332657535, 2811.45809925534]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.16320607513012, 4.05765428344905, 4.05147708968699]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.32641215026024, 8.1153085668981, 8.10295417937398]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "42.8953324296065" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "329.33969238683" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "3.3473195251917" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "NaN" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "NaN" %% xsd:int,
+        crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
+    wasGeneratedBy(niiri:992e1b6a07509a3db325ed8f8bfff412, niiri:f5c1c82a9559f27878c8865f0d227dde, -)
+    entity(niiri:9315492073c635bc63a9934fefeda6b6,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "150" %% xsd:int,
+        nidm_pValue: = "1" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:e9451253b0a75869524801c98a6d921e',
+        nidm_hasMaximumIntensityProjection: = 'niiri:29a5a2562dde36cf7698f1dad4b98ea5',
+        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        crypto:sha512 = "662dfeb3cba04a6a6beda3e1e23ff90c951f3ffae3d379b8fbfef06307db3055236586cace653593957e67f60c9dbbaadb5f3cc87c0ecc9dcfb81727d86f177f" %% xsd:string])
+    entity(niiri:e9451253b0a75869524801c98a6d921e,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:29a5a2562dde36cf7698f1dad4b98ea5,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:9315492073c635bc63a9934fefeda6b6, niiri:f5c1c82a9559f27878c8865f0d227dde, -)
+    entity(niiri:43fc9ecb30d51558da2aa2580905eaab,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2637" %% xsd:int,
+        nidm_clusterSizeInResels: = "38.5295371441299" %% xsd:float,
+        nidm_pValueUncorrected: = "6.6293581341946e-09" %% xsd:float,
+        nidm_pValueFWER: = "2.1833083851952e-06" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "1" %% xsd:int])
+    wasDerivedFrom(niiri:43fc9ecb30d51558da2aa2580905eaab, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:417cabd3eeb412117d20f4882d064567,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1415" %% xsd:int,
+        nidm_clusterSizeInResels: = "20.6747421535623" %% xsd:float,
+        nidm_pValueUncorrected: = "3.97587518110427e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.0013085566013008" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "2" %% xsd:int])
+    wasDerivedFrom(niiri:417cabd3eeb412117d20f4882d064567, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:6cc5ea3c57b906137def3d6777b0000f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "376" %% xsd:int,
+        nidm_clusterSizeInResels: = "5.49378307402079" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00585910744472404" %% xsd:float,
+        nidm_pValueFWER: = "0.854799051393012" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "3" %% xsd:int])
+    wasDerivedFrom(niiri:6cc5ea3c57b906137def3d6777b0000f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c29516aed6cf24b95d9653e2365e0ced,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "128" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.87022402519857" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0816050965065906" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999997872" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "4" %% xsd:int])
+    wasDerivedFrom(niiri:c29516aed6cf24b95d9653e2365e0ced, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:1c26e68b379e5bd715e75014cca849ab,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "31" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.452944881102778" %% xsd:float,
+        nidm_pValueUncorrected: = "0.377711191466036" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "5" %% xsd:int])
+    wasDerivedFrom(niiri:1c26e68b379e5bd715e75014cca849ab, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:8b5d6e1bd5480bd6366d0094c92d4851,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "482" %% xsd:int,
+        nidm_clusterSizeInResels: = "7.04256234488835" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00232217436293709" %% xsd:float,
+        nidm_pValueFWER: = "0.5345656346398" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "6" %% xsd:int])
+    wasDerivedFrom(niiri:8b5d6e1bd5480bd6366d0094c92d4851, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:7e631bc430702f08996bcc12a090f463,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "31" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.452944881102778" %% xsd:float,
+        nidm_pValueUncorrected: = "0.377711191466036" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "7" %% xsd:int])
+    wasDerivedFrom(niiri:7e631bc430702f08996bcc12a090f463, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c21e2ede0b4f245e2d9f679a7862569e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "292" %% xsd:int,
+        nidm_clusterSizeInResels: = "4.26644855748423" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0130040406385965" %% xsd:float,
+        nidm_pValueFWER: = "0.986195307987511" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "8" %% xsd:int])
+    wasDerivedFrom(niiri:c21e2ede0b4f245e2d9f679a7862569e, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c8c6cee0456ea9b67ae74c71ec73d58a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "454" %% xsd:int,
+        nidm_clusterSizeInResels: = "6.63345083937617" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00294388790129395" %% xsd:float,
+        nidm_pValueFWER: = "0.620742215844192" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "9" %% xsd:int])
+    wasDerivedFrom(niiri:c8c6cee0456ea9b67ae74c71ec73d58a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "30" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.385747209296087" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "10" %% xsd:int])
+    wasDerivedFrom(niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c8915bbac48c4a94d3bf54f07d28091a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "121" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.76794614882052" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0894880360135627" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999841" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "11" %% xsd:int])
+    wasDerivedFrom(niiri:c8915bbac48c4a94d3bf54f07d28091a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:81f39aacce9db78e536cab5c96400969,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "152" %% xsd:int,
+        nidm_clusterSizeInResels: = "2.2208910299233" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0602023253747671" %% xsd:float,
+        nidm_pValueFWER: = "0.999999997549602" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "12" %% xsd:int])
+    wasDerivedFrom(niiri:81f39aacce9db78e536cab5c96400969, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:95cfa48491de3b2db8a60dc29bdeb6af,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "118" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.72411277322993" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0931458632313952" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999952" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "13" %% xsd:int])
+    wasDerivedFrom(niiri:95cfa48491de3b2db8a60dc29bdeb6af, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:e7fc37cb04d1a3f58136cfb12f992f34,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "41" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.599056133071416" %% xsd:float,
+        nidm_pValueUncorrected: = "0.309402133457245" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "14" %% xsd:int])
+    wasDerivedFrom(niiri:e7fc37cb04d1a3f58136cfb12f992f34, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:de5b4d0f5d84034ba5fd7975873cc2e6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "53" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.774389635433782" %% xsd:float,
+        nidm_pValueUncorrected: = "0.248554717392983" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "15" %% xsd:int])
+    wasDerivedFrom(niiri:de5b4d0f5d84034ba5fd7975873cc2e6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:1d6209037825fb7ee168299aa10d5ad7,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "38" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.555222757480825" %% xsd:float,
+        nidm_pValueUncorrected: = "0.32786058081731" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "16" %% xsd:int])
+    wasDerivedFrom(niiri:1d6209037825fb7ee168299aa10d5ad7, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:b1918e5ede22fa7e1d3a1399a34a2d45,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160722377165502" %% xsd:float,
+        nidm_pValueUncorrected: = "0.613857878847171" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "17" %% xsd:int])
+    wasDerivedFrom(niiri:b1918e5ede22fa7e1d3a1399a34a2d45, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:5d9799711b35085d7a8bcba1641700b1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "51" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.745167385040054" %% xsd:float,
+        nidm_pValueUncorrected: = "0.257471294871549" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "18" %% xsd:int])
+    wasDerivedFrom(niiri:5d9799711b35085d7a8bcba1641700b1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:437180e47264cc4e09dc17b204fd0a89,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "24" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.350667004724731" %% xsd:float,
+        nidm_pValueUncorrected: = "0.440034324197539" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "19" %% xsd:int])
+    wasDerivedFrom(niiri:437180e47264cc4e09dc17b204fd0a89, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:1cd87c105e9a1996f42e3171bad089a8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "19" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.277611378740412" %% xsd:float,
+        nidm_pValueUncorrected: = "0.495339905158013" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "20" %% xsd:int])
+    wasDerivedFrom(niiri:1cd87c105e9a1996f42e3171bad089a8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:cc02b2de189bcf80b0afcbe487b0d1e8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "23" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.336055879527868" %% xsd:float,
+        nidm_pValueUncorrected: = "0.450256284065057" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "21" %% xsd:int])
+    wasDerivedFrom(niiri:cc02b2de189bcf80b0afcbe487b0d1e8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:3ae2e3cf05ec7ac4b46544f268071134,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.073055625984319" %% xsd:float,
+        nidm_pValueUncorrected: = "0.749394292194427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "22" %% xsd:int])
+    wasDerivedFrom(niiri:3ae2e3cf05ec7ac4b46544f268071134, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:3c84c74526e078ad8336fd968ec9d7f0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "20" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.483381408929991" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "23" %% xsd:int])
+    wasDerivedFrom(niiri:3c84c74526e078ad8336fd968ec9d7f0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:8a1438a34faf87d03af2d9853b038bb2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "13" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.189944627559229" %% xsd:float,
+        nidm_pValueUncorrected: = "0.579562911476358" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "24" %% xsd:int])
+    wasDerivedFrom(niiri:8a1438a34faf87d03af2d9853b038bb2, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:5aecd2a653cabfaff01cc936a5319173,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "42" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.61366725826828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.303579503022166" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "25" %% xsd:int])
+    wasDerivedFrom(niiri:5aecd2a653cabfaff01cc936a5319173, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:04baa9610947313ff840ab800dc602ff,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "34" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.496778256693369" %% xsd:float,
+        nidm_pValueUncorrected: = "0.355060142353217" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "26" %% xsd:int])
+    wasDerivedFrom(niiri:04baa9610947313ff840ab800dc602ff, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:bbf4ae108fc8903d38a040cb96a5f8c7,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.520844357026983" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "27" %% xsd:int])
+    wasDerivedFrom(niiri:bbf4ae108fc8903d38a040cb96a5f8c7, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:4df2335aa8db3e5be136eacbcea883d6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "38" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.555222757480825" %% xsd:float,
+        nidm_pValueUncorrected: = "0.32786058081731" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "28" %% xsd:int])
+    wasDerivedFrom(niiri:4df2335aa8db3e5be136eacbcea883d6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:9d79a6339d6f2901fb1cf662d6f17331,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "19" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.277611378740412" %% xsd:float,
+        nidm_pValueUncorrected: = "0.495339905158013" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "29" %% xsd:int])
+    wasDerivedFrom(niiri:9d79a6339d6f2901fb1cf662d6f17331, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:b8abe2a725005d9ab6e1e988f192f41c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.520844357026983" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "30" %% xsd:int])
+    wasDerivedFrom(niiri:b8abe2a725005d9ab6e1e988f192f41c, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:483de03930aa5641b0fe297f66f6c4ed,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "29" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.42372263070905" %% xsd:float,
+        nidm_pValueUncorrected: = "0.394046894825167" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "31" %% xsd:int])
+    wasDerivedFrom(niiri:483de03930aa5641b0fe297f66f6c4ed, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:4f303edac6b82f93c47e1a6448e1cb52,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.073055625984319" %% xsd:float,
+        nidm_pValueUncorrected: = "0.749394292194427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "32" %% xsd:int])
+    wasDerivedFrom(niiri:4f303edac6b82f93c47e1a6448e1cb52, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:d987cfa4a10011187d0a3eef178d5a46,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "37" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.540611632283961" %% xsd:float,
+        nidm_pValueUncorrected: = "0.334367142215632" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "33" %% xsd:int])
+    wasDerivedFrom(niiri:d987cfa4a10011187d0a3eef178d5a46, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:98d187b5c539ea98df7343b0d0821b17,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "38" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.555222757480825" %% xsd:float,
+        nidm_pValueUncorrected: = "0.32786058081731" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "34" %% xsd:int])
+    wasDerivedFrom(niiri:98d187b5c539ea98df7343b0d0821b17, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:5c38b60ed820b070d98e016bc1431008,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.520844357026983" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "35" %% xsd:int])
+    wasDerivedFrom(niiri:5c38b60ed820b070d98e016bc1431008, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:a86e2297836b759380804c1713e267cd,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.11688900157491" %% xsd:float,
+        nidm_pValueUncorrected: = "0.673916689895827" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "36" %% xsd:int])
+    wasDerivedFrom(niiri:a86e2297836b759380804c1713e267cd, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:f4ed594992095609e2ba62eca01c9faf,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "22" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.321444754331004" %% xsd:float,
+        nidm_pValueUncorrected: = "0.460870231738788" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "37" %% xsd:int])
+    wasDerivedFrom(niiri:f4ed594992095609e2ba62eca01c9faf, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c8ce85b44b984de4fe78c06b64713bb8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.175333502362366" %% xsd:float,
+        nidm_pValueUncorrected: = "0.596225577050815" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "38" %% xsd:int])
+    wasDerivedFrom(niiri:c8ce85b44b984de4fe78c06b64713bb8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:55d04469f144e7c5053124929003df79,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160722377165502" %% xsd:float,
+        nidm_pValueUncorrected: = "0.613857878847171" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "39" %% xsd:int])
+    wasDerivedFrom(niiri:55d04469f144e7c5053124929003df79, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:895da0556b5b38697a9d4eacde3a587e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "23" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.336055879527868" %% xsd:float,
+        nidm_pValueUncorrected: = "0.450256284065057" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "40" %% xsd:int])
+    wasDerivedFrom(niiri:895da0556b5b38697a9d4eacde3a587e, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:30470d6217b4a75fdd554906028c6670,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.175333502362366" %% xsd:float,
+        nidm_pValueUncorrected: = "0.596225577050815" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "41" %% xsd:int])
+    wasDerivedFrom(niiri:30470d6217b4a75fdd554906028c6670, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:62c58cbe35737a64415ff840b7810e7d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102277876378047" %% xsd:float,
+        nidm_pValueUncorrected: = "0.69695451079807" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "42" %% xsd:int])
+    wasDerivedFrom(niiri:62c58cbe35737a64415ff840b7810e7d, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:ec26c7d95e0c041f81b882cd245b0915,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "43" %% xsd:int])
+    wasDerivedFrom(niiri:ec26c7d95e0c041f81b882cd245b0915, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:6750b72bbafd12ba75c6c383539599c6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "21" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.30683362913414" %% xsd:float,
+        nidm_pValueUncorrected: = "0.471902282658156" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "44" %% xsd:int])
+    wasDerivedFrom(niiri:6750b72bbafd12ba75c6c383539599c6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:ccbc770b946f9dfd1beecfa8843cb3fd,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.721967329508528" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "45" %% xsd:int])
+    wasDerivedFrom(niiri:ccbc770b946f9dfd1beecfa8843cb3fd, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:daf3e2ea8bf3273801d2e921f611a23f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "24" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.350667004724731" %% xsd:float,
+        nidm_pValueUncorrected: = "0.440034324197539" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "46" %% xsd:int])
+    wasDerivedFrom(niiri:daf3e2ea8bf3273801d2e921f611a23f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:3df484ba108f4b88e1a4f123023bad18,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102277876378047" %% xsd:float,
+        nidm_pValueUncorrected: = "0.69695451079807" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "47" %% xsd:int])
+    wasDerivedFrom(niiri:3df484ba108f4b88e1a4f123023bad18, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:0b63cbadf7d3234250fdc4f399321ae5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "48" %% xsd:int])
+    wasDerivedFrom(niiri:0b63cbadf7d3234250fdc4f399321ae5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:16c6b9ef292ea8d86c2980e2bfee9806,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "19" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.277611378740412" %% xsd:float,
+        nidm_pValueUncorrected: = "0.495339905158013" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "49" %% xsd:int])
+    wasDerivedFrom(niiri:16c6b9ef292ea8d86c2980e2bfee9806, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.160722377165502" %% xsd:float,
+        nidm_pValueUncorrected: = "0.613857878847171" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "50" %% xsd:int])
+    wasDerivedFrom(niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:fb45985c130da20eafb7b2bc740e6b34,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.632579519337259" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "51" %% xsd:int])
+    wasDerivedFrom(niiri:fb45985c130da20eafb7b2bc740e6b34, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:65722b667917e9f42cf82ee2175b666b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "17" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.248389128346685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.520844357026983" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "52" %% xsd:int])
+    wasDerivedFrom(niiri:65722b667917e9f42cf82ee2175b666b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:59675618f95ad14de633584e8aa5881a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.77988160960367" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "53" %% xsd:int])
+    wasDerivedFrom(niiri:59675618f95ad14de633584e8aa5881a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:2efe263e1c4f04d8ddb54023002360d9,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102277876378047" %% xsd:float,
+        nidm_pValueUncorrected: = "0.69695451079807" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "54" %% xsd:int])
+    wasDerivedFrom(niiri:2efe263e1c4f04d8ddb54023002360d9, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:fa0929f452cd3f13857c087a02f6da1f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "16" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.233778003149821" %% xsd:float,
+        nidm_pValueUncorrected: = "0.534477368719457" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "55" %% xsd:int])
+    wasDerivedFrom(niiri:fa0929f452cd3f13857c087a02f6da1f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:4c6401bfd1d939fec8234ff093a37d0d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "13" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.189944627559229" %% xsd:float,
+        nidm_pValueUncorrected: = "0.579562911476358" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "56" %% xsd:int])
+    wasDerivedFrom(niiri:4c6401bfd1d939fec8234ff093a37d0d, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:b40302277817265d7af623887ab2e22c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.073055625984319" %% xsd:float,
+        nidm_pValueUncorrected: = "0.749394292194427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "57" %% xsd:int])
+    wasDerivedFrom(niiri:b40302277817265d7af623887ab2e22c, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:e3091fadc7ff93e5e16f94b04590b938,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.721967329508528" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "58" %% xsd:int])
+    wasDerivedFrom(niiri:e3091fadc7ff93e5e16f94b04590b938, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:e36b80790f32a55a90c503e6f29918bb,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.632579519337259" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "59" %% xsd:int])
+    wasDerivedFrom(niiri:e36b80790f32a55a90c503e6f29918bb, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:6e8c86e4ccb82a0a6076eb58e14b07a6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "60" %% xsd:int])
+    wasDerivedFrom(niiri:6e8c86e4ccb82a0a6076eb58e14b07a6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:42f7f7a26e0c7f6124775e7e757b315c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.77988160960367" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "61" %% xsd:int])
+    wasDerivedFrom(niiri:42f7f7a26e0c7f6124775e7e757b315c, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:14ff66df771d191b9d2e8a3b0f78eda6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "62" %% xsd:int])
+    wasDerivedFrom(niiri:14ff66df771d191b9d2e8a3b0f78eda6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:912e881f26994ef7af5c7f0b222db9ea,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.175333502362366" %% xsd:float,
+        nidm_pValueUncorrected: = "0.596225577050815" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "63" %% xsd:int])
+    wasDerivedFrom(niiri:912e881f26994ef7af5c7f0b222db9ea, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:9a1887d93b55705b2ff04804a00c27c3,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "7" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.102277876378047" %% xsd:float,
+        nidm_pValueUncorrected: = "0.69695451079807" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "64" %% xsd:int])
+    wasDerivedFrom(niiri:9a1887d93b55705b2ff04804a00c27c3, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:e6e6da4cb58bd6ee501d8b5597467832,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.77988160960367" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "65" %% xsd:int])
+    wasDerivedFrom(niiri:e6e6da4cb58bd6ee501d8b5597467832, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "66" %% xsd:int])
+    wasDerivedFrom(niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:949a7d86dacbe35af10b6aad92fe2224,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.721967329508528" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "67" %% xsd:int])
+    wasDerivedFrom(niiri:949a7d86dacbe35af10b6aad92fe2224, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:6cc27bdc40320dac88fe94690c9a2006,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "68" %% xsd:int])
+    wasDerivedFrom(niiri:6cc27bdc40320dac88fe94690c9a2006, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c04d4059d5535de349435e25559a51cf,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.11688900157491" %% xsd:float,
+        nidm_pValueUncorrected: = "0.673916689895827" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "69" %% xsd:int])
+    wasDerivedFrom(niiri:c04d4059d5535de349435e25559a51cf, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:4b22fd081d5be6319a728e5343897301,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.073055625984319" %% xsd:float,
+        nidm_pValueUncorrected: = "0.749394292194427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "70" %% xsd:int])
+    wasDerivedFrom(niiri:4b22fd081d5be6319a728e5343897301, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:f0f729dae8a39ee9247f706bc80f8df0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "9" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.131500126771774" %% xsd:float,
+        nidm_pValueUncorrected: = "0.652537593858019" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "71" %% xsd:int])
+    wasDerivedFrom(niiri:f0f729dae8a39ee9247f706bc80f8df0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:cd47d3687de0d428289d5ee8d941860d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0072" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.77988160960367" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "72" %% xsd:int])
+    wasDerivedFrom(niiri:cd47d3687de0d428289d5ee8d941860d, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:20959c12c3afc9ceb8477f395c0f1d11,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0073" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "73" %% xsd:int])
+    wasDerivedFrom(niiri:20959c12c3afc9ceb8477f395c0f1d11, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:4eb3e8fe236fda4e725ee89c277cccc8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0074" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "74" %% xsd:int])
+    wasDerivedFrom(niiri:4eb3e8fe236fda4e725ee89c277cccc8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0075" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "75" %% xsd:int])
+    wasDerivedFrom(niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:4fad08e49bad24baddc3d418f97db0ce,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0076" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "76" %% xsd:int])
+    wasDerivedFrom(niiri:4fad08e49bad24baddc3d418f97db0ce, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:d9eee0810d67b936a31fa3c66d2e8721,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0077" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "77" %% xsd:int])
+    wasDerivedFrom(niiri:d9eee0810d67b936a31fa3c66d2e8721, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c8715267e94716796c464182b4ba6959,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0078" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "78" %% xsd:int])
+    wasDerivedFrom(niiri:c8715267e94716796c464182b4ba6959, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:8f90bd7cc0deb45b7b7bd4b560274456,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0079" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "79" %% xsd:int])
+    wasDerivedFrom(niiri:8f90bd7cc0deb45b7b7bd4b560274456, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:38f5a60345c88d7c9e0484d8735d5ffe,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0080" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "80" %% xsd:int])
+    wasDerivedFrom(niiri:38f5a60345c88d7c9e0484d8735d5ffe, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:e6b43073ea58d734c57cff5767e3921f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0081" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "13" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.189944627559229" %% xsd:float,
+        nidm_pValueUncorrected: = "0.579562911476358" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "81" %% xsd:int])
+    wasDerivedFrom(niiri:e6b43073ea58d734c57cff5767e3921f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:1cdb6dbe1bc79e13d52d0d3c171bab06,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0082" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "82" %% xsd:int])
+    wasDerivedFrom(niiri:1cdb6dbe1bc79e13d52d0d3c171bab06, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:ee19df6f4d0113ba7e7f064a4048e753,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0083" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "83" %% xsd:int])
+    wasDerivedFrom(niiri:ee19df6f4d0113ba7e7f064a4048e753, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:71af61a5c3e3beaf82f85e9971911d0f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0084" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "84" %% xsd:int])
+    wasDerivedFrom(niiri:71af61a5c3e3beaf82f85e9971911d0f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:46c8b3f4803e6bb0b2862d8598ece061,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0085" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.175333502362366" %% xsd:float,
+        nidm_pValueUncorrected: = "0.596225577050815" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "85" %% xsd:int])
+    wasDerivedFrom(niiri:46c8b3f4803e6bb0b2862d8598ece061, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:5e385b701ab7f21285e4ab5006f3b0cc,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0086" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "86" %% xsd:int])
+    wasDerivedFrom(niiri:5e385b701ab7f21285e4ab5006f3b0cc, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:9b4e4e9b57eb3e981b1ba74aae8a7114,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0087" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.721967329508528" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "87" %% xsd:int])
+    wasDerivedFrom(niiri:9b4e4e9b57eb3e981b1ba74aae8a7114, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:6d27ace5181c44103420a9d6058ab0d2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0088" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.073055625984319" %% xsd:float,
+        nidm_pValueUncorrected: = "0.749394292194427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "88" %% xsd:int])
+    wasDerivedFrom(niiri:6d27ace5181c44103420a9d6058ab0d2, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:315d7b893c25221ef60daf1e43984066,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0089" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "89" %% xsd:int])
+    wasDerivedFrom(niiri:315d7b893c25221ef60daf1e43984066, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:34f88b9c2c80714dbe516b3f7ef092bb,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0090" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.073055625984319" %% xsd:float,
+        nidm_pValueUncorrected: = "0.749394292194427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "90" %% xsd:int])
+    wasDerivedFrom(niiri:34f88b9c2c80714dbe516b3f7ef092bb, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c07d0db5466c33ca960e3dd77f21333c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0091" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "91" %% xsd:int])
+    wasDerivedFrom(niiri:c07d0db5466c33ca960e3dd77f21333c, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:90645273f08ccfc7b9bf300a122cc2af,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0092" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "92" %% xsd:int])
+    wasDerivedFrom(niiri:90645273f08ccfc7b9bf300a122cc2af, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c12f0aee596eddb11ad8e3268c4eb077,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0093" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "93" %% xsd:int])
+    wasDerivedFrom(niiri:c12f0aee596eddb11ad8e3268c4eb077, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:b74b40058d530ee5632e1df25f911065,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0094" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "94" %% xsd:int])
+    wasDerivedFrom(niiri:b74b40058d530ee5632e1df25f911065, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:169fad64b64219293f6c913c296583bc,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0095" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "95" %% xsd:int])
+    wasDerivedFrom(niiri:169fad64b64219293f6c913c296583bc, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c9ba05614242ea84b1cd6a9c5ec414e4,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0096" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "96" %% xsd:int])
+    wasDerivedFrom(niiri:c9ba05614242ea84b1cd6a9c5ec414e4, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:be38e2f5b8c4edd116eb0a55684fdab2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0097" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "97" %% xsd:int])
+    wasDerivedFrom(niiri:be38e2f5b8c4edd116eb0a55684fdab2, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:9506dd108b62896cd6d8225dfc0e2e59,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0098" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "98" %% xsd:int])
+    wasDerivedFrom(niiri:9506dd108b62896cd6d8225dfc0e2e59, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:f404d574847ee68f9dc6bd08393bd9a1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0099" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0876667511811828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.721967329508528" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "99" %% xsd:int])
+    wasDerivedFrom(niiri:f404d574847ee68f9dc6bd08393bd9a1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:99948f53ace7073cd3002a5850ecd361,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0100" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "100" %% xsd:int])
+    wasDerivedFrom(niiri:99948f53ace7073cd3002a5850ecd361, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:c8c7dba5be58cecd8f14593ccfb69e4b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0101" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "101" %% xsd:int])
+    wasDerivedFrom(niiri:c8c7dba5be58cecd8f14593ccfb69e4b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:a56ce0c60fde3ec8bf474d645a951d38,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0102" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "102" %% xsd:int])
+    wasDerivedFrom(niiri:a56ce0c60fde3ec8bf474d645a951d38, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:82e02fb05b18c0c2a70d55d5e415aee5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0103" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "103" %% xsd:int])
+    wasDerivedFrom(niiri:82e02fb05b18c0c2a70d55d5e415aee5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:8d8ac9fae20babb989f7c367a4c4a609,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0104" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.073055625984319" %% xsd:float,
+        nidm_pValueUncorrected: = "0.749394292194427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "104" %% xsd:int])
+    wasDerivedFrom(niiri:8d8ac9fae20babb989f7c367a4c4a609, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:1a41584c1187bb4a87d3cc1af9993773,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0105" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "105" %% xsd:int])
+    wasDerivedFrom(niiri:1a41584c1187bb4a87d3cc1af9993773, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:43ed38ee11c52db758569877faabd695,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0106" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "106" %% xsd:int])
+    wasDerivedFrom(niiri:43ed38ee11c52db758569877faabd695, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:ee629aca5d18e60c2724bfd2e1b3fc6b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0107" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "107" %% xsd:int])
+    wasDerivedFrom(niiri:ee629aca5d18e60c2724bfd2e1b3fc6b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:8b0a58d02f59556fa0151651c6d40cc0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0108" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "108" %% xsd:int])
+    wasDerivedFrom(niiri:8b0a58d02f59556fa0151651c6d40cc0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:eeb7c0ae3047601cda9c179c68e75d65,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0109" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "109" %% xsd:int])
+    wasDerivedFrom(niiri:eeb7c0ae3047601cda9c179c68e75d65, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:543214dac714341af8aeaa4b70f41266,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0110" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "110" %% xsd:int])
+    wasDerivedFrom(niiri:543214dac714341af8aeaa4b70f41266, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:86191fa377232381128e79c2a57a4af6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0111" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "111" %% xsd:int])
+    wasDerivedFrom(niiri:86191fa377232381128e79c2a57a4af6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:6f236184b94e16d3fb82cdd60cd19a6d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0112" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "112" %% xsd:int])
+    wasDerivedFrom(niiri:6f236184b94e16d3fb82cdd60cd19a6d, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:9ae54c5470ad002b7ae47f7b67b248ad,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0113" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "113" %% xsd:int])
+    wasDerivedFrom(niiri:9ae54c5470ad002b7ae47f7b67b248ad, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:0104fa6d88bd50793a3b65b47635e2c6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0114" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "114" %% xsd:int])
+    wasDerivedFrom(niiri:0104fa6d88bd50793a3b65b47635e2c6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:1ff5ea3ca56fb13894e4e43c39a861c9,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0115" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.77988160960367" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "115" %% xsd:int])
+    wasDerivedFrom(niiri:1ff5ea3ca56fb13894e4e43c39a861c9, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:9e02c41cd62cc06c92b5e2b56a706886,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0116" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "116" %% xsd:int])
+    wasDerivedFrom(niiri:9e02c41cd62cc06c92b5e2b56a706886, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:a5e308239dff195e8c67ca5b964d553a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0117" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "117" %% xsd:int])
+    wasDerivedFrom(niiri:a5e308239dff195e8c67ca5b964d553a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:aeffc3536799596ea12e2467fc52bd65,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0118" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "118" %% xsd:int])
+    wasDerivedFrom(niiri:aeffc3536799596ea12e2467fc52bd65, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:3e987521ad9deca092879412707ea491,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0119" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "119" %% xsd:int])
+    wasDerivedFrom(niiri:3e987521ad9deca092879412707ea491, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:f54f30ee52ac26f6dae0749e096ea6c1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0120" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "120" %% xsd:int])
+    wasDerivedFrom(niiri:f54f30ee52ac26f6dae0749e096ea6c1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:692bc9543cbfc2b98e06dde4c8e7603f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0121" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "121" %% xsd:int])
+    wasDerivedFrom(niiri:692bc9543cbfc2b98e06dde4c8e7603f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:be235801557e66b2190c98cd649588c0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0122" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "122" %% xsd:int])
+    wasDerivedFrom(niiri:be235801557e66b2190c98cd649588c0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:baf9fc0b69478678bb8ed7430b24c094,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0123" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "123" %% xsd:int])
+    wasDerivedFrom(niiri:baf9fc0b69478678bb8ed7430b24c094, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:27343a380f46da81b03903d4cf6193dc,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0124" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "124" %% xsd:int])
+    wasDerivedFrom(niiri:27343a380f46da81b03903d4cf6193dc, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:158f1d535951e2b7d78ea10b066c15f3,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0125" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "125" %% xsd:int])
+    wasDerivedFrom(niiri:158f1d535951e2b7d78ea10b066c15f3, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:842d2062c93ff252780aae9939a20111,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0126" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "126" %% xsd:int])
+    wasDerivedFrom(niiri:842d2062c93ff252780aae9939a20111, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:d27fbf9c8044e6b188c300c4990f6f54,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0127" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "127" %% xsd:int])
+    wasDerivedFrom(niiri:d27fbf9c8044e6b188c300c4990f6f54, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:2a4965b8fc709556c2aa1abb6adf5441,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0128" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "128" %% xsd:int])
+    wasDerivedFrom(niiri:2a4965b8fc709556c2aa1abb6adf5441, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:9cc63018305b210a50122f137d979802,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0129" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0584445007874552" %% xsd:float,
+        nidm_pValueUncorrected: = "0.77988160960367" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "129" %% xsd:int])
+    wasDerivedFrom(niiri:9cc63018305b210a50122f137d979802, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:965ac0d53ae837b608d6841eb6671ec5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0130" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "130" %% xsd:int])
+    wasDerivedFrom(niiri:965ac0d53ae837b608d6841eb6671ec5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:d20a800c34ef4ebbc2c9d064007ca5a5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0131" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "131" %% xsd:int])
+    wasDerivedFrom(niiri:d20a800c34ef4ebbc2c9d064007ca5a5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:0a26619869c6304390cf220d86997062,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0132" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "132" %% xsd:int])
+    wasDerivedFrom(niiri:0a26619869c6304390cf220d86997062, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:6a5b8fb86c67c0eb5b9c606e6b810510,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0133" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "133" %% xsd:int])
+    wasDerivedFrom(niiri:6a5b8fb86c67c0eb5b9c606e6b810510, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:99f3a2d8e7661135dd74892e7227bd72,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0134" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "134" %% xsd:int])
+    wasDerivedFrom(niiri:99f3a2d8e7661135dd74892e7227bd72, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:64a5de9f75df294ee267e34b2597bc84,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0135" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "135" %% xsd:int])
+    wasDerivedFrom(niiri:64a5de9f75df294ee267e34b2597bc84, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:2c98abbba202c2ed1fa8e08549a97cb1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0136" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0438333755905914" %% xsd:float,
+        nidm_pValueUncorrected: = "0.814463523065273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "136" %% xsd:int])
+    wasDerivedFrom(niiri:2c98abbba202c2ed1fa8e08549a97cb1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:35bfc5987aa4a1eba01be33e4c1ee7f2,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0137" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "137" %% xsd:int])
+    wasDerivedFrom(niiri:35bfc5987aa4a1eba01be33e4c1ee7f2, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:33395b862a603ee1373735759fed1bcb,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0138" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "138" %% xsd:int])
+    wasDerivedFrom(niiri:33395b862a603ee1373735759fed1bcb, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:635a4fc24d89b14d261b42d568e53ac8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0139" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "139" %% xsd:int])
+    wasDerivedFrom(niiri:635a4fc24d89b14d261b42d568e53ac8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:55b4eeddb69bb03436464cf696dd593b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0140" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0292222503937276" %% xsd:float,
+        nidm_pValueUncorrected: = "0.855031924102486" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "140" %% xsd:int])
+    wasDerivedFrom(niiri:55b4eeddb69bb03436464cf696dd593b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:493898a476d4ce4bf533682e007422c5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0141" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "141" %% xsd:int])
+    wasDerivedFrom(niiri:493898a476d4ce4bf533682e007422c5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:b841eb2677ab2ad59ce73103265cdee0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0142" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "142" %% xsd:int])
+    wasDerivedFrom(niiri:b841eb2677ab2ad59ce73103265cdee0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:4c7ec0be40515b0eae812fe9befe02f1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0143" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "143" %% xsd:int])
+    wasDerivedFrom(niiri:4c7ec0be40515b0eae812fe9befe02f1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0144" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "144" %% xsd:int])
+    wasDerivedFrom(niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:9d494c09341573a6df3c044f6f353a5a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0145" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "145" %% xsd:int])
+    wasDerivedFrom(niiri:9d494c09341573a6df3c044f6f353a5a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:630ac6074dee24b42295002659ee6cd4,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0146" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "146" %% xsd:int])
+    wasDerivedFrom(niiri:630ac6074dee24b42295002659ee6cd4, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:97f9982dca21f34e7ea0fcb977fcf50b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0147" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "147" %% xsd:int])
+    wasDerivedFrom(niiri:97f9982dca21f34e7ea0fcb977fcf50b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:b7588b8a823a7341bbdb4d3e8686e040,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0148" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "148" %% xsd:int])
+    wasDerivedFrom(niiri:b7588b8a823a7341bbdb4d3e8686e040, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:31b704c584e2aae3b394c52754216fae,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0149" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "149" %% xsd:int])
+    wasDerivedFrom(niiri:31b704c584e2aae3b394c52754216fae, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:2eff95031f5301f6a29990e69708dce1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0150" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0146111251968638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.906048723849963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "150" %% xsd:int])
+    wasDerivedFrom(niiri:2eff95031f5301f6a29990e69708dce1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
+    entity(niiri:47e960742a534223746b8914f30df973,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0001" %% xsd:string,
+        prov:location = 'niiri:7ffeabdba971025768378cc6c32ca5fe',
+        prov:value = "2.18819689750671" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.5114661254844" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000222821126723893" %% xsd:float,
+        nidm_pValueFWER: = "0.999999868311968" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:7ffeabdba971025768378cc6c32ca5fe,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0001" %% xsd:string,
+        nidm_coordinateVector: = "[-28,24,4]" %% xsd:string])
+    wasDerivedFrom(niiri:47e960742a534223746b8914f30df973, niiri:43fc9ecb30d51558da2aa2580905eaab, -, -, -)
+    entity(niiri:78e2d8c40d6e4600a75cdea76efced8c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0002" %% xsd:string,
+        prov:location = 'niiri:35dde01361b1ceeb6c6b77cfaa742ec4',
+        prov:value = "2.07190132141113" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.35835159739265" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000392044053194152" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999969126" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:35dde01361b1ceeb6c6b77cfaa742ec4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0002" %% xsd:string,
+        nidm_coordinateVector: = "[-28,26,12]" %% xsd:string])
+    wasDerivedFrom(niiri:78e2d8c40d6e4600a75cdea76efced8c, niiri:43fc9ecb30d51558da2aa2580905eaab, -, -, -)
+    entity(niiri:dc356018e062c59172dcd1e78418a358,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0003" %% xsd:string,
+        prov:location = 'niiri:eb6d8af6a185c83b9c38e3a1630a4622',
+        prov:value = "1.94285821914673" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.18853089402481" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000714988643396364" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:eb6d8af6a185c83b9c38e3a1630a4622,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0003" %% xsd:string,
+        nidm_coordinateVector: = "[-42,20,36]" %% xsd:string])
+    wasDerivedFrom(niiri:dc356018e062c59172dcd1e78418a358, niiri:43fc9ecb30d51558da2aa2580905eaab, -, -, -)
+    entity(niiri:59f453279ae60b2e7633608a74b392af,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0004" %% xsd:string,
+        prov:location = 'niiri:8613dd8cea932331a073b148edfe5144',
+        prov:value = "2.1167094707489" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.41734061195353" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000316180548517564" %% xsd:float,
+        nidm_pValueFWER: = "0.999999998897938" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:8613dd8cea932331a073b148edfe5144,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0004" %% xsd:string,
+        nidm_coordinateVector: = "[36,-84,2]" %% xsd:string])
+    wasDerivedFrom(niiri:59f453279ae60b2e7633608a74b392af, niiri:417cabd3eeb412117d20f4882d064567, -, -, -)
+    entity(niiri:30c43a8440f4ec3cda96fcd40be4d4d5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0005" %% xsd:string,
+        prov:location = 'niiri:c5988d123290f51d40d4592a7961f1d1',
+        prov:value = "2.00524592399597" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.27061943294259" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000536561087325027" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999999994" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:c5988d123290f51d40d4592a7961f1d1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0005" %% xsd:string,
+        nidm_coordinateVector: = "[34,-84,14]" %% xsd:string])
+    wasDerivedFrom(niiri:30c43a8440f4ec3cda96fcd40be4d4d5, niiri:417cabd3eeb412117d20f4882d064567, -, -, -)
+    entity(niiri:7188131da5a3b3086de0052afecc1b23,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0006" %% xsd:string,
+        prov:location = 'niiri:8014c5c8b33dfb4ba42f7cc5ed169849',
+        prov:value = "1.9834691286087" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.24196265203981" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000593547891254209" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999994" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:8014c5c8b33dfb4ba42f7cc5ed169849,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0006" %% xsd:string,
+        nidm_coordinateVector: = "[34,-78,36]" %% xsd:string])
+    wasDerivedFrom(niiri:7188131da5a3b3086de0052afecc1b23, niiri:417cabd3eeb412117d20f4882d064567, -, -, -)
+    entity(niiri:12ddd7ac78265e0515a406f79cd7b60b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0007" %% xsd:string,
+        prov:location = 'niiri:4f09bb3884a3beab368df1e4cbdd6c5a',
+        prov:value = "2.07622194290161" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.36403923290147" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000384053116980865" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999955495" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:4f09bb3884a3beab368df1e4cbdd6c5a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0007" %% xsd:string,
+        nidm_coordinateVector: = "[52,48,12]" %% xsd:string])
+    wasDerivedFrom(niiri:12ddd7ac78265e0515a406f79cd7b60b, niiri:6cc5ea3c57b906137def3d6777b0000f, -, -, -)
+    entity(niiri:a8daaa449eaabd54146c2443c52b2405,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0008" %% xsd:string,
+        prov:location = 'niiri:ced65fab2ecc31645054de6698a6e193',
+        prov:value = "2.0327205657959" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.306778623673" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000471877215462824" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999097" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ced65fab2ecc31645054de6698a6e193,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0008" %% xsd:string,
+        nidm_coordinateVector: = "[30,68,12]" %% xsd:string])
+    wasDerivedFrom(niiri:a8daaa449eaabd54146c2443c52b2405, niiri:6cc5ea3c57b906137def3d6777b0000f, -, -, -)
+    entity(niiri:073f17f5ff09cc49a92a3da9639c7ec8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0009" %% xsd:string,
+        prov:location = 'niiri:9e58a2008800aed167f2193e6475edaa',
+        prov:value = "1.63326919078827" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.78184273056811" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00270256128658664" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:9e58a2008800aed167f2193e6475edaa,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0009" %% xsd:string,
+        nidm_coordinateVector: = "[14,74,6]" %% xsd:string])
+    wasDerivedFrom(niiri:073f17f5ff09cc49a92a3da9639c7ec8, niiri:6cc5ea3c57b906137def3d6777b0000f, -, -, -)
+    entity(niiri:d0393b0ebc9411a5d45ca86b90a5f75a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0010" %% xsd:string,
+        prov:location = 'niiri:32c57c9426babf3fe0244d15351d0daf',
+        prov:value = "2.04988360404968" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.32936904595179" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000435214929046523" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999995547" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:32c57c9426babf3fe0244d15351d0daf,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0010" %% xsd:string,
+        nidm_coordinateVector: = "[34,-54,52]" %% xsd:string])
+    wasDerivedFrom(niiri:d0393b0ebc9411a5d45ca86b90a5f75a, niiri:c29516aed6cf24b95d9653e2365e0ced, -, -, -)
+    entity(niiri:603843b40d6d98501a421775119d3ad1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0011" %% xsd:string,
+        prov:location = 'niiri:fcdba63eb7662475636125721f54320e',
+        prov:value = "1.17590498924255" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.18553018514689" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0144249976129074" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:fcdba63eb7662475636125721f54320e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0011" %% xsd:string,
+        nidm_coordinateVector: = "[26,-48,50]" %% xsd:string])
+    wasDerivedFrom(niiri:603843b40d6d98501a421775119d3ad1, niiri:c29516aed6cf24b95d9653e2365e0ced, -, -, -)
+    entity(niiri:16b2952800d349d84a763795197c8b0b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0012" %% xsd:string,
+        prov:location = 'niiri:ac144f9a90591900cfb49f146349a1b8',
+        prov:value = "1.17325437068939" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.18210185402812" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0145510082060974" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ac144f9a90591900cfb49f146349a1b8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0012" %% xsd:string,
+        nidm_coordinateVector: = "[32,-54,62]" %% xsd:string])
+    wasDerivedFrom(niiri:16b2952800d349d84a763795197c8b0b, niiri:c29516aed6cf24b95d9653e2365e0ced, -, -, -)
+    entity(niiri:d7a85cf00dbcad11964be5f20d4b99ff,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0013" %% xsd:string,
+        prov:location = 'niiri:0de0e683dce5cc8a49c6c73eedac8c40',
+        prov:value = "1.69681537151337" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.86519802999163" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00208374267085354" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:0de0e683dce5cc8a49c6c73eedac8c40,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0013" %% xsd:string,
+        nidm_coordinateVector: = "[-28,50,36]" %% xsd:string])
+    wasDerivedFrom(niiri:d7a85cf00dbcad11964be5f20d4b99ff, niiri:1c26e68b379e5bd715e75014cca849ab, -, -, -)
+    entity(niiri:90e0ff48a341c849ccd5b511385d366a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0014" %% xsd:string,
+        prov:location = 'niiri:c1f676e8a11713f1a14d11da4d4c21cd',
+        prov:value = "0.933988809585571" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.8747737054388" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0304119310280364" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:c1f676e8a11713f1a14d11da4d4c21cd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0014" %% xsd:string,
+        nidm_coordinateVector: = "[-46,38,30]" %% xsd:string])
+    wasDerivedFrom(niiri:90e0ff48a341c849ccd5b511385d366a, niiri:1c26e68b379e5bd715e75014cca849ab, -, -, -)
+    entity(niiri:d405f97c1debf6dfef53e4c341960b1c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0015" %% xsd:string,
+        prov:location = 'niiri:bac6269bd3bba27583f4d36c34dcbaf1',
+        prov:value = "1.66940176486969" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.82922911554701" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00233301407977504" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:bac6269bd3bba27583f4d36c34dcbaf1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0015" %% xsd:string,
+        nidm_coordinateVector: = "[16,-94,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:d405f97c1debf6dfef53e4c341960b1c, niiri:8b5d6e1bd5480bd6366d0094c92d4851, -, -, -)
+    entity(niiri:4e793a27eff6bd141a437820cd72dd10,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0016" %% xsd:string,
+        prov:location = 'niiri:02f3a870411865e426e29828e46ed3f9',
+        prov:value = "1.5886458158493" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.72335979311329" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00323108192435606" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:02f3a870411865e426e29828e46ed3f9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0016" %% xsd:string,
+        nidm_coordinateVector: = "[24,-92,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:4e793a27eff6bd141a437820cd72dd10, niiri:8b5d6e1bd5480bd6366d0094c92d4851, -, -, -)
+    entity(niiri:7eccc401f6068789908f149147981921,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0017" %% xsd:string,
+        prov:location = 'niiri:371d66a66b29fdb967d17dd294dfe6e3',
+        prov:value = "1.51174938678741" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.62269482082508" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00436186877852962" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:371d66a66b29fdb967d17dd294dfe6e3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0017" %% xsd:string,
+        nidm_coordinateVector: = "[34,-84,-48]" %% xsd:string])
+    wasDerivedFrom(niiri:7eccc401f6068789908f149147981921, niiri:8b5d6e1bd5480bd6366d0094c92d4851, -, -, -)
+    entity(niiri:bc7a7d099b4aa5c027485a3f6e273f75,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0018" %% xsd:string,
+        prov:location = 'niiri:05b822162b985baea86f5f76eaf274eb',
+        prov:value = "1.6600536108017" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.81696686061887" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00242397637898328" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:05b822162b985baea86f5f76eaf274eb,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0018" %% xsd:string,
+        nidm_coordinateVector: = "[-44,-56,-32]" %% xsd:string])
+    wasDerivedFrom(niiri:bc7a7d099b4aa5c027485a3f6e273f75, niiri:7e631bc430702f08996bcc12a090f463, -, -, -)
+    entity(niiri:5d6079cd009bcfed9d07102c8bf1cd64,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0019" %% xsd:string,
+        prov:location = 'niiri:b5301e158adbbc221d5e73c472172d3e',
+        prov:value = "1.5787501335144" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.71039687336073" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00336013715292427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:b5301e158adbbc221d5e73c472172d3e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0019" %% xsd:string,
+        nidm_coordinateVector: = "[-10,72,0]" %% xsd:string])
+    wasDerivedFrom(niiri:5d6079cd009bcfed9d07102c8bf1cd64, niiri:c21e2ede0b4f245e2d9f679a7862569e, -, -, -)
+    entity(niiri:67a82cc3c6fe87003f709a11853632a1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0020" %% xsd:string,
+        prov:location = 'niiri:be6a1b05017c497d1872f0ed60f8f931',
+        prov:value = "1.37760043144226" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.44750858968075" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0071923848185762" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:be6a1b05017c497d1872f0ed60f8f931,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0020" %% xsd:string,
+        nidm_coordinateVector: = "[-24,68,10]" %% xsd:string])
+    wasDerivedFrom(niiri:67a82cc3c6fe87003f709a11853632a1, niiri:c21e2ede0b4f245e2d9f679a7862569e, -, -, -)
+    entity(niiri:8fbbec051d375de1ec30261a1f32f9a5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0021" %% xsd:string,
+        prov:location = 'niiri:9d8f2d489780f5c4762d7ff3891155a2',
+        prov:value = "1.35886359214783" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.42309168524595" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00769452108984159" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:9d8f2d489780f5c4762d7ff3891155a2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0021" %% xsd:string,
+        nidm_coordinateVector: = "[-14,64,28]" %% xsd:string])
+    wasDerivedFrom(niiri:8fbbec051d375de1ec30261a1f32f9a5, niiri:c21e2ede0b4f245e2d9f679a7862569e, -, -, -)
+    entity(niiri:722e903ee5178a4981cc55266210bd89,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0022" %% xsd:string,
+        prov:location = 'niiri:9f719f92694484cd7261b1c6255b52c0',
+        prov:value = "1.53290164470673" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.65036951622375" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00402018893002576" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:9f719f92694484cd7261b1c6255b52c0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0022" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-80,10]" %% xsd:string])
+    wasDerivedFrom(niiri:722e903ee5178a4981cc55266210bd89, niiri:c8c6cee0456ea9b67ae74c71ec73d58a, -, -, -)
+    entity(niiri:43c73ccd4ff874b4159d8e343817709e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0023" %% xsd:string,
+        prov:location = 'niiri:d6269808ee48c8a2f54e9d917e97a97d',
+        prov:value = "1.34681856632233" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.4074027844201" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00803321955273906" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:d6269808ee48c8a2f54e9d917e97a97d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0023" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-88,8]" %% xsd:string])
+    wasDerivedFrom(niiri:43c73ccd4ff874b4159d8e343817709e, niiri:c8c6cee0456ea9b67ae74c71ec73d58a, -, -, -)
+    entity(niiri:5b402b3505886d69eee1da65259dfff5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0024" %% xsd:string,
+        prov:location = 'niiri:e3be3bddf8e8cf2bc774db0b5fd4ccf9',
+        prov:value = "1.31222748756409" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.36238178325093" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00907896581463363" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:e3be3bddf8e8cf2bc774db0b5fd4ccf9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0024" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-78,26]" %% xsd:string])
+    wasDerivedFrom(niiri:5b402b3505886d69eee1da65259dfff5, niiri:c8c6cee0456ea9b67ae74c71ec73d58a, -, -, -)
+    entity(niiri:5516b5835629ab543345d78e4c6e7f84,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0025" %% xsd:string,
+        prov:location = 'niiri:5fa024f29ffd7dd65df2521965746c10',
+        prov:value = "1.47698056697845" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.57723307746183" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00497973845037369" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:5fa024f29ffd7dd65df2521965746c10,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0025" %% xsd:string,
+        nidm_coordinateVector: = "[24,-64,62]" %% xsd:string])
+    wasDerivedFrom(niiri:5516b5835629ab543345d78e4c6e7f84, niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5, -, -, -)
+    entity(niiri:b0048f0b19299e2890e2feec137562bd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0026" %% xsd:string,
+        prov:location = 'niiri:dfffa57a27812cbdb97937c604ce644d',
+        prov:value = "1.47098410129547" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.56939616988394" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00509379579800051" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:dfffa57a27812cbdb97937c604ce644d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0026" %% xsd:string,
+        nidm_coordinateVector: = "[42,2,42]" %% xsd:string])
+    wasDerivedFrom(niiri:b0048f0b19299e2890e2feec137562bd, niiri:c8915bbac48c4a94d3bf54f07d28091a, -, -, -)
+    entity(niiri:44cc0c30dff2ae8e59814059b0d808d8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0027" %% xsd:string,
+        prov:location = 'niiri:9cfb25b1548c7ea2a37d91c1cdc97937',
+        prov:value = "1.28529334068298" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.32736401858338" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00997294956075112" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:9cfb25b1548c7ea2a37d91c1cdc97937,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0027" %% xsd:string,
+        nidm_coordinateVector: = "[52,6,36]" %% xsd:string])
+    wasDerivedFrom(niiri:44cc0c30dff2ae8e59814059b0d808d8, niiri:c8915bbac48c4a94d3bf54f07d28091a, -, -, -)
+    entity(niiri:8f81caeadc613b2befe266e538a005b4,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0028" %% xsd:string,
+        prov:location = 'niiri:192ea9c42130b9f2836346385ffa8ac6',
+        prov:value = "1.46635723114014" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.56334999311601" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00518337435668992" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:192ea9c42130b9f2836346385ffa8ac6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0028" %% xsd:string,
+        nidm_coordinateVector: = "[-28,-60,54]" %% xsd:string])
+    wasDerivedFrom(niiri:8f81caeadc613b2befe266e538a005b4, niiri:81f39aacce9db78e536cab5c96400969, -, -, -)
+    entity(niiri:49b88a38ee8eb23aa88417b585a3c019,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0029" %% xsd:string,
+        prov:location = 'niiri:2e4756a1fc7f488d50c7e456c8606411',
+        prov:value = "1.35919630527496" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.42352513638295" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00768534474692273" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:2e4756a1fc7f488d50c7e456c8606411,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0029" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-56,62]" %% xsd:string])
+    wasDerivedFrom(niiri:49b88a38ee8eb23aa88417b585a3c019, niiri:81f39aacce9db78e536cab5c96400969, -, -, -)
+    entity(niiri:d526e3755e8ee1eb281731fad0d751f7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0030" %% xsd:string,
+        prov:location = 'niiri:7f8d1d4f81b26e2e937ef2c6c7065a2f',
+        prov:value = "1.3043509721756" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.35213781333103" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00933292892535331" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:7f8d1d4f81b26e2e937ef2c6c7065a2f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0030" %% xsd:string,
+        nidm_coordinateVector: = "[-18,-62,52]" %% xsd:string])
+    wasDerivedFrom(niiri:d526e3755e8ee1eb281731fad0d751f7, niiri:81f39aacce9db78e536cab5c96400969, -, -, -)
+    entity(niiri:803b5b1f8348b033ada171621cc5c167,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0031" %% xsd:string,
+        prov:location = 'niiri:a13a3d48a1429418bba0b99d4e9725bb',
+        prov:value = "1.45064067840576" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.54281750257153" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00549813229675677" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:a13a3d48a1429418bba0b99d4e9725bb,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0031" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-84,-48]" %% xsd:string])
+    wasDerivedFrom(niiri:803b5b1f8348b033ada171621cc5c167, niiri:95cfa48491de3b2db8a60dc29bdeb6af, -, -, -)
+    entity(niiri:10252df0ea1e4565a8207dad73957039,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0032" %% xsd:string,
+        prov:location = 'niiri:6e55e818af807eb11d9ab4e1a7d892a8',
+        prov:value = "1.37874686717987" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.44900302114624" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00716261232865922" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:6e55e818af807eb11d9ab4e1a7d892a8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0032" %% xsd:string,
+        nidm_coordinateVector: = "[-22,-84,-50]" %% xsd:string])
+    wasDerivedFrom(niiri:10252df0ea1e4565a8207dad73957039, niiri:95cfa48491de3b2db8a60dc29bdeb6af, -, -, -)
+    entity(niiri:1b619cb22a788dbfcac8e6547b8cf9c3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0033" %% xsd:string,
+        prov:location = 'niiri:a196ba726a6cf6e1af92ce4f926bddd6',
+        prov:value = "1.1024569272995" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.09070134301333" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0182774222681363" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:a196ba726a6cf6e1af92ce4f926bddd6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0033" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-90,-42]" %% xsd:string])
+    wasDerivedFrom(niiri:1b619cb22a788dbfcac8e6547b8cf9c3, niiri:95cfa48491de3b2db8a60dc29bdeb6af, -, -, -)
+    entity(niiri:e7bccdc00c0d8eba721b2ada820c74eb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0034" %% xsd:string,
+        prov:location = 'niiri:07a292d3fca36fc7398026cd440e98ff',
+        prov:value = "1.43723428249359" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.52530953068747" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00577982121839438" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:07a292d3fca36fc7398026cd440e98ff,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0034" %% xsd:string,
+        nidm_coordinateVector: = "[-24,40,46]" %% xsd:string])
+    wasDerivedFrom(niiri:e7bccdc00c0d8eba721b2ada820c74eb, niiri:e7fc37cb04d1a3f58136cfb12f992f34, -, -, -)
+    entity(niiri:b04044222ee790cf55bdaa521739b13d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0035" %% xsd:string,
+        prov:location = 'niiri:ee1d4ec9c2f0fec55c6dd0053012c88a',
+        prov:value = "1.11286687850952" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.10411930550185" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0176840206088169" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ee1d4ec9c2f0fec55c6dd0053012c88a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0035" %% xsd:string,
+        nidm_coordinateVector: = "[-16,50,46]" %% xsd:string])
+    wasDerivedFrom(niiri:b04044222ee790cf55bdaa521739b13d, niiri:e7fc37cb04d1a3f58136cfb12f992f34, -, -, -)
+    entity(niiri:2d1b96b3d3613decbd596f70088a278e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0036" %% xsd:string,
+        prov:location = 'niiri:e1970f3d88404b41f93f350066b20ee5',
+        prov:value = "1.42738270759583" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.51244786328393" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00599484099495173" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:e1970f3d88404b41f93f350066b20ee5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0036" %% xsd:string,
+        nidm_coordinateVector: = "[40,32,42]" %% xsd:string])
+    wasDerivedFrom(niiri:2d1b96b3d3613decbd596f70088a278e, niiri:de5b4d0f5d84034ba5fd7975873cc2e6, -, -, -)
+    entity(niiri:7cd243c2f0efa2926ee101eb0ddaa71f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0037" %% xsd:string,
+        prov:location = 'niiri:2d93df4bc1c8bdc309f561183cf1d559',
+        prov:value = "1.05634605884552" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.03136304442869" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0211090901815698" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:2d93df4bc1c8bdc309f561183cf1d559,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0037" %% xsd:string,
+        nidm_coordinateVector: = "[38,40,36]" %% xsd:string])
+    wasDerivedFrom(niiri:7cd243c2f0efa2926ee101eb0ddaa71f, niiri:de5b4d0f5d84034ba5fd7975873cc2e6, -, -, -)
+    entity(niiri:af520ea7a2b622b616f138da20521f11,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0038" %% xsd:string,
+        prov:location = 'niiri:25eebb30f786b56bc44db03461f48217',
+        prov:value = "1.40870463848114" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.4880722231724" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00642188235953201" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:25eebb30f786b56bc44db03461f48217,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0038" %% xsd:string,
+        nidm_coordinateVector: = "[-42,-84,-6]" %% xsd:string])
+    wasDerivedFrom(niiri:af520ea7a2b622b616f138da20521f11, niiri:1d6209037825fb7ee168299aa10d5ad7, -, -, -)
+    entity(niiri:1296043c9bfe3127d5cc76c217e1e26d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0039" %% xsd:string,
+        prov:location = 'niiri:21698b9502c51709153adfed9abb8986',
+        prov:value = "1.13220155239105" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.12906102075628" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0166246060871375" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:21698b9502c51709153adfed9abb8986,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0039" %% xsd:string,
+        nidm_coordinateVector: = "[-50,-78,0]" %% xsd:string])
+    wasDerivedFrom(niiri:1296043c9bfe3127d5cc76c217e1e26d, niiri:1d6209037825fb7ee168299aa10d5ad7, -, -, -)
+    entity(niiri:23d6198c7c453ccfbd7fb701c34b6e26,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0040" %% xsd:string,
+        prov:location = 'niiri:28a96db39c58e234af2cc132fa98f4bc',
+        prov:value = "1.34917068481445" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.41046599292312" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00796607827138629" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:28a96db39c58e234af2cc132fa98f4bc,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0040" %% xsd:string,
+        nidm_coordinateVector: = "[12,-20,80]" %% xsd:string])
+    wasDerivedFrom(niiri:23d6198c7c453ccfbd7fb701c34b6e26, niiri:b1918e5ede22fa7e1d3a1399a34a2d45, -, -, -)
+    entity(niiri:2b724527e8d3c9b6e97424cd9b8d15aa,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0041" %% xsd:string,
+        prov:location = 'niiri:42b34ad9cce6394b101fbaa08a07f29f',
+        prov:value = "1.34354746341705" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.40314315325023" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0081274114265858" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:42b34ad9cce6394b101fbaa08a07f29f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0041" %% xsd:string,
+        nidm_coordinateVector: = "[18,48,44]" %% xsd:string])
+    wasDerivedFrom(niiri:2b724527e8d3c9b6e97424cd9b8d15aa, niiri:5d9799711b35085d7a8bcba1641700b1, -, -, -)
+    entity(niiri:4de941e56885958a7463bfabb4b85cf9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0042" %% xsd:string,
+        prov:location = 'niiri:91689c74edc5692bdf656cdf4e590451',
+        prov:value = "1.14962959289551" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.15156492154198" %% xsd:float,
+        nidm_pValueUncorrected: = "0.015715818709074" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:91689c74edc5692bdf656cdf4e590451,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0042" %% xsd:string,
+        nidm_coordinateVector: = "[8,52,46]" %% xsd:string])
+    wasDerivedFrom(niiri:4de941e56885958a7463bfabb4b85cf9, niiri:5d9799711b35085d7a8bcba1641700b1, -, -, -)
+    entity(niiri:2a1e41375178ee6048cfe473ad850d9d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0043" %% xsd:string,
+        prov:location = 'niiri:d103ae494461197404d4d98c94ab55d0',
+        prov:value = "1.33556091785431" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.39274498818401" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00836142979663967" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:d103ae494461197404d4d98c94ab55d0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0043" %% xsd:string,
+        nidm_coordinateVector: = "[64,-52,2]" %% xsd:string])
+    wasDerivedFrom(niiri:2a1e41375178ee6048cfe473ad850d9d, niiri:437180e47264cc4e09dc17b204fd0a89, -, -, -)
+    entity(niiri:b2e28fc4cb7873bae7dfcec9c622a9c0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0044" %% xsd:string,
+        prov:location = 'niiri:d4322ad7c793d679b708c35788e9eb73',
+        prov:value = "1.30518817901611" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.35322652463791" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00930564616578244" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:d4322ad7c793d679b708c35788e9eb73,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0044" %% xsd:string,
+        nidm_coordinateVector: = "[26,-74,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:b2e28fc4cb7873bae7dfcec9c622a9c0, niiri:1cd87c105e9a1996f42e3171bad089a8, -, -, -)
+    entity(niiri:4957f8f40371d5539e9b85697134e63f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0045" %% xsd:string,
+        prov:location = 'niiri:5e9202a8879f71e2067d4c3d52dedb20',
+        prov:value = "1.30020189285278" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.34674279460019" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00946916148556731" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:5e9202a8879f71e2067d4c3d52dedb20,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0045" %% xsd:string,
+        nidm_coordinateVector: = "[-44,-82,-34]" %% xsd:string])
+    wasDerivedFrom(niiri:4957f8f40371d5539e9b85697134e63f, niiri:cc02b2de189bcf80b0afcbe487b0d1e8, -, -, -)
+    entity(niiri:6c2bd69486f6f2fc98bdad9a9249cde9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0046" %% xsd:string,
+        prov:location = 'niiri:372619818a34b671fccfef60836977b8',
+        prov:value = "1.2840074300766" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.32569303609441" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0100174661332294" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:372619818a34b671fccfef60836977b8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0046" %% xsd:string,
+        nidm_coordinateVector: = "[-6,62,36]" %% xsd:string])
+    wasDerivedFrom(niiri:6c2bd69486f6f2fc98bdad9a9249cde9, niiri:3ae2e3cf05ec7ac4b46544f268071134, -, -, -)
+    entity(niiri:8bc88f0d5c04e29ab34863cd24e68863,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0047" %% xsd:string,
+        prov:location = 'niiri:ce40992a0b5e259f1b43758c5d68ea28',
+        prov:value = "1.26505351066589" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.30107272004429" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0106937605017341" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ce40992a0b5e259f1b43758c5d68ea28,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0047" %% xsd:string,
+        nidm_coordinateVector: = "[-50,-2,50]" %% xsd:string])
+    wasDerivedFrom(niiri:8bc88f0d5c04e29ab34863cd24e68863, niiri:3c84c74526e078ad8336fd968ec9d7f0, -, -, -)
+    entity(niiri:8a59a15e6d4b148aaa0593801d721b02,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0048" %% xsd:string,
+        prov:location = 'niiri:4f32af48b33fc420912cf278bf0e8c3c',
+        prov:value = "1.24030959606171" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.26895897281379" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0116354104606456" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:4f32af48b33fc420912cf278bf0e8c3c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0048" %% xsd:string,
+        nidm_coordinateVector: = "[-18,6,32]" %% xsd:string])
+    wasDerivedFrom(niiri:8a59a15e6d4b148aaa0593801d721b02, niiri:8a1438a34faf87d03af2d9853b038bb2, -, -, -)
+    entity(niiri:22b4df385352baee01307cab01764e69,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0049" %% xsd:string,
+        prov:location = 'niiri:6b72057b1a69bb07b793d0aaa063f078',
+        prov:value = "1.23086047172546" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.25670403369037" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0120132873197203" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:6b72057b1a69bb07b793d0aaa063f078,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0049" %% xsd:string,
+        nidm_coordinateVector: = "[32,-44,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:22b4df385352baee01307cab01764e69, niiri:5aecd2a653cabfaff01cc936a5319173, -, -, -)
+    entity(niiri:6bd95507897b5f8465d65ded242e547c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0050" %% xsd:string,
+        prov:location = 'niiri:cb9c025473a7e46fa185ff9de6d2eecf',
+        prov:value = "1.22944271564484" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.25486570897048" %% xsd:float,
+        nidm_pValueUncorrected: = "0.012070879644426" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:cb9c025473a7e46fa185ff9de6d2eecf,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0050" %% xsd:string,
+        nidm_coordinateVector: = "[-46,-10,58]" %% xsd:string])
+    wasDerivedFrom(niiri:6bd95507897b5f8465d65ded242e547c, niiri:04baa9610947313ff840ab800dc602ff, -, -, -)
+    entity(niiri:4143adeb44c98572c57b47081885265e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0051" %% xsd:string,
+        prov:location = 'niiri:4071d9d4ce99f6a6d655e297984278e8',
+        prov:value = "1.22471487522125" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.24873618228261" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0122646428654261" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:4071d9d4ce99f6a6d655e297984278e8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0051" %% xsd:string,
+        nidm_coordinateVector: = "[-22,-94,26]" %% xsd:string])
+    wasDerivedFrom(niiri:4143adeb44c98572c57b47081885265e, niiri:bbf4ae108fc8903d38a040cb96a5f8c7, -, -, -)
+    entity(niiri:677b1c427e116e323ccaeb43a4fcc8ea,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0052" %% xsd:string,
+        prov:location = 'niiri:59ab9ec5ff9c6474e96185492d155b6a',
+        prov:value = "1.21706402301788" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.23881967357295" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0125838258304741" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:59ab9ec5ff9c6474e96185492d155b6a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0052" %% xsd:string,
+        nidm_coordinateVector: = "[36,32,8]" %% xsd:string])
+    wasDerivedFrom(niiri:677b1c427e116e323ccaeb43a4fcc8ea, niiri:4df2335aa8db3e5be136eacbcea883d6, -, -, -)
+    entity(niiri:5f1c8d3e35aa5357a031ef92edb5ec90,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0053" %% xsd:string,
+        prov:location = 'niiri:a57e5490085c1d02f350a38c8affd373',
+        prov:value = "1.1321427822113" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.12898516834439" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0166277437596988" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:a57e5490085c1d02f350a38c8affd373,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0053" %% xsd:string,
+        nidm_coordinateVector: = "[32,28,2]" %% xsd:string])
+    wasDerivedFrom(niiri:5f1c8d3e35aa5357a031ef92edb5ec90, niiri:4df2335aa8db3e5be136eacbcea883d6, -, -, -)
+    entity(niiri:71e9024f0319e7ffdb91e7e9ef0f632b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0054" %% xsd:string,
+        prov:location = 'niiri:05aeae1bb56c868f7f9ca3927fd6f960',
+        prov:value = "1.21668255329132" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.23832532460858" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0125999239065135" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:05aeae1bb56c868f7f9ca3927fd6f960,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0054" %% xsd:string,
+        nidm_coordinateVector: = "[-36,-42,38]" %% xsd:string])
+    wasDerivedFrom(niiri:71e9024f0319e7ffdb91e7e9ef0f632b, niiri:9d79a6339d6f2901fb1cf662d6f17331, -, -, -)
+    entity(niiri:089018a569a6a201160974bff8392bfd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0055" %% xsd:string,
+        prov:location = 'niiri:e27e392fffbf5a9a3177a7ac19ff9008',
+        prov:value = "1.19720852375031" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.21309986746215" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0134453806257753" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:e27e392fffbf5a9a3177a7ac19ff9008,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0055" %% xsd:string,
+        nidm_coordinateVector: = "[2,68,26]" %% xsd:string])
+    wasDerivedFrom(niiri:089018a569a6a201160974bff8392bfd, niiri:b8abe2a725005d9ab6e1e988f192f41c, -, -, -)
+    entity(niiri:c4700a2462ced300c4a44bf88e97f271,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0056" %% xsd:string,
+        prov:location = 'niiri:1ded169ba4a3f3e742789782ebf9e21d',
+        prov:value = "1.1896378993988" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.20329932117063" %% xsd:float,
+        nidm_pValueUncorrected: = "0.013786829398946" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:1ded169ba4a3f3e742789782ebf9e21d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0056" %% xsd:string,
+        nidm_coordinateVector: = "[46,14,2]" %% xsd:string])
+    wasDerivedFrom(niiri:c4700a2462ced300c4a44bf88e97f271, niiri:483de03930aa5641b0fe297f66f6c4ed, -, -, -)
+    entity(niiri:be0117fcc9b16f8118a34f6688a334a6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0057" %% xsd:string,
+        prov:location = 'niiri:a404d8c08401c4552c6273afdc67726c',
+        prov:value = "0.84699684381485" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.76435736331002" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0388359158916027" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:a404d8c08401c4552c6273afdc67726c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0057" %% xsd:string,
+        nidm_coordinateVector: = "[40,10,10]" %% xsd:string])
+    wasDerivedFrom(niiri:be0117fcc9b16f8118a34f6688a334a6, niiri:483de03930aa5641b0fe297f66f6c4ed, -, -, -)
+    entity(niiri:303d5f4df2d0d08184a8559af50bd6c1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0058" %% xsd:string,
+        prov:location = 'niiri:070a4d4397d04007720d2af356c40f7a',
+        prov:value = "1.18655109405518" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.19930428061828" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0139281467706139" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:070a4d4397d04007720d2af356c40f7a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0058" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-28,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:303d5f4df2d0d08184a8559af50bd6c1, niiri:4f303edac6b82f93c47e1a6448e1cb52, -, -, -)
+    entity(niiri:60e4d404f23dc518a79132762c323919,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0059" %% xsd:string,
+        prov:location = 'niiri:8c5cc76b2edcfc58bde42f3e4a12935f',
+        prov:value = "1.17589449882507" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.18551661590201" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0144254945017301" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:8c5cc76b2edcfc58bde42f3e4a12935f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0059" %% xsd:string,
+        nidm_coordinateVector: = "[-18,30,50]" %% xsd:string])
+    wasDerivedFrom(niiri:60e4d404f23dc518a79132762c323919, niiri:d987cfa4a10011187d0a3eef178d5a46, -, -, -)
+    entity(niiri:b38281d4642204a1940b6ebe7b4e1531,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0060" %% xsd:string,
+        prov:location = 'niiri:3e550c577ebfcc9bdf25a911ee937fbe',
+        prov:value = "1.17159426212311" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.17995487813573" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0146304032058477" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:3e550c577ebfcc9bdf25a911ee937fbe,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0060" %% xsd:string,
+        nidm_coordinateVector: = "[-14,-26,66]" %% xsd:string])
+    wasDerivedFrom(niiri:b38281d4642204a1940b6ebe7b4e1531, niiri:98d187b5c539ea98df7343b0d0821b17, -, -, -)
+    entity(niiri:e54beb18ffa5912f369d1f235557359f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0061" %% xsd:string,
+        prov:location = 'niiri:7e83d5be32f3ac082fae74d72a17293b',
+        prov:value = "1.1714745759964" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.17980009775463" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0146361413495164" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:7e83d5be32f3ac082fae74d72a17293b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0061" %% xsd:string,
+        nidm_coordinateVector: = "[18,60,34]" %% xsd:string])
+    wasDerivedFrom(niiri:e54beb18ffa5912f369d1f235557359f, niiri:5c38b60ed820b070d98e016bc1431008, -, -, -)
+    entity(niiri:5cdcba284a1740e0a95bf39bfc59090f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0062" %% xsd:string,
+        prov:location = 'niiri:4d1d923218a5a86f14b80c5d9024c436',
+        prov:value = "1.17128801345825" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.17955883330163" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0146450895624214" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:4d1d923218a5a86f14b80c5d9024c436,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0062" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-72,-50]" %% xsd:string])
+    wasDerivedFrom(niiri:5cdcba284a1740e0a95bf39bfc59090f, niiri:a86e2297836b759380804c1713e267cd, -, -, -)
+    entity(niiri:9608a0b9921f169205a67f91b0c8646d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0063" %% xsd:string,
+        prov:location = 'niiri:5ea0a149f7e30f52d50d149bf7dc7f86',
+        prov:value = "1.15287852287292" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.15576230673889" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0155511150762138" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:5ea0a149f7e30f52d50d149bf7dc7f86,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0063" %% xsd:string,
+        nidm_coordinateVector: = "[10,6,74]" %% xsd:string])
+    wasDerivedFrom(niiri:9608a0b9921f169205a67f91b0c8646d, niiri:f4ed594992095609e2ba62eca01c9faf, -, -, -)
+    entity(niiri:f8ec021e67601d83fa30a8d652cef986,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0064" %% xsd:string,
+        prov:location = 'niiri:8800f25bc9569134e36fe056c55dccea',
+        prov:value = "1.14964759349823" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.15158817513994" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0157149021414998" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:8800f25bc9569134e36fe056c55dccea,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0064" %% xsd:string,
+        nidm_coordinateVector: = "[-40,48,22]" %% xsd:string])
+    wasDerivedFrom(niiri:f8ec021e67601d83fa30a8d652cef986, niiri:c8ce85b44b984de4fe78c06b64713bb8, -, -, -)
+    entity(niiri:f317a0bc0be15c3af8b8f12eddef0171,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0065" %% xsd:string,
+        prov:location = 'niiri:f23773c36e8aa842670cc820c8e3cf8e',
+        prov:value = "1.14813911914825" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.14963956628403" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0157918680840622" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:f23773c36e8aa842670cc820c8e3cf8e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0065" %% xsd:string,
+        nidm_coordinateVector: = "[10,-78,-40]" %% xsd:string])
+    wasDerivedFrom(niiri:f317a0bc0be15c3af8b8f12eddef0171, niiri:55d04469f144e7c5053124929003df79, -, -, -)
+    entity(niiri:131fdfd62367b034e5115d813dae4043,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0066" %% xsd:string,
+        prov:location = 'niiri:9d2a2a255f2ef73de9a55449d983e205',
+        prov:value = "1.14065408706665" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.13997280538058" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0161784822721924" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:9d2a2a255f2ef73de9a55449d983e205,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0066" %% xsd:string,
+        nidm_coordinateVector: = "[-12,2,70]" %% xsd:string])
+    wasDerivedFrom(niiri:131fdfd62367b034e5115d813dae4043, niiri:895da0556b5b38697a9d4eacde3a587e, -, -, -)
+    entity(niiri:411f4505c8a2beb209d54060d7e4a887,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0067" %% xsd:string,
+        prov:location = 'niiri:d9f9f53784b39c50a0d16feea151376a',
+        prov:value = "1.1338312625885" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.13116451819532" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0165377954988448" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:d9f9f53784b39c50a0d16feea151376a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0067" %% xsd:string,
+        nidm_coordinateVector: = "[22,-18,48]" %% xsd:string])
+    wasDerivedFrom(niiri:411f4505c8a2beb209d54060d7e4a887, niiri:30470d6217b4a75fdd554906028c6670, -, -, -)
+    entity(niiri:8fb2c69443ae1c39858b37ffc89e3b1a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0068" %% xsd:string,
+        prov:location = 'niiri:70474983d603f7935620a9ebd96f0f94',
+        prov:value = "1.11546647548676" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.10747127106409" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0175383747043093" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:70474983d603f7935620a9ebd96f0f94,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0068" %% xsd:string,
+        nidm_coordinateVector: = "[30,-18,16]" %% xsd:string])
+    wasDerivedFrom(niiri:8fb2c69443ae1c39858b37ffc89e3b1a, niiri:62c58cbe35737a64415ff840b7810e7d, -, -, -)
+    entity(niiri:22b280391bbb882a2a96e664a5ba3c29,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0069" %% xsd:string,
+        prov:location = 'niiri:1a565db1a9411cc339a617addf6cb2b3',
+        prov:value = "1.11363661289215" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.10511176477938" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0176407901931581" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:1a565db1a9411cc339a617addf6cb2b3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0069" %% xsd:string,
+        nidm_coordinateVector: = "[16,2,56]" %% xsd:string])
+    wasDerivedFrom(niiri:22b280391bbb882a2a96e664a5ba3c29, niiri:ec26c7d95e0c041f81b882cd245b0915, -, -, -)
+    entity(niiri:dfa59695fa3a75f5938b98bd6d614080,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0070" %% xsd:string,
+        prov:location = 'niiri:0fdedeb914d8a7a9aa38eebe69a60433',
+        prov:value = "1.10444390773773" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.09326187305734" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0181628920812176" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:0fdedeb914d8a7a9aa38eebe69a60433,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0070" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-52,14]" %% xsd:string])
+    wasDerivedFrom(niiri:dfa59695fa3a75f5938b98bd6d614080, niiri:6750b72bbafd12ba75c6c383539599c6, -, -, -)
+    entity(niiri:95ed835f52649487e78cce778a0a0b58,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0071" %% xsd:string,
+        prov:location = 'niiri:0e6389f3c537bf47d48480692de843a2',
+        prov:value = "1.01987111568451" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.98454402904349" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0235976124289208" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:0e6389f3c537bf47d48480692de843a2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0071" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-60,18]" %% xsd:string])
+    wasDerivedFrom(niiri:95ed835f52649487e78cce778a0a0b58, niiri:6750b72bbafd12ba75c6c383539599c6, -, -, -)
+    entity(niiri:142a7d0d29db608b63eb9837dffcce93,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0072" %% xsd:string,
+        prov:location = 'niiri:ce0896936b4f6f9d75172c347b6d85ae',
+        prov:value = "0.951668322086334" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.89731313030669" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0288933115272303" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ce0896936b4f6f9d75172c347b6d85ae,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0072" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-50,20]" %% xsd:string])
+    wasDerivedFrom(niiri:142a7d0d29db608b63eb9837dffcce93, niiri:6750b72bbafd12ba75c6c383539599c6, -, -, -)
+    entity(niiri:49f19b782f800a88c614d1eb19240c3f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0073" %% xsd:string,
+        prov:location = 'niiri:b0ec65390cf89796648ae2492af92382',
+        prov:value = "1.10060369968414" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.08831343102831" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0183847853440164" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:b0ec65390cf89796648ae2492af92382,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0073" %% xsd:string,
+        nidm_coordinateVector: = "[10,50,18]" %% xsd:string])
+    wasDerivedFrom(niiri:49f19b782f800a88c614d1eb19240c3f, niiri:ccbc770b946f9dfd1beecfa8843cb3fd, -, -, -)
+    entity(niiri:bd9ec3b420daeb84caf491e82d75c544,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0074" %% xsd:string,
+        prov:location = 'niiri:b599d290461736cc005eec1c5e81ed4c',
+        prov:value = "1.09576165676117" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.08207556282094" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0186677841332979" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:b599d290461736cc005eec1c5e81ed4c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0074" %% xsd:string,
+        nidm_coordinateVector: = "[-46,6,34]" %% xsd:string])
+    wasDerivedFrom(niiri:bd9ec3b420daeb84caf491e82d75c544, niiri:daf3e2ea8bf3273801d2e921f611a23f, -, -, -)
+    entity(niiri:d2067075554add565f286f8aa6960f34,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0075" %% xsd:string,
+        prov:location = 'niiri:5a8493408aba2205a6a5eccb4d185561',
+        prov:value = "1.09575474262238" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.08206665675352" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0186681908185171" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:5a8493408aba2205a6a5eccb4d185561,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0075" %% xsd:string,
+        nidm_coordinateVector: = "[28,-8,70]" %% xsd:string])
+    wasDerivedFrom(niiri:d2067075554add565f286f8aa6960f34, niiri:3df484ba108f4b88e1a4f123023bad18, -, -, -)
+    entity(niiri:35a385cc559c54821f03c31abe4e3a40,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0076" %% xsd:string,
+        prov:location = 'niiri:9c0fa7da9a830b1787be277dabdda98a',
+        prov:value = "1.07974576950073" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.06145507795256" %% xsd:float,
+        nidm_pValueUncorrected: = "0.019629822462089" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:9c0fa7da9a830b1787be277dabdda98a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0076" %% xsd:string,
+        nidm_coordinateVector: = "[-58,18,30]" %% xsd:string])
+    wasDerivedFrom(niiri:35a385cc559c54821f03c31abe4e3a40, niiri:0b63cbadf7d3234250fdc4f399321ae5, -, -, -)
+    entity(niiri:cc689c4588c375b1d453ed77ddd6fb6d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0077" %% xsd:string,
+        prov:location = 'niiri:753bdbe5b8284958a521269d13a1e404',
+        prov:value = "1.07930290699005" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.06088516484109" %% xsd:float,
+        nidm_pValueUncorrected: = "0.019656998463677" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:753bdbe5b8284958a521269d13a1e404,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0077" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-66,24]" %% xsd:string])
+    wasDerivedFrom(niiri:cc689c4588c375b1d453ed77ddd6fb6d, niiri:16c6b9ef292ea8d86c2980e2bfee9806, -, -, -)
+    entity(niiri:d1dbb47690cc5b2c83785482d78f16a7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0078" %% xsd:string,
+        prov:location = 'niiri:bf94253209f4ce76ed67120ac09947a0',
+        prov:value = "1.07559859752655" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.05611872869022" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0198855367075194" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:bf94253209f4ce76ed67120ac09947a0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0078" %% xsd:string,
+        nidm_coordinateVector: = "[34,34,-20]" %% xsd:string])
+    wasDerivedFrom(niiri:d1dbb47690cc5b2c83785482d78f16a7, niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239, -, -, -)
+    entity(niiri:2122013d54fe0ea832506bdf2d8540de,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0079" %% xsd:string,
+        prov:location = 'niiri:c574ef3b9be61ebed55b8533b9f46810',
+        prov:value = "1.07552266120911" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.05602103030259" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0198902445740951" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:c574ef3b9be61ebed55b8533b9f46810,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0079" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-10,4]" %% xsd:string])
+    wasDerivedFrom(niiri:2122013d54fe0ea832506bdf2d8540de, niiri:fb45985c130da20eafb7b2bc740e6b34, -, -, -)
+    entity(niiri:0d7fd935b6f12b8a45e5998c9e7df404,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0080" %% xsd:string,
+        prov:location = 'niiri:cff65d718e4f4c00b6a73fca81e2a08a',
+        prov:value = "1.06592130661011" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.04367166566034" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0204929970846689" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:cff65d718e4f4c00b6a73fca81e2a08a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0080" %% xsd:string,
+        nidm_coordinateVector: = "[8,-70,-18]" %% xsd:string])
+    wasDerivedFrom(niiri:0d7fd935b6f12b8a45e5998c9e7df404, niiri:65722b667917e9f42cf82ee2175b666b, -, -, -)
+    entity(niiri:9f539949d98077facdaf736080419084,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0081" %% xsd:string,
+        prov:location = 'niiri:245a5e3a98a4a35d29a45725ace42bd7',
+        prov:value = "1.05881226062775" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.03453256202328" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0209489644915043" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:245a5e3a98a4a35d29a45725ace42bd7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0081" %% xsd:string,
+        nidm_coordinateVector: = "[18,-56,74]" %% xsd:string])
+    wasDerivedFrom(niiri:9f539949d98077facdaf736080419084, niiri:59675618f95ad14de633584e8aa5881a, -, -, -)
+    entity(niiri:fb1dc826dd07c70437b4e3753dad9238,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0082" %% xsd:string,
+        prov:location = 'niiri:8d1ef8a5bb276ca7bcbedc1eb36d2523',
+        prov:value = "1.05682730674744" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.03198149751153" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0210777645475412" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:8d1ef8a5bb276ca7bcbedc1eb36d2523,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0082" %% xsd:string,
+        nidm_coordinateVector: = "[28,-2,6]" %% xsd:string])
+    wasDerivedFrom(niiri:fb1dc826dd07c70437b4e3753dad9238, niiri:2efe263e1c4f04d8ddb54023002360d9, -, -, -)
+    entity(niiri:b318391d5530313f8dbf1afdf06198b0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0083" %% xsd:string,
+        prov:location = 'niiri:f705d3b5969c62171b8d06eb1edb92c5',
+        prov:value = "1.05488443374634" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.02948481888272" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0212044668522343" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:f705d3b5969c62171b8d06eb1edb92c5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0083" %% xsd:string,
+        nidm_coordinateVector: = "[12,-58,-26]" %% xsd:string])
+    wasDerivedFrom(niiri:b318391d5530313f8dbf1afdf06198b0, niiri:fa0929f452cd3f13857c087a02f6da1f, -, -, -)
+    entity(niiri:654841e54cd036eaea7a9254bc97bbae,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0084" %% xsd:string,
+        prov:location = 'niiri:025393763cebc3e6ed872ebae1ed7c39',
+        prov:value = "1.05219066143036" %% xsd:float,
+        nidm_equivalentZStatistic: = "2.02602370012315" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0213811780074668" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:025393763cebc3e6ed872ebae1ed7c39,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0084" %% xsd:string,
+        nidm_coordinateVector: = "[46,-60,-36]" %% xsd:string])
+    wasDerivedFrom(niiri:654841e54cd036eaea7a9254bc97bbae, niiri:4c6401bfd1d939fec8234ff093a37d0d, -, -, -)
+    entity(niiri:4a63aa7cb3283e351b1f1db27351b99b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0085" %% xsd:string,
+        prov:location = 'niiri:c9a40f2012163b6c974d796fd3afd59f',
+        prov:value = "1.02921843528748" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.9965316371229" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0229380428256576" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:c9a40f2012163b6c974d796fd3afd59f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0085" %% xsd:string,
+        nidm_coordinateVector: = "[56,10,22]" %% xsd:string])
+    wasDerivedFrom(niiri:4a63aa7cb3283e351b1f1db27351b99b, niiri:b40302277817265d7af623887ab2e22c, -, -, -)
+    entity(niiri:17f16c1d68762a38e70a1c58b234a67a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0086" %% xsd:string,
+        prov:location = 'niiri:49e9405a1f52c29499902ca446cc4c53',
+        prov:value = "1.02376317977905" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.98953456023084" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0233211155368704" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:49e9405a1f52c29499902ca446cc4c53,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0086" %% xsd:string,
+        nidm_coordinateVector: = "[48,-40,48]" %% xsd:string])
+    wasDerivedFrom(niiri:17f16c1d68762a38e70a1c58b234a67a, niiri:e3091fadc7ff93e5e16f94b04590b938, -, -, -)
+    entity(niiri:23433a28a600a0042f6709ad738f2eb9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0087" %% xsd:string,
+        prov:location = 'niiri:47c5f8b5b08ae3c044df320c0c5c11c8',
+        prov:value = "1.01926970481873" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.98377299631032" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0236405758837211" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:47c5f8b5b08ae3c044df320c0c5c11c8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0087" %% xsd:string,
+        nidm_coordinateVector: = "[-6,-74,6]" %% xsd:string])
+    wasDerivedFrom(niiri:23433a28a600a0042f6709ad738f2eb9, niiri:e36b80790f32a55a90c503e6f29918bb, -, -, -)
+    entity(niiri:8799123eb9c654ee018726ee3931235b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0088" %% xsd:string,
+        prov:location = 'niiri:bd086e9bb08a9f7d410c5f66d4534fb1',
+        prov:value = "1.01770269870758" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.9817641782018" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0237528202287247" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:bd086e9bb08a9f7d410c5f66d4534fb1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0088" %% xsd:string,
+        nidm_coordinateVector: = "[20,60,-18]" %% xsd:string])
+    wasDerivedFrom(niiri:8799123eb9c654ee018726ee3931235b, niiri:6e8c86e4ccb82a0a6076eb58e14b07a6, -, -, -)
+    entity(niiri:6ba4662560eeacf1805f42b92357c2d2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0089" %% xsd:string,
+        prov:location = 'niiri:ec4549b9790223d5e2588c6af87cbf82',
+        prov:value = "0.994811475276947" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.95244337576045" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0254427937463042" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ec4549b9790223d5e2588c6af87cbf82,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0089" %% xsd:string,
+        nidm_coordinateVector: = "[6,-2,60]" %% xsd:string])
+    wasDerivedFrom(niiri:6ba4662560eeacf1805f42b92357c2d2, niiri:42f7f7a26e0c7f6124775e7e757b315c, -, -, -)
+    entity(niiri:3bda2d8d3c0edb9b3f719a8dae269a32,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0090" %% xsd:string,
+        prov:location = 'niiri:a7cb0f2475eb4b3ff5c54ba281637639',
+        prov:value = "0.99255907535553" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.94956085899435" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0256142412083677" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:a7cb0f2475eb4b3ff5c54ba281637639,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0090" %% xsd:string,
+        nidm_coordinateVector: = "[10,-42,48]" %% xsd:string])
+    wasDerivedFrom(niiri:3bda2d8d3c0edb9b3f719a8dae269a32, niiri:14ff66df771d191b9d2e8a3b0f78eda6, -, -, -)
+    entity(niiri:5cc4fd8f0181f9da651d725a89ad5e16,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0091" %% xsd:string,
+        prov:location = 'niiri:d21ede16c4ae0337bd51853a10b823a9',
+        prov:value = "0.984159111976624" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.93881506095718" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0262619307677786" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:d21ede16c4ae0337bd51853a10b823a9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0091" %% xsd:string,
+        nidm_coordinateVector: = "[44,-2,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:5cc4fd8f0181f9da651d725a89ad5e16, niiri:912e881f26994ef7af5c7f0b222db9ea, -, -, -)
+    entity(niiri:2aa6a02038d33bce0ab53247bbf23d60,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0092" %% xsd:string,
+        prov:location = 'niiri:722f766abf24b819064c7c6e42c70bea',
+        prov:value = "0.981177926063538" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.93500289088164" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0264949704670242" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:722f766abf24b819064c7c6e42c70bea,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0092" %% xsd:string,
+        nidm_coordinateVector: = "[-16,-98,-6]" %% xsd:string])
+    wasDerivedFrom(niiri:2aa6a02038d33bce0ab53247bbf23d60, niiri:9a1887d93b55705b2ff04804a00c27c3, -, -, -)
+    entity(niiri:cec30b5da4341b39910fe9e39affefb2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0093" %% xsd:string,
+        prov:location = 'niiri:332a4bdfcb6f14b5c9d4279cb47be873',
+        prov:value = "0.979127943515778" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.93238197004834" %% xsd:float,
+        nidm_pValueUncorrected: = "0.026656188878889" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:332a4bdfcb6f14b5c9d4279cb47be873,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0093" %% xsd:string,
+        nidm_coordinateVector: = "[18,-54,-16]" %% xsd:string])
+    wasDerivedFrom(niiri:cec30b5da4341b39910fe9e39affefb2, niiri:e6e6da4cb58bd6ee501d8b5597467832, -, -, -)
+    entity(niiri:19d11b85cd1659ff5c89792f9cde9c94,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0094" %% xsd:string,
+        prov:location = 'niiri:4a95f88e28460ccd588491bc3403c7b9',
+        prov:value = "0.971426725387573" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.92253941721557" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0272689593644924" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:4a95f88e28460ccd588491bc3403c7b9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0094" %% xsd:string,
+        nidm_coordinateVector: = "[4,60,38]" %% xsd:string])
+    wasDerivedFrom(niiri:19d11b85cd1659ff5c89792f9cde9c94, niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0, -, -, -)
+    entity(niiri:d0eaf64ed42fd3f849b5e11ace433bd6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0095" %% xsd:string,
+        prov:location = 'niiri:4bc70f64f7da756569d0cd25adc88adf',
+        prov:value = "0.967807769775391" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.91791614515868" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0275608223501947" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:4bc70f64f7da756569d0cd25adc88adf,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0095" %% xsd:string,
+        nidm_coordinateVector: = "[20,18,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:d0eaf64ed42fd3f849b5e11ace433bd6, niiri:949a7d86dacbe35af10b6aad92fe2224, -, -, -)
+    entity(niiri:b15e367317090ff6141a89644f5183f5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0096" %% xsd:string,
+        prov:location = 'niiri:5f5788776577f486d7c0d234240362e9',
+        prov:value = "0.959724724292755" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.90759446601654" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0282218254783678" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:5f5788776577f486d7c0d234240362e9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0096" %% xsd:string,
+        nidm_coordinateVector: = "[30,-32,10]" %% xsd:string])
+    wasDerivedFrom(niiri:b15e367317090ff6141a89644f5183f5, niiri:6cc27bdc40320dac88fe94690c9a2006, -, -, -)
+    entity(niiri:816a2af39c014a3eff563b63568227ba,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0097" %% xsd:string,
+        prov:location = 'niiri:49d25efc3a1a6a15fd15ecbfc808987c',
+        prov:value = "0.957907795906067" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.90527520238565" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0283721535699227" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:49d25efc3a1a6a15fd15ecbfc808987c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0097" %% xsd:string,
+        nidm_coordinateVector: = "[10,12,-10]" %% xsd:string])
+    wasDerivedFrom(niiri:816a2af39c014a3eff563b63568227ba, niiri:c04d4059d5535de349435e25559a51cf, -, -, -)
+    entity(niiri:35f059b4066985dec95a60afb4757fa5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0098" %% xsd:string,
+        prov:location = 'niiri:ae652a26b3559a00177ccb1d38ddf2ea',
+        prov:value = "0.95493882894516" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.90148608420821" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0286191867597474" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ae652a26b3559a00177ccb1d38ddf2ea,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0098" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-94,-10]" %% xsd:string])
+    wasDerivedFrom(niiri:35f059b4066985dec95a60afb4757fa5, niiri:4b22fd081d5be6319a728e5343897301, -, -, -)
+    entity(niiri:f01e638e0603ba7659f5763a2d8bc4dd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0099" %% xsd:string,
+        prov:location = 'niiri:7f5fa73a008f806d34e4133d4c182481',
+        prov:value = "0.950750410556793" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.89614212461773" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0289706268368529" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:7f5fa73a008f806d34e4133d4c182481,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0099" %% xsd:string,
+        nidm_coordinateVector: = "[-50,-18,0]" %% xsd:string])
+    wasDerivedFrom(niiri:f01e638e0603ba7659f5763a2d8bc4dd, niiri:f0f729dae8a39ee9247f706bc80f8df0, -, -, -)
+    entity(niiri:f28c4268c860430233ff3485efbc9bb1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0100" %% xsd:string,
+        prov:location = 'niiri:497cb86fef9441e29d59581837fa7a72',
+        prov:value = "0.949834227561951" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.89497340726092" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0290479624174936" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:497cb86fef9441e29d59581837fa7a72,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0100" %% xsd:string,
+        nidm_coordinateVector: = "[42,36,18]" %% xsd:string])
+    wasDerivedFrom(niiri:f28c4268c860430233ff3485efbc9bb1, niiri:cd47d3687de0d428289d5ee8d941860d, -, -, -)
+    entity(niiri:e78b40e65bb076e872f92f8886d6fb55,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0101" %% xsd:string,
+        prov:location = 'niiri:e7a5dbf5431a99354087860b2a10d16c',
+        prov:value = "0.949459254741669" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.89449510188639" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0290796619499293" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:e7a5dbf5431a99354087860b2a10d16c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0101" %% xsd:string,
+        nidm_coordinateVector: = "[46,-78,16]" %% xsd:string])
+    wasDerivedFrom(niiri:e78b40e65bb076e872f92f8886d6fb55, niiri:20959c12c3afc9ceb8477f395c0f1d11, -, -, -)
+    entity(niiri:574b80e813133039f7edba5d74c437a7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0102" %% xsd:string,
+        prov:location = 'niiri:ec5e4ec4f22a9fe5061299186eb1a7df',
+        prov:value = "0.942987263202667" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.88624180999136" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0296311883673402" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ec5e4ec4f22a9fe5061299186eb1a7df,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0102" %% xsd:string,
+        nidm_coordinateVector: = "[-52,40,8]" %% xsd:string])
+    wasDerivedFrom(niiri:574b80e813133039f7edba5d74c437a7, niiri:4eb3e8fe236fda4e725ee89c277cccc8, -, -, -)
+    entity(niiri:73e1b25dd37be5347183ed76eca13450,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0103" %% xsd:string,
+        prov:location = 'niiri:7d6edf93aed55973698b99ba16ef1865',
+        prov:value = "0.937418699264526" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.87914396799602" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0301124189915838" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:7d6edf93aed55973698b99ba16ef1865,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0103" %% xsd:string,
+        nidm_coordinateVector: = "[-12,42,48]" %% xsd:string])
+    wasDerivedFrom(niiri:73e1b25dd37be5347183ed76eca13450, niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca, -, -, -)
+    entity(niiri:eb93d84a711109bd9b54c6b018d686d3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0104" %% xsd:string,
+        prov:location = 'niiri:65fa8002172898322aa4954394e16e2d',
+        prov:value = "0.933299362659454" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.87389537802186" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0304724233227471" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:65fa8002172898322aa4954394e16e2d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0104" %% xsd:string,
+        nidm_coordinateVector: = "[44,40,-20]" %% xsd:string])
+    wasDerivedFrom(niiri:eb93d84a711109bd9b54c6b018d686d3, niiri:4fad08e49bad24baddc3d418f97db0ce, -, -, -)
+    entity(niiri:14289e9dd02f6ca24827f1eb68744a10,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0105" %% xsd:string,
+        prov:location = 'niiri:b49fe1898121cadf26b62d7cef891fd4',
+        prov:value = "0.931596636772156" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.87172638333963" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0306222337565211" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:b49fe1898121cadf26b62d7cef891fd4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0105" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-74,-42]" %% xsd:string])
+    wasDerivedFrom(niiri:14289e9dd02f6ca24827f1eb68744a10, niiri:d9eee0810d67b936a31fa3c66d2e8721, -, -, -)
+    entity(niiri:ff6121b7a9f9dbe98a1c2aa743d5f4e8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0106" %% xsd:string,
+        prov:location = 'niiri:45e6af0f0dc689c25f2e728abf47ad38',
+        prov:value = "0.921256303787231" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.85856093332641" %% xsd:float,
+        nidm_pValueUncorrected: = "0.031544699452275" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:45e6af0f0dc689c25f2e728abf47ad38,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0106" %% xsd:string,
+        nidm_coordinateVector: = "[-10,-26,78]" %% xsd:string])
+    wasDerivedFrom(niiri:ff6121b7a9f9dbe98a1c2aa743d5f4e8, niiri:c8715267e94716796c464182b4ba6959, -, -, -)
+    entity(niiri:e90e1fca92a0e22c713f9682392e7f12,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0107" %% xsd:string,
+        prov:location = 'niiri:fbbb756202b6d0be6eafa6dc866cd8c3',
+        prov:value = "0.913095474243164" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.84817837718658" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0322882711892066" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:fbbb756202b6d0be6eafa6dc866cd8c3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0107" %% xsd:string,
+        nidm_coordinateVector: = "[-22,-34,-42]" %% xsd:string])
+    wasDerivedFrom(niiri:e90e1fca92a0e22c713f9682392e7f12, niiri:8f90bd7cc0deb45b7b7bd4b560274456, -, -, -)
+    entity(niiri:b40b3acb742819cbaef72868cf6ef19a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0108" %% xsd:string,
+        prov:location = 'niiri:0c0e1df808ce80ff1bf83deb70997dda',
+        prov:value = "0.910208523273468" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.84450717202411" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0325546307872665" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:0c0e1df808ce80ff1bf83deb70997dda,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0108" %% xsd:string,
+        nidm_coordinateVector: = "[-34,-52,40]" %% xsd:string])
+    wasDerivedFrom(niiri:b40b3acb742819cbaef72868cf6ef19a, niiri:38f5a60345c88d7c9e0484d8735d5ffe, -, -, -)
+    entity(niiri:25eb200bd03f426290a68a7c2b8e19fe,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0109" %% xsd:string,
+        prov:location = 'niiri:711f57ca8088fe4976d46723159bf11a',
+        prov:value = "0.909155905246735" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.84316882767473" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0326521823346975" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:711f57ca8088fe4976d46723159bf11a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0109" %% xsd:string,
+        nidm_coordinateVector: = "[12,-70,-24]" %% xsd:string])
+    wasDerivedFrom(niiri:25eb200bd03f426290a68a7c2b8e19fe, niiri:e6b43073ea58d734c57cff5767e3921f, -, -, -)
+    entity(niiri:f22a9c0971a349a072973dd922cf0da5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0110" %% xsd:string,
+        prov:location = 'niiri:06bc6317f5dd0e19d7b2145cfc317c31',
+        prov:value = "0.907121956348419" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.84058311467862" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0328413370266359" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:06bc6317f5dd0e19d7b2145cfc317c31,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0110" %% xsd:string,
+        nidm_coordinateVector: = "[56,-36,52]" %% xsd:string])
+    wasDerivedFrom(niiri:f22a9c0971a349a072973dd922cf0da5, niiri:1cdb6dbe1bc79e13d52d0d3c171bab06, -, -, -)
+    entity(niiri:922af964cb0b1e93f68e8fa36f07f1ce,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0111" %% xsd:string,
+        prov:location = 'niiri:bf0370f8604a56c53402a8729aefae6b',
+        prov:value = "0.904614567756653" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.83739614411337" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0330757178223472" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:bf0370f8604a56c53402a8729aefae6b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0111" %% xsd:string,
+        nidm_coordinateVector: = "[36,-54,16]" %% xsd:string])
+    wasDerivedFrom(niiri:922af964cb0b1e93f68e8fa36f07f1ce, niiri:ee19df6f4d0113ba7e7f064a4048e753, -, -, -)
+    entity(niiri:3ba3e2d5a8b08d5f3408511de2fcea57,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0112" %% xsd:string,
+        prov:location = 'niiri:24965870248323c4385441c6aa85db8e',
+        prov:value = "0.902757167816162" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.83503576989372" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0332501948262349" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:24965870248323c4385441c6aa85db8e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0112" %% xsd:string,
+        nidm_coordinateVector: = "[14,50,12]" %% xsd:string])
+    wasDerivedFrom(niiri:3ba3e2d5a8b08d5f3408511de2fcea57, niiri:71af61a5c3e3beaf82f85e9971911d0f, -, -, -)
+    entity(niiri:c2e1702c643d5c90a4a81f48e223bd8e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0113" %% xsd:string,
+        prov:location = 'niiri:500217872b9641815f5c9ecf02da9de8',
+        prov:value = "0.901206791400909" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.83306584752486" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0333963896408318" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:500217872b9641815f5c9ecf02da9de8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0113" %% xsd:string,
+        nidm_coordinateVector: = "[-10,-70,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:c2e1702c643d5c90a4a81f48e223bd8e, niiri:46c8b3f4803e6bb0b2862d8598ece061, -, -, -)
+    entity(niiri:9554f50419ea4f396d53059910e8f01c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0114" %% xsd:string,
+        prov:location = 'niiri:ebfb05b2fc04e2d96ab9a666523e58b8',
+        prov:value = "0.797126054763794" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.70146355236453" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0444279881500879" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:ebfb05b2fc04e2d96ab9a666523e58b8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0114" %% xsd:string,
+        nidm_coordinateVector: = "[-16,-64,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:9554f50419ea4f396d53059910e8f01c, niiri:46c8b3f4803e6bb0b2862d8598ece061, -, -, -)
+    entity(niiri:7b3ef4930118f8730b06d784120ed132,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0115" %% xsd:string,
+        prov:location = 'niiri:1c34ff628baa6e5b4cebfc783d6f6235',
+        prov:value = "0.899936437606812" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.83145192034408" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0335165588882574" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:1c34ff628baa6e5b4cebfc783d6f6235,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0115" %% xsd:string,
+        nidm_coordinateVector: = "[10,-18,-14]" %% xsd:string])
+    wasDerivedFrom(niiri:7b3ef4930118f8730b06d784120ed132, niiri:5e385b701ab7f21285e4ab5006f3b0cc, -, -, -)
+    entity(niiri:2b60d3a424b67aec66f9f99b0fccbb0d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0116" %% xsd:string,
+        prov:location = 'niiri:65f8612f3ec48ab25895d29bc35e3436',
+        prov:value = "0.895962595939636" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.8264044782252" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0338946789087741" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:65f8612f3ec48ab25895d29bc35e3436,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0116" %% xsd:string,
+        nidm_coordinateVector: = "[-42,-50,-42]" %% xsd:string])
+    wasDerivedFrom(niiri:2b60d3a424b67aec66f9f99b0fccbb0d, niiri:9b4e4e9b57eb3e981b1ba74aae8a7114, -, -, -)
+    entity(niiri:1b85cec52ecc08fb6123be4911d70832,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0117" %% xsd:string,
+        prov:location = 'niiri:87e9ae97ab2460fd67bf107c00b14f4d',
+        prov:value = "0.893008887767792" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.8226539056953" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0341779128567976" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:87e9ae97ab2460fd67bf107c00b14f4d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0117" %% xsd:string,
+        nidm_coordinateVector: = "[-60,-32,46]" %% xsd:string])
+    wasDerivedFrom(niiri:1b85cec52ecc08fb6123be4911d70832, niiri:6d27ace5181c44103420a9d6058ab0d2, -, -, -)
+    entity(niiri:1d5890d8c4a830c8c8f1f464ee06b062,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0118" %% xsd:string,
+        prov:location = 'niiri:23b41b3bc0b16ebee53dd102abdb11d4',
+        prov:value = "0.888202428817749" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.81655281460242" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0346428070130568" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:23b41b3bc0b16ebee53dd102abdb11d4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0118" %% xsd:string,
+        nidm_coordinateVector: = "[56,-42,24]" %% xsd:string])
+    wasDerivedFrom(niiri:1d5890d8c4a830c8c8f1f464ee06b062, niiri:315d7b893c25221ef60daf1e43984066, -, -, -)
+    entity(niiri:2565e317445870947786d1813b8bf01d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0119" %% xsd:string,
+        prov:location = 'niiri:f0a8bf2c4bce9536b2e34cad8fad2f2e',
+        prov:value = "0.886661469936371" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.81459734206643" %% xsd:float,
+        nidm_pValueUncorrected: = "0.034792905633808" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:f0a8bf2c4bce9536b2e34cad8fad2f2e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0119" %% xsd:string,
+        nidm_coordinateVector: = "[-34,-90,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:2565e317445870947786d1813b8bf01d, niiri:34f88b9c2c80714dbe516b3f7ef092bb, -, -, -)
+    entity(niiri:e73954e3237244d481bbcd6dc6911176,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0120" %% xsd:string,
+        prov:location = 'niiri:d5854cc9ae10a2a740a4698cfa6ad761',
+        prov:value = "0.88604724407196" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.81381796560484" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0348528778271762" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:d5854cc9ae10a2a740a4698cfa6ad761,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0120" %% xsd:string,
+        nidm_coordinateVector: = "[-6,-72,-20]" %% xsd:string])
+    wasDerivedFrom(niiri:e73954e3237244d481bbcd6dc6911176, niiri:c07d0db5466c33ca960e3dd77f21333c, -, -, -)
+    entity(niiri:65e5e429d1c98e7a5de78ee327bfe175,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0121" %% xsd:string,
+        prov:location = 'niiri:9e7452e38b1a293e96d87620eeb74352',
+        prov:value = "0.884565353393555" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.81193780520014" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0349979035410456" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:9e7452e38b1a293e96d87620eeb74352,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0121" %% xsd:string,
+        nidm_coordinateVector: = "[62,-24,46]" %% xsd:string])
+    wasDerivedFrom(niiri:65e5e429d1c98e7a5de78ee327bfe175, niiri:90645273f08ccfc7b9bf300a122cc2af, -, -, -)
+    entity(niiri:5eb9c920dba7f075a9df90020235c1a9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0122" %% xsd:string,
+        prov:location = 'niiri:c6ecfbf5d1e362ea14e87e5b5f48caf5',
+        prov:value = "0.882052361965179" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.80874999534025" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0352449260120304" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:c6ecfbf5d1e362ea14e87e5b5f48caf5,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0122" %% xsd:string,
+        nidm_coordinateVector: = "[-16,34,12]" %% xsd:string])
+    wasDerivedFrom(niiri:5eb9c920dba7f075a9df90020235c1a9, niiri:c12f0aee596eddb11ad8e3268c4eb077, -, -, -)
+    entity(niiri:506119698918e1fef046ce6c81d77ebe,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0123" %% xsd:string,
+        prov:location = 'niiri:09cff2c449ad605890a3ec72e7672784',
+        prov:value = "0.878161370754242" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.8038155651472" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0356301124625072" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:09cff2c449ad605890a3ec72e7672784,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0123" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-46,76]" %% xsd:string])
+    wasDerivedFrom(niiri:506119698918e1fef046ce6c81d77ebe, niiri:b74b40058d530ee5632e1df25f911065, -, -, -)
+    entity(niiri:d2d194c38029ea3cc730205928385128,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0124" %% xsd:string,
+        prov:location = 'niiri:205f90e44f29beb0016b33f7cd420e9d',
+        prov:value = "0.875840246677399" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.80087281439492" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0358614643888427" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:205f90e44f29beb0016b33f7cd420e9d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0124" %% xsd:string,
+        nidm_coordinateVector: = "[-40,-6,34]" %% xsd:string])
+    wasDerivedFrom(niiri:d2d194c38029ea3cc730205928385128, niiri:169fad64b64219293f6c913c296583bc, -, -, -)
+    entity(niiri:743c6582a5009b8dc4efb633233a4535,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0125" %% xsd:string,
+        prov:location = 'niiri:bcb2bb47914ac9215957ebf283630732',
+        prov:value = "0.875353574752808" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.80025588397551" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0359101216845089" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:bcb2bb47914ac9215957ebf283630732,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0125" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-12,8]" %% xsd:string])
+    wasDerivedFrom(niiri:743c6582a5009b8dc4efb633233a4535, niiri:c9ba05614242ea84b1cd6a9c5ec414e4, -, -, -)
+    entity(niiri:c71bc3fe49c5d5a474cc15dc6dffb62d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0126" %% xsd:string,
+        prov:location = 'niiri:b96787f5a81fc13105fb48a6fd5ea1a0',
+        prov:value = "0.87107241153717" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.79483003828998" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0363403916799833" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:b96787f5a81fc13105fb48a6fd5ea1a0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0126" %% xsd:string,
+        nidm_coordinateVector: = "[12,-44,-14]" %% xsd:string])
+    wasDerivedFrom(niiri:c71bc3fe49c5d5a474cc15dc6dffb62d, niiri:be38e2f5b8c4edd116eb0a55684fdab2, -, -, -)
+    entity(niiri:f05e911e91200fba2a69c0dbec52ed46,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0127" %% xsd:string,
+        prov:location = 'niiri:2d89278f9562ee144eb9d57189b71a2e',
+        prov:value = "0.865115165710449" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.78728350813392" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0369458390734643" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:2d89278f9562ee144eb9d57189b71a2e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0127" %% xsd:string,
+        nidm_coordinateVector: = "[2,56,-22]" %% xsd:string])
+    wasDerivedFrom(niiri:f05e911e91200fba2a69c0dbec52ed46, niiri:9506dd108b62896cd6d8225dfc0e2e59, -, -, -)
+    entity(niiri:718114da93378acb4349a929b4418bb3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0128" %% xsd:string,
+        prov:location = 'niiri:76adcb2ddad656b23a665afa9087a907',
+        prov:value = "0.864862859249115" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.78696398255915" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0369716550398422" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:76adcb2ddad656b23a665afa9087a907,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0128" %% xsd:string,
+        nidm_coordinateVector: = "[-4,12,50]" %% xsd:string])
+    wasDerivedFrom(niiri:718114da93378acb4349a929b4418bb3, niiri:f404d574847ee68f9dc6bd08393bd9a1, -, -, -)
+    entity(niiri:03fc56b39e281ca8fbd18fd8b73b3a30,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0129" %% xsd:string,
+        prov:location = 'niiri:655c697c890d155ad920137ad8bbdd3a',
+        prov:value = "0.864512741565704" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.78652059943143" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0370075024642879" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:655c697c890d155ad920137ad8bbdd3a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0129" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-78,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:03fc56b39e281ca8fbd18fd8b73b3a30, niiri:99948f53ace7073cd3002a5850ecd361, -, -, -)
+    entity(niiri:9fe346931ab5bee817eaea36f0a39a81,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0130" %% xsd:string,
+        prov:location = 'niiri:1a069cea9796d88418c354fa8b495668',
+        prov:value = "0.860980033874512" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.7820476459466" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0373707311326116" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:1a069cea9796d88418c354fa8b495668,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0130" %% xsd:string,
+        nidm_coordinateVector: = "[12,-92,28]" %% xsd:string])
+    wasDerivedFrom(niiri:9fe346931ab5bee817eaea36f0a39a81, niiri:c8c7dba5be58cecd8f14593ccfb69e4b, -, -, -)
+    entity(niiri:1957ce020c99ce3df85faf2ec5078f77,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0131" %% xsd:string,
+        prov:location = 'niiri:98d11bc4b0ace2128270a5af1f3a8e18',
+        prov:value = "0.854242324829102" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.77352076998315" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0380712266728884" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:98d11bc4b0ace2128270a5af1f3a8e18,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0131" %% xsd:string,
+        nidm_coordinateVector: = "[44,-50,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:1957ce020c99ce3df85faf2ec5078f77, niiri:a56ce0c60fde3ec8bf474d645a951d38, -, -, -)
+    entity(niiri:66c1e77cf01db1d64aa08bccb30f1ff7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0132" %% xsd:string,
+        prov:location = 'niiri:8f8663ded34d0a964fe049c0fc2e394e',
+        prov:value = "0.853475153446198" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.77255022378467" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0381516330201062" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:8f8663ded34d0a964fe049c0fc2e394e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0132" %% xsd:string,
+        nidm_coordinateVector: = "[20,48,8]" %% xsd:string])
+    wasDerivedFrom(niiri:66c1e77cf01db1d64aa08bccb30f1ff7, niiri:82e02fb05b18c0c2a70d55d5e415aee5, -, -, -)
+    entity(niiri:b889d456c0879821e4ba3febfc7cbcc0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0133" %% xsd:string,
+        prov:location = 'niiri:7dea8bfc01118debf10f84544e468a5c',
+        prov:value = "0.848101913928986" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.76575454216401" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0387185189613873" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:7dea8bfc01118debf10f84544e468a5c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0133" %% xsd:string,
+        nidm_coordinateVector: = "[22,-10,68]" %% xsd:string])
+    wasDerivedFrom(niiri:b889d456c0879821e4ba3febfc7cbcc0, niiri:8d8ac9fae20babb989f7c367a4c4a609, -, -, -)
+    entity(niiri:97a3bf83baba0ea813905300ee82fe23,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0134" %% xsd:string,
+        prov:location = 'niiri:1b9230ed2c839aa6d24e8d83c79d5dd6',
+        prov:value = "0.845535814762115" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.76251036116829" %% xsd:float,
+        nidm_pValueUncorrected: = "0.038991553676096" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:1b9230ed2c839aa6d24e8d83c79d5dd6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0134" %% xsd:string,
+        nidm_coordinateVector: = "[10,16,62]" %% xsd:string])
+    wasDerivedFrom(niiri:97a3bf83baba0ea813905300ee82fe23, niiri:1a41584c1187bb4a87d3cc1af9993773, -, -, -)
+    entity(niiri:6fbe9b8954c9f730c642daa8c4847b4a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0135" %% xsd:string,
+        prov:location = 'niiri:d1448e12a92a065f7e0cabf0e49e1ad3',
+        prov:value = "0.845024406909943" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.76186391162221" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0390461466343727" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:d1448e12a92a065f7e0cabf0e49e1ad3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0135" %% xsd:string,
+        nidm_coordinateVector: = "[-30,-60,-28]" %% xsd:string])
+    wasDerivedFrom(niiri:6fbe9b8954c9f730c642daa8c4847b4a, niiri:43ed38ee11c52db758569877faabd695, -, -, -)
+    entity(niiri:2549eeee38c0e38dc94943a1ee2e5a72,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0136" %% xsd:string,
+        prov:location = 'niiri:c7735a5f5f10a0bd82c11474f8038741',
+        prov:value = "0.842050552368164" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.75810541868522" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0393647869826912" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:c7735a5f5f10a0bd82c11474f8038741,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0136" %% xsd:string,
+        nidm_coordinateVector: = "[20,6,44]" %% xsd:string])
+    wasDerivedFrom(niiri:2549eeee38c0e38dc94943a1ee2e5a72, niiri:ee629aca5d18e60c2724bfd2e1b3fc6b, -, -, -)
+    entity(niiri:b8cf304e8ace22648efb5f4a9981bb03,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0137" %% xsd:string,
+        prov:location = 'niiri:04749d474e0bfc0ede32e54c5c11feca',
+        prov:value = "0.837220907211304" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.75200380991823" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0398865764002145" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:04749d474e0bfc0ede32e54c5c11feca,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0137" %% xsd:string,
+        nidm_coordinateVector: = "[-4,-100,4]" %% xsd:string])
+    wasDerivedFrom(niiri:b8cf304e8ace22648efb5f4a9981bb03, niiri:8b0a58d02f59556fa0151651c6d40cc0, -, -, -)
+    entity(niiri:95679c7d59594699386070848d7545e6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0138" %% xsd:string,
+        prov:location = 'niiri:55bb0fca7b0a040e7258ea87a9d4c539',
+        prov:value = "0.83669376373291" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.75133800938073" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0399438520830083" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:55bb0fca7b0a040e7258ea87a9d4c539,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0138" %% xsd:string,
+        nidm_coordinateVector: = "[26,36,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:95679c7d59594699386070848d7545e6, niiri:eeb7c0ae3047601cda9c179c68e75d65, -, -, -)
+    entity(niiri:972eb6a3d099f2c00c6eb4bbaa70ac1b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0139" %% xsd:string,
+        prov:location = 'niiri:eeb8c0cd15d6d5c6bc694fdae27267b2',
+        prov:value = "0.835819184780121" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.75023346183694" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0400390185167846" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:eeb8c0cd15d6d5c6bc694fdae27267b2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0139" %% xsd:string,
+        nidm_coordinateVector: = "[30,-36,28]" %% xsd:string])
+    wasDerivedFrom(niiri:972eb6a3d099f2c00c6eb4bbaa70ac1b, niiri:543214dac714341af8aeaa4b70f41266, -, -, -)
+    entity(niiri:5be765fc7b710cbdb2e1d4bd46ecce60,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0140" %% xsd:string,
+        prov:location = 'niiri:60dea246d45afec73eaabe894de2e0d3',
+        prov:value = "0.835755825042725" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.75015344548878" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0400459197758659" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:60dea246d45afec73eaabe894de2e0d3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0140" %% xsd:string,
+        nidm_coordinateVector: = "[16,48,10]" %% xsd:string])
+    wasDerivedFrom(niiri:5be765fc7b710cbdb2e1d4bd46ecce60, niiri:86191fa377232381128e79c2a57a4af6, -, -, -)
+    entity(niiri:af472b64871726e5127b3c3b9738e96f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0141" %% xsd:string,
+        prov:location = 'niiri:1d48f9534397006412e809a8ce1f6646',
+        prov:value = "0.827520847320557" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73975784824994" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0409507734302569" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:1d48f9534397006412e809a8ce1f6646,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0141" %% xsd:string,
+        nidm_coordinateVector: = "[24,34,2]" %% xsd:string])
+    wasDerivedFrom(niiri:af472b64871726e5127b3c3b9738e96f, niiri:6f236184b94e16d3fb82cdd60cd19a6d, -, -, -)
+    entity(niiri:652faa5c53b766d8b0cf903c07dea641,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0142" %% xsd:string,
+        prov:location = 'niiri:74cfe0dca1f5419de1c3a172a2352d1c',
+        prov:value = "0.825629651546478" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73737166192306" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0411607949360844" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:74cfe0dca1f5419de1c3a172a2352d1c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0142" %% xsd:string,
+        nidm_coordinateVector: = "[62,-42,44]" %% xsd:string])
+    wasDerivedFrom(niiri:652faa5c53b766d8b0cf903c07dea641, niiri:9ae54c5470ad002b7ae47f7b67b248ad, -, -, -)
+    entity(niiri:d26b4b3fb5276da558b2ded4146aecb4,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0143" %% xsd:string,
+        prov:location = 'niiri:88d33018c3f9dbc230683ee47c7f469a',
+        prov:value = "0.82505863904953" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73665128497546" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0412243706597636" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:88d33018c3f9dbc230683ee47c7f469a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0143" %% xsd:string,
+        nidm_coordinateVector: = "[-46,-40,38]" %% xsd:string])
+    wasDerivedFrom(niiri:d26b4b3fb5276da558b2ded4146aecb4, niiri:0104fa6d88bd50793a3b65b47635e2c6, -, -, -)
+    entity(niiri:5cc50ec6e00023b323ad96ff05dca350,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0144" %% xsd:string,
+        prov:location = 'niiri:b5c4ea65f2f942e5c79bd59f2797e844',
+        prov:value = "0.824967801570892" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73653669020128" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0412344913749479" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:b5c4ea65f2f942e5c79bd59f2797e844,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0144" %% xsd:string,
+        nidm_coordinateVector: = "[-12,-58,-54]" %% xsd:string])
+    wasDerivedFrom(niiri:5cc50ec6e00023b323ad96ff05dca350, niiri:1ff5ea3ca56fb13894e4e43c39a861c9, -, -, -)
+    entity(niiri:9e195ae526df87602b1a5980eb32f1a3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0145" %% xsd:string,
+        prov:location = 'niiri:09ab1d1db3cfbdd5ba683bbafc0a37e6',
+        prov:value = "0.824692487716675" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73618937818564" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0412651773815628" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:09ab1d1db3cfbdd5ba683bbafc0a37e6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0145" %% xsd:string,
+        nidm_coordinateVector: = "[26,-72,14]" %% xsd:string])
+    wasDerivedFrom(niiri:9e195ae526df87602b1a5980eb32f1a3, niiri:9e02c41cd62cc06c92b5e2b56a706886, -, -, -)
+    entity(niiri:9c93b5c306aacac5c321fe8b406ca25c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0146" %% xsd:string,
+        prov:location = 'niiri:87a6b40994dc4f90c9f3ccee7834c6b4',
+        prov:value = "0.822546482086182" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73348249441809" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0415049731433188" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:87a6b40994dc4f90c9f3ccee7834c6b4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0146" %% xsd:string,
+        nidm_coordinateVector: = "[-40,-10,40]" %% xsd:string])
+    wasDerivedFrom(niiri:9c93b5c306aacac5c321fe8b406ca25c, niiri:a5e308239dff195e8c67ca5b964d553a, -, -, -)
+    entity(niiri:87be53fc52f329c31a4bbf852d8d96af,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0147" %% xsd:string,
+        prov:location = 'niiri:8a23632000b73752391bf7b0889bdc03',
+        prov:value = "0.821757972240448" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73248804772578" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0415933516734939" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:8a23632000b73752391bf7b0889bdc03,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0147" %% xsd:string,
+        nidm_coordinateVector: = "[54,-52,42]" %% xsd:string])
+    wasDerivedFrom(niiri:87be53fc52f329c31a4bbf852d8d96af, niiri:aeffc3536799596ea12e2467fc52bd65, -, -, -)
+    entity(niiri:522075dd68ebe791546a697684de5db9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0148" %% xsd:string,
+        prov:location = 'niiri:45539f048650428b2f89835fd4f28adf',
+        prov:value = "0.821538865566254" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73221173057204" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0416179355971084" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:45539f048650428b2f89835fd4f28adf,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0148" %% xsd:string,
+        nidm_coordinateVector: = "[-10,-66,8]" %% xsd:string])
+    wasDerivedFrom(niiri:522075dd68ebe791546a697684de5db9, niiri:3e987521ad9deca092879412707ea491, -, -, -)
+    entity(niiri:322277ddac27387b3f1cf8caca630a5d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0149" %% xsd:string,
+        prov:location = 'niiri:dbba800ccf20410cbd8b17d4e7e3d71f',
+        prov:value = "0.821337878704071" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73195826984928" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0416404963346692" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:dbba800ccf20410cbd8b17d4e7e3d71f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0149" %% xsd:string,
+        nidm_coordinateVector: = "[20,-16,70]" %% xsd:string])
+    wasDerivedFrom(niiri:322277ddac27387b3f1cf8caca630a5d, niiri:f54f30ee52ac26f6dae0749e096ea6c1, -, -, -)
+    entity(niiri:c61ef0dd46c1c75dde8b0ff1cd46ff2a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0150" %% xsd:string,
+        prov:location = 'niiri:e6913f677376e8f8d0cbf5768e2b2957',
+        prov:value = "0.821269989013672" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.73187265661373" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0416481190738193" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:e6913f677376e8f8d0cbf5768e2b2957,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0150" %% xsd:string,
+        nidm_coordinateVector: = "[34,-56,18]" %% xsd:string])
+    wasDerivedFrom(niiri:c61ef0dd46c1c75dde8b0ff1cd46ff2a, niiri:692bc9543cbfc2b98e06dde4c8e7603f, -, -, -)
+    entity(niiri:a80bb377de34b37212750ae3db10e20a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0151" %% xsd:string,
+        prov:location = 'niiri:0458d3c1e0559783e4029b2a4be03a14',
+        prov:value = "0.82093757390976" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.7314534684428" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0416854586174026" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:0458d3c1e0559783e4029b2a4be03a14,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0151" %% xsd:string,
+        nidm_coordinateVector: = "[58,32,22]" %% xsd:string])
+    wasDerivedFrom(niiri:a80bb377de34b37212750ae3db10e20a, niiri:be235801557e66b2190c98cd649588c0, -, -, -)
+    entity(niiri:9fc68b058dc6ee748e78bc0342d26c9f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0152" %% xsd:string,
+        prov:location = 'niiri:243d348e8bb24e528c34f0f61a042268',
+        prov:value = "0.817427694797516" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.72702824070669" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0420812958690475" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:243d348e8bb24e528c34f0f61a042268,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0152" %% xsd:string,
+        nidm_coordinateVector: = "[-28,-74,18]" %% xsd:string])
+    wasDerivedFrom(niiri:9fc68b058dc6ee748e78bc0342d26c9f, niiri:baf9fc0b69478678bb8ed7430b24c094, -, -, -)
+    entity(niiri:b25ee7d26cd1e25affee2f1c6bc4278f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0153" %% xsd:string,
+        prov:location = 'niiri:f793261af421559e7bb8429a67afd216',
+        prov:value = "0.816389560699463" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.72571967296696" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0421989285126135" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:f793261af421559e7bb8429a67afd216,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0153" %% xsd:string,
+        nidm_coordinateVector: = "[28,-30,34]" %% xsd:string])
+    wasDerivedFrom(niiri:b25ee7d26cd1e25affee2f1c6bc4278f, niiri:27343a380f46da81b03903d4cf6193dc, -, -, -)
+    entity(niiri:b9cefb671f41cdcd2b2e4c69d6b7b359,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0154" %% xsd:string,
+        prov:location = 'niiri:e532ce509b03d476f34fbe3e3016c83c',
+        prov:value = "0.810877442359924" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.71877398514755" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0428277671196435" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:e532ce509b03d476f34fbe3e3016c83c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0154" %% xsd:string,
+        nidm_coordinateVector: = "[-4,-92,4]" %% xsd:string])
+    wasDerivedFrom(niiri:b9cefb671f41cdcd2b2e4c69d6b7b359, niiri:158f1d535951e2b7d78ea10b066c15f3, -, -, -)
+    entity(niiri:2ad984f6f188e95e289d863a3dc28223,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0155" %% xsd:string,
+        prov:location = 'niiri:9a5b03d3a41f3e346f8f366b062b7b4b',
+        prov:value = "0.810260891914368" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.71799733032142" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0428985511130971" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:9a5b03d3a41f3e346f8f366b062b7b4b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0155" %% xsd:string,
+        nidm_coordinateVector: = "[-18,-22,44]" %% xsd:string])
+    wasDerivedFrom(niiri:2ad984f6f188e95e289d863a3dc28223, niiri:842d2062c93ff252780aae9939a20111, -, -, -)
+    entity(niiri:3271f178664f3539edaa018f6f207fa8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0156" %% xsd:string,
+        prov:location = 'niiri:90a5129a6c43a75a468beb3757198213',
+        prov:value = "0.809625387191772" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.71719685114941" %% xsd:float,
+        nidm_pValueUncorrected: = "0.042971605350922" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:90a5129a6c43a75a468beb3757198213,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0156" %% xsd:string,
+        nidm_coordinateVector: = "[-8,-88,-48]" %% xsd:string])
+    wasDerivedFrom(niiri:3271f178664f3539edaa018f6f207fa8, niiri:d27fbf9c8044e6b188c300c4990f6f54, -, -, -)
+    entity(niiri:e89619f00261dd896c5e6b49b91ad9fa,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0157" %% xsd:string,
+        prov:location = 'niiri:cb30d0dcf44e480e9d546d120872d8b2',
+        prov:value = "0.807083547115326" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.71399568809748" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0432647588890963" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:cb30d0dcf44e480e9d546d120872d8b2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0157" %% xsd:string,
+        nidm_coordinateVector: = "[-28,-90,-14]" %% xsd:string])
+    wasDerivedFrom(niiri:e89619f00261dd896c5e6b49b91ad9fa, niiri:2a4965b8fc709556c2aa1abb6adf5441, -, -, -)
+    entity(niiri:d514e4693dd32deec29d4b4747f44ab2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0158" %% xsd:string,
+        prov:location = 'niiri:b4bd0cc943eb4c6123bcaa4505ed1439',
+        prov:value = "0.804524898529053" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.71077421355999" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0435614007800803" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:b4bd0cc943eb4c6123bcaa4505ed1439,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0158" %% xsd:string,
+        nidm_coordinateVector: = "[54,18,14]" %% xsd:string])
+    wasDerivedFrom(niiri:d514e4693dd32deec29d4b4747f44ab2, niiri:9cc63018305b210a50122f137d979802, -, -, -)
+    entity(niiri:56f159e4b339f215b07ab529dcb6afe5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0159" %% xsd:string,
+        prov:location = 'niiri:0e2f64a7d2cf43118af0d523a1045abf',
+        prov:value = "0.801611304283142" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.70710689586196" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0439010928174099" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:0e2f64a7d2cf43118af0d523a1045abf,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0159" %% xsd:string,
+        nidm_coordinateVector: = "[38,-48,18]" %% xsd:string])
+    wasDerivedFrom(niiri:56f159e4b339f215b07ab529dcb6afe5, niiri:965ac0d53ae837b608d6841eb6671ec5, -, -, -)
+    entity(niiri:3775e9935ca298404180c033594cef47,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0160" %% xsd:string,
+        prov:location = 'niiri:974a061454302498849b51020d3bcaf0',
+        prov:value = "0.801064372062683" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.70641860205681" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0439650847967754" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:974a061454302498849b51020d3bcaf0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0160" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-70,28]" %% xsd:string])
+    wasDerivedFrom(niiri:3775e9935ca298404180c033594cef47, niiri:d20a800c34ef4ebbc2c9d064007ca5a5, -, -, -)
+    entity(niiri:67775b1fe689aac8a236bd5098ede3ac,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0161" %% xsd:string,
+        prov:location = 'niiri:2c52525c383497b335b50a9120c734ec',
+        prov:value = "0.796977043151855" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.70127611195347" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0444455757271468" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:2c52525c383497b335b50a9120c734ec,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0161" %% xsd:string,
+        nidm_coordinateVector: = "[40,-8,-32]" %% xsd:string])
+    wasDerivedFrom(niiri:67775b1fe689aac8a236bd5098ede3ac, niiri:0a26619869c6304390cf220d86997062, -, -, -)
+    entity(niiri:5338ab94ade7000ed4f4bdf7d9d76d2b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0162" %% xsd:string,
+        prov:location = 'niiri:f70d129d0d7c22e30869fb59d6e5cc46',
+        prov:value = "0.795195400714874" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.69903522990177" %% xsd:float,
+        nidm_pValueUncorrected: = "0.044656272931023" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:f70d129d0d7c22e30869fb59d6e5cc46,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0162" %% xsd:string,
+        nidm_coordinateVector: = "[10,-10,4]" %% xsd:string])
+    wasDerivedFrom(niiri:5338ab94ade7000ed4f4bdf7d9d76d2b, niiri:6a5b8fb86c67c0eb5b9c606e6b810510, -, -, -)
+    entity(niiri:47f63f9dd57bbc2ec925efae82f98e54,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0163" %% xsd:string,
+        prov:location = 'niiri:f5fa7f06451efb337a56d65fce6310d4',
+        prov:value = "0.793771862983704" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.69724506469093" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0448251692331177" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:f5fa7f06451efb337a56d65fce6310d4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0163" %% xsd:string,
+        nidm_coordinateVector: = "[36,-38,16]" %% xsd:string])
+    wasDerivedFrom(niiri:47f63f9dd57bbc2ec925efae82f98e54, niiri:99f3a2d8e7661135dd74892e7227bd72, -, -, -)
+    entity(niiri:e057cf1a39f015eb9f597ecf60c28d8d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0164" %% xsd:string,
+        prov:location = 'niiri:408e388806b9aac265fd41d04872e446',
+        prov:value = "0.791125535964966" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.69391791067376" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0451404415013222" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:408e388806b9aac265fd41d04872e446,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0164" %% xsd:string,
+        nidm_coordinateVector: = "[36,-58,-34]" %% xsd:string])
+    wasDerivedFrom(niiri:e057cf1a39f015eb9f597ecf60c28d8d, niiri:64a5de9f75df294ee267e34b2597bc84, -, -, -)
+    entity(niiri:f4707b696468bcd21beacb40c56d4112,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0165" %% xsd:string,
+        prov:location = 'niiri:8770aec72d29d54ccbc74852e6556723',
+        prov:value = "0.790164232254028" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.69270952448475" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0452553857167721" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:8770aec72d29d54ccbc74852e6556723,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0165" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-68,40]" %% xsd:string])
+    wasDerivedFrom(niiri:f4707b696468bcd21beacb40c56d4112, niiri:2c98abbba202c2ed1fa8e08549a97cb1, -, -, -)
+    entity(niiri:0855ebe4c0e33757d2de5fe5b72c3aa4,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0166" %% xsd:string,
+        prov:location = 'niiri:1304b6c03fd823e5f08127fb56383466',
+        prov:value = "0.789975047111511" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.6924717281141" %% xsd:float,
+        nidm_pValueUncorrected: = "0.045278033108256" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:1304b6c03fd823e5f08127fb56383466,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0166" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-66,-54]" %% xsd:string])
+    wasDerivedFrom(niiri:0855ebe4c0e33757d2de5fe5b72c3aa4, niiri:35bfc5987aa4a1eba01be33e4c1ee7f2, -, -, -)
+    entity(niiri:767f2a4a4176e20fbe7980bfd92d4d37,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0167" %% xsd:string,
+        prov:location = 'niiri:48c823ec7d05b841c28208a512ace325',
+        prov:value = "0.785030126571655" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.68625793462611" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0458730647233518" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:48c823ec7d05b841c28208a512ace325,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0167" %% xsd:string,
+        nidm_coordinateVector: = "[-38,-4,36]" %% xsd:string])
+    wasDerivedFrom(niiri:767f2a4a4176e20fbe7980bfd92d4d37, niiri:33395b862a603ee1373735759fed1bcb, -, -, -)
+    entity(niiri:efc75d1d378ad8d8e290d9c8d692030e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0168" %% xsd:string,
+        prov:location = 'niiri:cf847ee221aa1a3ba5ad8ab6ceda969c',
+        prov:value = "0.783349096775055" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.68414631143602" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0460766980434556" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:cf847ee221aa1a3ba5ad8ab6ceda969c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0168" %% xsd:string,
+        nidm_coordinateVector: = "[-50,10,-6]" %% xsd:string])
+    wasDerivedFrom(niiri:efc75d1d378ad8d8e290d9c8d692030e, niiri:635a4fc24d89b14d261b42d568e53ac8, -, -, -)
+    entity(niiri:f23899f7631f3a7071c3337dd7fc2238,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0169" %% xsd:string,
+        prov:location = 'niiri:0bb4251c6e182321ff1b00b360bea5db',
+        prov:value = "0.780271351337433" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.68028121266012" %% xsd:float,
+        nidm_pValueUncorrected: = "0.046451307319556" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:0bb4251c6e182321ff1b00b360bea5db,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0169" %% xsd:string,
+        nidm_coordinateVector: = "[-18,-22,34]" %% xsd:string])
+    wasDerivedFrom(niiri:f23899f7631f3a7071c3337dd7fc2238, niiri:55b4eeddb69bb03436464cf696dd593b, -, -, -)
+    entity(niiri:e0c716598553c866132acb9e00a99269,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0170" %% xsd:string,
+        prov:location = 'niiri:bd016d0a131f74cd47766a37849f8af4',
+        prov:value = "0.778013467788696" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.67744654581037" %% xsd:float,
+        nidm_pValueUncorrected: = "0.046727596979824" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:bd016d0a131f74cd47766a37849f8af4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0170" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-22,38]" %% xsd:string])
+    wasDerivedFrom(niiri:e0c716598553c866132acb9e00a99269, niiri:493898a476d4ce4bf533682e007422c5, -, -, -)
+    entity(niiri:23993fd78665c8c8cea4bbea816aa847,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0171" %% xsd:string,
+        prov:location = 'niiri:34c3f1555e908f480a1cd6c4105ace9b',
+        prov:value = "0.775993704795837" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.67491142741087" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0469758055929785" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:34c3f1555e908f480a1cd6c4105ace9b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0171" %% xsd:string,
+        nidm_coordinateVector: = "[12,-92,2]" %% xsd:string])
+    wasDerivedFrom(niiri:23993fd78665c8c8cea4bbea816aa847, niiri:b841eb2677ab2ad59ce73103265cdee0, -, -, -)
+    entity(niiri:2f0c7a7defde925468925744ec810146,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0172" %% xsd:string,
+        prov:location = 'niiri:da9b38041402957b6d2f062656d107ff',
+        prov:value = "0.774858772754669" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.67348715940063" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0471157161396256" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:da9b38041402957b6d2f062656d107ff,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0172" %% xsd:string,
+        nidm_coordinateVector: = "[52,-44,58]" %% xsd:string])
+    wasDerivedFrom(niiri:2f0c7a7defde925468925744ec810146, niiri:4c7ec0be40515b0eae812fe9befe02f1, -, -, -)
+    entity(niiri:f05db93a343d1865fd10001c92a30d32,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0173" %% xsd:string,
+        prov:location = 'niiri:5a77aafacf3c36dfd821f2078711b553',
+        prov:value = "0.766564428806305" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.66308376386524" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0481478347201374" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:5a77aafacf3c36dfd821f2078711b553,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0173" %% xsd:string,
+        nidm_coordinateVector: = "[46,30,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:f05db93a343d1865fd10001c92a30d32, niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22, -, -, -)
+    entity(niiri:8185514955cc636d4b50aa7fd9985960,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0174" %% xsd:string,
+        prov:location = 'niiri:59906cc8f0c4f1ad9a16e5f64ecc97e9',
+        prov:value = "0.766485750675201" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.66298512623431" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0481577064245639" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:59906cc8f0c4f1ad9a16e5f64ecc97e9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0174" %% xsd:string,
+        nidm_coordinateVector: = "[20,-72,-22]" %% xsd:string])
+    wasDerivedFrom(niiri:8185514955cc636d4b50aa7fd9985960, niiri:9d494c09341573a6df3c044f6f353a5a, -, -, -)
+    entity(niiri:f82c4e460ed68891672a882b6ca47ce7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0175" %% xsd:string,
+        prov:location = 'niiri:6b08822f4f84a3704fb33481c32938e7',
+        prov:value = "0.764753878116608" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.66081412523685" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0483753916847881" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:6b08822f4f84a3704fb33481c32938e7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0175" %% xsd:string,
+        nidm_coordinateVector: = "[30,-32,14]" %% xsd:string])
+    wasDerivedFrom(niiri:f82c4e460ed68891672a882b6ca47ce7, niiri:630ac6074dee24b42295002659ee6cd4, -, -, -)
+    entity(niiri:085070c6b1c81a70c7d9316dc333c5af,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0176" %% xsd:string,
+        prov:location = 'niiri:f2d70aea1159517722dc1f0e96049f7f',
+        prov:value = "0.764399468898773" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.66036990560998" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0484200302267611" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:f2d70aea1159517722dc1f0e96049f7f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0176" %% xsd:string,
+        nidm_coordinateVector: = "[-8,-2,66]" %% xsd:string])
+    wasDerivedFrom(niiri:085070c6b1c81a70c7d9316dc333c5af, niiri:97f9982dca21f34e7ea0fcb977fcf50b, -, -, -)
+    entity(niiri:35df629079347c6c083f74c21c155794,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0177" %% xsd:string,
+        prov:location = 'niiri:6c5f4e78e250aba08a965b5ca9cce21d',
+        prov:value = "0.763978481292725" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.65984225927592" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0484730949107541" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:6c5f4e78e250aba08a965b5ca9cce21d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0177" %% xsd:string,
+        nidm_coordinateVector: = "[-20,10,-22]" %% xsd:string])
+    wasDerivedFrom(niiri:35df629079347c6c083f74c21c155794, niiri:b7588b8a823a7341bbdb4d3e8686e040, -, -, -)
+    entity(niiri:81ebc55180aab5f90eb8e98ffc27a319,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0178" %% xsd:string,
+        prov:location = 'niiri:82ba696cda1e7d2d87bd5e1ac789e9b4',
+        prov:value = "0.763044834136963" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.65867215934383" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0485909362055301" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:82ba696cda1e7d2d87bd5e1ac789e9b4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0178" %% xsd:string,
+        nidm_coordinateVector: = "[-62,2,14]" %% xsd:string])
+    wasDerivedFrom(niiri:81ebc55180aab5f90eb8e98ffc27a319, niiri:31b704c584e2aae3b394c52754216fae, -, -, -)
+    entity(niiri:21c18d8c769fb0c198241386ba803d0e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0179" %% xsd:string,
+        prov:location = 'niiri:38c7639cf73f14cd5fd84daa5a16b606',
+        prov:value = "0.762995421886444" %% xsd:float,
+        nidm_equivalentZStatistic: = "1.65861023655314" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0485971788535396" %% xsd:float,
+        nidm_pValueFWER: = "1" %% xsd:float,
+        nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
+    entity(niiri:38c7639cf73f14cd5fd84daa5a16b606,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0179" %% xsd:string,
+        nidm_coordinateVector: = "[-12,-28,80]" %% xsd:string])
+    wasDerivedFrom(niiri:21c18d8c769fb0c198241386ba803d0e, niiri:2eff95031f5301f6a29990e69708dce1, -, -, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_partial_conjunction/nidm.provn
+++ b/spmexport/ex_spm_partial_conjunction/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:040b09b9b063245a4737fca3df5cdd7d,
+  entity(niiri:243ddea5e5dff3c37c34dba282896eea,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:81951937f6ae09441f641771cfea9128,
+  agent(niiri:25efcb2fdf89f72335565444747a8325,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:cc2545342f68b7d4d79cd122b1fcabbb,
+  activity(niiri:bc9474858aa89d5580813e5a520e15a8,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:cc2545342f68b7d4d79cd122b1fcabbb, niiri:81951937f6ae09441f641771cfea9128, -)
-  wasGeneratedBy(niiri:040b09b9b063245a4737fca3df5cdd7d, niiri:cc2545342f68b7d4d79cd122b1fcabbb, 2016-01-11T10:11:58)
-  bundle niiri:040b09b9b063245a4737fca3df5cdd7d
+  wasAssociatedWith(niiri:bc9474858aa89d5580813e5a520e15a8, niiri:25efcb2fdf89f72335565444747a8325, -)
+  wasGeneratedBy(niiri:243ddea5e5dff3c37c34dba282896eea, niiri:bc9474858aa89d5580813e5a520e15a8, 2016-01-11T10:34:17)
+  bundle niiri:243ddea5e5dff3c37c34dba282896eea
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -126,12 +126,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:ca46a12c6a6d80a84b02ee07a74d055c,
+    agent(niiri:1d7e73278ccee95e211689d9de8f4d4a,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:4ddf2148145597f7f7c9369cb269b13f,
+    entity(niiri:a56db6367efd1f7176e69f24b028de94,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -140,189 +140,189 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:1c3284ad8fc17300f53a85a850aa14b6,
+    entity(niiri:03e7d0232ea5517ed14b6e2311b82699,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:1a568ef0c2c5aa1a886880bbdf2d08f8,
+    entity(niiri:df0cfe4ba2647dd9f372f5d3b73c6885,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:87e000d813ecf48e9045ac10927bd76c,
+    entity(niiri:1388e1cf368a92acbd46e47523c2061a,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:29dae04876f55e477f52f60d27b0ce4d',
+        dc:description = 'niiri:d17dbd59c5c8179a99d73392215c0c41',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:1a568ef0c2c5aa1a886880bbdf2d08f8',
+        nidm_hasDriftModel: = 'niiri:df0cfe4ba2647dd9f372f5d3b73c6885',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:29dae04876f55e477f52f60d27b0ce4d,
+    entity(niiri:d17dbd59c5c8179a99d73392215c0c41,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:07c328d2e12fa56c0f2874230dfc8be8,
+    entity(niiri:05be31167ef4404a70e4f0e58bd930aa,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:a36c7399032b89af037fcdfdcf2d9f29,
+    activity(niiri:8d051ec65c19e120a2e66d23f309c6e9,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:a36c7399032b89af037fcdfdcf2d9f29, niiri:ca46a12c6a6d80a84b02ee07a74d055c, -)
-    used(niiri:a36c7399032b89af037fcdfdcf2d9f29, niiri:87e000d813ecf48e9045ac10927bd76c, -)
-    used(niiri:a36c7399032b89af037fcdfdcf2d9f29, niiri:1c3284ad8fc17300f53a85a850aa14b6, -)
-    used(niiri:a36c7399032b89af037fcdfdcf2d9f29, niiri:07c328d2e12fa56c0f2874230dfc8be8, -)
-    entity(niiri:297de961f206e0187be8fdda200091ee,
+    wasAssociatedWith(niiri:8d051ec65c19e120a2e66d23f309c6e9, niiri:1d7e73278ccee95e211689d9de8f4d4a, -)
+    used(niiri:8d051ec65c19e120a2e66d23f309c6e9, niiri:1388e1cf368a92acbd46e47523c2061a, -)
+    used(niiri:8d051ec65c19e120a2e66d23f309c6e9, niiri:03e7d0232ea5517ed14b6e2311b82699, -)
+    used(niiri:8d051ec65c19e120a2e66d23f309c6e9, niiri:05be31167ef4404a70e4f0e58bd930aa, -)
+    entity(niiri:d17318e0fda06cc6303389a919cffce0,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    entity(niiri:ec2656e975a6d0642c33357bfa356e4b,
+    entity(niiri:511e38d9f81db913e57cb2fda1bf7292,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
-    wasDerivedFrom(niiri:297de961f206e0187be8fdda200091ee, niiri:ec2656e975a6d0642c33357bfa356e4b, -, -, -)
-    wasGeneratedBy(niiri:297de961f206e0187be8fdda200091ee, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:a354106ee78314547a9438f2bb2dee6c,
+    wasDerivedFrom(niiri:d17318e0fda06cc6303389a919cffce0, niiri:511e38d9f81db913e57cb2fda1bf7292, -, -, -)
+    wasGeneratedBy(niiri:d17318e0fda06cc6303389a919cffce0, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:b24768aaee9add9a163a13028ada6ac2,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "108.038318634033" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
-    wasGeneratedBy(niiri:a354106ee78314547a9438f2bb2dee6c, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:38c86177a556ef8eb57c8feb5a72bbe6,
+    wasGeneratedBy(niiri:b24768aaee9add9a163a13028ada6ac2, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:fbf0025dc56929ec686d1a867cba4ed9,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
-    entity(niiri:379fb8881957a95b855265fdeb2eae08,
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
+    entity(niiri:c6f77d4608bf5adce440967ee6f38924,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f" %% xsd:string])
-    wasDerivedFrom(niiri:38c86177a556ef8eb57c8feb5a72bbe6, niiri:379fb8881957a95b855265fdeb2eae08, -, -, -)
-    wasGeneratedBy(niiri:38c86177a556ef8eb57c8feb5a72bbe6, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:0640a7b36210753d2e9b544c3f195a55,
+    wasDerivedFrom(niiri:fbf0025dc56929ec686d1a867cba4ed9, niiri:c6f77d4608bf5adce440967ee6f38924, -, -, -)
+    wasGeneratedBy(niiri:fbf0025dc56929ec686d1a867cba4ed9, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:b0bd46832f113e655723b654eb1eb6ad,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
-    entity(niiri:6b197125a990fba281a71f02c3a45aac,
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
+    entity(niiri:42e752fc06737a9878924396d3bfcce9,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
-    wasDerivedFrom(niiri:0640a7b36210753d2e9b544c3f195a55, niiri:6b197125a990fba281a71f02c3a45aac, -, -, -)
-    wasGeneratedBy(niiri:0640a7b36210753d2e9b544c3f195a55, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:2d0fff51543ffad218594440febbbc00,
+    wasDerivedFrom(niiri:b0bd46832f113e655723b654eb1eb6ad, niiri:42e752fc06737a9878924396d3bfcce9, -, -, -)
+    wasGeneratedBy(niiri:b0bd46832f113e655723b654eb1eb6ad, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:09ee1b58f1cd2a34771305a61a8d1d32,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
-    entity(niiri:2bcd6acc3147da711188ef3d9591491e,
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
+    entity(niiri:a2c15aa0c4d45f52407ac5827bbf73bb,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb" %% xsd:string])
-    wasDerivedFrom(niiri:2d0fff51543ffad218594440febbbc00, niiri:2bcd6acc3147da711188ef3d9591491e, -, -, -)
-    wasGeneratedBy(niiri:2d0fff51543ffad218594440febbbc00, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:1e3dffce54f22bc8a196481235889e5a,
+    wasDerivedFrom(niiri:09ee1b58f1cd2a34771305a61a8d1d32, niiri:a2c15aa0c4d45f52407ac5827bbf73bb, -, -, -)
+    wasGeneratedBy(niiri:09ee1b58f1cd2a34771305a61a8d1d32, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:16ce2036a3b6f15ece6fc491d108ae37,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
-    entity(niiri:59d5f854810e0cf53187fca482714676,
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
+    entity(niiri:ee716d14a7ac59b3c4521ed8cbff1e3a,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6" %% xsd:string])
-    wasDerivedFrom(niiri:1e3dffce54f22bc8a196481235889e5a, niiri:59d5f854810e0cf53187fca482714676, -, -, -)
-    wasGeneratedBy(niiri:1e3dffce54f22bc8a196481235889e5a, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:883679c50b07b857a6c67ccde5dc3273,
+    wasDerivedFrom(niiri:16ce2036a3b6f15ece6fc491d108ae37, niiri:ee716d14a7ac59b3c4521ed8cbff1e3a, -, -, -)
+    wasGeneratedBy(niiri:16ce2036a3b6f15ece6fc491d108ae37, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:c856b511969b2c541b07a88189532fa6,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
-    entity(niiri:0db23e51e95f52cb9f0539d9da712088,
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
+    entity(niiri:33afe3bb4683b8e28103d232fdf92af8,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff" %% xsd:string])
-    wasDerivedFrom(niiri:883679c50b07b857a6c67ccde5dc3273, niiri:0db23e51e95f52cb9f0539d9da712088, -, -, -)
-    wasGeneratedBy(niiri:883679c50b07b857a6c67ccde5dc3273, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:67e0052a2914e6b58321e390f9d4a9ea,
+    wasDerivedFrom(niiri:c856b511969b2c541b07a88189532fa6, niiri:33afe3bb4683b8e28103d232fdf92af8, -, -, -)
+    wasGeneratedBy(niiri:c856b511969b2c541b07a88189532fa6, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:e8f6f2e9821e3f9556f500048b8ae9b5,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 6" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f'])
-    entity(niiri:7654bad538105caaf15e55efcb04c343,
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
+    entity(niiri:8167c647e0923c3553c7c0ffc2d666d4,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0006.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
-    wasDerivedFrom(niiri:67e0052a2914e6b58321e390f9d4a9ea, niiri:7654bad538105caaf15e55efcb04c343, -, -, -)
-    wasGeneratedBy(niiri:67e0052a2914e6b58321e390f9d4a9ea, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:a79b8d0835c3bf79e9faf32502e506b4,
+    wasDerivedFrom(niiri:e8f6f2e9821e3f9556f500048b8ae9b5, niiri:8167c647e0923c3553c7c0ffc2d666d4, -, -, -)
+    wasGeneratedBy(niiri:e8f6f2e9821e3f9556f500048b8ae9b5, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:ecf064f9baf28d8f742bd2855558502d,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8" %% xsd:string])
-    entity(niiri:28c03f1f4b9973dbb638d943ac9944e6,
+    entity(niiri:2cbf5c3625b82cb3fee7b9e869188b55,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81" %% xsd:string])
-    wasDerivedFrom(niiri:a79b8d0835c3bf79e9faf32502e506b4, niiri:28c03f1f4b9973dbb638d943ac9944e6, -, -, -)
-    wasGeneratedBy(niiri:a79b8d0835c3bf79e9faf32502e506b4, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:089005ddd166a56358c0d0ec21720e18,
+    wasDerivedFrom(niiri:ecf064f9baf28d8f742bd2855558502d, niiri:2cbf5c3625b82cb3fee7b9e869188b55, -, -, -)
+    wasGeneratedBy(niiri:ecf064f9baf28d8f742bd2855558502d, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:0c0eb1d804cee8231e915a5fdfc5ab8b,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8" %% xsd:string])
-    entity(niiri:949f5e9e8329eea5ff262f3113b92d3c,
+    entity(niiri:eeee4f9f7f0c1ed7696258b61716b549,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29" %% xsd:string])
-    wasDerivedFrom(niiri:089005ddd166a56358c0d0ec21720e18, niiri:949f5e9e8329eea5ff262f3113b92d3c, -, -, -)
-    wasGeneratedBy(niiri:089005ddd166a56358c0d0ec21720e18, niiri:a36c7399032b89af037fcdfdcf2d9f29, -)
-    entity(niiri:6310b38d15cf70fcc0b18a630086f710,
+    wasDerivedFrom(niiri:0c0eb1d804cee8231e915a5fdfc5ab8b, niiri:eeee4f9f7f0c1ed7696258b61716b549, -, -, -)
+    wasGeneratedBy(niiri:0c0eb1d804cee8231e915a5fdfc5ab8b, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
+    entity(niiri:0e92041f1c22bfbe8b6d3bba28b3ce18,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         prov:label = "Contrast: mr vs plain" %% xsd:string,
         prov:value = "[1, 1, -1, -1, 0, 0]" %% xsd:string])
-    activity(niiri:470a6da8f55eec239393f9743368624c,
+    activity(niiri:4ee8aaeabfe9f5181a4281676d9a033d,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation 1"])
-    wasAssociatedWith(niiri:470a6da8f55eec239393f9743368624c, niiri:ca46a12c6a6d80a84b02ee07a74d055c, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:297de961f206e0187be8fdda200091ee, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:a79b8d0835c3bf79e9faf32502e506b4, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:87e000d813ecf48e9045ac10927bd76c, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:6310b38d15cf70fcc0b18a630086f710, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:38c86177a556ef8eb57c8feb5a72bbe6, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:0640a7b36210753d2e9b544c3f195a55, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:2d0fff51543ffad218594440febbbc00, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:1e3dffce54f22bc8a196481235889e5a, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:883679c50b07b857a6c67ccde5dc3273, -)
-    used(niiri:470a6da8f55eec239393f9743368624c, niiri:67e0052a2914e6b58321e390f9d4a9ea, -)
-    entity(niiri:7512552d6509729de4464db02c1b2b85,
+    wasAssociatedWith(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:1d7e73278ccee95e211689d9de8f4d4a, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:d17318e0fda06cc6303389a919cffce0, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:ecf064f9baf28d8f742bd2855558502d, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:1388e1cf368a92acbd46e47523c2061a, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:0e92041f1c22bfbe8b6d3bba28b3ce18, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:fbf0025dc56929ec686d1a867cba4ed9, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:b0bd46832f113e655723b654eb1eb6ad, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:09ee1b58f1cd2a34771305a61a8d1d32, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:16ce2036a3b6f15ece6fc491d108ae37, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:c856b511969b2c541b07a88189532fa6, -)
+    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:e8f6f2e9821e3f9556f500048b8ae9b5, -)
+    entity(niiri:3ccd77b3de962099cf8ce0c08029054a,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic_0001.nii.gz" %% xsd:string,
@@ -332,61 +332,61 @@ document
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "3d222abce9f360902d01cb45ffaaa3d711c699c6771f36ee61630ccc2fec2275897a15dd31b846a074e20b59337bae8b171223c15f22d8f2168a1967e85b397a" %% xsd:string])
-    entity(niiri:fb4dee4e1331d80c18561bf743daf272,
+    entity(niiri:f9a3461abe033c0b4194f4eb1324b723,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782" %% xsd:string])
-    wasDerivedFrom(niiri:7512552d6509729de4464db02c1b2b85, niiri:fb4dee4e1331d80c18561bf743daf272, -, -, -)
-    wasGeneratedBy(niiri:7512552d6509729de4464db02c1b2b85, niiri:470a6da8f55eec239393f9743368624c, -)
-    entity(niiri:b4a484110c0e0f1679fe0a5f8bdff03e,
+    wasDerivedFrom(niiri:3ccd77b3de962099cf8ce0c08029054a, niiri:f9a3461abe033c0b4194f4eb1324b723, -, -, -)
+    wasGeneratedBy(niiri:3ccd77b3de962099cf8ce0c08029054a, niiri:4ee8aaeabfe9f5181a4281676d9a033d, -)
+    entity(niiri:8fec6cee88576b42702d9e1f7488e362,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: mr vs plain" %% xsd:string,
         nidm_contrastName: = "mr vs plain" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5" %% xsd:string])
-    entity(niiri:1dd135affe7808067a99b5363be9574c,
+    entity(niiri:3dcfcea6814505f9436e9dba6e69af0a,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28" %% xsd:string])
-    wasDerivedFrom(niiri:b4a484110c0e0f1679fe0a5f8bdff03e, niiri:1dd135affe7808067a99b5363be9574c, -, -, -)
-    wasGeneratedBy(niiri:b4a484110c0e0f1679fe0a5f8bdff03e, niiri:470a6da8f55eec239393f9743368624c, -)
-    entity(niiri:759cc611eb1badedf971eb0bbd3381ef,
+    wasDerivedFrom(niiri:8fec6cee88576b42702d9e1f7488e362, niiri:3dcfcea6814505f9436e9dba6e69af0a, -, -, -)
+    wasGeneratedBy(niiri:8fec6cee88576b42702d9e1f7488e362, niiri:4ee8aaeabfe9f5181a4281676d9a033d, -)
+    entity(niiri:4ad1bd5ff050ee049008dafae70fffb2,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b" %% xsd:string])
-    wasGeneratedBy(niiri:759cc611eb1badedf971eb0bbd3381ef, niiri:470a6da8f55eec239393f9743368624c, -)
-    entity(niiri:830506c8d8c91472fbeb134a312b9816,
+    wasGeneratedBy(niiri:4ad1bd5ff050ee049008dafae70fffb2, niiri:4ee8aaeabfe9f5181a4281676d9a033d, -)
+    entity(niiri:13fb71f74ac2523fac8d4fe8ab7ecb1d,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
         prov:label = "Contrast: switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
         prov:value = "[0.953151930124911, -1.04684806987509, 1.04684806987509, -0.953151930124911, 0, 0]" %% xsd:string])
-    activity(niiri:d74adb2677a9d89623e02872d79aefab,
+    activity(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation 2"])
-    wasAssociatedWith(niiri:d74adb2677a9d89623e02872d79aefab, niiri:ca46a12c6a6d80a84b02ee07a74d055c, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:297de961f206e0187be8fdda200091ee, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:a79b8d0835c3bf79e9faf32502e506b4, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:87e000d813ecf48e9045ac10927bd76c, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:830506c8d8c91472fbeb134a312b9816, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:38c86177a556ef8eb57c8feb5a72bbe6, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:0640a7b36210753d2e9b544c3f195a55, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:2d0fff51543ffad218594440febbbc00, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:1e3dffce54f22bc8a196481235889e5a, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:883679c50b07b857a6c67ccde5dc3273, -)
-    used(niiri:d74adb2677a9d89623e02872d79aefab, niiri:67e0052a2914e6b58321e390f9d4a9ea, -)
-    entity(niiri:3847144ad5571b76c8855c604579438d,
+    wasAssociatedWith(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:1d7e73278ccee95e211689d9de8f4d4a, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:d17318e0fda06cc6303389a919cffce0, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:ecf064f9baf28d8f742bd2855558502d, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:1388e1cf368a92acbd46e47523c2061a, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:13fb71f74ac2523fac8d4fe8ab7ecb1d, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:fbf0025dc56929ec686d1a867cba4ed9, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:b0bd46832f113e655723b654eb1eb6ad, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:09ee1b58f1cd2a34771305a61a8d1d32, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:16ce2036a3b6f15ece6fc491d108ae37, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:c856b511969b2c541b07a88189532fa6, -)
+    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:e8f6f2e9821e3f9556f500048b8ae9b5, -)
+    entity(niiri:406c820ff107488cd976836b2d5c6516,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic_0002.nii.gz" %% xsd:string,
@@ -396,104 +396,104 @@ document
         nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "ec2f61dbf28ab2256a374dc5e3a93ba3a54e520c6bccd089dfbd07421e445b4881154433ea31e32587c1fae170daa5dc0a21f6efc328b90727d8d25bbd524e2f" %% xsd:string])
-    entity(niiri:d321a1053a1ad60011b5d0c936fced97,
+    entity(niiri:e928c1c55744b1fd90a0de8fa5ab64b3,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "4a7d076c01440a170e048ebe9644f90193b2aaf1291f454bdc6be2cf17e11a66b1d177025f5ed77434afe780ff8dcba710ec41120246e38894f823eb0fd88621" %% xsd:string])
-    wasDerivedFrom(niiri:3847144ad5571b76c8855c604579438d, niiri:d321a1053a1ad60011b5d0c936fced97, -, -, -)
-    wasGeneratedBy(niiri:3847144ad5571b76c8855c604579438d, niiri:d74adb2677a9d89623e02872d79aefab, -)
-    entity(niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc,
+    wasDerivedFrom(niiri:406c820ff107488cd976836b2d5c6516, niiri:e928c1c55744b1fd90a0de8fa5ab64b3, -, -, -)
+    wasGeneratedBy(niiri:406c820ff107488cd976836b2d5c6516, niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, -)
+    entity(niiri:769ec268b92ea35935ef54cff37b9b03,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast_0002.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
         nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "31a00f409f493fc214fe1f84fe2a799bb96d1e03d67f2ce5b8c5b5fdb934bb0005f1be68addb81934052af4643c3099542ea4944013e9346042a44c2ed8f3788" %% xsd:string])
-    entity(niiri:a98253404e56b8be6f3aecf1424cb0f4,
+    entity(niiri:37d6e69cac2b0a5b938bfdfb712bf881,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "6d92adc90c0045445b66064818fdae617474690e92e9cb332e73fa8bf27f6d1d18367c0648ffbc74196a5c2ce9f4af4186394628eed475a0e2866efe3d4eee9b" %% xsd:string])
-    wasDerivedFrom(niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc, niiri:a98253404e56b8be6f3aecf1424cb0f4, -, -, -)
-    wasGeneratedBy(niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc, niiri:d74adb2677a9d89623e02872d79aefab, -)
-    entity(niiri:ec1657f37e3b226c40848c8427be67c3,
+    wasDerivedFrom(niiri:769ec268b92ea35935ef54cff37b9b03, niiri:37d6e69cac2b0a5b938bfdfb712bf881, -, -, -)
+    wasGeneratedBy(niiri:769ec268b92ea35935ef54cff37b9b03, niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, -)
+    entity(niiri:791b2b0b99cd2c0794a3a2a508127afe,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError_0002.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "ac87f548f0d92f929c05476d2aacbc7e5319da6d62a5585a72d714be836b1b86962a36c6d473ae84c17cd613d683976e9fc562d6d7692cb8e942966f71e34a08" %% xsd:string])
-    wasGeneratedBy(niiri:ec1657f37e3b226c40848c8427be67c3, niiri:d74adb2677a9d89623e02872d79aefab, -)
-    entity(niiri:bcc964db0d0638d6cba59069ee9e794b,
+    wasGeneratedBy(niiri:791b2b0b99cd2c0794a3a2a508127afe, niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, -)
+    entity(niiri:926b152f947e98d6025b235c27f919b2,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.048771 (unc.)" %% xsd:string,
         prov:value = "0.0487705355732563" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:d7de198640509df2418dca3bf55b09d0',
-        nidm_equivalentThreshold: = 'niiri:33a31ffbbf2d136c84bd8c001890f221'])
-    entity(niiri:d7de198640509df2418dca3bf55b09d0,
+        nidm_equivalentThreshold: = 'niiri:6c13a2215653fb5c58245ecb3124b723',
+        nidm_equivalentThreshold: = 'niiri:e14ba17059f36074630699f7fc00a61e'])
+    entity(niiri:6c13a2215653fb5c58245ecb3124b723,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.761625168301108" %% xsd:float])
-    entity(niiri:33a31ffbbf2d136c84bd8c001890f221,
+    entity(niiri:e14ba17059f36074630699f7fc00a61e,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:f41b4c97497eeb8255330583a8825b93,
+    entity(niiri:57dbc4426669cb76ea05d5c255480994,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:22c0ec80ae0df81cd54796dadc1cfffb',
-        nidm_equivalentThreshold: = 'niiri:0b3f07f9fa7448b8eeed2625fdc5d588'])
-    entity(niiri:22c0ec80ae0df81cd54796dadc1cfffb,
+        nidm_equivalentThreshold: = 'niiri:461720f2996e5344ac089e2cec429c07',
+        nidm_equivalentThreshold: = 'niiri:abec52af88c1f072dc3422a358ae41ff'])
+    entity(niiri:461720f2996e5344ac089e2cec429c07,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:0b3f07f9fa7448b8eeed2625fdc5d588,
+    entity(niiri:abec52af88c1f072dc3422a358ae41ff,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:a71a2dfa1ab66a64c9d2c36c5c2f03b1,
+    entity(niiri:3d219576930e0e1002fa5ad61a717666,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:074ce8c7927ae74cf34930d375480b95,
+    entity(niiri:a5a3ea39278acdf05599017327bbbab6,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:f5c1c82a9559f27878c8865f0d227dde,
+    activity(niiri:8ca7abe146d9bd8a996b72f2d817f4e9,
         [prov:type = "spm_PartialConjunctionInference",
         prov:label = " Partial Conjunction Inference",
         spm_partialConjunctionDegree: = "2" %% xsd:int])
-    wasAssociatedWith(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:ca46a12c6a6d80a84b02ee07a74d055c, -)
-    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:bcc964db0d0638d6cba59069ee9e794b, -)
-    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:f41b4c97497eeb8255330583a8825b93, -)
-    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:7512552d6509729de4464db02c1b2b85, -)
-    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:3847144ad5571b76c8855c604579438d, -)
-    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:089005ddd166a56358c0d0ec21720e18, -)
-    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:297de961f206e0187be8fdda200091ee, -)
-    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:a71a2dfa1ab66a64c9d2c36c5c2f03b1, -)
-    used(niiri:f5c1c82a9559f27878c8865f0d227dde, niiri:074ce8c7927ae74cf34930d375480b95, -)
-    entity(niiri:992e1b6a07509a3db325ed8f8bfff412,
+    wasAssociatedWith(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:1d7e73278ccee95e211689d9de8f4d4a, -)
+    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:926b152f947e98d6025b235c27f919b2, -)
+    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:57dbc4426669cb76ea05d5c255480994, -)
+    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:3ccd77b3de962099cf8ce0c08029054a, -)
+    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:406c820ff107488cd976836b2d5c6516, -)
+    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:0c0eb1d804cee8231e915a5fdfc5ab8b, -)
+    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:d17318e0fda06cc6303389a919cffce0, -)
+    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:3d219576930e0e1002fa5ad61a717666, -)
+    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:a5a3ea39278acdf05599017327bbbab6, -)
+    entity(niiri:d31b1142c5902eeff2fda19317e15bea,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
         nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
         nidm_reselSizeInVoxels: = "68.4409986586553" %% xsd:float,
@@ -509,8 +509,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "NaN" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "NaN" %% xsd:int,
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    wasGeneratedBy(niiri:992e1b6a07509a3db325ed8f8bfff412, niiri:f5c1c82a9559f27878c8865f0d227dde, -)
-    entity(niiri:9315492073c635bc63a9934fefeda6b6,
+    wasGeneratedBy(niiri:d31b1142c5902eeff2fda19317e15bea, niiri:8ca7abe146d9bd8a996b72f2d817f4e9, -)
+    entity(niiri:d4dd8ab29b5f9534a65e9a4b237ca312,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -518,22 +518,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "150" %% xsd:int,
         nidm_pValue: = "1" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:e9451253b0a75869524801c98a6d921e',
-        nidm_hasMaximumIntensityProjection: = 'niiri:29a5a2562dde36cf7698f1dad4b98ea5',
-        nidm_inCoordinateSpace: = 'niiri:4ddf2148145597f7f7c9369cb269b13f',
+        nidm_hasClusterLabelsMap: = 'niiri:216bc8b13e5d82e899e5c52cbb83016c',
+        nidm_hasMaximumIntensityProjection: = 'niiri:84d7cbdeb48144857ed31bb58c5ddc5b',
+        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
         crypto:sha512 = "662dfeb3cba04a6a6beda3e1e23ff90c951f3ffae3d379b8fbfef06307db3055236586cace653593957e67f60c9dbbaadb5f3cc87c0ecc9dcfb81727d86f177f" %% xsd:string])
-    entity(niiri:e9451253b0a75869524801c98a6d921e,
+    entity(niiri:216bc8b13e5d82e899e5c52cbb83016c,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:29a5a2562dde36cf7698f1dad4b98ea5,
+    entity(niiri:84d7cbdeb48144857ed31bb58c5ddc5b,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:9315492073c635bc63a9934fefeda6b6, niiri:f5c1c82a9559f27878c8865f0d227dde, -)
-    entity(niiri:43fc9ecb30d51558da2aa2580905eaab,
+    wasGeneratedBy(niiri:d4dd8ab29b5f9534a65e9a4b237ca312, niiri:8ca7abe146d9bd8a996b72f2d817f4e9, -)
+    entity(niiri:4362f5eac9972bf179ea49be33151c8e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2637" %% xsd:int,
@@ -542,8 +542,8 @@ document
         nidm_pValueFWER: = "2.1833083851952e-06" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:43fc9ecb30d51558da2aa2580905eaab, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:417cabd3eeb412117d20f4882d064567,
+    wasDerivedFrom(niiri:4362f5eac9972bf179ea49be33151c8e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:00f296730dd06a43e5f7334c226305c6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1415" %% xsd:int,
@@ -552,8 +552,8 @@ document
         nidm_pValueFWER: = "0.0013085566013008" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:417cabd3eeb412117d20f4882d064567, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:6cc5ea3c57b906137def3d6777b0000f,
+    wasDerivedFrom(niiri:00f296730dd06a43e5f7334c226305c6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:39a3babf6ed520d78e67263717ca5dbb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "376" %% xsd:int,
@@ -562,8 +562,8 @@ document
         nidm_pValueFWER: = "0.854799051393012" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:6cc5ea3c57b906137def3d6777b0000f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c29516aed6cf24b95d9653e2365e0ced,
+    wasDerivedFrom(niiri:39a3babf6ed520d78e67263717ca5dbb, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:26ed93f97118482ea99f750276db5700,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "128" %% xsd:int,
@@ -572,8 +572,8 @@ document
         nidm_pValueFWER: = "0.999999999997872" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:c29516aed6cf24b95d9653e2365e0ced, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:1c26e68b379e5bd715e75014cca849ab,
+    wasDerivedFrom(niiri:26ed93f97118482ea99f750276db5700, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:c0faffa954cb5edf1bd166b3c13b64b6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "31" %% xsd:int,
@@ -582,8 +582,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:1c26e68b379e5bd715e75014cca849ab, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:8b5d6e1bd5480bd6366d0094c92d4851,
+    wasDerivedFrom(niiri:c0faffa954cb5edf1bd166b3c13b64b6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:1baee1eea0758a922f6c4f1f12441da6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "482" %% xsd:int,
@@ -592,8 +592,8 @@ document
         nidm_pValueFWER: = "0.5345656346398" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:8b5d6e1bd5480bd6366d0094c92d4851, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:7e631bc430702f08996bcc12a090f463,
+    wasDerivedFrom(niiri:1baee1eea0758a922f6c4f1f12441da6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:1aa58b6ce0025b1ec01cb8a983388e1d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "31" %% xsd:int,
@@ -602,8 +602,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:7e631bc430702f08996bcc12a090f463, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c21e2ede0b4f245e2d9f679a7862569e,
+    wasDerivedFrom(niiri:1aa58b6ce0025b1ec01cb8a983388e1d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:3198b98e15c5c56654d8a4ffe4b44ce8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "292" %% xsd:int,
@@ -612,8 +612,8 @@ document
         nidm_pValueFWER: = "0.986195307987511" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:c21e2ede0b4f245e2d9f679a7862569e, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c8c6cee0456ea9b67ae74c71ec73d58a,
+    wasDerivedFrom(niiri:3198b98e15c5c56654d8a4ffe4b44ce8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:7d6744d8bee9e326b4381ceb83e93c8d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "454" %% xsd:int,
@@ -622,8 +622,8 @@ document
         nidm_pValueFWER: = "0.620742215844192" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:c8c6cee0456ea9b67ae74c71ec73d58a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5,
+    wasDerivedFrom(niiri:7d6744d8bee9e326b4381ceb83e93c8d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:1593dbfe6a27c4bfd6c7c865a55e6758,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "30" %% xsd:int,
@@ -632,8 +632,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c8915bbac48c4a94d3bf54f07d28091a,
+    wasDerivedFrom(niiri:1593dbfe6a27c4bfd6c7c865a55e6758, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:537cd4e035d031e1d96dcc9b62c35112,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "121" %% xsd:int,
@@ -642,8 +642,8 @@ document
         nidm_pValueFWER: = "0.999999999999841" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:c8915bbac48c4a94d3bf54f07d28091a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:81f39aacce9db78e536cab5c96400969,
+    wasDerivedFrom(niiri:537cd4e035d031e1d96dcc9b62c35112, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:3330f53a36ff5c9ef2f20b1290e9d286,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "152" %% xsd:int,
@@ -652,8 +652,8 @@ document
         nidm_pValueFWER: = "0.999999997549602" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:81f39aacce9db78e536cab5c96400969, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:95cfa48491de3b2db8a60dc29bdeb6af,
+    wasDerivedFrom(niiri:3330f53a36ff5c9ef2f20b1290e9d286, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9c973b3443bcab76e6ce5b021d6b1a13,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "118" %% xsd:int,
@@ -662,8 +662,8 @@ document
         nidm_pValueFWER: = "0.999999999999952" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:95cfa48491de3b2db8a60dc29bdeb6af, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:e7fc37cb04d1a3f58136cfb12f992f34,
+    wasDerivedFrom(niiri:9c973b3443bcab76e6ce5b021d6b1a13, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:27a3407fb41dee69924952963bf01095,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "41" %% xsd:int,
@@ -672,8 +672,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:e7fc37cb04d1a3f58136cfb12f992f34, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:de5b4d0f5d84034ba5fd7975873cc2e6,
+    wasDerivedFrom(niiri:27a3407fb41dee69924952963bf01095, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9c3f0991818d487326255d5ca7862e30,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "53" %% xsd:int,
@@ -682,8 +682,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:de5b4d0f5d84034ba5fd7975873cc2e6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:1d6209037825fb7ee168299aa10d5ad7,
+    wasDerivedFrom(niiri:9c3f0991818d487326255d5ca7862e30, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:73094daa238696f8de11ef4e56a95c30,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "38" %% xsd:int,
@@ -692,8 +692,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:1d6209037825fb7ee168299aa10d5ad7, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:b1918e5ede22fa7e1d3a1399a34a2d45,
+    wasDerivedFrom(niiri:73094daa238696f8de11ef4e56a95c30, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:35af8997746066bb4be8d3a9cebf0640,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -702,8 +702,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:b1918e5ede22fa7e1d3a1399a34a2d45, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:5d9799711b35085d7a8bcba1641700b1,
+    wasDerivedFrom(niiri:35af8997746066bb4be8d3a9cebf0640, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9d0b757e22fc3f0156790583744c1334,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "51" %% xsd:int,
@@ -712,8 +712,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:5d9799711b35085d7a8bcba1641700b1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:437180e47264cc4e09dc17b204fd0a89,
+    wasDerivedFrom(niiri:9d0b757e22fc3f0156790583744c1334, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8d3362f5850c9379377b0d1f0b1c2735,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -722,8 +722,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:437180e47264cc4e09dc17b204fd0a89, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:1cd87c105e9a1996f42e3171bad089a8,
+    wasDerivedFrom(niiri:8d3362f5850c9379377b0d1f0b1c2735, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:227019e17364687787db60a4a8267663,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -732,8 +732,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:1cd87c105e9a1996f42e3171bad089a8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:cc02b2de189bcf80b0afcbe487b0d1e8,
+    wasDerivedFrom(niiri:227019e17364687787db60a4a8267663, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8669f380bd303fec5b169e636d626ce3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "23" %% xsd:int,
@@ -742,8 +742,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:cc02b2de189bcf80b0afcbe487b0d1e8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:3ae2e3cf05ec7ac4b46544f268071134,
+    wasDerivedFrom(niiri:8669f380bd303fec5b169e636d626ce3, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:f38934924fa68b3b9a71fb9c8171e8b6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -752,8 +752,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:3ae2e3cf05ec7ac4b46544f268071134, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:3c84c74526e078ad8336fd968ec9d7f0,
+    wasDerivedFrom(niiri:f38934924fa68b3b9a71fb9c8171e8b6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:1793504b32e2869dcb2fbd3af062f8bc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "20" %% xsd:int,
@@ -762,8 +762,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:3c84c74526e078ad8336fd968ec9d7f0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:8a1438a34faf87d03af2d9853b038bb2,
+    wasDerivedFrom(niiri:1793504b32e2869dcb2fbd3af062f8bc, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:55aacac3d3863ecd2c5789acfd6b261d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -772,8 +772,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:8a1438a34faf87d03af2d9853b038bb2, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:5aecd2a653cabfaff01cc936a5319173,
+    wasDerivedFrom(niiri:55aacac3d3863ecd2c5789acfd6b261d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:03238c6a619b9f265421cbb7a0cda76e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "42" %% xsd:int,
@@ -782,8 +782,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:5aecd2a653cabfaff01cc936a5319173, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:04baa9610947313ff840ab800dc602ff,
+    wasDerivedFrom(niiri:03238c6a619b9f265421cbb7a0cda76e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:bc83f4e59851c0ed8424e3172a378ee4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "34" %% xsd:int,
@@ -792,8 +792,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:04baa9610947313ff840ab800dc602ff, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:bbf4ae108fc8903d38a040cb96a5f8c7,
+    wasDerivedFrom(niiri:bc83f4e59851c0ed8424e3172a378ee4, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:c340f3ccccc1a020f9aef989954e51fc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -802,8 +802,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:bbf4ae108fc8903d38a040cb96a5f8c7, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:4df2335aa8db3e5be136eacbcea883d6,
+    wasDerivedFrom(niiri:c340f3ccccc1a020f9aef989954e51fc, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "38" %% xsd:int,
@@ -812,8 +812,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:4df2335aa8db3e5be136eacbcea883d6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:9d79a6339d6f2901fb1cf662d6f17331,
+    wasDerivedFrom(niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:cb85dd1324b2d86671b2fe868f4dafc0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -822,8 +822,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:9d79a6339d6f2901fb1cf662d6f17331, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:b8abe2a725005d9ab6e1e988f192f41c,
+    wasDerivedFrom(niiri:cb85dd1324b2d86671b2fe868f4dafc0, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:0dc11dbfea7cb1fef76a1c48d7f8750f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -832,8 +832,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:b8abe2a725005d9ab6e1e988f192f41c, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:483de03930aa5641b0fe297f66f6c4ed,
+    wasDerivedFrom(niiri:0dc11dbfea7cb1fef76a1c48d7f8750f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:6db75fb201d2decf706c9d2dd225cb5a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
         nidm_clusterSizeInVoxels: = "29" %% xsd:int,
@@ -842,8 +842,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "31" %% xsd:int])
-    wasDerivedFrom(niiri:483de03930aa5641b0fe297f66f6c4ed, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:4f303edac6b82f93c47e1a6448e1cb52,
+    wasDerivedFrom(niiri:6db75fb201d2decf706c9d2dd225cb5a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8fae62d51a220dbd34d1d3074ad97c80,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -852,8 +852,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "32" %% xsd:int])
-    wasDerivedFrom(niiri:4f303edac6b82f93c47e1a6448e1cb52, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:d987cfa4a10011187d0a3eef178d5a46,
+    wasDerivedFrom(niiri:8fae62d51a220dbd34d1d3074ad97c80, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:1b3f6a9bf76e54ad12539e190c7c838c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
         nidm_clusterSizeInVoxels: = "37" %% xsd:int,
@@ -862,8 +862,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "33" %% xsd:int])
-    wasDerivedFrom(niiri:d987cfa4a10011187d0a3eef178d5a46, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:98d187b5c539ea98df7343b0d0821b17,
+    wasDerivedFrom(niiri:1b3f6a9bf76e54ad12539e190c7c838c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:dc2d50ba6c535742eed46213fc557f6a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
         nidm_clusterSizeInVoxels: = "38" %% xsd:int,
@@ -872,8 +872,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "34" %% xsd:int])
-    wasDerivedFrom(niiri:98d187b5c539ea98df7343b0d0821b17, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:5c38b60ed820b070d98e016bc1431008,
+    wasDerivedFrom(niiri:dc2d50ba6c535742eed46213fc557f6a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:416dfaa44bb6a7fe97539c984a9173c3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -882,8 +882,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "35" %% xsd:int])
-    wasDerivedFrom(niiri:5c38b60ed820b070d98e016bc1431008, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:a86e2297836b759380804c1713e267cd,
+    wasDerivedFrom(niiri:416dfaa44bb6a7fe97539c984a9173c3, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:31033e543fb9492bc06e61625ca6b410,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -892,8 +892,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "36" %% xsd:int])
-    wasDerivedFrom(niiri:a86e2297836b759380804c1713e267cd, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:f4ed594992095609e2ba62eca01c9faf,
+    wasDerivedFrom(niiri:31033e543fb9492bc06e61625ca6b410, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:7a8b21e9acaff0531c73c9fe0bfaeb53,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
         nidm_clusterSizeInVoxels: = "22" %% xsd:int,
@@ -902,8 +902,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "37" %% xsd:int])
-    wasDerivedFrom(niiri:f4ed594992095609e2ba62eca01c9faf, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c8ce85b44b984de4fe78c06b64713bb8,
+    wasDerivedFrom(niiri:7a8b21e9acaff0531c73c9fe0bfaeb53, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:5102964768a1c4313f8c0e48d48f8b40,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -912,8 +912,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "38" %% xsd:int])
-    wasDerivedFrom(niiri:c8ce85b44b984de4fe78c06b64713bb8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:55d04469f144e7c5053124929003df79,
+    wasDerivedFrom(niiri:5102964768a1c4313f8c0e48d48f8b40, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:256070c77a58b8b64913a5b6bfb81f60,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -922,8 +922,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "39" %% xsd:int])
-    wasDerivedFrom(niiri:55d04469f144e7c5053124929003df79, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:895da0556b5b38697a9d4eacde3a587e,
+    wasDerivedFrom(niiri:256070c77a58b8b64913a5b6bfb81f60, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:96604941a960daa1e224727cb5ba2d60,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
         nidm_clusterSizeInVoxels: = "23" %% xsd:int,
@@ -932,8 +932,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "40" %% xsd:int])
-    wasDerivedFrom(niiri:895da0556b5b38697a9d4eacde3a587e, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:30470d6217b4a75fdd554906028c6670,
+    wasDerivedFrom(niiri:96604941a960daa1e224727cb5ba2d60, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:529af4aecda9065e5cce8adf4cdfd5c6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -942,8 +942,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "41" %% xsd:int])
-    wasDerivedFrom(niiri:30470d6217b4a75fdd554906028c6670, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:62c58cbe35737a64415ff840b7810e7d,
+    wasDerivedFrom(niiri:529af4aecda9065e5cce8adf4cdfd5c6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:bdef3fee2464d33f021c131ff78646c7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -952,8 +952,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "42" %% xsd:int])
-    wasDerivedFrom(niiri:62c58cbe35737a64415ff840b7810e7d, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:ec26c7d95e0c041f81b882cd245b0915,
+    wasDerivedFrom(niiri:bdef3fee2464d33f021c131ff78646c7, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:e8088392c69eb956afef92cedfa6aeb4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -962,8 +962,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "43" %% xsd:int])
-    wasDerivedFrom(niiri:ec26c7d95e0c041f81b882cd245b0915, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:6750b72bbafd12ba75c6c383539599c6,
+    wasDerivedFrom(niiri:e8088392c69eb956afef92cedfa6aeb4, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8b4322c153a15066be2583d11b23925c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
         nidm_clusterSizeInVoxels: = "21" %% xsd:int,
@@ -972,8 +972,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "44" %% xsd:int])
-    wasDerivedFrom(niiri:6750b72bbafd12ba75c6c383539599c6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:ccbc770b946f9dfd1beecfa8843cb3fd,
+    wasDerivedFrom(niiri:8b4322c153a15066be2583d11b23925c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:0c0e48a110ec2c20b75585b9e5372d67,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -982,8 +982,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "45" %% xsd:int])
-    wasDerivedFrom(niiri:ccbc770b946f9dfd1beecfa8843cb3fd, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:daf3e2ea8bf3273801d2e921f611a23f,
+    wasDerivedFrom(niiri:0c0e48a110ec2c20b75585b9e5372d67, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:1bf866f2d8a1a832a120aa9c02c60efd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -992,8 +992,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "46" %% xsd:int])
-    wasDerivedFrom(niiri:daf3e2ea8bf3273801d2e921f611a23f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:3df484ba108f4b88e1a4f123023bad18,
+    wasDerivedFrom(niiri:1bf866f2d8a1a832a120aa9c02c60efd, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:a44aefad34ca2359e69bf6f9306bc2c6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -1002,8 +1002,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "47" %% xsd:int])
-    wasDerivedFrom(niiri:3df484ba108f4b88e1a4f123023bad18, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:0b63cbadf7d3234250fdc4f399321ae5,
+    wasDerivedFrom(niiri:a44aefad34ca2359e69bf6f9306bc2c6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:ab78ea55fc7f212636dd2f73bdc99032,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1012,8 +1012,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "48" %% xsd:int])
-    wasDerivedFrom(niiri:0b63cbadf7d3234250fdc4f399321ae5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:16c6b9ef292ea8d86c2980e2bfee9806,
+    wasDerivedFrom(niiri:ab78ea55fc7f212636dd2f73bdc99032, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:4128bacb45b84a2304aceeb9a3a06db7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -1022,8 +1022,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "49" %% xsd:int])
-    wasDerivedFrom(niiri:16c6b9ef292ea8d86c2980e2bfee9806, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239,
+    wasDerivedFrom(niiri:4128bacb45b84a2304aceeb9a3a06db7, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:282d81c6243a1094abf4c4787764df02,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -1032,8 +1032,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "50" %% xsd:int])
-    wasDerivedFrom(niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:fb45985c130da20eafb7b2bc740e6b34,
+    wasDerivedFrom(niiri:282d81c6243a1094abf4c4787764df02, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -1042,8 +1042,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "51" %% xsd:int])
-    wasDerivedFrom(niiri:fb45985c130da20eafb7b2bc740e6b34, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:65722b667917e9f42cf82ee2175b666b,
+    wasDerivedFrom(niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:e58cf8e24a087d5746f02fb59416d367,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -1052,8 +1052,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "52" %% xsd:int])
-    wasDerivedFrom(niiri:65722b667917e9f42cf82ee2175b666b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:59675618f95ad14de633584e8aa5881a,
+    wasDerivedFrom(niiri:e58cf8e24a087d5746f02fb59416d367, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:47a95f63466991d3e681c4886347a76b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1062,8 +1062,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "53" %% xsd:int])
-    wasDerivedFrom(niiri:59675618f95ad14de633584e8aa5881a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:2efe263e1c4f04d8ddb54023002360d9,
+    wasDerivedFrom(niiri:47a95f63466991d3e681c4886347a76b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:6a2d34c94894023a09a46d7ba699025b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -1072,8 +1072,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "54" %% xsd:int])
-    wasDerivedFrom(niiri:2efe263e1c4f04d8ddb54023002360d9, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:fa0929f452cd3f13857c087a02f6da1f,
+    wasDerivedFrom(niiri:6a2d34c94894023a09a46d7ba699025b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:6ac7ce35dfb3dcf2c2696278c805c40a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -1082,8 +1082,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "55" %% xsd:int])
-    wasDerivedFrom(niiri:fa0929f452cd3f13857c087a02f6da1f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:4c6401bfd1d939fec8234ff093a37d0d,
+    wasDerivedFrom(niiri:6ac7ce35dfb3dcf2c2696278c805c40a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:60e118fd5205eaa96f4b55808761eaf7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -1092,8 +1092,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "56" %% xsd:int])
-    wasDerivedFrom(niiri:4c6401bfd1d939fec8234ff093a37d0d, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:b40302277817265d7af623887ab2e22c,
+    wasDerivedFrom(niiri:60e118fd5205eaa96f4b55808761eaf7, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:afff6750152337d325f510f877cd2b9c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1102,8 +1102,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "57" %% xsd:int])
-    wasDerivedFrom(niiri:b40302277817265d7af623887ab2e22c, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:e3091fadc7ff93e5e16f94b04590b938,
+    wasDerivedFrom(niiri:afff6750152337d325f510f877cd2b9c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:c87d05b7d28080150c45409119a926f8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -1112,8 +1112,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "58" %% xsd:int])
-    wasDerivedFrom(niiri:e3091fadc7ff93e5e16f94b04590b938, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:e36b80790f32a55a90c503e6f29918bb,
+    wasDerivedFrom(niiri:c87d05b7d28080150c45409119a926f8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:f1bb918000bbcdd8562fb7b7887a394d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -1122,8 +1122,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "59" %% xsd:int])
-    wasDerivedFrom(niiri:e36b80790f32a55a90c503e6f29918bb, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:6e8c86e4ccb82a0a6076eb58e14b07a6,
+    wasDerivedFrom(niiri:f1bb918000bbcdd8562fb7b7887a394d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1132,8 +1132,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "60" %% xsd:int])
-    wasDerivedFrom(niiri:6e8c86e4ccb82a0a6076eb58e14b07a6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:42f7f7a26e0c7f6124775e7e757b315c,
+    wasDerivedFrom(niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1142,8 +1142,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "61" %% xsd:int])
-    wasDerivedFrom(niiri:42f7f7a26e0c7f6124775e7e757b315c, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:14ff66df771d191b9d2e8a3b0f78eda6,
+    wasDerivedFrom(niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9e7cd816ef42776bf358bfe67f08f014,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1152,8 +1152,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "62" %% xsd:int])
-    wasDerivedFrom(niiri:14ff66df771d191b9d2e8a3b0f78eda6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:912e881f26994ef7af5c7f0b222db9ea,
+    wasDerivedFrom(niiri:9e7cd816ef42776bf358bfe67f08f014, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:712375a17d0ff43c9dca459517dff9b2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -1162,8 +1162,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "63" %% xsd:int])
-    wasDerivedFrom(niiri:912e881f26994ef7af5c7f0b222db9ea, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:9a1887d93b55705b2ff04804a00c27c3,
+    wasDerivedFrom(niiri:712375a17d0ff43c9dca459517dff9b2, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:feddd730f38d65d4f1fd0e8616bcc9a5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -1172,8 +1172,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "64" %% xsd:int])
-    wasDerivedFrom(niiri:9a1887d93b55705b2ff04804a00c27c3, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:e6e6da4cb58bd6ee501d8b5597467832,
+    wasDerivedFrom(niiri:feddd730f38d65d4f1fd0e8616bcc9a5, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8041bc77682f50b65136018ca10c889c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1182,8 +1182,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "65" %% xsd:int])
-    wasDerivedFrom(niiri:e6e6da4cb58bd6ee501d8b5597467832, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0,
+    wasDerivedFrom(niiri:8041bc77682f50b65136018ca10c889c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:e852e949acffc71ed6cce677c7be19d6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1192,8 +1192,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "66" %% xsd:int])
-    wasDerivedFrom(niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:949a7d86dacbe35af10b6aad92fe2224,
+    wasDerivedFrom(niiri:e852e949acffc71ed6cce677c7be19d6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:0d099ee69c96416336f843fd890da4a0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -1202,8 +1202,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "67" %% xsd:int])
-    wasDerivedFrom(niiri:949a7d86dacbe35af10b6aad92fe2224, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:6cc27bdc40320dac88fe94690c9a2006,
+    wasDerivedFrom(niiri:0d099ee69c96416336f843fd890da4a0, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:6d0ee7f5877dfa2620f95f47e06e2a9a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1212,8 +1212,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "68" %% xsd:int])
-    wasDerivedFrom(niiri:6cc27bdc40320dac88fe94690c9a2006, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c04d4059d5535de349435e25559a51cf,
+    wasDerivedFrom(niiri:6d0ee7f5877dfa2620f95f47e06e2a9a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:6ab419381418bd7fca0cb5bac6782b77,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -1222,8 +1222,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "69" %% xsd:int])
-    wasDerivedFrom(niiri:c04d4059d5535de349435e25559a51cf, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:4b22fd081d5be6319a728e5343897301,
+    wasDerivedFrom(niiri:6ab419381418bd7fca0cb5bac6782b77, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:b19325ccb6192dba58545cbeb7bc92e1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1232,8 +1232,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "70" %% xsd:int])
-    wasDerivedFrom(niiri:4b22fd081d5be6319a728e5343897301, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:f0f729dae8a39ee9247f706bc80f8df0,
+    wasDerivedFrom(niiri:b19325ccb6192dba58545cbeb7bc92e1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:745fe95a68372701f2888393e817a23e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -1242,8 +1242,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "71" %% xsd:int])
-    wasDerivedFrom(niiri:f0f729dae8a39ee9247f706bc80f8df0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:cd47d3687de0d428289d5ee8d941860d,
+    wasDerivedFrom(niiri:745fe95a68372701f2888393e817a23e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:b1a5489610b480473aa63e95806df7d1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0072" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1252,8 +1252,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "72" %% xsd:int])
-    wasDerivedFrom(niiri:cd47d3687de0d428289d5ee8d941860d, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:20959c12c3afc9ceb8477f395c0f1d11,
+    wasDerivedFrom(niiri:b1a5489610b480473aa63e95806df7d1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:f6763487f8266f7e66acb49862c0bfa1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0073" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1262,8 +1262,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "73" %% xsd:int])
-    wasDerivedFrom(niiri:20959c12c3afc9ceb8477f395c0f1d11, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:4eb3e8fe236fda4e725ee89c277cccc8,
+    wasDerivedFrom(niiri:f6763487f8266f7e66acb49862c0bfa1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:f1b9cbe1f5cc757318e116f47537c68e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0074" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1272,8 +1272,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "74" %% xsd:int])
-    wasDerivedFrom(niiri:4eb3e8fe236fda4e725ee89c277cccc8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca,
+    wasDerivedFrom(niiri:f1b9cbe1f5cc757318e116f47537c68e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:0299ab45ec018b51a01d2a8fe08bf4d0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0075" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1282,8 +1282,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "75" %% xsd:int])
-    wasDerivedFrom(niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:4fad08e49bad24baddc3d418f97db0ce,
+    wasDerivedFrom(niiri:0299ab45ec018b51a01d2a8fe08bf4d0, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:3bd0b694ec1e521a7072b15be74aa42c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0076" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1292,8 +1292,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "76" %% xsd:int])
-    wasDerivedFrom(niiri:4fad08e49bad24baddc3d418f97db0ce, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:d9eee0810d67b936a31fa3c66d2e8721,
+    wasDerivedFrom(niiri:3bd0b694ec1e521a7072b15be74aa42c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:af9bee597f1e82856f732971c03e4ba5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0077" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1302,8 +1302,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "77" %% xsd:int])
-    wasDerivedFrom(niiri:d9eee0810d67b936a31fa3c66d2e8721, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c8715267e94716796c464182b4ba6959,
+    wasDerivedFrom(niiri:af9bee597f1e82856f732971c03e4ba5, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:7a01ea3f3b5332ecf281a7f277911529,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0078" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1312,8 +1312,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "78" %% xsd:int])
-    wasDerivedFrom(niiri:c8715267e94716796c464182b4ba6959, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:8f90bd7cc0deb45b7b7bd4b560274456,
+    wasDerivedFrom(niiri:7a01ea3f3b5332ecf281a7f277911529, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8d9244867124b8976a02c802025ebf7a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0079" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1322,8 +1322,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "79" %% xsd:int])
-    wasDerivedFrom(niiri:8f90bd7cc0deb45b7b7bd4b560274456, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:38f5a60345c88d7c9e0484d8735d5ffe,
+    wasDerivedFrom(niiri:8d9244867124b8976a02c802025ebf7a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:1acfcd5791fd893baf49e6750646bcbc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0080" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1332,8 +1332,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "80" %% xsd:int])
-    wasDerivedFrom(niiri:38f5a60345c88d7c9e0484d8735d5ffe, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:e6b43073ea58d734c57cff5767e3921f,
+    wasDerivedFrom(niiri:1acfcd5791fd893baf49e6750646bcbc, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:6bafc27afb06adc8274b4e85b0eb95cc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0081" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -1342,8 +1342,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "81" %% xsd:int])
-    wasDerivedFrom(niiri:e6b43073ea58d734c57cff5767e3921f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:1cdb6dbe1bc79e13d52d0d3c171bab06,
+    wasDerivedFrom(niiri:6bafc27afb06adc8274b4e85b0eb95cc, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:ee5baff089dc6387c53821c05a9e9154,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0082" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1352,8 +1352,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "82" %% xsd:int])
-    wasDerivedFrom(niiri:1cdb6dbe1bc79e13d52d0d3c171bab06, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:ee19df6f4d0113ba7e7f064a4048e753,
+    wasDerivedFrom(niiri:ee5baff089dc6387c53821c05a9e9154, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:e4e0f746d182d60a55906480bc82791f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0083" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1362,8 +1362,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "83" %% xsd:int])
-    wasDerivedFrom(niiri:ee19df6f4d0113ba7e7f064a4048e753, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:71af61a5c3e3beaf82f85e9971911d0f,
+    wasDerivedFrom(niiri:e4e0f746d182d60a55906480bc82791f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:07ef8bc1f56adef8bb96bf2e4e871509,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0084" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1372,8 +1372,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "84" %% xsd:int])
-    wasDerivedFrom(niiri:71af61a5c3e3beaf82f85e9971911d0f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:46c8b3f4803e6bb0b2862d8598ece061,
+    wasDerivedFrom(niiri:07ef8bc1f56adef8bb96bf2e4e871509, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:4909c1eb824545b47aa0943b33200588,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0085" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -1382,8 +1382,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "85" %% xsd:int])
-    wasDerivedFrom(niiri:46c8b3f4803e6bb0b2862d8598ece061, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:5e385b701ab7f21285e4ab5006f3b0cc,
+    wasDerivedFrom(niiri:4909c1eb824545b47aa0943b33200588, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9c28e7c0288f5d8601280d59308426e4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0086" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1392,8 +1392,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "86" %% xsd:int])
-    wasDerivedFrom(niiri:5e385b701ab7f21285e4ab5006f3b0cc, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:9b4e4e9b57eb3e981b1ba74aae8a7114,
+    wasDerivedFrom(niiri:9c28e7c0288f5d8601280d59308426e4, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:49c7e8d7404b8a93cc2dc6a52274f6ef,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0087" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -1402,8 +1402,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "87" %% xsd:int])
-    wasDerivedFrom(niiri:9b4e4e9b57eb3e981b1ba74aae8a7114, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:6d27ace5181c44103420a9d6058ab0d2,
+    wasDerivedFrom(niiri:49c7e8d7404b8a93cc2dc6a52274f6ef, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:5bc798e43cab1c880a412761cd0dabce,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0088" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1412,8 +1412,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "88" %% xsd:int])
-    wasDerivedFrom(niiri:6d27ace5181c44103420a9d6058ab0d2, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:315d7b893c25221ef60daf1e43984066,
+    wasDerivedFrom(niiri:5bc798e43cab1c880a412761cd0dabce, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:d5f0da3a07b3d47197bf039d8d42b58f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0089" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1422,8 +1422,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "89" %% xsd:int])
-    wasDerivedFrom(niiri:315d7b893c25221ef60daf1e43984066, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:34f88b9c2c80714dbe516b3f7ef092bb,
+    wasDerivedFrom(niiri:d5f0da3a07b3d47197bf039d8d42b58f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:a57d901560addc33f414ddaed9a0c7fb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0090" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1432,8 +1432,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "90" %% xsd:int])
-    wasDerivedFrom(niiri:34f88b9c2c80714dbe516b3f7ef092bb, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c07d0db5466c33ca960e3dd77f21333c,
+    wasDerivedFrom(niiri:a57d901560addc33f414ddaed9a0c7fb, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:01d84a7c8c63b90d178c8c7623156c7d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0091" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1442,8 +1442,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "91" %% xsd:int])
-    wasDerivedFrom(niiri:c07d0db5466c33ca960e3dd77f21333c, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:90645273f08ccfc7b9bf300a122cc2af,
+    wasDerivedFrom(niiri:01d84a7c8c63b90d178c8c7623156c7d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:99056f1d754fd9f25d80632f06577e33,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0092" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1452,8 +1452,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "92" %% xsd:int])
-    wasDerivedFrom(niiri:90645273f08ccfc7b9bf300a122cc2af, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c12f0aee596eddb11ad8e3268c4eb077,
+    wasDerivedFrom(niiri:99056f1d754fd9f25d80632f06577e33, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:a0ee8183a98a000be01c4577a35a0d8c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0093" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1462,8 +1462,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "93" %% xsd:int])
-    wasDerivedFrom(niiri:c12f0aee596eddb11ad8e3268c4eb077, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:b74b40058d530ee5632e1df25f911065,
+    wasDerivedFrom(niiri:a0ee8183a98a000be01c4577a35a0d8c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:40c9456923bb7d18a8a4ec203aeea09d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0094" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1472,8 +1472,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "94" %% xsd:int])
-    wasDerivedFrom(niiri:b74b40058d530ee5632e1df25f911065, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:169fad64b64219293f6c913c296583bc,
+    wasDerivedFrom(niiri:40c9456923bb7d18a8a4ec203aeea09d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:3cd64da8230af3c597bfb4e11e589670,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0095" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1482,8 +1482,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "95" %% xsd:int])
-    wasDerivedFrom(niiri:169fad64b64219293f6c913c296583bc, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c9ba05614242ea84b1cd6a9c5ec414e4,
+    wasDerivedFrom(niiri:3cd64da8230af3c597bfb4e11e589670, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:32e5e0304b5a2c92b091fa83edcab359,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0096" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1492,8 +1492,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "96" %% xsd:int])
-    wasDerivedFrom(niiri:c9ba05614242ea84b1cd6a9c5ec414e4, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:be38e2f5b8c4edd116eb0a55684fdab2,
+    wasDerivedFrom(niiri:32e5e0304b5a2c92b091fa83edcab359, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:bf704e8aea1497f2136b7d0b3dde0bf6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0097" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1502,8 +1502,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "97" %% xsd:int])
-    wasDerivedFrom(niiri:be38e2f5b8c4edd116eb0a55684fdab2, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:9506dd108b62896cd6d8225dfc0e2e59,
+    wasDerivedFrom(niiri:bf704e8aea1497f2136b7d0b3dde0bf6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:316701aef465a5778181dd76a5331844,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0098" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1512,8 +1512,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "98" %% xsd:int])
-    wasDerivedFrom(niiri:9506dd108b62896cd6d8225dfc0e2e59, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:f404d574847ee68f9dc6bd08393bd9a1,
+    wasDerivedFrom(niiri:316701aef465a5778181dd76a5331844, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:90bdcb5fb7ef48121124edfe5e0439e6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0099" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -1522,8 +1522,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "99" %% xsd:int])
-    wasDerivedFrom(niiri:f404d574847ee68f9dc6bd08393bd9a1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:99948f53ace7073cd3002a5850ecd361,
+    wasDerivedFrom(niiri:90bdcb5fb7ef48121124edfe5e0439e6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:d1db945756296f3d178c9d95312fcba1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0100" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1532,8 +1532,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "100" %% xsd:int])
-    wasDerivedFrom(niiri:99948f53ace7073cd3002a5850ecd361, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:c8c7dba5be58cecd8f14593ccfb69e4b,
+    wasDerivedFrom(niiri:d1db945756296f3d178c9d95312fcba1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0101" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1542,8 +1542,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "101" %% xsd:int])
-    wasDerivedFrom(niiri:c8c7dba5be58cecd8f14593ccfb69e4b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:a56ce0c60fde3ec8bf474d645a951d38,
+    wasDerivedFrom(niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0102" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1552,8 +1552,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "102" %% xsd:int])
-    wasDerivedFrom(niiri:a56ce0c60fde3ec8bf474d645a951d38, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:82e02fb05b18c0c2a70d55d5e415aee5,
+    wasDerivedFrom(niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9304b0681f39be2e136e7d42baff625c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0103" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1562,8 +1562,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "103" %% xsd:int])
-    wasDerivedFrom(niiri:82e02fb05b18c0c2a70d55d5e415aee5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:8d8ac9fae20babb989f7c367a4c4a609,
+    wasDerivedFrom(niiri:9304b0681f39be2e136e7d42baff625c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:c4a9ab38a5b5faf27a110372a76b690b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0104" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1572,8 +1572,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "104" %% xsd:int])
-    wasDerivedFrom(niiri:8d8ac9fae20babb989f7c367a4c4a609, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:1a41584c1187bb4a87d3cc1af9993773,
+    wasDerivedFrom(niiri:c4a9ab38a5b5faf27a110372a76b690b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:b08c64db49c2acab9dde84fc5aaafee1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0105" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1582,8 +1582,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "105" %% xsd:int])
-    wasDerivedFrom(niiri:1a41584c1187bb4a87d3cc1af9993773, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:43ed38ee11c52db758569877faabd695,
+    wasDerivedFrom(niiri:b08c64db49c2acab9dde84fc5aaafee1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:a8f46a35300a709894debac1a5c7d877,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0106" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1592,8 +1592,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "106" %% xsd:int])
-    wasDerivedFrom(niiri:43ed38ee11c52db758569877faabd695, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:ee629aca5d18e60c2724bfd2e1b3fc6b,
+    wasDerivedFrom(niiri:a8f46a35300a709894debac1a5c7d877, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:147fb623ae052dca9733d6d1d2297af8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0107" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1602,8 +1602,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "107" %% xsd:int])
-    wasDerivedFrom(niiri:ee629aca5d18e60c2724bfd2e1b3fc6b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:8b0a58d02f59556fa0151651c6d40cc0,
+    wasDerivedFrom(niiri:147fb623ae052dca9733d6d1d2297af8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:eb257014e1b6b6961786c8543836a579,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0108" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1612,8 +1612,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "108" %% xsd:int])
-    wasDerivedFrom(niiri:8b0a58d02f59556fa0151651c6d40cc0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:eeb7c0ae3047601cda9c179c68e75d65,
+    wasDerivedFrom(niiri:eb257014e1b6b6961786c8543836a579, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:3c0db86cde8ac7aa1cb1f7b208b617e8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0109" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1622,8 +1622,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "109" %% xsd:int])
-    wasDerivedFrom(niiri:eeb7c0ae3047601cda9c179c68e75d65, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:543214dac714341af8aeaa4b70f41266,
+    wasDerivedFrom(niiri:3c0db86cde8ac7aa1cb1f7b208b617e8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:e578dd3a170f088e47efd39f45837f4e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0110" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1632,8 +1632,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "110" %% xsd:int])
-    wasDerivedFrom(niiri:543214dac714341af8aeaa4b70f41266, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:86191fa377232381128e79c2a57a4af6,
+    wasDerivedFrom(niiri:e578dd3a170f088e47efd39f45837f4e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:ab7f882f69e9de3fd22bc39f3519003d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0111" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1642,8 +1642,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "111" %% xsd:int])
-    wasDerivedFrom(niiri:86191fa377232381128e79c2a57a4af6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:6f236184b94e16d3fb82cdd60cd19a6d,
+    wasDerivedFrom(niiri:ab7f882f69e9de3fd22bc39f3519003d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:ca827c13c9bc5f06b55e3bd1cd175793,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0112" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1652,8 +1652,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "112" %% xsd:int])
-    wasDerivedFrom(niiri:6f236184b94e16d3fb82cdd60cd19a6d, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:9ae54c5470ad002b7ae47f7b67b248ad,
+    wasDerivedFrom(niiri:ca827c13c9bc5f06b55e3bd1cd175793, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8472115c12bd571d534dfe5bac960c80,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0113" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1662,8 +1662,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "113" %% xsd:int])
-    wasDerivedFrom(niiri:9ae54c5470ad002b7ae47f7b67b248ad, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:0104fa6d88bd50793a3b65b47635e2c6,
+    wasDerivedFrom(niiri:8472115c12bd571d534dfe5bac960c80, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:812c44e9a98ad090a6f8b72ffea8eb49,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0114" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1672,8 +1672,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "114" %% xsd:int])
-    wasDerivedFrom(niiri:0104fa6d88bd50793a3b65b47635e2c6, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:1ff5ea3ca56fb13894e4e43c39a861c9,
+    wasDerivedFrom(niiri:812c44e9a98ad090a6f8b72ffea8eb49, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:eb1e036b54bfd5155015ad5c924a62ce,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0115" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1682,8 +1682,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "115" %% xsd:int])
-    wasDerivedFrom(niiri:1ff5ea3ca56fb13894e4e43c39a861c9, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:9e02c41cd62cc06c92b5e2b56a706886,
+    wasDerivedFrom(niiri:eb1e036b54bfd5155015ad5c924a62ce, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8bac0f00c0d1f0f9f5c118004ab17321,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0116" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1692,8 +1692,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "116" %% xsd:int])
-    wasDerivedFrom(niiri:9e02c41cd62cc06c92b5e2b56a706886, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:a5e308239dff195e8c67ca5b964d553a,
+    wasDerivedFrom(niiri:8bac0f00c0d1f0f9f5c118004ab17321, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:4f4b190235fbb136b1bb7467b78730d6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0117" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1702,8 +1702,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "117" %% xsd:int])
-    wasDerivedFrom(niiri:a5e308239dff195e8c67ca5b964d553a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:aeffc3536799596ea12e2467fc52bd65,
+    wasDerivedFrom(niiri:4f4b190235fbb136b1bb7467b78730d6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:d04d2676281bca09e8a782500650e993,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0118" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1712,8 +1712,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "118" %% xsd:int])
-    wasDerivedFrom(niiri:aeffc3536799596ea12e2467fc52bd65, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:3e987521ad9deca092879412707ea491,
+    wasDerivedFrom(niiri:d04d2676281bca09e8a782500650e993, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:59c6e585fc56ebce5a5d95b959cc120d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0119" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1722,8 +1722,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "119" %% xsd:int])
-    wasDerivedFrom(niiri:3e987521ad9deca092879412707ea491, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:f54f30ee52ac26f6dae0749e096ea6c1,
+    wasDerivedFrom(niiri:59c6e585fc56ebce5a5d95b959cc120d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:a4d82c21752d17f68b6fbf41caa89a4b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0120" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1732,8 +1732,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "120" %% xsd:int])
-    wasDerivedFrom(niiri:f54f30ee52ac26f6dae0749e096ea6c1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:692bc9543cbfc2b98e06dde4c8e7603f,
+    wasDerivedFrom(niiri:a4d82c21752d17f68b6fbf41caa89a4b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9c09ac30035d9617daad1f111fa1b47f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0121" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1742,8 +1742,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "121" %% xsd:int])
-    wasDerivedFrom(niiri:692bc9543cbfc2b98e06dde4c8e7603f, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:be235801557e66b2190c98cd649588c0,
+    wasDerivedFrom(niiri:9c09ac30035d9617daad1f111fa1b47f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:b5d02c34e634c7f52d94137fbd9f8813,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0122" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1752,8 +1752,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "122" %% xsd:int])
-    wasDerivedFrom(niiri:be235801557e66b2190c98cd649588c0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:baf9fc0b69478678bb8ed7430b24c094,
+    wasDerivedFrom(niiri:b5d02c34e634c7f52d94137fbd9f8813, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:fc91a408c252d8e2b7beb4005554eaf8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0123" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1762,8 +1762,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "123" %% xsd:int])
-    wasDerivedFrom(niiri:baf9fc0b69478678bb8ed7430b24c094, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:27343a380f46da81b03903d4cf6193dc,
+    wasDerivedFrom(niiri:fc91a408c252d8e2b7beb4005554eaf8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9b0591f2b854d2643aaf1afaa93cb549,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0124" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1772,8 +1772,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "124" %% xsd:int])
-    wasDerivedFrom(niiri:27343a380f46da81b03903d4cf6193dc, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:158f1d535951e2b7d78ea10b066c15f3,
+    wasDerivedFrom(niiri:9b0591f2b854d2643aaf1afaa93cb549, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:d54744a8017e84d7adb355fc9412fba3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0125" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1782,8 +1782,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "125" %% xsd:int])
-    wasDerivedFrom(niiri:158f1d535951e2b7d78ea10b066c15f3, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:842d2062c93ff252780aae9939a20111,
+    wasDerivedFrom(niiri:d54744a8017e84d7adb355fc9412fba3, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:e49a03f4d60a11688f798fc5bc43c1b2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0126" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1792,8 +1792,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "126" %% xsd:int])
-    wasDerivedFrom(niiri:842d2062c93ff252780aae9939a20111, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:d27fbf9c8044e6b188c300c4990f6f54,
+    wasDerivedFrom(niiri:e49a03f4d60a11688f798fc5bc43c1b2, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:b04a187086857b7422c8096db14ee613,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0127" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1802,8 +1802,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "127" %% xsd:int])
-    wasDerivedFrom(niiri:d27fbf9c8044e6b188c300c4990f6f54, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:2a4965b8fc709556c2aa1abb6adf5441,
+    wasDerivedFrom(niiri:b04a187086857b7422c8096db14ee613, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:39ce93dd6abab662ab6da84a046a56bd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0128" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1812,8 +1812,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "128" %% xsd:int])
-    wasDerivedFrom(niiri:2a4965b8fc709556c2aa1abb6adf5441, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:9cc63018305b210a50122f137d979802,
+    wasDerivedFrom(niiri:39ce93dd6abab662ab6da84a046a56bd, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0129" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1822,8 +1822,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "129" %% xsd:int])
-    wasDerivedFrom(niiri:9cc63018305b210a50122f137d979802, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:965ac0d53ae837b608d6841eb6671ec5,
+    wasDerivedFrom(niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:ca20dee3ba6bf36049f99642c710470d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0130" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1832,8 +1832,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "130" %% xsd:int])
-    wasDerivedFrom(niiri:965ac0d53ae837b608d6841eb6671ec5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:d20a800c34ef4ebbc2c9d064007ca5a5,
+    wasDerivedFrom(niiri:ca20dee3ba6bf36049f99642c710470d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:26fa7a82c298f218eb7fd282cfbf7a81,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0131" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1842,8 +1842,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "131" %% xsd:int])
-    wasDerivedFrom(niiri:d20a800c34ef4ebbc2c9d064007ca5a5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:0a26619869c6304390cf220d86997062,
+    wasDerivedFrom(niiri:26fa7a82c298f218eb7fd282cfbf7a81, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:e518dd980ffdb694adcf472695d5a40a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0132" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1852,8 +1852,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "132" %% xsd:int])
-    wasDerivedFrom(niiri:0a26619869c6304390cf220d86997062, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:6a5b8fb86c67c0eb5b9c606e6b810510,
+    wasDerivedFrom(niiri:e518dd980ffdb694adcf472695d5a40a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:5f278b6b11fae0c4b4f9690852a71d0c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0133" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1862,8 +1862,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "133" %% xsd:int])
-    wasDerivedFrom(niiri:6a5b8fb86c67c0eb5b9c606e6b810510, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:99f3a2d8e7661135dd74892e7227bd72,
+    wasDerivedFrom(niiri:5f278b6b11fae0c4b4f9690852a71d0c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:87f8233f1c48acf6ecdd7339055182ae,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0134" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1872,8 +1872,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "134" %% xsd:int])
-    wasDerivedFrom(niiri:99f3a2d8e7661135dd74892e7227bd72, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:64a5de9f75df294ee267e34b2597bc84,
+    wasDerivedFrom(niiri:87f8233f1c48acf6ecdd7339055182ae, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:0189728b5aaa10d4eb4ff53d1fbc5843,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0135" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1882,8 +1882,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "135" %% xsd:int])
-    wasDerivedFrom(niiri:64a5de9f75df294ee267e34b2597bc84, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:2c98abbba202c2ed1fa8e08549a97cb1,
+    wasDerivedFrom(niiri:0189728b5aaa10d4eb4ff53d1fbc5843, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:453f1919d7df3d7e610709f6fdecbf62,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0136" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1892,8 +1892,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "136" %% xsd:int])
-    wasDerivedFrom(niiri:2c98abbba202c2ed1fa8e08549a97cb1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:35bfc5987aa4a1eba01be33e4c1ee7f2,
+    wasDerivedFrom(niiri:453f1919d7df3d7e610709f6fdecbf62, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:5b21dda7a2823d1c7efeff7947020767,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0137" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1902,8 +1902,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "137" %% xsd:int])
-    wasDerivedFrom(niiri:35bfc5987aa4a1eba01be33e4c1ee7f2, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:33395b862a603ee1373735759fed1bcb,
+    wasDerivedFrom(niiri:5b21dda7a2823d1c7efeff7947020767, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:a6dc495a077e17aa8f96566659037e0b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0138" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1912,8 +1912,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "138" %% xsd:int])
-    wasDerivedFrom(niiri:33395b862a603ee1373735759fed1bcb, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:635a4fc24d89b14d261b42d568e53ac8,
+    wasDerivedFrom(niiri:a6dc495a077e17aa8f96566659037e0b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:e5e5eeee288ec088072a80af972a3638,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0139" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1922,8 +1922,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "139" %% xsd:int])
-    wasDerivedFrom(niiri:635a4fc24d89b14d261b42d568e53ac8, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:55b4eeddb69bb03436464cf696dd593b,
+    wasDerivedFrom(niiri:e5e5eeee288ec088072a80af972a3638, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0140" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1932,8 +1932,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "140" %% xsd:int])
-    wasDerivedFrom(niiri:55b4eeddb69bb03436464cf696dd593b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:493898a476d4ce4bf533682e007422c5,
+    wasDerivedFrom(niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:66cf0dbeb1aa03edbab1a35c2d527a55,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0141" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1942,8 +1942,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "141" %% xsd:int])
-    wasDerivedFrom(niiri:493898a476d4ce4bf533682e007422c5, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:b841eb2677ab2ad59ce73103265cdee0,
+    wasDerivedFrom(niiri:66cf0dbeb1aa03edbab1a35c2d527a55, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:09d8898196c5c40aec6f995a2b0c383d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0142" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1952,8 +1952,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "142" %% xsd:int])
-    wasDerivedFrom(niiri:b841eb2677ab2ad59ce73103265cdee0, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:4c7ec0be40515b0eae812fe9befe02f1,
+    wasDerivedFrom(niiri:09d8898196c5c40aec6f995a2b0c383d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:bfe644ea717165d3b6b50431d8e57c87,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0143" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1962,8 +1962,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "143" %% xsd:int])
-    wasDerivedFrom(niiri:4c7ec0be40515b0eae812fe9befe02f1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22,
+    wasDerivedFrom(niiri:bfe644ea717165d3b6b50431d8e57c87, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:0d278ee0d105de3a7319a5acaa11c631,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0144" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1972,8 +1972,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "144" %% xsd:int])
-    wasDerivedFrom(niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:9d494c09341573a6df3c044f6f353a5a,
+    wasDerivedFrom(niiri:0d278ee0d105de3a7319a5acaa11c631, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:9a54b30308f71d0c474dab56acec5885,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0145" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1982,8 +1982,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "145" %% xsd:int])
-    wasDerivedFrom(niiri:9d494c09341573a6df3c044f6f353a5a, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:630ac6074dee24b42295002659ee6cd4,
+    wasDerivedFrom(niiri:9a54b30308f71d0c474dab56acec5885, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:f219989ec875846cc4815fffc10bd118,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0146" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1992,8 +1992,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "146" %% xsd:int])
-    wasDerivedFrom(niiri:630ac6074dee24b42295002659ee6cd4, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:97f9982dca21f34e7ea0fcb977fcf50b,
+    wasDerivedFrom(niiri:f219989ec875846cc4815fffc10bd118, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:4b37375a8d01d1d9009b430352062714,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0147" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -2002,8 +2002,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "147" %% xsd:int])
-    wasDerivedFrom(niiri:97f9982dca21f34e7ea0fcb977fcf50b, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:b7588b8a823a7341bbdb4d3e8686e040,
+    wasDerivedFrom(niiri:4b37375a8d01d1d9009b430352062714, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:0f0a4015dd42d89522302ce792b20d6d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0148" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -2012,8 +2012,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "148" %% xsd:int])
-    wasDerivedFrom(niiri:b7588b8a823a7341bbdb4d3e8686e040, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:31b704c584e2aae3b394c52754216fae,
+    wasDerivedFrom(niiri:0f0a4015dd42d89522302ce792b20d6d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0149" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -2022,8 +2022,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "149" %% xsd:int])
-    wasDerivedFrom(niiri:31b704c584e2aae3b394c52754216fae, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:2eff95031f5301f6a29990e69708dce1,
+    wasDerivedFrom(niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:f6e36041fd68625d6c7813fe63387c51,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0150" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -2032,2691 +2032,2691 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "150" %% xsd:int])
-    wasDerivedFrom(niiri:2eff95031f5301f6a29990e69708dce1, niiri:9315492073c635bc63a9934fefeda6b6, -, -, -)
-    entity(niiri:47e960742a534223746b8914f30df973,
+    wasDerivedFrom(niiri:f6e36041fd68625d6c7813fe63387c51, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
+    entity(niiri:442ae032432253444ea32f99f4dc387c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:7ffeabdba971025768378cc6c32ca5fe',
+        prov:location = 'niiri:a4693444c0135c8dfe9d5e4683a03a3a',
         prov:value = "2.18819689750671" %% xsd:float,
         nidm_equivalentZStatistic: = "3.5114661254844" %% xsd:float,
         nidm_pValueUncorrected: = "0.000222821126723893" %% xsd:float,
         nidm_pValueFWER: = "0.999999868311968" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7ffeabdba971025768378cc6c32ca5fe,
+    entity(niiri:a4693444c0135c8dfe9d5e4683a03a3a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[-28,24,4]" %% xsd:string])
-    wasDerivedFrom(niiri:47e960742a534223746b8914f30df973, niiri:43fc9ecb30d51558da2aa2580905eaab, -, -, -)
-    entity(niiri:78e2d8c40d6e4600a75cdea76efced8c,
+    wasDerivedFrom(niiri:442ae032432253444ea32f99f4dc387c, niiri:4362f5eac9972bf179ea49be33151c8e, -, -, -)
+    entity(niiri:2cc0e4b46ef04062f76f3cd9f58335d7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:35dde01361b1ceeb6c6b77cfaa742ec4',
+        prov:location = 'niiri:21b2ec6e254ee0565b8270bfcfc0e2c7',
         prov:value = "2.07190132141113" %% xsd:float,
         nidm_equivalentZStatistic: = "3.35835159739265" %% xsd:float,
         nidm_pValueUncorrected: = "0.000392044053194152" %% xsd:float,
         nidm_pValueFWER: = "0.999999999969126" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:35dde01361b1ceeb6c6b77cfaa742ec4,
+    entity(niiri:21b2ec6e254ee0565b8270bfcfc0e2c7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[-28,26,12]" %% xsd:string])
-    wasDerivedFrom(niiri:78e2d8c40d6e4600a75cdea76efced8c, niiri:43fc9ecb30d51558da2aa2580905eaab, -, -, -)
-    entity(niiri:dc356018e062c59172dcd1e78418a358,
+    wasDerivedFrom(niiri:2cc0e4b46ef04062f76f3cd9f58335d7, niiri:4362f5eac9972bf179ea49be33151c8e, -, -, -)
+    entity(niiri:bf2f05f6426d9b3de806efb87eb24421,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:eb6d8af6a185c83b9c38e3a1630a4622',
+        prov:location = 'niiri:63e78c482af8490d5dfa90d0a0e92669',
         prov:value = "1.94285821914673" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18853089402481" %% xsd:float,
         nidm_pValueUncorrected: = "0.000714988643396364" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:eb6d8af6a185c83b9c38e3a1630a4622,
+    entity(niiri:63e78c482af8490d5dfa90d0a0e92669,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[-42,20,36]" %% xsd:string])
-    wasDerivedFrom(niiri:dc356018e062c59172dcd1e78418a358, niiri:43fc9ecb30d51558da2aa2580905eaab, -, -, -)
-    entity(niiri:59f453279ae60b2e7633608a74b392af,
+    wasDerivedFrom(niiri:bf2f05f6426d9b3de806efb87eb24421, niiri:4362f5eac9972bf179ea49be33151c8e, -, -, -)
+    entity(niiri:6d4129ab6385c802707ca56c724df92f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:8613dd8cea932331a073b148edfe5144',
+        prov:location = 'niiri:de746baa0f488d3bbadc409c300d1274',
         prov:value = "2.1167094707489" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41734061195353" %% xsd:float,
         nidm_pValueUncorrected: = "0.000316180548517564" %% xsd:float,
         nidm_pValueFWER: = "0.999999998897938" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8613dd8cea932331a073b148edfe5144,
+    entity(niiri:de746baa0f488d3bbadc409c300d1274,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[36,-84,2]" %% xsd:string])
-    wasDerivedFrom(niiri:59f453279ae60b2e7633608a74b392af, niiri:417cabd3eeb412117d20f4882d064567, -, -, -)
-    entity(niiri:30c43a8440f4ec3cda96fcd40be4d4d5,
+    wasDerivedFrom(niiri:6d4129ab6385c802707ca56c724df92f, niiri:00f296730dd06a43e5f7334c226305c6, -, -, -)
+    entity(niiri:3398d8202d4e93e898d65527617056fc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:c5988d123290f51d40d4592a7961f1d1',
+        prov:location = 'niiri:787673d51909fd4b7955adca6289845e',
         prov:value = "2.00524592399597" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27061943294259" %% xsd:float,
         nidm_pValueUncorrected: = "0.000536561087325027" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999994" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c5988d123290f51d40d4592a7961f1d1,
+    entity(niiri:787673d51909fd4b7955adca6289845e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[34,-84,14]" %% xsd:string])
-    wasDerivedFrom(niiri:30c43a8440f4ec3cda96fcd40be4d4d5, niiri:417cabd3eeb412117d20f4882d064567, -, -, -)
-    entity(niiri:7188131da5a3b3086de0052afecc1b23,
+    wasDerivedFrom(niiri:3398d8202d4e93e898d65527617056fc, niiri:00f296730dd06a43e5f7334c226305c6, -, -, -)
+    entity(niiri:d0c21323683c00398f1fe5b8cd2b1821,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:8014c5c8b33dfb4ba42f7cc5ed169849',
+        prov:location = 'niiri:c2e490ac6fc0201797ed715401260ead',
         prov:value = "1.9834691286087" %% xsd:float,
         nidm_equivalentZStatistic: = "3.24196265203981" %% xsd:float,
         nidm_pValueUncorrected: = "0.000593547891254209" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999994" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8014c5c8b33dfb4ba42f7cc5ed169849,
+    entity(niiri:c2e490ac6fc0201797ed715401260ead,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[34,-78,36]" %% xsd:string])
-    wasDerivedFrom(niiri:7188131da5a3b3086de0052afecc1b23, niiri:417cabd3eeb412117d20f4882d064567, -, -, -)
-    entity(niiri:12ddd7ac78265e0515a406f79cd7b60b,
+    wasDerivedFrom(niiri:d0c21323683c00398f1fe5b8cd2b1821, niiri:00f296730dd06a43e5f7334c226305c6, -, -, -)
+    entity(niiri:1f3d65d5c16aacc0308451722678f7de,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:4f09bb3884a3beab368df1e4cbdd6c5a',
+        prov:location = 'niiri:7291a001aa765929838e01ce77a9da57',
         prov:value = "2.07622194290161" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36403923290147" %% xsd:float,
         nidm_pValueUncorrected: = "0.000384053116980865" %% xsd:float,
         nidm_pValueFWER: = "0.999999999955495" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4f09bb3884a3beab368df1e4cbdd6c5a,
+    entity(niiri:7291a001aa765929838e01ce77a9da57,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[52,48,12]" %% xsd:string])
-    wasDerivedFrom(niiri:12ddd7ac78265e0515a406f79cd7b60b, niiri:6cc5ea3c57b906137def3d6777b0000f, -, -, -)
-    entity(niiri:a8daaa449eaabd54146c2443c52b2405,
+    wasDerivedFrom(niiri:1f3d65d5c16aacc0308451722678f7de, niiri:39a3babf6ed520d78e67263717ca5dbb, -, -, -)
+    entity(niiri:6c8bcca3f301b2525f53e90e5d2e044e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:ced65fab2ecc31645054de6698a6e193',
+        prov:location = 'niiri:dcdc8cced1a70ed65194762748dd42f2',
         prov:value = "2.0327205657959" %% xsd:float,
         nidm_equivalentZStatistic: = "3.306778623673" %% xsd:float,
         nidm_pValueUncorrected: = "0.000471877215462824" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999097" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ced65fab2ecc31645054de6698a6e193,
+    entity(niiri:dcdc8cced1a70ed65194762748dd42f2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[30,68,12]" %% xsd:string])
-    wasDerivedFrom(niiri:a8daaa449eaabd54146c2443c52b2405, niiri:6cc5ea3c57b906137def3d6777b0000f, -, -, -)
-    entity(niiri:073f17f5ff09cc49a92a3da9639c7ec8,
+    wasDerivedFrom(niiri:6c8bcca3f301b2525f53e90e5d2e044e, niiri:39a3babf6ed520d78e67263717ca5dbb, -, -, -)
+    entity(niiri:dc9c09a94ef328a1469d800c80f6fc2f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:9e58a2008800aed167f2193e6475edaa',
+        prov:location = 'niiri:508dc677de99afa67c363c475a5c743e',
         prov:value = "1.63326919078827" %% xsd:float,
         nidm_equivalentZStatistic: = "2.78184273056811" %% xsd:float,
         nidm_pValueUncorrected: = "0.00270256128658664" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9e58a2008800aed167f2193e6475edaa,
+    entity(niiri:508dc677de99afa67c363c475a5c743e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[14,74,6]" %% xsd:string])
-    wasDerivedFrom(niiri:073f17f5ff09cc49a92a3da9639c7ec8, niiri:6cc5ea3c57b906137def3d6777b0000f, -, -, -)
-    entity(niiri:d0393b0ebc9411a5d45ca86b90a5f75a,
+    wasDerivedFrom(niiri:dc9c09a94ef328a1469d800c80f6fc2f, niiri:39a3babf6ed520d78e67263717ca5dbb, -, -, -)
+    entity(niiri:0445099b3ad94f2a7bffd17b72c32178,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:32c57c9426babf3fe0244d15351d0daf',
+        prov:location = 'niiri:d2747be6a82e62e1332bff6a58f4d7f5',
         prov:value = "2.04988360404968" %% xsd:float,
         nidm_equivalentZStatistic: = "3.32936904595179" %% xsd:float,
         nidm_pValueUncorrected: = "0.000435214929046523" %% xsd:float,
         nidm_pValueFWER: = "0.999999999995547" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:32c57c9426babf3fe0244d15351d0daf,
+    entity(niiri:d2747be6a82e62e1332bff6a58f4d7f5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[34,-54,52]" %% xsd:string])
-    wasDerivedFrom(niiri:d0393b0ebc9411a5d45ca86b90a5f75a, niiri:c29516aed6cf24b95d9653e2365e0ced, -, -, -)
-    entity(niiri:603843b40d6d98501a421775119d3ad1,
+    wasDerivedFrom(niiri:0445099b3ad94f2a7bffd17b72c32178, niiri:26ed93f97118482ea99f750276db5700, -, -, -)
+    entity(niiri:6cf57566c63330551854cd41c76c7945,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:fcdba63eb7662475636125721f54320e',
+        prov:location = 'niiri:2e98c4783a911189aca09f35a6897677',
         prov:value = "1.17590498924255" %% xsd:float,
         nidm_equivalentZStatistic: = "2.18553018514689" %% xsd:float,
         nidm_pValueUncorrected: = "0.0144249976129074" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:fcdba63eb7662475636125721f54320e,
+    entity(niiri:2e98c4783a911189aca09f35a6897677,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[26,-48,50]" %% xsd:string])
-    wasDerivedFrom(niiri:603843b40d6d98501a421775119d3ad1, niiri:c29516aed6cf24b95d9653e2365e0ced, -, -, -)
-    entity(niiri:16b2952800d349d84a763795197c8b0b,
+    wasDerivedFrom(niiri:6cf57566c63330551854cd41c76c7945, niiri:26ed93f97118482ea99f750276db5700, -, -, -)
+    entity(niiri:43ebe5004c0f1a88f50fa9cffeb58814,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:ac144f9a90591900cfb49f146349a1b8',
+        prov:location = 'niiri:f2579430fdf3f2f8395d1d9fb3007977',
         prov:value = "1.17325437068939" %% xsd:float,
         nidm_equivalentZStatistic: = "2.18210185402812" %% xsd:float,
         nidm_pValueUncorrected: = "0.0145510082060974" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ac144f9a90591900cfb49f146349a1b8,
+    entity(niiri:f2579430fdf3f2f8395d1d9fb3007977,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[32,-54,62]" %% xsd:string])
-    wasDerivedFrom(niiri:16b2952800d349d84a763795197c8b0b, niiri:c29516aed6cf24b95d9653e2365e0ced, -, -, -)
-    entity(niiri:d7a85cf00dbcad11964be5f20d4b99ff,
+    wasDerivedFrom(niiri:43ebe5004c0f1a88f50fa9cffeb58814, niiri:26ed93f97118482ea99f750276db5700, -, -, -)
+    entity(niiri:d5d5aad603484d20a1db3818d3e3212c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:0de0e683dce5cc8a49c6c73eedac8c40',
+        prov:location = 'niiri:0fa634cf4f8cd761e5a8e1556dae51af',
         prov:value = "1.69681537151337" %% xsd:float,
         nidm_equivalentZStatistic: = "2.86519802999163" %% xsd:float,
         nidm_pValueUncorrected: = "0.00208374267085354" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0de0e683dce5cc8a49c6c73eedac8c40,
+    entity(niiri:0fa634cf4f8cd761e5a8e1556dae51af,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[-28,50,36]" %% xsd:string])
-    wasDerivedFrom(niiri:d7a85cf00dbcad11964be5f20d4b99ff, niiri:1c26e68b379e5bd715e75014cca849ab, -, -, -)
-    entity(niiri:90e0ff48a341c849ccd5b511385d366a,
+    wasDerivedFrom(niiri:d5d5aad603484d20a1db3818d3e3212c, niiri:c0faffa954cb5edf1bd166b3c13b64b6, -, -, -)
+    entity(niiri:98d4353d19758293894ef727f5c50955,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:c1f676e8a11713f1a14d11da4d4c21cd',
+        prov:location = 'niiri:f1befc6625b08ba88efdc7f2bfff4a08',
         prov:value = "0.933988809585571" %% xsd:float,
         nidm_equivalentZStatistic: = "1.8747737054388" %% xsd:float,
         nidm_pValueUncorrected: = "0.0304119310280364" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c1f676e8a11713f1a14d11da4d4c21cd,
+    entity(niiri:f1befc6625b08ba88efdc7f2bfff4a08,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[-46,38,30]" %% xsd:string])
-    wasDerivedFrom(niiri:90e0ff48a341c849ccd5b511385d366a, niiri:1c26e68b379e5bd715e75014cca849ab, -, -, -)
-    entity(niiri:d405f97c1debf6dfef53e4c341960b1c,
+    wasDerivedFrom(niiri:98d4353d19758293894ef727f5c50955, niiri:c0faffa954cb5edf1bd166b3c13b64b6, -, -, -)
+    entity(niiri:36a41856d01473f63c7c845ca39839d6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:bac6269bd3bba27583f4d36c34dcbaf1',
+        prov:location = 'niiri:605d54e8c542405ec983a5d0a512106f',
         prov:value = "1.66940176486969" %% xsd:float,
         nidm_equivalentZStatistic: = "2.82922911554701" %% xsd:float,
         nidm_pValueUncorrected: = "0.00233301407977504" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:bac6269bd3bba27583f4d36c34dcbaf1,
+    entity(niiri:605d54e8c542405ec983a5d0a512106f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[16,-94,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:d405f97c1debf6dfef53e4c341960b1c, niiri:8b5d6e1bd5480bd6366d0094c92d4851, -, -, -)
-    entity(niiri:4e793a27eff6bd141a437820cd72dd10,
+    wasDerivedFrom(niiri:36a41856d01473f63c7c845ca39839d6, niiri:1baee1eea0758a922f6c4f1f12441da6, -, -, -)
+    entity(niiri:d8f65681bb1bfa31766963ffbe28cead,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:02f3a870411865e426e29828e46ed3f9',
+        prov:location = 'niiri:8e641bae5b55cb975397775ca4f1465e',
         prov:value = "1.5886458158493" %% xsd:float,
         nidm_equivalentZStatistic: = "2.72335979311329" %% xsd:float,
         nidm_pValueUncorrected: = "0.00323108192435606" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:02f3a870411865e426e29828e46ed3f9,
+    entity(niiri:8e641bae5b55cb975397775ca4f1465e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[24,-92,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:4e793a27eff6bd141a437820cd72dd10, niiri:8b5d6e1bd5480bd6366d0094c92d4851, -, -, -)
-    entity(niiri:7eccc401f6068789908f149147981921,
+    wasDerivedFrom(niiri:d8f65681bb1bfa31766963ffbe28cead, niiri:1baee1eea0758a922f6c4f1f12441da6, -, -, -)
+    entity(niiri:b277f286259eb04c946603cb6ba51822,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:371d66a66b29fdb967d17dd294dfe6e3',
+        prov:location = 'niiri:225f9a677dc138e3dd97c18cbf2884ef',
         prov:value = "1.51174938678741" %% xsd:float,
         nidm_equivalentZStatistic: = "2.62269482082508" %% xsd:float,
         nidm_pValueUncorrected: = "0.00436186877852962" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:371d66a66b29fdb967d17dd294dfe6e3,
+    entity(niiri:225f9a677dc138e3dd97c18cbf2884ef,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[34,-84,-48]" %% xsd:string])
-    wasDerivedFrom(niiri:7eccc401f6068789908f149147981921, niiri:8b5d6e1bd5480bd6366d0094c92d4851, -, -, -)
-    entity(niiri:bc7a7d099b4aa5c027485a3f6e273f75,
+    wasDerivedFrom(niiri:b277f286259eb04c946603cb6ba51822, niiri:1baee1eea0758a922f6c4f1f12441da6, -, -, -)
+    entity(niiri:cee39f86215489cfd805b4d5f5dab3a2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:05b822162b985baea86f5f76eaf274eb',
+        prov:location = 'niiri:9d6418747114ca65b24a6f9e53156964',
         prov:value = "1.6600536108017" %% xsd:float,
         nidm_equivalentZStatistic: = "2.81696686061887" %% xsd:float,
         nidm_pValueUncorrected: = "0.00242397637898328" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:05b822162b985baea86f5f76eaf274eb,
+    entity(niiri:9d6418747114ca65b24a6f9e53156964,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[-44,-56,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:bc7a7d099b4aa5c027485a3f6e273f75, niiri:7e631bc430702f08996bcc12a090f463, -, -, -)
-    entity(niiri:5d6079cd009bcfed9d07102c8bf1cd64,
+    wasDerivedFrom(niiri:cee39f86215489cfd805b4d5f5dab3a2, niiri:1aa58b6ce0025b1ec01cb8a983388e1d, -, -, -)
+    entity(niiri:10d3d3d8948f818e3d2670f3b08476f8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:b5301e158adbbc221d5e73c472172d3e',
+        prov:location = 'niiri:5c9455cedfce2a1f699bcd725ce4b27e',
         prov:value = "1.5787501335144" %% xsd:float,
         nidm_equivalentZStatistic: = "2.71039687336073" %% xsd:float,
         nidm_pValueUncorrected: = "0.00336013715292427" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b5301e158adbbc221d5e73c472172d3e,
+    entity(niiri:5c9455cedfce2a1f699bcd725ce4b27e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[-10,72,0]" %% xsd:string])
-    wasDerivedFrom(niiri:5d6079cd009bcfed9d07102c8bf1cd64, niiri:c21e2ede0b4f245e2d9f679a7862569e, -, -, -)
-    entity(niiri:67a82cc3c6fe87003f709a11853632a1,
+    wasDerivedFrom(niiri:10d3d3d8948f818e3d2670f3b08476f8, niiri:3198b98e15c5c56654d8a4ffe4b44ce8, -, -, -)
+    entity(niiri:fb4201c849e6cb24fb95b4ccf6b6e5b3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:be6a1b05017c497d1872f0ed60f8f931',
+        prov:location = 'niiri:76b9f21dd86f54f4686cb3f8ad313ccc',
         prov:value = "1.37760043144226" %% xsd:float,
         nidm_equivalentZStatistic: = "2.44750858968075" %% xsd:float,
         nidm_pValueUncorrected: = "0.0071923848185762" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:be6a1b05017c497d1872f0ed60f8f931,
+    entity(niiri:76b9f21dd86f54f4686cb3f8ad313ccc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[-24,68,10]" %% xsd:string])
-    wasDerivedFrom(niiri:67a82cc3c6fe87003f709a11853632a1, niiri:c21e2ede0b4f245e2d9f679a7862569e, -, -, -)
-    entity(niiri:8fbbec051d375de1ec30261a1f32f9a5,
+    wasDerivedFrom(niiri:fb4201c849e6cb24fb95b4ccf6b6e5b3, niiri:3198b98e15c5c56654d8a4ffe4b44ce8, -, -, -)
+    entity(niiri:50e767c1e55c55fd6f705e63b8194c22,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:9d8f2d489780f5c4762d7ff3891155a2',
+        prov:location = 'niiri:200e07f7941deec2e3926a00d9c097f1',
         prov:value = "1.35886359214783" %% xsd:float,
         nidm_equivalentZStatistic: = "2.42309168524595" %% xsd:float,
         nidm_pValueUncorrected: = "0.00769452108984159" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9d8f2d489780f5c4762d7ff3891155a2,
+    entity(niiri:200e07f7941deec2e3926a00d9c097f1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[-14,64,28]" %% xsd:string])
-    wasDerivedFrom(niiri:8fbbec051d375de1ec30261a1f32f9a5, niiri:c21e2ede0b4f245e2d9f679a7862569e, -, -, -)
-    entity(niiri:722e903ee5178a4981cc55266210bd89,
+    wasDerivedFrom(niiri:50e767c1e55c55fd6f705e63b8194c22, niiri:3198b98e15c5c56654d8a4ffe4b44ce8, -, -, -)
+    entity(niiri:651e85007a5f5536ec2697c8749ec5f0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:9f719f92694484cd7261b1c6255b52c0',
+        prov:location = 'niiri:a825a8bc763b96a41ba63085944a53f5',
         prov:value = "1.53290164470673" %% xsd:float,
         nidm_equivalentZStatistic: = "2.65036951622375" %% xsd:float,
         nidm_pValueUncorrected: = "0.00402018893002576" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9f719f92694484cd7261b1c6255b52c0,
+    entity(niiri:a825a8bc763b96a41ba63085944a53f5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[-32,-80,10]" %% xsd:string])
-    wasDerivedFrom(niiri:722e903ee5178a4981cc55266210bd89, niiri:c8c6cee0456ea9b67ae74c71ec73d58a, -, -, -)
-    entity(niiri:43c73ccd4ff874b4159d8e343817709e,
+    wasDerivedFrom(niiri:651e85007a5f5536ec2697c8749ec5f0, niiri:7d6744d8bee9e326b4381ceb83e93c8d, -, -, -)
+    entity(niiri:97da40b69bc71f2a3cbe9bddb8d74db7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:d6269808ee48c8a2f54e9d917e97a97d',
+        prov:location = 'niiri:92aaec6881a3d0f16d11925a7c0e8a35',
         prov:value = "1.34681856632233" %% xsd:float,
         nidm_equivalentZStatistic: = "2.4074027844201" %% xsd:float,
         nidm_pValueUncorrected: = "0.00803321955273906" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d6269808ee48c8a2f54e9d917e97a97d,
+    entity(niiri:92aaec6881a3d0f16d11925a7c0e8a35,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-32,-88,8]" %% xsd:string])
-    wasDerivedFrom(niiri:43c73ccd4ff874b4159d8e343817709e, niiri:c8c6cee0456ea9b67ae74c71ec73d58a, -, -, -)
-    entity(niiri:5b402b3505886d69eee1da65259dfff5,
+    wasDerivedFrom(niiri:97da40b69bc71f2a3cbe9bddb8d74db7, niiri:7d6744d8bee9e326b4381ceb83e93c8d, -, -, -)
+    entity(niiri:4a7114ba39dbababe80905fe47a8cbc5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:e3be3bddf8e8cf2bc774db0b5fd4ccf9',
+        prov:location = 'niiri:a5814c8553718d88d2b132f5baa18703',
         prov:value = "1.31222748756409" %% xsd:float,
         nidm_equivalentZStatistic: = "2.36238178325093" %% xsd:float,
         nidm_pValueUncorrected: = "0.00907896581463363" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e3be3bddf8e8cf2bc774db0b5fd4ccf9,
+    entity(niiri:a5814c8553718d88d2b132f5baa18703,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[-30,-78,26]" %% xsd:string])
-    wasDerivedFrom(niiri:5b402b3505886d69eee1da65259dfff5, niiri:c8c6cee0456ea9b67ae74c71ec73d58a, -, -, -)
-    entity(niiri:5516b5835629ab543345d78e4c6e7f84,
+    wasDerivedFrom(niiri:4a7114ba39dbababe80905fe47a8cbc5, niiri:7d6744d8bee9e326b4381ceb83e93c8d, -, -, -)
+    entity(niiri:891a014c9e49c38970fb24d2eaae740d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:5fa024f29ffd7dd65df2521965746c10',
+        prov:location = 'niiri:7d0bd7b1f39fd643840af9787a78ba95',
         prov:value = "1.47698056697845" %% xsd:float,
         nidm_equivalentZStatistic: = "2.57723307746183" %% xsd:float,
         nidm_pValueUncorrected: = "0.00497973845037369" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5fa024f29ffd7dd65df2521965746c10,
+    entity(niiri:7d0bd7b1f39fd643840af9787a78ba95,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[24,-64,62]" %% xsd:string])
-    wasDerivedFrom(niiri:5516b5835629ab543345d78e4c6e7f84, niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5, -, -, -)
-    entity(niiri:b0048f0b19299e2890e2feec137562bd,
+    wasDerivedFrom(niiri:891a014c9e49c38970fb24d2eaae740d, niiri:1593dbfe6a27c4bfd6c7c865a55e6758, -, -, -)
+    entity(niiri:f4b89e59bc3ef696d8778bd6b6dea759,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:dfffa57a27812cbdb97937c604ce644d',
+        prov:location = 'niiri:1d699923abf53a3abefc6961b7996e12',
         prov:value = "1.47098410129547" %% xsd:float,
         nidm_equivalentZStatistic: = "2.56939616988394" %% xsd:float,
         nidm_pValueUncorrected: = "0.00509379579800051" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:dfffa57a27812cbdb97937c604ce644d,
+    entity(niiri:1d699923abf53a3abefc6961b7996e12,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[42,2,42]" %% xsd:string])
-    wasDerivedFrom(niiri:b0048f0b19299e2890e2feec137562bd, niiri:c8915bbac48c4a94d3bf54f07d28091a, -, -, -)
-    entity(niiri:44cc0c30dff2ae8e59814059b0d808d8,
+    wasDerivedFrom(niiri:f4b89e59bc3ef696d8778bd6b6dea759, niiri:537cd4e035d031e1d96dcc9b62c35112, -, -, -)
+    entity(niiri:6d3354cad50b2f85dd7cb7909270bbd9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:9cfb25b1548c7ea2a37d91c1cdc97937',
+        prov:location = 'niiri:a0853cb3b872dd490c0e659c3b8de3c5',
         prov:value = "1.28529334068298" %% xsd:float,
         nidm_equivalentZStatistic: = "2.32736401858338" %% xsd:float,
         nidm_pValueUncorrected: = "0.00997294956075112" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9cfb25b1548c7ea2a37d91c1cdc97937,
+    entity(niiri:a0853cb3b872dd490c0e659c3b8de3c5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[52,6,36]" %% xsd:string])
-    wasDerivedFrom(niiri:44cc0c30dff2ae8e59814059b0d808d8, niiri:c8915bbac48c4a94d3bf54f07d28091a, -, -, -)
-    entity(niiri:8f81caeadc613b2befe266e538a005b4,
+    wasDerivedFrom(niiri:6d3354cad50b2f85dd7cb7909270bbd9, niiri:537cd4e035d031e1d96dcc9b62c35112, -, -, -)
+    entity(niiri:c9fd614181dc2572b186e5053efcd59d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:192ea9c42130b9f2836346385ffa8ac6',
+        prov:location = 'niiri:f39a7e048d6696e150550855cdb219a4',
         prov:value = "1.46635723114014" %% xsd:float,
         nidm_equivalentZStatistic: = "2.56334999311601" %% xsd:float,
         nidm_pValueUncorrected: = "0.00518337435668992" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:192ea9c42130b9f2836346385ffa8ac6,
+    entity(niiri:f39a7e048d6696e150550855cdb219a4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[-28,-60,54]" %% xsd:string])
-    wasDerivedFrom(niiri:8f81caeadc613b2befe266e538a005b4, niiri:81f39aacce9db78e536cab5c96400969, -, -, -)
-    entity(niiri:49b88a38ee8eb23aa88417b585a3c019,
+    wasDerivedFrom(niiri:c9fd614181dc2572b186e5053efcd59d, niiri:3330f53a36ff5c9ef2f20b1290e9d286, -, -, -)
+    entity(niiri:a16bea998c35dc62efc05b93e35b430f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:2e4756a1fc7f488d50c7e456c8606411',
+        prov:location = 'niiri:b2d449babe5545c90ba00fa714a59c65',
         prov:value = "1.35919630527496" %% xsd:float,
         nidm_equivalentZStatistic: = "2.42352513638295" %% xsd:float,
         nidm_pValueUncorrected: = "0.00768534474692273" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2e4756a1fc7f488d50c7e456c8606411,
+    entity(niiri:b2d449babe5545c90ba00fa714a59c65,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[-30,-56,62]" %% xsd:string])
-    wasDerivedFrom(niiri:49b88a38ee8eb23aa88417b585a3c019, niiri:81f39aacce9db78e536cab5c96400969, -, -, -)
-    entity(niiri:d526e3755e8ee1eb281731fad0d751f7,
+    wasDerivedFrom(niiri:a16bea998c35dc62efc05b93e35b430f, niiri:3330f53a36ff5c9ef2f20b1290e9d286, -, -, -)
+    entity(niiri:0103dbc26eaf007da3744695bb9e0aa0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:7f8d1d4f81b26e2e937ef2c6c7065a2f',
+        prov:location = 'niiri:cba23a81a0efa6d0d2133678dd3ac39f',
         prov:value = "1.3043509721756" %% xsd:float,
         nidm_equivalentZStatistic: = "2.35213781333103" %% xsd:float,
         nidm_pValueUncorrected: = "0.00933292892535331" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7f8d1d4f81b26e2e937ef2c6c7065a2f,
+    entity(niiri:cba23a81a0efa6d0d2133678dd3ac39f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[-18,-62,52]" %% xsd:string])
-    wasDerivedFrom(niiri:d526e3755e8ee1eb281731fad0d751f7, niiri:81f39aacce9db78e536cab5c96400969, -, -, -)
-    entity(niiri:803b5b1f8348b033ada171621cc5c167,
+    wasDerivedFrom(niiri:0103dbc26eaf007da3744695bb9e0aa0, niiri:3330f53a36ff5c9ef2f20b1290e9d286, -, -, -)
+    entity(niiri:f75194d50d0d5b9cd1dcdbd886ebd682,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:a13a3d48a1429418bba0b99d4e9725bb',
+        prov:location = 'niiri:1adec05c4ab0624228a2752245a4ad8b',
         prov:value = "1.45064067840576" %% xsd:float,
         nidm_equivalentZStatistic: = "2.54281750257153" %% xsd:float,
         nidm_pValueUncorrected: = "0.00549813229675677" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a13a3d48a1429418bba0b99d4e9725bb,
+    entity(niiri:1adec05c4ab0624228a2752245a4ad8b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[-30,-84,-48]" %% xsd:string])
-    wasDerivedFrom(niiri:803b5b1f8348b033ada171621cc5c167, niiri:95cfa48491de3b2db8a60dc29bdeb6af, -, -, -)
-    entity(niiri:10252df0ea1e4565a8207dad73957039,
+    wasDerivedFrom(niiri:f75194d50d0d5b9cd1dcdbd886ebd682, niiri:9c973b3443bcab76e6ce5b021d6b1a13, -, -, -)
+    entity(niiri:acc4812fde8a87c23d34ba26b370d53f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:6e55e818af807eb11d9ab4e1a7d892a8',
+        prov:location = 'niiri:886a9d589ec63742ed0ea381ebb81a8f',
         prov:value = "1.37874686717987" %% xsd:float,
         nidm_equivalentZStatistic: = "2.44900302114624" %% xsd:float,
         nidm_pValueUncorrected: = "0.00716261232865922" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6e55e818af807eb11d9ab4e1a7d892a8,
+    entity(niiri:886a9d589ec63742ed0ea381ebb81a8f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[-22,-84,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:10252df0ea1e4565a8207dad73957039, niiri:95cfa48491de3b2db8a60dc29bdeb6af, -, -, -)
-    entity(niiri:1b619cb22a788dbfcac8e6547b8cf9c3,
+    wasDerivedFrom(niiri:acc4812fde8a87c23d34ba26b370d53f, niiri:9c973b3443bcab76e6ce5b021d6b1a13, -, -, -)
+    entity(niiri:15ccd6b0b7514b3584e9c6b60bb007cb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0033" %% xsd:string,
-        prov:location = 'niiri:a196ba726a6cf6e1af92ce4f926bddd6',
+        prov:location = 'niiri:156b51e696a83a537ee4ec10986ac2ce',
         prov:value = "1.1024569272995" %% xsd:float,
         nidm_equivalentZStatistic: = "2.09070134301333" %% xsd:float,
         nidm_pValueUncorrected: = "0.0182774222681363" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a196ba726a6cf6e1af92ce4f926bddd6,
+    entity(niiri:156b51e696a83a537ee4ec10986ac2ce,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0033" %% xsd:string,
         nidm_coordinateVector: = "[-24,-90,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:1b619cb22a788dbfcac8e6547b8cf9c3, niiri:95cfa48491de3b2db8a60dc29bdeb6af, -, -, -)
-    entity(niiri:e7bccdc00c0d8eba721b2ada820c74eb,
+    wasDerivedFrom(niiri:15ccd6b0b7514b3584e9c6b60bb007cb, niiri:9c973b3443bcab76e6ce5b021d6b1a13, -, -, -)
+    entity(niiri:4777cf2071b7b41500a1f57022890df8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0034" %% xsd:string,
-        prov:location = 'niiri:07a292d3fca36fc7398026cd440e98ff',
+        prov:location = 'niiri:1af93548bf2bbf22f69bc6640b686613',
         prov:value = "1.43723428249359" %% xsd:float,
         nidm_equivalentZStatistic: = "2.52530953068747" %% xsd:float,
         nidm_pValueUncorrected: = "0.00577982121839438" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:07a292d3fca36fc7398026cd440e98ff,
+    entity(niiri:1af93548bf2bbf22f69bc6640b686613,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0034" %% xsd:string,
         nidm_coordinateVector: = "[-24,40,46]" %% xsd:string])
-    wasDerivedFrom(niiri:e7bccdc00c0d8eba721b2ada820c74eb, niiri:e7fc37cb04d1a3f58136cfb12f992f34, -, -, -)
-    entity(niiri:b04044222ee790cf55bdaa521739b13d,
+    wasDerivedFrom(niiri:4777cf2071b7b41500a1f57022890df8, niiri:27a3407fb41dee69924952963bf01095, -, -, -)
+    entity(niiri:eacfb263b90cde13ef784658cf25eb48,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0035" %% xsd:string,
-        prov:location = 'niiri:ee1d4ec9c2f0fec55c6dd0053012c88a',
+        prov:location = 'niiri:7ac57d87a6011aa306f5300c51620b1f',
         prov:value = "1.11286687850952" %% xsd:float,
         nidm_equivalentZStatistic: = "2.10411930550185" %% xsd:float,
         nidm_pValueUncorrected: = "0.0176840206088169" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ee1d4ec9c2f0fec55c6dd0053012c88a,
+    entity(niiri:7ac57d87a6011aa306f5300c51620b1f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0035" %% xsd:string,
         nidm_coordinateVector: = "[-16,50,46]" %% xsd:string])
-    wasDerivedFrom(niiri:b04044222ee790cf55bdaa521739b13d, niiri:e7fc37cb04d1a3f58136cfb12f992f34, -, -, -)
-    entity(niiri:2d1b96b3d3613decbd596f70088a278e,
+    wasDerivedFrom(niiri:eacfb263b90cde13ef784658cf25eb48, niiri:27a3407fb41dee69924952963bf01095, -, -, -)
+    entity(niiri:f954f6180923bbe6c50483cd884c34cb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0036" %% xsd:string,
-        prov:location = 'niiri:e1970f3d88404b41f93f350066b20ee5',
+        prov:location = 'niiri:7beb4ee855117da9771f3319e86d6926',
         prov:value = "1.42738270759583" %% xsd:float,
         nidm_equivalentZStatistic: = "2.51244786328393" %% xsd:float,
         nidm_pValueUncorrected: = "0.00599484099495173" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e1970f3d88404b41f93f350066b20ee5,
+    entity(niiri:7beb4ee855117da9771f3319e86d6926,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0036" %% xsd:string,
         nidm_coordinateVector: = "[40,32,42]" %% xsd:string])
-    wasDerivedFrom(niiri:2d1b96b3d3613decbd596f70088a278e, niiri:de5b4d0f5d84034ba5fd7975873cc2e6, -, -, -)
-    entity(niiri:7cd243c2f0efa2926ee101eb0ddaa71f,
+    wasDerivedFrom(niiri:f954f6180923bbe6c50483cd884c34cb, niiri:9c3f0991818d487326255d5ca7862e30, -, -, -)
+    entity(niiri:f04690c008db60f141bbb5f8963ea62f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0037" %% xsd:string,
-        prov:location = 'niiri:2d93df4bc1c8bdc309f561183cf1d559',
+        prov:location = 'niiri:dc9d047e50802cd5dfea68f14c77fdb3',
         prov:value = "1.05634605884552" %% xsd:float,
         nidm_equivalentZStatistic: = "2.03136304442869" %% xsd:float,
         nidm_pValueUncorrected: = "0.0211090901815698" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2d93df4bc1c8bdc309f561183cf1d559,
+    entity(niiri:dc9d047e50802cd5dfea68f14c77fdb3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0037" %% xsd:string,
         nidm_coordinateVector: = "[38,40,36]" %% xsd:string])
-    wasDerivedFrom(niiri:7cd243c2f0efa2926ee101eb0ddaa71f, niiri:de5b4d0f5d84034ba5fd7975873cc2e6, -, -, -)
-    entity(niiri:af520ea7a2b622b616f138da20521f11,
+    wasDerivedFrom(niiri:f04690c008db60f141bbb5f8963ea62f, niiri:9c3f0991818d487326255d5ca7862e30, -, -, -)
+    entity(niiri:f2927e668b305ce4095e4a1fae3d5ba5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0038" %% xsd:string,
-        prov:location = 'niiri:25eebb30f786b56bc44db03461f48217',
+        prov:location = 'niiri:ee21681844ab92db1f554ed686e6cb97',
         prov:value = "1.40870463848114" %% xsd:float,
         nidm_equivalentZStatistic: = "2.4880722231724" %% xsd:float,
         nidm_pValueUncorrected: = "0.00642188235953201" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:25eebb30f786b56bc44db03461f48217,
+    entity(niiri:ee21681844ab92db1f554ed686e6cb97,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0038" %% xsd:string,
         nidm_coordinateVector: = "[-42,-84,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:af520ea7a2b622b616f138da20521f11, niiri:1d6209037825fb7ee168299aa10d5ad7, -, -, -)
-    entity(niiri:1296043c9bfe3127d5cc76c217e1e26d,
+    wasDerivedFrom(niiri:f2927e668b305ce4095e4a1fae3d5ba5, niiri:73094daa238696f8de11ef4e56a95c30, -, -, -)
+    entity(niiri:402e0d4048e6d12f11de0e3c9bdf055c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0039" %% xsd:string,
-        prov:location = 'niiri:21698b9502c51709153adfed9abb8986',
+        prov:location = 'niiri:9e67d185caabdc161e0d312461d9cdd0',
         prov:value = "1.13220155239105" %% xsd:float,
         nidm_equivalentZStatistic: = "2.12906102075628" %% xsd:float,
         nidm_pValueUncorrected: = "0.0166246060871375" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:21698b9502c51709153adfed9abb8986,
+    entity(niiri:9e67d185caabdc161e0d312461d9cdd0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0039" %% xsd:string,
         nidm_coordinateVector: = "[-50,-78,0]" %% xsd:string])
-    wasDerivedFrom(niiri:1296043c9bfe3127d5cc76c217e1e26d, niiri:1d6209037825fb7ee168299aa10d5ad7, -, -, -)
-    entity(niiri:23d6198c7c453ccfbd7fb701c34b6e26,
+    wasDerivedFrom(niiri:402e0d4048e6d12f11de0e3c9bdf055c, niiri:73094daa238696f8de11ef4e56a95c30, -, -, -)
+    entity(niiri:ce6f3e2f152234ea375751cc54fa9c85,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0040" %% xsd:string,
-        prov:location = 'niiri:28a96db39c58e234af2cc132fa98f4bc',
+        prov:location = 'niiri:93fdcdaf5f69c6e135d078d6217da497',
         prov:value = "1.34917068481445" %% xsd:float,
         nidm_equivalentZStatistic: = "2.41046599292312" %% xsd:float,
         nidm_pValueUncorrected: = "0.00796607827138629" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:28a96db39c58e234af2cc132fa98f4bc,
+    entity(niiri:93fdcdaf5f69c6e135d078d6217da497,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0040" %% xsd:string,
         nidm_coordinateVector: = "[12,-20,80]" %% xsd:string])
-    wasDerivedFrom(niiri:23d6198c7c453ccfbd7fb701c34b6e26, niiri:b1918e5ede22fa7e1d3a1399a34a2d45, -, -, -)
-    entity(niiri:2b724527e8d3c9b6e97424cd9b8d15aa,
+    wasDerivedFrom(niiri:ce6f3e2f152234ea375751cc54fa9c85, niiri:35af8997746066bb4be8d3a9cebf0640, -, -, -)
+    entity(niiri:b988b89ef13b4938653637ed36c2bc4d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0041" %% xsd:string,
-        prov:location = 'niiri:42b34ad9cce6394b101fbaa08a07f29f',
+        prov:location = 'niiri:8bc4c3b0a3463c5ccd6748b60c01b1b7',
         prov:value = "1.34354746341705" %% xsd:float,
         nidm_equivalentZStatistic: = "2.40314315325023" %% xsd:float,
         nidm_pValueUncorrected: = "0.0081274114265858" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:42b34ad9cce6394b101fbaa08a07f29f,
+    entity(niiri:8bc4c3b0a3463c5ccd6748b60c01b1b7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0041" %% xsd:string,
         nidm_coordinateVector: = "[18,48,44]" %% xsd:string])
-    wasDerivedFrom(niiri:2b724527e8d3c9b6e97424cd9b8d15aa, niiri:5d9799711b35085d7a8bcba1641700b1, -, -, -)
-    entity(niiri:4de941e56885958a7463bfabb4b85cf9,
+    wasDerivedFrom(niiri:b988b89ef13b4938653637ed36c2bc4d, niiri:9d0b757e22fc3f0156790583744c1334, -, -, -)
+    entity(niiri:1d5df79c27d668272e122666fca002b8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0042" %% xsd:string,
-        prov:location = 'niiri:91689c74edc5692bdf656cdf4e590451',
+        prov:location = 'niiri:6429c604174465ae78baf35ecfc017c4',
         prov:value = "1.14962959289551" %% xsd:float,
         nidm_equivalentZStatistic: = "2.15156492154198" %% xsd:float,
         nidm_pValueUncorrected: = "0.015715818709074" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:91689c74edc5692bdf656cdf4e590451,
+    entity(niiri:6429c604174465ae78baf35ecfc017c4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0042" %% xsd:string,
         nidm_coordinateVector: = "[8,52,46]" %% xsd:string])
-    wasDerivedFrom(niiri:4de941e56885958a7463bfabb4b85cf9, niiri:5d9799711b35085d7a8bcba1641700b1, -, -, -)
-    entity(niiri:2a1e41375178ee6048cfe473ad850d9d,
+    wasDerivedFrom(niiri:1d5df79c27d668272e122666fca002b8, niiri:9d0b757e22fc3f0156790583744c1334, -, -, -)
+    entity(niiri:3141b4c6e901f4ec1f5e0352c6d0360d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0043" %% xsd:string,
-        prov:location = 'niiri:d103ae494461197404d4d98c94ab55d0',
+        prov:location = 'niiri:65ae40d69c72f6ee264d19c45986f3b4',
         prov:value = "1.33556091785431" %% xsd:float,
         nidm_equivalentZStatistic: = "2.39274498818401" %% xsd:float,
         nidm_pValueUncorrected: = "0.00836142979663967" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d103ae494461197404d4d98c94ab55d0,
+    entity(niiri:65ae40d69c72f6ee264d19c45986f3b4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0043" %% xsd:string,
         nidm_coordinateVector: = "[64,-52,2]" %% xsd:string])
-    wasDerivedFrom(niiri:2a1e41375178ee6048cfe473ad850d9d, niiri:437180e47264cc4e09dc17b204fd0a89, -, -, -)
-    entity(niiri:b2e28fc4cb7873bae7dfcec9c622a9c0,
+    wasDerivedFrom(niiri:3141b4c6e901f4ec1f5e0352c6d0360d, niiri:8d3362f5850c9379377b0d1f0b1c2735, -, -, -)
+    entity(niiri:469e72c7f14e92f86f0ec5262a435c39,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0044" %% xsd:string,
-        prov:location = 'niiri:d4322ad7c793d679b708c35788e9eb73',
+        prov:location = 'niiri:a51b4e8c46bf9aa3e74eadca19ad0968',
         prov:value = "1.30518817901611" %% xsd:float,
         nidm_equivalentZStatistic: = "2.35322652463791" %% xsd:float,
         nidm_pValueUncorrected: = "0.00930564616578244" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d4322ad7c793d679b708c35788e9eb73,
+    entity(niiri:a51b4e8c46bf9aa3e74eadca19ad0968,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0044" %% xsd:string,
         nidm_coordinateVector: = "[26,-74,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:b2e28fc4cb7873bae7dfcec9c622a9c0, niiri:1cd87c105e9a1996f42e3171bad089a8, -, -, -)
-    entity(niiri:4957f8f40371d5539e9b85697134e63f,
+    wasDerivedFrom(niiri:469e72c7f14e92f86f0ec5262a435c39, niiri:227019e17364687787db60a4a8267663, -, -, -)
+    entity(niiri:99a673bf7bd432cda404ddae34a3c146,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0045" %% xsd:string,
-        prov:location = 'niiri:5e9202a8879f71e2067d4c3d52dedb20',
+        prov:location = 'niiri:85071e33199bbf64537a2df42a3a1673',
         prov:value = "1.30020189285278" %% xsd:float,
         nidm_equivalentZStatistic: = "2.34674279460019" %% xsd:float,
         nidm_pValueUncorrected: = "0.00946916148556731" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5e9202a8879f71e2067d4c3d52dedb20,
+    entity(niiri:85071e33199bbf64537a2df42a3a1673,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0045" %% xsd:string,
         nidm_coordinateVector: = "[-44,-82,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:4957f8f40371d5539e9b85697134e63f, niiri:cc02b2de189bcf80b0afcbe487b0d1e8, -, -, -)
-    entity(niiri:6c2bd69486f6f2fc98bdad9a9249cde9,
+    wasDerivedFrom(niiri:99a673bf7bd432cda404ddae34a3c146, niiri:8669f380bd303fec5b169e636d626ce3, -, -, -)
+    entity(niiri:09715737634975b7e4a53926319b1bee,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0046" %% xsd:string,
-        prov:location = 'niiri:372619818a34b671fccfef60836977b8',
+        prov:location = 'niiri:b8520f4b473a7db7a8a22098c02388df',
         prov:value = "1.2840074300766" %% xsd:float,
         nidm_equivalentZStatistic: = "2.32569303609441" %% xsd:float,
         nidm_pValueUncorrected: = "0.0100174661332294" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:372619818a34b671fccfef60836977b8,
+    entity(niiri:b8520f4b473a7db7a8a22098c02388df,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0046" %% xsd:string,
         nidm_coordinateVector: = "[-6,62,36]" %% xsd:string])
-    wasDerivedFrom(niiri:6c2bd69486f6f2fc98bdad9a9249cde9, niiri:3ae2e3cf05ec7ac4b46544f268071134, -, -, -)
-    entity(niiri:8bc88f0d5c04e29ab34863cd24e68863,
+    wasDerivedFrom(niiri:09715737634975b7e4a53926319b1bee, niiri:f38934924fa68b3b9a71fb9c8171e8b6, -, -, -)
+    entity(niiri:a950180a6b2d1ba6bd0c8453f6aa57c6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0047" %% xsd:string,
-        prov:location = 'niiri:ce40992a0b5e259f1b43758c5d68ea28',
+        prov:location = 'niiri:1f3bac07c06f6c4da947941a3e0d40d2',
         prov:value = "1.26505351066589" %% xsd:float,
         nidm_equivalentZStatistic: = "2.30107272004429" %% xsd:float,
         nidm_pValueUncorrected: = "0.0106937605017341" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ce40992a0b5e259f1b43758c5d68ea28,
+    entity(niiri:1f3bac07c06f6c4da947941a3e0d40d2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0047" %% xsd:string,
         nidm_coordinateVector: = "[-50,-2,50]" %% xsd:string])
-    wasDerivedFrom(niiri:8bc88f0d5c04e29ab34863cd24e68863, niiri:3c84c74526e078ad8336fd968ec9d7f0, -, -, -)
-    entity(niiri:8a59a15e6d4b148aaa0593801d721b02,
+    wasDerivedFrom(niiri:a950180a6b2d1ba6bd0c8453f6aa57c6, niiri:1793504b32e2869dcb2fbd3af062f8bc, -, -, -)
+    entity(niiri:a59a5d4bd11645916f5cb26b0edecf9d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0048" %% xsd:string,
-        prov:location = 'niiri:4f32af48b33fc420912cf278bf0e8c3c',
+        prov:location = 'niiri:686f5e6308163bd9a97c3148f494b7b8',
         prov:value = "1.24030959606171" %% xsd:float,
         nidm_equivalentZStatistic: = "2.26895897281379" %% xsd:float,
         nidm_pValueUncorrected: = "0.0116354104606456" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4f32af48b33fc420912cf278bf0e8c3c,
+    entity(niiri:686f5e6308163bd9a97c3148f494b7b8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0048" %% xsd:string,
         nidm_coordinateVector: = "[-18,6,32]" %% xsd:string])
-    wasDerivedFrom(niiri:8a59a15e6d4b148aaa0593801d721b02, niiri:8a1438a34faf87d03af2d9853b038bb2, -, -, -)
-    entity(niiri:22b4df385352baee01307cab01764e69,
+    wasDerivedFrom(niiri:a59a5d4bd11645916f5cb26b0edecf9d, niiri:55aacac3d3863ecd2c5789acfd6b261d, -, -, -)
+    entity(niiri:fb31a7b6c3f653a71eb02bc199c1c87d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0049" %% xsd:string,
-        prov:location = 'niiri:6b72057b1a69bb07b793d0aaa063f078',
+        prov:location = 'niiri:86d95b0aaa548888f11ac1f3260b8a14',
         prov:value = "1.23086047172546" %% xsd:float,
         nidm_equivalentZStatistic: = "2.25670403369037" %% xsd:float,
         nidm_pValueUncorrected: = "0.0120132873197203" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6b72057b1a69bb07b793d0aaa063f078,
+    entity(niiri:86d95b0aaa548888f11ac1f3260b8a14,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0049" %% xsd:string,
         nidm_coordinateVector: = "[32,-44,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:22b4df385352baee01307cab01764e69, niiri:5aecd2a653cabfaff01cc936a5319173, -, -, -)
-    entity(niiri:6bd95507897b5f8465d65ded242e547c,
+    wasDerivedFrom(niiri:fb31a7b6c3f653a71eb02bc199c1c87d, niiri:03238c6a619b9f265421cbb7a0cda76e, -, -, -)
+    entity(niiri:573a177d63d9c9f2fb4fa151422f89eb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0050" %% xsd:string,
-        prov:location = 'niiri:cb9c025473a7e46fa185ff9de6d2eecf',
+        prov:location = 'niiri:d21d8383c2ef494476f34cb7efde4323',
         prov:value = "1.22944271564484" %% xsd:float,
         nidm_equivalentZStatistic: = "2.25486570897048" %% xsd:float,
         nidm_pValueUncorrected: = "0.012070879644426" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:cb9c025473a7e46fa185ff9de6d2eecf,
+    entity(niiri:d21d8383c2ef494476f34cb7efde4323,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0050" %% xsd:string,
         nidm_coordinateVector: = "[-46,-10,58]" %% xsd:string])
-    wasDerivedFrom(niiri:6bd95507897b5f8465d65ded242e547c, niiri:04baa9610947313ff840ab800dc602ff, -, -, -)
-    entity(niiri:4143adeb44c98572c57b47081885265e,
+    wasDerivedFrom(niiri:573a177d63d9c9f2fb4fa151422f89eb, niiri:bc83f4e59851c0ed8424e3172a378ee4, -, -, -)
+    entity(niiri:9fac645dbbfbce2fe558862574fd138e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0051" %% xsd:string,
-        prov:location = 'niiri:4071d9d4ce99f6a6d655e297984278e8',
+        prov:location = 'niiri:df5af951356032bbf21dae5e4eafe818',
         prov:value = "1.22471487522125" %% xsd:float,
         nidm_equivalentZStatistic: = "2.24873618228261" %% xsd:float,
         nidm_pValueUncorrected: = "0.0122646428654261" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4071d9d4ce99f6a6d655e297984278e8,
+    entity(niiri:df5af951356032bbf21dae5e4eafe818,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0051" %% xsd:string,
         nidm_coordinateVector: = "[-22,-94,26]" %% xsd:string])
-    wasDerivedFrom(niiri:4143adeb44c98572c57b47081885265e, niiri:bbf4ae108fc8903d38a040cb96a5f8c7, -, -, -)
-    entity(niiri:677b1c427e116e323ccaeb43a4fcc8ea,
+    wasDerivedFrom(niiri:9fac645dbbfbce2fe558862574fd138e, niiri:c340f3ccccc1a020f9aef989954e51fc, -, -, -)
+    entity(niiri:85c21df54812854d9dcc91de1c9501e3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0052" %% xsd:string,
-        prov:location = 'niiri:59ab9ec5ff9c6474e96185492d155b6a',
+        prov:location = 'niiri:b1d19ddb93361faaef7a254dcfaf85f5',
         prov:value = "1.21706402301788" %% xsd:float,
         nidm_equivalentZStatistic: = "2.23881967357295" %% xsd:float,
         nidm_pValueUncorrected: = "0.0125838258304741" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:59ab9ec5ff9c6474e96185492d155b6a,
+    entity(niiri:b1d19ddb93361faaef7a254dcfaf85f5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0052" %% xsd:string,
         nidm_coordinateVector: = "[36,32,8]" %% xsd:string])
-    wasDerivedFrom(niiri:677b1c427e116e323ccaeb43a4fcc8ea, niiri:4df2335aa8db3e5be136eacbcea883d6, -, -, -)
-    entity(niiri:5f1c8d3e35aa5357a031ef92edb5ec90,
+    wasDerivedFrom(niiri:85c21df54812854d9dcc91de1c9501e3, niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5, -, -, -)
+    entity(niiri:419edd7ae0533f67f4b514cad51a7e40,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0053" %% xsd:string,
-        prov:location = 'niiri:a57e5490085c1d02f350a38c8affd373',
+        prov:location = 'niiri:9e821e6d86a5b665b7128c83d0b55b57',
         prov:value = "1.1321427822113" %% xsd:float,
         nidm_equivalentZStatistic: = "2.12898516834439" %% xsd:float,
         nidm_pValueUncorrected: = "0.0166277437596988" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a57e5490085c1d02f350a38c8affd373,
+    entity(niiri:9e821e6d86a5b665b7128c83d0b55b57,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0053" %% xsd:string,
         nidm_coordinateVector: = "[32,28,2]" %% xsd:string])
-    wasDerivedFrom(niiri:5f1c8d3e35aa5357a031ef92edb5ec90, niiri:4df2335aa8db3e5be136eacbcea883d6, -, -, -)
-    entity(niiri:71e9024f0319e7ffdb91e7e9ef0f632b,
+    wasDerivedFrom(niiri:419edd7ae0533f67f4b514cad51a7e40, niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5, -, -, -)
+    entity(niiri:cbe78a0c214f75fee02b8f4215a8d050,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0054" %% xsd:string,
-        prov:location = 'niiri:05aeae1bb56c868f7f9ca3927fd6f960',
+        prov:location = 'niiri:61ea3aa03f07e52544d1f2c561b325f5',
         prov:value = "1.21668255329132" %% xsd:float,
         nidm_equivalentZStatistic: = "2.23832532460858" %% xsd:float,
         nidm_pValueUncorrected: = "0.0125999239065135" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:05aeae1bb56c868f7f9ca3927fd6f960,
+    entity(niiri:61ea3aa03f07e52544d1f2c561b325f5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0054" %% xsd:string,
         nidm_coordinateVector: = "[-36,-42,38]" %% xsd:string])
-    wasDerivedFrom(niiri:71e9024f0319e7ffdb91e7e9ef0f632b, niiri:9d79a6339d6f2901fb1cf662d6f17331, -, -, -)
-    entity(niiri:089018a569a6a201160974bff8392bfd,
+    wasDerivedFrom(niiri:cbe78a0c214f75fee02b8f4215a8d050, niiri:cb85dd1324b2d86671b2fe868f4dafc0, -, -, -)
+    entity(niiri:0a98388a34991d9fe59b4a9cf396642c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0055" %% xsd:string,
-        prov:location = 'niiri:e27e392fffbf5a9a3177a7ac19ff9008',
+        prov:location = 'niiri:ef543ad68b3140441251e0efe0af7cd1',
         prov:value = "1.19720852375031" %% xsd:float,
         nidm_equivalentZStatistic: = "2.21309986746215" %% xsd:float,
         nidm_pValueUncorrected: = "0.0134453806257753" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e27e392fffbf5a9a3177a7ac19ff9008,
+    entity(niiri:ef543ad68b3140441251e0efe0af7cd1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0055" %% xsd:string,
         nidm_coordinateVector: = "[2,68,26]" %% xsd:string])
-    wasDerivedFrom(niiri:089018a569a6a201160974bff8392bfd, niiri:b8abe2a725005d9ab6e1e988f192f41c, -, -, -)
-    entity(niiri:c4700a2462ced300c4a44bf88e97f271,
+    wasDerivedFrom(niiri:0a98388a34991d9fe59b4a9cf396642c, niiri:0dc11dbfea7cb1fef76a1c48d7f8750f, -, -, -)
+    entity(niiri:acf1658fdc834ef5f68e881f5de034af,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0056" %% xsd:string,
-        prov:location = 'niiri:1ded169ba4a3f3e742789782ebf9e21d',
+        prov:location = 'niiri:ba2d9a0c93e36c103ea6c6300ded5fa8',
         prov:value = "1.1896378993988" %% xsd:float,
         nidm_equivalentZStatistic: = "2.20329932117063" %% xsd:float,
         nidm_pValueUncorrected: = "0.013786829398946" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1ded169ba4a3f3e742789782ebf9e21d,
+    entity(niiri:ba2d9a0c93e36c103ea6c6300ded5fa8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0056" %% xsd:string,
         nidm_coordinateVector: = "[46,14,2]" %% xsd:string])
-    wasDerivedFrom(niiri:c4700a2462ced300c4a44bf88e97f271, niiri:483de03930aa5641b0fe297f66f6c4ed, -, -, -)
-    entity(niiri:be0117fcc9b16f8118a34f6688a334a6,
+    wasDerivedFrom(niiri:acf1658fdc834ef5f68e881f5de034af, niiri:6db75fb201d2decf706c9d2dd225cb5a, -, -, -)
+    entity(niiri:82118381b7674f736b0f0cd125544fe3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0057" %% xsd:string,
-        prov:location = 'niiri:a404d8c08401c4552c6273afdc67726c',
+        prov:location = 'niiri:d8f27c43af5b906ba5f0b6da34c9df35',
         prov:value = "0.84699684381485" %% xsd:float,
         nidm_equivalentZStatistic: = "1.76435736331002" %% xsd:float,
         nidm_pValueUncorrected: = "0.0388359158916027" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a404d8c08401c4552c6273afdc67726c,
+    entity(niiri:d8f27c43af5b906ba5f0b6da34c9df35,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0057" %% xsd:string,
         nidm_coordinateVector: = "[40,10,10]" %% xsd:string])
-    wasDerivedFrom(niiri:be0117fcc9b16f8118a34f6688a334a6, niiri:483de03930aa5641b0fe297f66f6c4ed, -, -, -)
-    entity(niiri:303d5f4df2d0d08184a8559af50bd6c1,
+    wasDerivedFrom(niiri:82118381b7674f736b0f0cd125544fe3, niiri:6db75fb201d2decf706c9d2dd225cb5a, -, -, -)
+    entity(niiri:71125be49af0dc99c2e40193fb5e66b2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0058" %% xsd:string,
-        prov:location = 'niiri:070a4d4397d04007720d2af356c40f7a',
+        prov:location = 'niiri:fdf68d1a3ec000d7fa998a7c58e56d5d',
         prov:value = "1.18655109405518" %% xsd:float,
         nidm_equivalentZStatistic: = "2.19930428061828" %% xsd:float,
         nidm_pValueUncorrected: = "0.0139281467706139" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:070a4d4397d04007720d2af356c40f7a,
+    entity(niiri:fdf68d1a3ec000d7fa998a7c58e56d5d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0058" %% xsd:string,
         nidm_coordinateVector: = "[-32,-28,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:303d5f4df2d0d08184a8559af50bd6c1, niiri:4f303edac6b82f93c47e1a6448e1cb52, -, -, -)
-    entity(niiri:60e4d404f23dc518a79132762c323919,
+    wasDerivedFrom(niiri:71125be49af0dc99c2e40193fb5e66b2, niiri:8fae62d51a220dbd34d1d3074ad97c80, -, -, -)
+    entity(niiri:4e602b57e82d39a3379ea0238f2f065a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0059" %% xsd:string,
-        prov:location = 'niiri:8c5cc76b2edcfc58bde42f3e4a12935f',
+        prov:location = 'niiri:2f57e4ad9e363502818b5b7af383279e',
         prov:value = "1.17589449882507" %% xsd:float,
         nidm_equivalentZStatistic: = "2.18551661590201" %% xsd:float,
         nidm_pValueUncorrected: = "0.0144254945017301" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8c5cc76b2edcfc58bde42f3e4a12935f,
+    entity(niiri:2f57e4ad9e363502818b5b7af383279e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0059" %% xsd:string,
         nidm_coordinateVector: = "[-18,30,50]" %% xsd:string])
-    wasDerivedFrom(niiri:60e4d404f23dc518a79132762c323919, niiri:d987cfa4a10011187d0a3eef178d5a46, -, -, -)
-    entity(niiri:b38281d4642204a1940b6ebe7b4e1531,
+    wasDerivedFrom(niiri:4e602b57e82d39a3379ea0238f2f065a, niiri:1b3f6a9bf76e54ad12539e190c7c838c, -, -, -)
+    entity(niiri:127254d5f8144e53a6000f178ba9832f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0060" %% xsd:string,
-        prov:location = 'niiri:3e550c577ebfcc9bdf25a911ee937fbe',
+        prov:location = 'niiri:f78dbb802d360f040867d01f91280a3e',
         prov:value = "1.17159426212311" %% xsd:float,
         nidm_equivalentZStatistic: = "2.17995487813573" %% xsd:float,
         nidm_pValueUncorrected: = "0.0146304032058477" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:3e550c577ebfcc9bdf25a911ee937fbe,
+    entity(niiri:f78dbb802d360f040867d01f91280a3e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0060" %% xsd:string,
         nidm_coordinateVector: = "[-14,-26,66]" %% xsd:string])
-    wasDerivedFrom(niiri:b38281d4642204a1940b6ebe7b4e1531, niiri:98d187b5c539ea98df7343b0d0821b17, -, -, -)
-    entity(niiri:e54beb18ffa5912f369d1f235557359f,
+    wasDerivedFrom(niiri:127254d5f8144e53a6000f178ba9832f, niiri:dc2d50ba6c535742eed46213fc557f6a, -, -, -)
+    entity(niiri:323e53e57a73eedef512b5baa864925b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0061" %% xsd:string,
-        prov:location = 'niiri:7e83d5be32f3ac082fae74d72a17293b',
+        prov:location = 'niiri:e99f8650eabbc3b1cd1432e8b2374a82',
         prov:value = "1.1714745759964" %% xsd:float,
         nidm_equivalentZStatistic: = "2.17980009775463" %% xsd:float,
         nidm_pValueUncorrected: = "0.0146361413495164" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7e83d5be32f3ac082fae74d72a17293b,
+    entity(niiri:e99f8650eabbc3b1cd1432e8b2374a82,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0061" %% xsd:string,
         nidm_coordinateVector: = "[18,60,34]" %% xsd:string])
-    wasDerivedFrom(niiri:e54beb18ffa5912f369d1f235557359f, niiri:5c38b60ed820b070d98e016bc1431008, -, -, -)
-    entity(niiri:5cdcba284a1740e0a95bf39bfc59090f,
+    wasDerivedFrom(niiri:323e53e57a73eedef512b5baa864925b, niiri:416dfaa44bb6a7fe97539c984a9173c3, -, -, -)
+    entity(niiri:617a5f940f4b8fb780b2b0fba6f13c31,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0062" %% xsd:string,
-        prov:location = 'niiri:4d1d923218a5a86f14b80c5d9024c436',
+        prov:location = 'niiri:45d2e869fd9ca2ba349709e3128b5308',
         prov:value = "1.17128801345825" %% xsd:float,
         nidm_equivalentZStatistic: = "2.17955883330163" %% xsd:float,
         nidm_pValueUncorrected: = "0.0146450895624214" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4d1d923218a5a86f14b80c5d9024c436,
+    entity(niiri:45d2e869fd9ca2ba349709e3128b5308,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0062" %% xsd:string,
         nidm_coordinateVector: = "[-30,-72,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:5cdcba284a1740e0a95bf39bfc59090f, niiri:a86e2297836b759380804c1713e267cd, -, -, -)
-    entity(niiri:9608a0b9921f169205a67f91b0c8646d,
+    wasDerivedFrom(niiri:617a5f940f4b8fb780b2b0fba6f13c31, niiri:31033e543fb9492bc06e61625ca6b410, -, -, -)
+    entity(niiri:14ae1fa9257e4c53338274fcc108384b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0063" %% xsd:string,
-        prov:location = 'niiri:5ea0a149f7e30f52d50d149bf7dc7f86',
+        prov:location = 'niiri:f5920a1ad34f8b842af3e79ef81c8e61',
         prov:value = "1.15287852287292" %% xsd:float,
         nidm_equivalentZStatistic: = "2.15576230673889" %% xsd:float,
         nidm_pValueUncorrected: = "0.0155511150762138" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5ea0a149f7e30f52d50d149bf7dc7f86,
+    entity(niiri:f5920a1ad34f8b842af3e79ef81c8e61,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0063" %% xsd:string,
         nidm_coordinateVector: = "[10,6,74]" %% xsd:string])
-    wasDerivedFrom(niiri:9608a0b9921f169205a67f91b0c8646d, niiri:f4ed594992095609e2ba62eca01c9faf, -, -, -)
-    entity(niiri:f8ec021e67601d83fa30a8d652cef986,
+    wasDerivedFrom(niiri:14ae1fa9257e4c53338274fcc108384b, niiri:7a8b21e9acaff0531c73c9fe0bfaeb53, -, -, -)
+    entity(niiri:7eb75ab35a0ed1f5c8a184d8d88a9b5c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0064" %% xsd:string,
-        prov:location = 'niiri:8800f25bc9569134e36fe056c55dccea',
+        prov:location = 'niiri:7e6b90a96f7d814724fd0f217cbe1716',
         prov:value = "1.14964759349823" %% xsd:float,
         nidm_equivalentZStatistic: = "2.15158817513994" %% xsd:float,
         nidm_pValueUncorrected: = "0.0157149021414998" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8800f25bc9569134e36fe056c55dccea,
+    entity(niiri:7e6b90a96f7d814724fd0f217cbe1716,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0064" %% xsd:string,
         nidm_coordinateVector: = "[-40,48,22]" %% xsd:string])
-    wasDerivedFrom(niiri:f8ec021e67601d83fa30a8d652cef986, niiri:c8ce85b44b984de4fe78c06b64713bb8, -, -, -)
-    entity(niiri:f317a0bc0be15c3af8b8f12eddef0171,
+    wasDerivedFrom(niiri:7eb75ab35a0ed1f5c8a184d8d88a9b5c, niiri:5102964768a1c4313f8c0e48d48f8b40, -, -, -)
+    entity(niiri:23a04d6d64ae1555176652a69477cb6e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0065" %% xsd:string,
-        prov:location = 'niiri:f23773c36e8aa842670cc820c8e3cf8e',
+        prov:location = 'niiri:ceee7ccdc7c470b175dedd001c1ea7f6',
         prov:value = "1.14813911914825" %% xsd:float,
         nidm_equivalentZStatistic: = "2.14963956628403" %% xsd:float,
         nidm_pValueUncorrected: = "0.0157918680840622" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f23773c36e8aa842670cc820c8e3cf8e,
+    entity(niiri:ceee7ccdc7c470b175dedd001c1ea7f6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0065" %% xsd:string,
         nidm_coordinateVector: = "[10,-78,-40]" %% xsd:string])
-    wasDerivedFrom(niiri:f317a0bc0be15c3af8b8f12eddef0171, niiri:55d04469f144e7c5053124929003df79, -, -, -)
-    entity(niiri:131fdfd62367b034e5115d813dae4043,
+    wasDerivedFrom(niiri:23a04d6d64ae1555176652a69477cb6e, niiri:256070c77a58b8b64913a5b6bfb81f60, -, -, -)
+    entity(niiri:cf610736c17264f136dfe0eb89ee2a05,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0066" %% xsd:string,
-        prov:location = 'niiri:9d2a2a255f2ef73de9a55449d983e205',
+        prov:location = 'niiri:279a6a11962ed1f111fb8d7a02bb5d8a',
         prov:value = "1.14065408706665" %% xsd:float,
         nidm_equivalentZStatistic: = "2.13997280538058" %% xsd:float,
         nidm_pValueUncorrected: = "0.0161784822721924" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9d2a2a255f2ef73de9a55449d983e205,
+    entity(niiri:279a6a11962ed1f111fb8d7a02bb5d8a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0066" %% xsd:string,
         nidm_coordinateVector: = "[-12,2,70]" %% xsd:string])
-    wasDerivedFrom(niiri:131fdfd62367b034e5115d813dae4043, niiri:895da0556b5b38697a9d4eacde3a587e, -, -, -)
-    entity(niiri:411f4505c8a2beb209d54060d7e4a887,
+    wasDerivedFrom(niiri:cf610736c17264f136dfe0eb89ee2a05, niiri:96604941a960daa1e224727cb5ba2d60, -, -, -)
+    entity(niiri:515a57e55082e7aaafd8054cc4375e77,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0067" %% xsd:string,
-        prov:location = 'niiri:d9f9f53784b39c50a0d16feea151376a',
+        prov:location = 'niiri:fe98447baa6baac51db022671fc048f4',
         prov:value = "1.1338312625885" %% xsd:float,
         nidm_equivalentZStatistic: = "2.13116451819532" %% xsd:float,
         nidm_pValueUncorrected: = "0.0165377954988448" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d9f9f53784b39c50a0d16feea151376a,
+    entity(niiri:fe98447baa6baac51db022671fc048f4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0067" %% xsd:string,
         nidm_coordinateVector: = "[22,-18,48]" %% xsd:string])
-    wasDerivedFrom(niiri:411f4505c8a2beb209d54060d7e4a887, niiri:30470d6217b4a75fdd554906028c6670, -, -, -)
-    entity(niiri:8fb2c69443ae1c39858b37ffc89e3b1a,
+    wasDerivedFrom(niiri:515a57e55082e7aaafd8054cc4375e77, niiri:529af4aecda9065e5cce8adf4cdfd5c6, -, -, -)
+    entity(niiri:7d5fd522914b718d895ca04f556b7437,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0068" %% xsd:string,
-        prov:location = 'niiri:70474983d603f7935620a9ebd96f0f94',
+        prov:location = 'niiri:966a95b3241bbaf0d187fd1e341c79bf',
         prov:value = "1.11546647548676" %% xsd:float,
         nidm_equivalentZStatistic: = "2.10747127106409" %% xsd:float,
         nidm_pValueUncorrected: = "0.0175383747043093" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:70474983d603f7935620a9ebd96f0f94,
+    entity(niiri:966a95b3241bbaf0d187fd1e341c79bf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0068" %% xsd:string,
         nidm_coordinateVector: = "[30,-18,16]" %% xsd:string])
-    wasDerivedFrom(niiri:8fb2c69443ae1c39858b37ffc89e3b1a, niiri:62c58cbe35737a64415ff840b7810e7d, -, -, -)
-    entity(niiri:22b280391bbb882a2a96e664a5ba3c29,
+    wasDerivedFrom(niiri:7d5fd522914b718d895ca04f556b7437, niiri:bdef3fee2464d33f021c131ff78646c7, -, -, -)
+    entity(niiri:3eefe07ca12961dd4d03965206e8cb06,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0069" %% xsd:string,
-        prov:location = 'niiri:1a565db1a9411cc339a617addf6cb2b3',
+        prov:location = 'niiri:a233e11baaca31ed80be42d76e85c346',
         prov:value = "1.11363661289215" %% xsd:float,
         nidm_equivalentZStatistic: = "2.10511176477938" %% xsd:float,
         nidm_pValueUncorrected: = "0.0176407901931581" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1a565db1a9411cc339a617addf6cb2b3,
+    entity(niiri:a233e11baaca31ed80be42d76e85c346,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0069" %% xsd:string,
         nidm_coordinateVector: = "[16,2,56]" %% xsd:string])
-    wasDerivedFrom(niiri:22b280391bbb882a2a96e664a5ba3c29, niiri:ec26c7d95e0c041f81b882cd245b0915, -, -, -)
-    entity(niiri:dfa59695fa3a75f5938b98bd6d614080,
+    wasDerivedFrom(niiri:3eefe07ca12961dd4d03965206e8cb06, niiri:e8088392c69eb956afef92cedfa6aeb4, -, -, -)
+    entity(niiri:ec714042c4c04e8a27fea498c29a9f63,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0070" %% xsd:string,
-        prov:location = 'niiri:0fdedeb914d8a7a9aa38eebe69a60433',
+        prov:location = 'niiri:9467ed32fd2aaef55d31182b82d68662',
         prov:value = "1.10444390773773" %% xsd:float,
         nidm_equivalentZStatistic: = "2.09326187305734" %% xsd:float,
         nidm_pValueUncorrected: = "0.0181628920812176" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0fdedeb914d8a7a9aa38eebe69a60433,
+    entity(niiri:9467ed32fd2aaef55d31182b82d68662,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0070" %% xsd:string,
         nidm_coordinateVector: = "[-32,-52,14]" %% xsd:string])
-    wasDerivedFrom(niiri:dfa59695fa3a75f5938b98bd6d614080, niiri:6750b72bbafd12ba75c6c383539599c6, -, -, -)
-    entity(niiri:95ed835f52649487e78cce778a0a0b58,
+    wasDerivedFrom(niiri:ec714042c4c04e8a27fea498c29a9f63, niiri:8b4322c153a15066be2583d11b23925c, -, -, -)
+    entity(niiri:b5ad2afffcf7769dff075c2ad1bcfb1d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0071" %% xsd:string,
-        prov:location = 'niiri:0e6389f3c537bf47d48480692de843a2',
+        prov:location = 'niiri:1e589a760119fa51b33a0aee5879a1c9',
         prov:value = "1.01987111568451" %% xsd:float,
         nidm_equivalentZStatistic: = "1.98454402904349" %% xsd:float,
         nidm_pValueUncorrected: = "0.0235976124289208" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0e6389f3c537bf47d48480692de843a2,
+    entity(niiri:1e589a760119fa51b33a0aee5879a1c9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0071" %% xsd:string,
         nidm_coordinateVector: = "[-32,-60,18]" %% xsd:string])
-    wasDerivedFrom(niiri:95ed835f52649487e78cce778a0a0b58, niiri:6750b72bbafd12ba75c6c383539599c6, -, -, -)
-    entity(niiri:142a7d0d29db608b63eb9837dffcce93,
+    wasDerivedFrom(niiri:b5ad2afffcf7769dff075c2ad1bcfb1d, niiri:8b4322c153a15066be2583d11b23925c, -, -, -)
+    entity(niiri:82ce4d65f10bc5c571a676520fb3526a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0072" %% xsd:string,
-        prov:location = 'niiri:ce0896936b4f6f9d75172c347b6d85ae',
+        prov:location = 'niiri:7edb55b74d2a34760e50cf1502d58c54',
         prov:value = "0.951668322086334" %% xsd:float,
         nidm_equivalentZStatistic: = "1.89731313030669" %% xsd:float,
         nidm_pValueUncorrected: = "0.0288933115272303" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ce0896936b4f6f9d75172c347b6d85ae,
+    entity(niiri:7edb55b74d2a34760e50cf1502d58c54,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0072" %% xsd:string,
         nidm_coordinateVector: = "[-24,-50,20]" %% xsd:string])
-    wasDerivedFrom(niiri:142a7d0d29db608b63eb9837dffcce93, niiri:6750b72bbafd12ba75c6c383539599c6, -, -, -)
-    entity(niiri:49f19b782f800a88c614d1eb19240c3f,
+    wasDerivedFrom(niiri:82ce4d65f10bc5c571a676520fb3526a, niiri:8b4322c153a15066be2583d11b23925c, -, -, -)
+    entity(niiri:51c84dd2b7a652dbbe29eec2ec10da45,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0073" %% xsd:string,
-        prov:location = 'niiri:b0ec65390cf89796648ae2492af92382',
+        prov:location = 'niiri:42bd98c846ed3e6b2f8267e9e359b51c',
         prov:value = "1.10060369968414" %% xsd:float,
         nidm_equivalentZStatistic: = "2.08831343102831" %% xsd:float,
         nidm_pValueUncorrected: = "0.0183847853440164" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b0ec65390cf89796648ae2492af92382,
+    entity(niiri:42bd98c846ed3e6b2f8267e9e359b51c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0073" %% xsd:string,
         nidm_coordinateVector: = "[10,50,18]" %% xsd:string])
-    wasDerivedFrom(niiri:49f19b782f800a88c614d1eb19240c3f, niiri:ccbc770b946f9dfd1beecfa8843cb3fd, -, -, -)
-    entity(niiri:bd9ec3b420daeb84caf491e82d75c544,
+    wasDerivedFrom(niiri:51c84dd2b7a652dbbe29eec2ec10da45, niiri:0c0e48a110ec2c20b75585b9e5372d67, -, -, -)
+    entity(niiri:4c431af959a928867e01e3773e1b88b0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0074" %% xsd:string,
-        prov:location = 'niiri:b599d290461736cc005eec1c5e81ed4c',
+        prov:location = 'niiri:84ebd2f1bc394a77f0212ac8234096da',
         prov:value = "1.09576165676117" %% xsd:float,
         nidm_equivalentZStatistic: = "2.08207556282094" %% xsd:float,
         nidm_pValueUncorrected: = "0.0186677841332979" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b599d290461736cc005eec1c5e81ed4c,
+    entity(niiri:84ebd2f1bc394a77f0212ac8234096da,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0074" %% xsd:string,
         nidm_coordinateVector: = "[-46,6,34]" %% xsd:string])
-    wasDerivedFrom(niiri:bd9ec3b420daeb84caf491e82d75c544, niiri:daf3e2ea8bf3273801d2e921f611a23f, -, -, -)
-    entity(niiri:d2067075554add565f286f8aa6960f34,
+    wasDerivedFrom(niiri:4c431af959a928867e01e3773e1b88b0, niiri:1bf866f2d8a1a832a120aa9c02c60efd, -, -, -)
+    entity(niiri:35a5c8c115f0abfbfa3d921633f364a7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0075" %% xsd:string,
-        prov:location = 'niiri:5a8493408aba2205a6a5eccb4d185561',
+        prov:location = 'niiri:3018cf0b63274458035abe5fb99ee859',
         prov:value = "1.09575474262238" %% xsd:float,
         nidm_equivalentZStatistic: = "2.08206665675352" %% xsd:float,
         nidm_pValueUncorrected: = "0.0186681908185171" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5a8493408aba2205a6a5eccb4d185561,
+    entity(niiri:3018cf0b63274458035abe5fb99ee859,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0075" %% xsd:string,
         nidm_coordinateVector: = "[28,-8,70]" %% xsd:string])
-    wasDerivedFrom(niiri:d2067075554add565f286f8aa6960f34, niiri:3df484ba108f4b88e1a4f123023bad18, -, -, -)
-    entity(niiri:35a385cc559c54821f03c31abe4e3a40,
+    wasDerivedFrom(niiri:35a5c8c115f0abfbfa3d921633f364a7, niiri:a44aefad34ca2359e69bf6f9306bc2c6, -, -, -)
+    entity(niiri:d9f041fefa100fdb8132c7a4b6108de0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0076" %% xsd:string,
-        prov:location = 'niiri:9c0fa7da9a830b1787be277dabdda98a',
+        prov:location = 'niiri:b4abdf84c2b011481d11ad3d94001873',
         prov:value = "1.07974576950073" %% xsd:float,
         nidm_equivalentZStatistic: = "2.06145507795256" %% xsd:float,
         nidm_pValueUncorrected: = "0.019629822462089" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9c0fa7da9a830b1787be277dabdda98a,
+    entity(niiri:b4abdf84c2b011481d11ad3d94001873,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0076" %% xsd:string,
         nidm_coordinateVector: = "[-58,18,30]" %% xsd:string])
-    wasDerivedFrom(niiri:35a385cc559c54821f03c31abe4e3a40, niiri:0b63cbadf7d3234250fdc4f399321ae5, -, -, -)
-    entity(niiri:cc689c4588c375b1d453ed77ddd6fb6d,
+    wasDerivedFrom(niiri:d9f041fefa100fdb8132c7a4b6108de0, niiri:ab78ea55fc7f212636dd2f73bdc99032, -, -, -)
+    entity(niiri:b1760aaa8500b6832a7af07d81d63e5d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0077" %% xsd:string,
-        prov:location = 'niiri:753bdbe5b8284958a521269d13a1e404',
+        prov:location = 'niiri:285bc9cc2ba32db7f5e98cd91fb2cfdc',
         prov:value = "1.07930290699005" %% xsd:float,
         nidm_equivalentZStatistic: = "2.06088516484109" %% xsd:float,
         nidm_pValueUncorrected: = "0.019656998463677" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:753bdbe5b8284958a521269d13a1e404,
+    entity(niiri:285bc9cc2ba32db7f5e98cd91fb2cfdc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0077" %% xsd:string,
         nidm_coordinateVector: = "[-24,-66,24]" %% xsd:string])
-    wasDerivedFrom(niiri:cc689c4588c375b1d453ed77ddd6fb6d, niiri:16c6b9ef292ea8d86c2980e2bfee9806, -, -, -)
-    entity(niiri:d1dbb47690cc5b2c83785482d78f16a7,
+    wasDerivedFrom(niiri:b1760aaa8500b6832a7af07d81d63e5d, niiri:4128bacb45b84a2304aceeb9a3a06db7, -, -, -)
+    entity(niiri:7e3b976cef84740109d0eb1268357e83,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0078" %% xsd:string,
-        prov:location = 'niiri:bf94253209f4ce76ed67120ac09947a0',
+        prov:location = 'niiri:926d256b539273b87002cdf595c1f8fd',
         prov:value = "1.07559859752655" %% xsd:float,
         nidm_equivalentZStatistic: = "2.05611872869022" %% xsd:float,
         nidm_pValueUncorrected: = "0.0198855367075194" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:bf94253209f4ce76ed67120ac09947a0,
+    entity(niiri:926d256b539273b87002cdf595c1f8fd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0078" %% xsd:string,
         nidm_coordinateVector: = "[34,34,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:d1dbb47690cc5b2c83785482d78f16a7, niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239, -, -, -)
-    entity(niiri:2122013d54fe0ea832506bdf2d8540de,
+    wasDerivedFrom(niiri:7e3b976cef84740109d0eb1268357e83, niiri:282d81c6243a1094abf4c4787764df02, -, -, -)
+    entity(niiri:73165ed86c4c250a74adde2ee20f14b8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0079" %% xsd:string,
-        prov:location = 'niiri:c574ef3b9be61ebed55b8533b9f46810',
+        prov:location = 'niiri:c0f34ced902e532fff9b867f315ddc89',
         prov:value = "1.07552266120911" %% xsd:float,
         nidm_equivalentZStatistic: = "2.05602103030259" %% xsd:float,
         nidm_pValueUncorrected: = "0.0198902445740951" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c574ef3b9be61ebed55b8533b9f46810,
+    entity(niiri:c0f34ced902e532fff9b867f315ddc89,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0079" %% xsd:string,
         nidm_coordinateVector: = "[-32,-10,4]" %% xsd:string])
-    wasDerivedFrom(niiri:2122013d54fe0ea832506bdf2d8540de, niiri:fb45985c130da20eafb7b2bc740e6b34, -, -, -)
-    entity(niiri:0d7fd935b6f12b8a45e5998c9e7df404,
+    wasDerivedFrom(niiri:73165ed86c4c250a74adde2ee20f14b8, niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb, -, -, -)
+    entity(niiri:9aafe36d107ae7055a61332c58a0078a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0080" %% xsd:string,
-        prov:location = 'niiri:cff65d718e4f4c00b6a73fca81e2a08a',
+        prov:location = 'niiri:8884d81ec71e104a0c484f8f5375a98f',
         prov:value = "1.06592130661011" %% xsd:float,
         nidm_equivalentZStatistic: = "2.04367166566034" %% xsd:float,
         nidm_pValueUncorrected: = "0.0204929970846689" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:cff65d718e4f4c00b6a73fca81e2a08a,
+    entity(niiri:8884d81ec71e104a0c484f8f5375a98f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0080" %% xsd:string,
         nidm_coordinateVector: = "[8,-70,-18]" %% xsd:string])
-    wasDerivedFrom(niiri:0d7fd935b6f12b8a45e5998c9e7df404, niiri:65722b667917e9f42cf82ee2175b666b, -, -, -)
-    entity(niiri:9f539949d98077facdaf736080419084,
+    wasDerivedFrom(niiri:9aafe36d107ae7055a61332c58a0078a, niiri:e58cf8e24a087d5746f02fb59416d367, -, -, -)
+    entity(niiri:05e6dc235f43178bc7d691271ff32879,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0081" %% xsd:string,
-        prov:location = 'niiri:245a5e3a98a4a35d29a45725ace42bd7',
+        prov:location = 'niiri:35353ef550e7b9afa6ef357536b0eef1',
         prov:value = "1.05881226062775" %% xsd:float,
         nidm_equivalentZStatistic: = "2.03453256202328" %% xsd:float,
         nidm_pValueUncorrected: = "0.0209489644915043" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:245a5e3a98a4a35d29a45725ace42bd7,
+    entity(niiri:35353ef550e7b9afa6ef357536b0eef1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0081" %% xsd:string,
         nidm_coordinateVector: = "[18,-56,74]" %% xsd:string])
-    wasDerivedFrom(niiri:9f539949d98077facdaf736080419084, niiri:59675618f95ad14de633584e8aa5881a, -, -, -)
-    entity(niiri:fb1dc826dd07c70437b4e3753dad9238,
+    wasDerivedFrom(niiri:05e6dc235f43178bc7d691271ff32879, niiri:47a95f63466991d3e681c4886347a76b, -, -, -)
+    entity(niiri:9dcb3cd8472b6b25eb1fbcfcb93000f6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0082" %% xsd:string,
-        prov:location = 'niiri:8d1ef8a5bb276ca7bcbedc1eb36d2523',
+        prov:location = 'niiri:f3eeefc4c0d3dd27751aef22dbdb7c8c',
         prov:value = "1.05682730674744" %% xsd:float,
         nidm_equivalentZStatistic: = "2.03198149751153" %% xsd:float,
         nidm_pValueUncorrected: = "0.0210777645475412" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8d1ef8a5bb276ca7bcbedc1eb36d2523,
+    entity(niiri:f3eeefc4c0d3dd27751aef22dbdb7c8c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0082" %% xsd:string,
         nidm_coordinateVector: = "[28,-2,6]" %% xsd:string])
-    wasDerivedFrom(niiri:fb1dc826dd07c70437b4e3753dad9238, niiri:2efe263e1c4f04d8ddb54023002360d9, -, -, -)
-    entity(niiri:b318391d5530313f8dbf1afdf06198b0,
+    wasDerivedFrom(niiri:9dcb3cd8472b6b25eb1fbcfcb93000f6, niiri:6a2d34c94894023a09a46d7ba699025b, -, -, -)
+    entity(niiri:e9806207a16169f3be4d10f35b194c85,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0083" %% xsd:string,
-        prov:location = 'niiri:f705d3b5969c62171b8d06eb1edb92c5',
+        prov:location = 'niiri:766104bfba8f24878b83241025cb8ce1',
         prov:value = "1.05488443374634" %% xsd:float,
         nidm_equivalentZStatistic: = "2.02948481888272" %% xsd:float,
         nidm_pValueUncorrected: = "0.0212044668522343" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f705d3b5969c62171b8d06eb1edb92c5,
+    entity(niiri:766104bfba8f24878b83241025cb8ce1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0083" %% xsd:string,
         nidm_coordinateVector: = "[12,-58,-26]" %% xsd:string])
-    wasDerivedFrom(niiri:b318391d5530313f8dbf1afdf06198b0, niiri:fa0929f452cd3f13857c087a02f6da1f, -, -, -)
-    entity(niiri:654841e54cd036eaea7a9254bc97bbae,
+    wasDerivedFrom(niiri:e9806207a16169f3be4d10f35b194c85, niiri:6ac7ce35dfb3dcf2c2696278c805c40a, -, -, -)
+    entity(niiri:6c0046aab9a8b299190ccc8aaedee47d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0084" %% xsd:string,
-        prov:location = 'niiri:025393763cebc3e6ed872ebae1ed7c39',
+        prov:location = 'niiri:d186aa78992fc5d9cfe80768c6680e50',
         prov:value = "1.05219066143036" %% xsd:float,
         nidm_equivalentZStatistic: = "2.02602370012315" %% xsd:float,
         nidm_pValueUncorrected: = "0.0213811780074668" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:025393763cebc3e6ed872ebae1ed7c39,
+    entity(niiri:d186aa78992fc5d9cfe80768c6680e50,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0084" %% xsd:string,
         nidm_coordinateVector: = "[46,-60,-36]" %% xsd:string])
-    wasDerivedFrom(niiri:654841e54cd036eaea7a9254bc97bbae, niiri:4c6401bfd1d939fec8234ff093a37d0d, -, -, -)
-    entity(niiri:4a63aa7cb3283e351b1f1db27351b99b,
+    wasDerivedFrom(niiri:6c0046aab9a8b299190ccc8aaedee47d, niiri:60e118fd5205eaa96f4b55808761eaf7, -, -, -)
+    entity(niiri:08ed1b983e3a1203b8770d31cb409572,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0085" %% xsd:string,
-        prov:location = 'niiri:c9a40f2012163b6c974d796fd3afd59f',
+        prov:location = 'niiri:c6cce78c32c1be7e581a855e903919a1',
         prov:value = "1.02921843528748" %% xsd:float,
         nidm_equivalentZStatistic: = "1.9965316371229" %% xsd:float,
         nidm_pValueUncorrected: = "0.0229380428256576" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c9a40f2012163b6c974d796fd3afd59f,
+    entity(niiri:c6cce78c32c1be7e581a855e903919a1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0085" %% xsd:string,
         nidm_coordinateVector: = "[56,10,22]" %% xsd:string])
-    wasDerivedFrom(niiri:4a63aa7cb3283e351b1f1db27351b99b, niiri:b40302277817265d7af623887ab2e22c, -, -, -)
-    entity(niiri:17f16c1d68762a38e70a1c58b234a67a,
+    wasDerivedFrom(niiri:08ed1b983e3a1203b8770d31cb409572, niiri:afff6750152337d325f510f877cd2b9c, -, -, -)
+    entity(niiri:c3a91a1145ae795e0275567c7afd4153,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0086" %% xsd:string,
-        prov:location = 'niiri:49e9405a1f52c29499902ca446cc4c53',
+        prov:location = 'niiri:3f578a0866ace4a3d5417fd1bda419bc',
         prov:value = "1.02376317977905" %% xsd:float,
         nidm_equivalentZStatistic: = "1.98953456023084" %% xsd:float,
         nidm_pValueUncorrected: = "0.0233211155368704" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:49e9405a1f52c29499902ca446cc4c53,
+    entity(niiri:3f578a0866ace4a3d5417fd1bda419bc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0086" %% xsd:string,
         nidm_coordinateVector: = "[48,-40,48]" %% xsd:string])
-    wasDerivedFrom(niiri:17f16c1d68762a38e70a1c58b234a67a, niiri:e3091fadc7ff93e5e16f94b04590b938, -, -, -)
-    entity(niiri:23433a28a600a0042f6709ad738f2eb9,
+    wasDerivedFrom(niiri:c3a91a1145ae795e0275567c7afd4153, niiri:c87d05b7d28080150c45409119a926f8, -, -, -)
+    entity(niiri:b4d3685e07ada48df1c6167a6925950e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0087" %% xsd:string,
-        prov:location = 'niiri:47c5f8b5b08ae3c044df320c0c5c11c8',
+        prov:location = 'niiri:795be4dc59029fec477cb821024b0305',
         prov:value = "1.01926970481873" %% xsd:float,
         nidm_equivalentZStatistic: = "1.98377299631032" %% xsd:float,
         nidm_pValueUncorrected: = "0.0236405758837211" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:47c5f8b5b08ae3c044df320c0c5c11c8,
+    entity(niiri:795be4dc59029fec477cb821024b0305,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0087" %% xsd:string,
         nidm_coordinateVector: = "[-6,-74,6]" %% xsd:string])
-    wasDerivedFrom(niiri:23433a28a600a0042f6709ad738f2eb9, niiri:e36b80790f32a55a90c503e6f29918bb, -, -, -)
-    entity(niiri:8799123eb9c654ee018726ee3931235b,
+    wasDerivedFrom(niiri:b4d3685e07ada48df1c6167a6925950e, niiri:f1bb918000bbcdd8562fb7b7887a394d, -, -, -)
+    entity(niiri:f80228783e894278ef084da2baf7ed31,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0088" %% xsd:string,
-        prov:location = 'niiri:bd086e9bb08a9f7d410c5f66d4534fb1',
+        prov:location = 'niiri:2ca83eae786b7fda7e22a5a70371af3d',
         prov:value = "1.01770269870758" %% xsd:float,
         nidm_equivalentZStatistic: = "1.9817641782018" %% xsd:float,
         nidm_pValueUncorrected: = "0.0237528202287247" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:bd086e9bb08a9f7d410c5f66d4534fb1,
+    entity(niiri:2ca83eae786b7fda7e22a5a70371af3d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0088" %% xsd:string,
         nidm_coordinateVector: = "[20,60,-18]" %% xsd:string])
-    wasDerivedFrom(niiri:8799123eb9c654ee018726ee3931235b, niiri:6e8c86e4ccb82a0a6076eb58e14b07a6, -, -, -)
-    entity(niiri:6ba4662560eeacf1805f42b92357c2d2,
+    wasDerivedFrom(niiri:f80228783e894278ef084da2baf7ed31, niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c, -, -, -)
+    entity(niiri:d9eeefbbebdab2ca09c4160ffbf3de45,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0089" %% xsd:string,
-        prov:location = 'niiri:ec4549b9790223d5e2588c6af87cbf82',
+        prov:location = 'niiri:53f418da90a8fac39b172895c357d44a',
         prov:value = "0.994811475276947" %% xsd:float,
         nidm_equivalentZStatistic: = "1.95244337576045" %% xsd:float,
         nidm_pValueUncorrected: = "0.0254427937463042" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ec4549b9790223d5e2588c6af87cbf82,
+    entity(niiri:53f418da90a8fac39b172895c357d44a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0089" %% xsd:string,
         nidm_coordinateVector: = "[6,-2,60]" %% xsd:string])
-    wasDerivedFrom(niiri:6ba4662560eeacf1805f42b92357c2d2, niiri:42f7f7a26e0c7f6124775e7e757b315c, -, -, -)
-    entity(niiri:3bda2d8d3c0edb9b3f719a8dae269a32,
+    wasDerivedFrom(niiri:d9eeefbbebdab2ca09c4160ffbf3de45, niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f, -, -, -)
+    entity(niiri:48c043bcf9f7016d4422cd1eb0275f46,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0090" %% xsd:string,
-        prov:location = 'niiri:a7cb0f2475eb4b3ff5c54ba281637639',
+        prov:location = 'niiri:6077c53ec3ce7550b6798aee6404ca8b',
         prov:value = "0.99255907535553" %% xsd:float,
         nidm_equivalentZStatistic: = "1.94956085899435" %% xsd:float,
         nidm_pValueUncorrected: = "0.0256142412083677" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a7cb0f2475eb4b3ff5c54ba281637639,
+    entity(niiri:6077c53ec3ce7550b6798aee6404ca8b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0090" %% xsd:string,
         nidm_coordinateVector: = "[10,-42,48]" %% xsd:string])
-    wasDerivedFrom(niiri:3bda2d8d3c0edb9b3f719a8dae269a32, niiri:14ff66df771d191b9d2e8a3b0f78eda6, -, -, -)
-    entity(niiri:5cc4fd8f0181f9da651d725a89ad5e16,
+    wasDerivedFrom(niiri:48c043bcf9f7016d4422cd1eb0275f46, niiri:9e7cd816ef42776bf358bfe67f08f014, -, -, -)
+    entity(niiri:3cfe0ff468e6f850a19584472f45a4ca,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0091" %% xsd:string,
-        prov:location = 'niiri:d21ede16c4ae0337bd51853a10b823a9',
+        prov:location = 'niiri:64683e1e79d133f97706c9c14ce1de9a',
         prov:value = "0.984159111976624" %% xsd:float,
         nidm_equivalentZStatistic: = "1.93881506095718" %% xsd:float,
         nidm_pValueUncorrected: = "0.0262619307677786" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d21ede16c4ae0337bd51853a10b823a9,
+    entity(niiri:64683e1e79d133f97706c9c14ce1de9a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0091" %% xsd:string,
         nidm_coordinateVector: = "[44,-2,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:5cc4fd8f0181f9da651d725a89ad5e16, niiri:912e881f26994ef7af5c7f0b222db9ea, -, -, -)
-    entity(niiri:2aa6a02038d33bce0ab53247bbf23d60,
+    wasDerivedFrom(niiri:3cfe0ff468e6f850a19584472f45a4ca, niiri:712375a17d0ff43c9dca459517dff9b2, -, -, -)
+    entity(niiri:4cbbdabb6d9ca2894ccd7d8bf83c4b92,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0092" %% xsd:string,
-        prov:location = 'niiri:722f766abf24b819064c7c6e42c70bea',
+        prov:location = 'niiri:057307222fb1d6a12be4aac362eeba79',
         prov:value = "0.981177926063538" %% xsd:float,
         nidm_equivalentZStatistic: = "1.93500289088164" %% xsd:float,
         nidm_pValueUncorrected: = "0.0264949704670242" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:722f766abf24b819064c7c6e42c70bea,
+    entity(niiri:057307222fb1d6a12be4aac362eeba79,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0092" %% xsd:string,
         nidm_coordinateVector: = "[-16,-98,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:2aa6a02038d33bce0ab53247bbf23d60, niiri:9a1887d93b55705b2ff04804a00c27c3, -, -, -)
-    entity(niiri:cec30b5da4341b39910fe9e39affefb2,
+    wasDerivedFrom(niiri:4cbbdabb6d9ca2894ccd7d8bf83c4b92, niiri:feddd730f38d65d4f1fd0e8616bcc9a5, -, -, -)
+    entity(niiri:a8d461e1b05a579974c9fa442ca95335,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0093" %% xsd:string,
-        prov:location = 'niiri:332a4bdfcb6f14b5c9d4279cb47be873',
+        prov:location = 'niiri:f56cb3f0f78382ca1667d4c9cb2a5fa9',
         prov:value = "0.979127943515778" %% xsd:float,
         nidm_equivalentZStatistic: = "1.93238197004834" %% xsd:float,
         nidm_pValueUncorrected: = "0.026656188878889" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:332a4bdfcb6f14b5c9d4279cb47be873,
+    entity(niiri:f56cb3f0f78382ca1667d4c9cb2a5fa9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0093" %% xsd:string,
         nidm_coordinateVector: = "[18,-54,-16]" %% xsd:string])
-    wasDerivedFrom(niiri:cec30b5da4341b39910fe9e39affefb2, niiri:e6e6da4cb58bd6ee501d8b5597467832, -, -, -)
-    entity(niiri:19d11b85cd1659ff5c89792f9cde9c94,
+    wasDerivedFrom(niiri:a8d461e1b05a579974c9fa442ca95335, niiri:8041bc77682f50b65136018ca10c889c, -, -, -)
+    entity(niiri:422e9504c658a0894198e2bc2af7dc45,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0094" %% xsd:string,
-        prov:location = 'niiri:4a95f88e28460ccd588491bc3403c7b9',
+        prov:location = 'niiri:85068ba7ad3e2344be6218dbd67be2d4',
         prov:value = "0.971426725387573" %% xsd:float,
         nidm_equivalentZStatistic: = "1.92253941721557" %% xsd:float,
         nidm_pValueUncorrected: = "0.0272689593644924" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4a95f88e28460ccd588491bc3403c7b9,
+    entity(niiri:85068ba7ad3e2344be6218dbd67be2d4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0094" %% xsd:string,
         nidm_coordinateVector: = "[4,60,38]" %% xsd:string])
-    wasDerivedFrom(niiri:19d11b85cd1659ff5c89792f9cde9c94, niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0, -, -, -)
-    entity(niiri:d0eaf64ed42fd3f849b5e11ace433bd6,
+    wasDerivedFrom(niiri:422e9504c658a0894198e2bc2af7dc45, niiri:e852e949acffc71ed6cce677c7be19d6, -, -, -)
+    entity(niiri:5f72f791f7614242b4b6ad4e858c999a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0095" %% xsd:string,
-        prov:location = 'niiri:4bc70f64f7da756569d0cd25adc88adf',
+        prov:location = 'niiri:dbc6a1f63f9fa825746e17ef6fa5f72a',
         prov:value = "0.967807769775391" %% xsd:float,
         nidm_equivalentZStatistic: = "1.91791614515868" %% xsd:float,
         nidm_pValueUncorrected: = "0.0275608223501947" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4bc70f64f7da756569d0cd25adc88adf,
+    entity(niiri:dbc6a1f63f9fa825746e17ef6fa5f72a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0095" %% xsd:string,
         nidm_coordinateVector: = "[20,18,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:d0eaf64ed42fd3f849b5e11ace433bd6, niiri:949a7d86dacbe35af10b6aad92fe2224, -, -, -)
-    entity(niiri:b15e367317090ff6141a89644f5183f5,
+    wasDerivedFrom(niiri:5f72f791f7614242b4b6ad4e858c999a, niiri:0d099ee69c96416336f843fd890da4a0, -, -, -)
+    entity(niiri:de1fef4fc7d400efc2f44d0c30039c86,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0096" %% xsd:string,
-        prov:location = 'niiri:5f5788776577f486d7c0d234240362e9',
+        prov:location = 'niiri:c12b5e9466736ae0a4035530d53f806a',
         prov:value = "0.959724724292755" %% xsd:float,
         nidm_equivalentZStatistic: = "1.90759446601654" %% xsd:float,
         nidm_pValueUncorrected: = "0.0282218254783678" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5f5788776577f486d7c0d234240362e9,
+    entity(niiri:c12b5e9466736ae0a4035530d53f806a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0096" %% xsd:string,
         nidm_coordinateVector: = "[30,-32,10]" %% xsd:string])
-    wasDerivedFrom(niiri:b15e367317090ff6141a89644f5183f5, niiri:6cc27bdc40320dac88fe94690c9a2006, -, -, -)
-    entity(niiri:816a2af39c014a3eff563b63568227ba,
+    wasDerivedFrom(niiri:de1fef4fc7d400efc2f44d0c30039c86, niiri:6d0ee7f5877dfa2620f95f47e06e2a9a, -, -, -)
+    entity(niiri:b8e4a8666a562187b667fd0000d52335,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0097" %% xsd:string,
-        prov:location = 'niiri:49d25efc3a1a6a15fd15ecbfc808987c',
+        prov:location = 'niiri:bfa0701f0eb2a5270ae3e9b16ebfc296',
         prov:value = "0.957907795906067" %% xsd:float,
         nidm_equivalentZStatistic: = "1.90527520238565" %% xsd:float,
         nidm_pValueUncorrected: = "0.0283721535699227" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:49d25efc3a1a6a15fd15ecbfc808987c,
+    entity(niiri:bfa0701f0eb2a5270ae3e9b16ebfc296,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0097" %% xsd:string,
         nidm_coordinateVector: = "[10,12,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:816a2af39c014a3eff563b63568227ba, niiri:c04d4059d5535de349435e25559a51cf, -, -, -)
-    entity(niiri:35f059b4066985dec95a60afb4757fa5,
+    wasDerivedFrom(niiri:b8e4a8666a562187b667fd0000d52335, niiri:6ab419381418bd7fca0cb5bac6782b77, -, -, -)
+    entity(niiri:d331e521291249d8ba1e2d26ee0d6359,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0098" %% xsd:string,
-        prov:location = 'niiri:ae652a26b3559a00177ccb1d38ddf2ea',
+        prov:location = 'niiri:2b7cd0cd9952e2971cceba9068ca4224',
         prov:value = "0.95493882894516" %% xsd:float,
         nidm_equivalentZStatistic: = "1.90148608420821" %% xsd:float,
         nidm_pValueUncorrected: = "0.0286191867597474" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ae652a26b3559a00177ccb1d38ddf2ea,
+    entity(niiri:2b7cd0cd9952e2971cceba9068ca4224,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0098" %% xsd:string,
         nidm_coordinateVector: = "[-26,-94,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:35f059b4066985dec95a60afb4757fa5, niiri:4b22fd081d5be6319a728e5343897301, -, -, -)
-    entity(niiri:f01e638e0603ba7659f5763a2d8bc4dd,
+    wasDerivedFrom(niiri:d331e521291249d8ba1e2d26ee0d6359, niiri:b19325ccb6192dba58545cbeb7bc92e1, -, -, -)
+    entity(niiri:8d11278149ef3ed6c1be32712cecb870,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0099" %% xsd:string,
-        prov:location = 'niiri:7f5fa73a008f806d34e4133d4c182481',
+        prov:location = 'niiri:444c6e0d2d8dae8e91a8b6fec5449cd8',
         prov:value = "0.950750410556793" %% xsd:float,
         nidm_equivalentZStatistic: = "1.89614212461773" %% xsd:float,
         nidm_pValueUncorrected: = "0.0289706268368529" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7f5fa73a008f806d34e4133d4c182481,
+    entity(niiri:444c6e0d2d8dae8e91a8b6fec5449cd8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0099" %% xsd:string,
         nidm_coordinateVector: = "[-50,-18,0]" %% xsd:string])
-    wasDerivedFrom(niiri:f01e638e0603ba7659f5763a2d8bc4dd, niiri:f0f729dae8a39ee9247f706bc80f8df0, -, -, -)
-    entity(niiri:f28c4268c860430233ff3485efbc9bb1,
+    wasDerivedFrom(niiri:8d11278149ef3ed6c1be32712cecb870, niiri:745fe95a68372701f2888393e817a23e, -, -, -)
+    entity(niiri:2c0d2607032810a81675ff4225065850,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0100" %% xsd:string,
-        prov:location = 'niiri:497cb86fef9441e29d59581837fa7a72',
+        prov:location = 'niiri:3e68989f6a6b2152794e95703c55559c',
         prov:value = "0.949834227561951" %% xsd:float,
         nidm_equivalentZStatistic: = "1.89497340726092" %% xsd:float,
         nidm_pValueUncorrected: = "0.0290479624174936" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:497cb86fef9441e29d59581837fa7a72,
+    entity(niiri:3e68989f6a6b2152794e95703c55559c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0100" %% xsd:string,
         nidm_coordinateVector: = "[42,36,18]" %% xsd:string])
-    wasDerivedFrom(niiri:f28c4268c860430233ff3485efbc9bb1, niiri:cd47d3687de0d428289d5ee8d941860d, -, -, -)
-    entity(niiri:e78b40e65bb076e872f92f8886d6fb55,
+    wasDerivedFrom(niiri:2c0d2607032810a81675ff4225065850, niiri:b1a5489610b480473aa63e95806df7d1, -, -, -)
+    entity(niiri:47b2ce9b5be41d91dfa11f100ed3ad82,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0101" %% xsd:string,
-        prov:location = 'niiri:e7a5dbf5431a99354087860b2a10d16c',
+        prov:location = 'niiri:eb5106a605d1357f4af29aa54137b817',
         prov:value = "0.949459254741669" %% xsd:float,
         nidm_equivalentZStatistic: = "1.89449510188639" %% xsd:float,
         nidm_pValueUncorrected: = "0.0290796619499293" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e7a5dbf5431a99354087860b2a10d16c,
+    entity(niiri:eb5106a605d1357f4af29aa54137b817,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0101" %% xsd:string,
         nidm_coordinateVector: = "[46,-78,16]" %% xsd:string])
-    wasDerivedFrom(niiri:e78b40e65bb076e872f92f8886d6fb55, niiri:20959c12c3afc9ceb8477f395c0f1d11, -, -, -)
-    entity(niiri:574b80e813133039f7edba5d74c437a7,
+    wasDerivedFrom(niiri:47b2ce9b5be41d91dfa11f100ed3ad82, niiri:f6763487f8266f7e66acb49862c0bfa1, -, -, -)
+    entity(niiri:bffc483b3f0c4050ac78cd4ff4a4338e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0102" %% xsd:string,
-        prov:location = 'niiri:ec5e4ec4f22a9fe5061299186eb1a7df',
+        prov:location = 'niiri:0cf2044fea597c136be141a7d8a4de31',
         prov:value = "0.942987263202667" %% xsd:float,
         nidm_equivalentZStatistic: = "1.88624180999136" %% xsd:float,
         nidm_pValueUncorrected: = "0.0296311883673402" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ec5e4ec4f22a9fe5061299186eb1a7df,
+    entity(niiri:0cf2044fea597c136be141a7d8a4de31,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0102" %% xsd:string,
         nidm_coordinateVector: = "[-52,40,8]" %% xsd:string])
-    wasDerivedFrom(niiri:574b80e813133039f7edba5d74c437a7, niiri:4eb3e8fe236fda4e725ee89c277cccc8, -, -, -)
-    entity(niiri:73e1b25dd37be5347183ed76eca13450,
+    wasDerivedFrom(niiri:bffc483b3f0c4050ac78cd4ff4a4338e, niiri:f1b9cbe1f5cc757318e116f47537c68e, -, -, -)
+    entity(niiri:b2f0952d4932beebb348b8767e1b15d6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0103" %% xsd:string,
-        prov:location = 'niiri:7d6edf93aed55973698b99ba16ef1865',
+        prov:location = 'niiri:7bb01c321a9f81f207675da840baca24',
         prov:value = "0.937418699264526" %% xsd:float,
         nidm_equivalentZStatistic: = "1.87914396799602" %% xsd:float,
         nidm_pValueUncorrected: = "0.0301124189915838" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7d6edf93aed55973698b99ba16ef1865,
+    entity(niiri:7bb01c321a9f81f207675da840baca24,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0103" %% xsd:string,
         nidm_coordinateVector: = "[-12,42,48]" %% xsd:string])
-    wasDerivedFrom(niiri:73e1b25dd37be5347183ed76eca13450, niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca, -, -, -)
-    entity(niiri:eb93d84a711109bd9b54c6b018d686d3,
+    wasDerivedFrom(niiri:b2f0952d4932beebb348b8767e1b15d6, niiri:0299ab45ec018b51a01d2a8fe08bf4d0, -, -, -)
+    entity(niiri:6bbcdf18aa971f01e2cb61e2a276a0c1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0104" %% xsd:string,
-        prov:location = 'niiri:65fa8002172898322aa4954394e16e2d',
+        prov:location = 'niiri:2cce387756fae768863a2b909443a366',
         prov:value = "0.933299362659454" %% xsd:float,
         nidm_equivalentZStatistic: = "1.87389537802186" %% xsd:float,
         nidm_pValueUncorrected: = "0.0304724233227471" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:65fa8002172898322aa4954394e16e2d,
+    entity(niiri:2cce387756fae768863a2b909443a366,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0104" %% xsd:string,
         nidm_coordinateVector: = "[44,40,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:eb93d84a711109bd9b54c6b018d686d3, niiri:4fad08e49bad24baddc3d418f97db0ce, -, -, -)
-    entity(niiri:14289e9dd02f6ca24827f1eb68744a10,
+    wasDerivedFrom(niiri:6bbcdf18aa971f01e2cb61e2a276a0c1, niiri:3bd0b694ec1e521a7072b15be74aa42c, -, -, -)
+    entity(niiri:e76b9afc8d6f8323f6709346e8342328,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0105" %% xsd:string,
-        prov:location = 'niiri:b49fe1898121cadf26b62d7cef891fd4',
+        prov:location = 'niiri:6b6cd0eb3c448196f54b71c1dba6e4d6',
         prov:value = "0.931596636772156" %% xsd:float,
         nidm_equivalentZStatistic: = "1.87172638333963" %% xsd:float,
         nidm_pValueUncorrected: = "0.0306222337565211" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b49fe1898121cadf26b62d7cef891fd4,
+    entity(niiri:6b6cd0eb3c448196f54b71c1dba6e4d6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0105" %% xsd:string,
         nidm_coordinateVector: = "[-20,-74,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:14289e9dd02f6ca24827f1eb68744a10, niiri:d9eee0810d67b936a31fa3c66d2e8721, -, -, -)
-    entity(niiri:ff6121b7a9f9dbe98a1c2aa743d5f4e8,
+    wasDerivedFrom(niiri:e76b9afc8d6f8323f6709346e8342328, niiri:af9bee597f1e82856f732971c03e4ba5, -, -, -)
+    entity(niiri:731e7e0e8812977914ca201d6ec12be9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0106" %% xsd:string,
-        prov:location = 'niiri:45e6af0f0dc689c25f2e728abf47ad38',
+        prov:location = 'niiri:b7cc5c0755b7af3c315c2d00ee88a4d2',
         prov:value = "0.921256303787231" %% xsd:float,
         nidm_equivalentZStatistic: = "1.85856093332641" %% xsd:float,
         nidm_pValueUncorrected: = "0.031544699452275" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:45e6af0f0dc689c25f2e728abf47ad38,
+    entity(niiri:b7cc5c0755b7af3c315c2d00ee88a4d2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0106" %% xsd:string,
         nidm_coordinateVector: = "[-10,-26,78]" %% xsd:string])
-    wasDerivedFrom(niiri:ff6121b7a9f9dbe98a1c2aa743d5f4e8, niiri:c8715267e94716796c464182b4ba6959, -, -, -)
-    entity(niiri:e90e1fca92a0e22c713f9682392e7f12,
+    wasDerivedFrom(niiri:731e7e0e8812977914ca201d6ec12be9, niiri:7a01ea3f3b5332ecf281a7f277911529, -, -, -)
+    entity(niiri:d920f5295c82c34ffdb61a212ac97bda,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0107" %% xsd:string,
-        prov:location = 'niiri:fbbb756202b6d0be6eafa6dc866cd8c3',
+        prov:location = 'niiri:b9e3cdf7fa9c85cc1bd3ef2b223e5f10',
         prov:value = "0.913095474243164" %% xsd:float,
         nidm_equivalentZStatistic: = "1.84817837718658" %% xsd:float,
         nidm_pValueUncorrected: = "0.0322882711892066" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:fbbb756202b6d0be6eafa6dc866cd8c3,
+    entity(niiri:b9e3cdf7fa9c85cc1bd3ef2b223e5f10,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0107" %% xsd:string,
         nidm_coordinateVector: = "[-22,-34,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:e90e1fca92a0e22c713f9682392e7f12, niiri:8f90bd7cc0deb45b7b7bd4b560274456, -, -, -)
-    entity(niiri:b40b3acb742819cbaef72868cf6ef19a,
+    wasDerivedFrom(niiri:d920f5295c82c34ffdb61a212ac97bda, niiri:8d9244867124b8976a02c802025ebf7a, -, -, -)
+    entity(niiri:60cd8b72aba218010406e59a4d283f22,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0108" %% xsd:string,
-        prov:location = 'niiri:0c0e1df808ce80ff1bf83deb70997dda',
+        prov:location = 'niiri:83348a06a08a490ee2ad27ad5f88b837',
         prov:value = "0.910208523273468" %% xsd:float,
         nidm_equivalentZStatistic: = "1.84450717202411" %% xsd:float,
         nidm_pValueUncorrected: = "0.0325546307872665" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0c0e1df808ce80ff1bf83deb70997dda,
+    entity(niiri:83348a06a08a490ee2ad27ad5f88b837,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0108" %% xsd:string,
         nidm_coordinateVector: = "[-34,-52,40]" %% xsd:string])
-    wasDerivedFrom(niiri:b40b3acb742819cbaef72868cf6ef19a, niiri:38f5a60345c88d7c9e0484d8735d5ffe, -, -, -)
-    entity(niiri:25eb200bd03f426290a68a7c2b8e19fe,
+    wasDerivedFrom(niiri:60cd8b72aba218010406e59a4d283f22, niiri:1acfcd5791fd893baf49e6750646bcbc, -, -, -)
+    entity(niiri:598d2ba06bdf7b67f6b54a339b88c029,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0109" %% xsd:string,
-        prov:location = 'niiri:711f57ca8088fe4976d46723159bf11a',
+        prov:location = 'niiri:df28a935119bc1a9fe922acf6abc9791',
         prov:value = "0.909155905246735" %% xsd:float,
         nidm_equivalentZStatistic: = "1.84316882767473" %% xsd:float,
         nidm_pValueUncorrected: = "0.0326521823346975" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:711f57ca8088fe4976d46723159bf11a,
+    entity(niiri:df28a935119bc1a9fe922acf6abc9791,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0109" %% xsd:string,
         nidm_coordinateVector: = "[12,-70,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:25eb200bd03f426290a68a7c2b8e19fe, niiri:e6b43073ea58d734c57cff5767e3921f, -, -, -)
-    entity(niiri:f22a9c0971a349a072973dd922cf0da5,
+    wasDerivedFrom(niiri:598d2ba06bdf7b67f6b54a339b88c029, niiri:6bafc27afb06adc8274b4e85b0eb95cc, -, -, -)
+    entity(niiri:a6db2f879c2f570c76c4c4fd60f93003,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0110" %% xsd:string,
-        prov:location = 'niiri:06bc6317f5dd0e19d7b2145cfc317c31',
+        prov:location = 'niiri:040670c2a1baf229dd4a840108736964',
         prov:value = "0.907121956348419" %% xsd:float,
         nidm_equivalentZStatistic: = "1.84058311467862" %% xsd:float,
         nidm_pValueUncorrected: = "0.0328413370266359" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:06bc6317f5dd0e19d7b2145cfc317c31,
+    entity(niiri:040670c2a1baf229dd4a840108736964,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0110" %% xsd:string,
         nidm_coordinateVector: = "[56,-36,52]" %% xsd:string])
-    wasDerivedFrom(niiri:f22a9c0971a349a072973dd922cf0da5, niiri:1cdb6dbe1bc79e13d52d0d3c171bab06, -, -, -)
-    entity(niiri:922af964cb0b1e93f68e8fa36f07f1ce,
+    wasDerivedFrom(niiri:a6db2f879c2f570c76c4c4fd60f93003, niiri:ee5baff089dc6387c53821c05a9e9154, -, -, -)
+    entity(niiri:069b63564a99aa9ff6d1ddb584fbf1db,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0111" %% xsd:string,
-        prov:location = 'niiri:bf0370f8604a56c53402a8729aefae6b',
+        prov:location = 'niiri:bfd62b4d2231ff667c215ff1fe989844',
         prov:value = "0.904614567756653" %% xsd:float,
         nidm_equivalentZStatistic: = "1.83739614411337" %% xsd:float,
         nidm_pValueUncorrected: = "0.0330757178223472" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:bf0370f8604a56c53402a8729aefae6b,
+    entity(niiri:bfd62b4d2231ff667c215ff1fe989844,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0111" %% xsd:string,
         nidm_coordinateVector: = "[36,-54,16]" %% xsd:string])
-    wasDerivedFrom(niiri:922af964cb0b1e93f68e8fa36f07f1ce, niiri:ee19df6f4d0113ba7e7f064a4048e753, -, -, -)
-    entity(niiri:3ba3e2d5a8b08d5f3408511de2fcea57,
+    wasDerivedFrom(niiri:069b63564a99aa9ff6d1ddb584fbf1db, niiri:e4e0f746d182d60a55906480bc82791f, -, -, -)
+    entity(niiri:ac8fabc6b095c00007fab8d02fe6ad74,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0112" %% xsd:string,
-        prov:location = 'niiri:24965870248323c4385441c6aa85db8e',
+        prov:location = 'niiri:fc4540b0a0db5dceda1b71fe564a0d94',
         prov:value = "0.902757167816162" %% xsd:float,
         nidm_equivalentZStatistic: = "1.83503576989372" %% xsd:float,
         nidm_pValueUncorrected: = "0.0332501948262349" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:24965870248323c4385441c6aa85db8e,
+    entity(niiri:fc4540b0a0db5dceda1b71fe564a0d94,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0112" %% xsd:string,
         nidm_coordinateVector: = "[14,50,12]" %% xsd:string])
-    wasDerivedFrom(niiri:3ba3e2d5a8b08d5f3408511de2fcea57, niiri:71af61a5c3e3beaf82f85e9971911d0f, -, -, -)
-    entity(niiri:c2e1702c643d5c90a4a81f48e223bd8e,
+    wasDerivedFrom(niiri:ac8fabc6b095c00007fab8d02fe6ad74, niiri:07ef8bc1f56adef8bb96bf2e4e871509, -, -, -)
+    entity(niiri:28e9ce4572be1966c1b7c8d5fcec989e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0113" %% xsd:string,
-        prov:location = 'niiri:500217872b9641815f5c9ecf02da9de8',
+        prov:location = 'niiri:4b30382d1e4ea48108691076704ac047',
         prov:value = "0.901206791400909" %% xsd:float,
         nidm_equivalentZStatistic: = "1.83306584752486" %% xsd:float,
         nidm_pValueUncorrected: = "0.0333963896408318" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:500217872b9641815f5c9ecf02da9de8,
+    entity(niiri:4b30382d1e4ea48108691076704ac047,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0113" %% xsd:string,
         nidm_coordinateVector: = "[-10,-70,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:c2e1702c643d5c90a4a81f48e223bd8e, niiri:46c8b3f4803e6bb0b2862d8598ece061, -, -, -)
-    entity(niiri:9554f50419ea4f396d53059910e8f01c,
+    wasDerivedFrom(niiri:28e9ce4572be1966c1b7c8d5fcec989e, niiri:4909c1eb824545b47aa0943b33200588, -, -, -)
+    entity(niiri:9b95918d4848aaeb3e55a87a62ab7a3e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0114" %% xsd:string,
-        prov:location = 'niiri:ebfb05b2fc04e2d96ab9a666523e58b8',
+        prov:location = 'niiri:fa0cc76b071f87753c14060810d31dfe',
         prov:value = "0.797126054763794" %% xsd:float,
         nidm_equivalentZStatistic: = "1.70146355236453" %% xsd:float,
         nidm_pValueUncorrected: = "0.0444279881500879" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ebfb05b2fc04e2d96ab9a666523e58b8,
+    entity(niiri:fa0cc76b071f87753c14060810d31dfe,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0114" %% xsd:string,
         nidm_coordinateVector: = "[-16,-64,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:9554f50419ea4f396d53059910e8f01c, niiri:46c8b3f4803e6bb0b2862d8598ece061, -, -, -)
-    entity(niiri:7b3ef4930118f8730b06d784120ed132,
+    wasDerivedFrom(niiri:9b95918d4848aaeb3e55a87a62ab7a3e, niiri:4909c1eb824545b47aa0943b33200588, -, -, -)
+    entity(niiri:5629d46077dec98c74dfbc8e049ea517,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0115" %% xsd:string,
-        prov:location = 'niiri:1c34ff628baa6e5b4cebfc783d6f6235',
+        prov:location = 'niiri:55609d261623909025c92a20fcf0610b',
         prov:value = "0.899936437606812" %% xsd:float,
         nidm_equivalentZStatistic: = "1.83145192034408" %% xsd:float,
         nidm_pValueUncorrected: = "0.0335165588882574" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1c34ff628baa6e5b4cebfc783d6f6235,
+    entity(niiri:55609d261623909025c92a20fcf0610b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0115" %% xsd:string,
         nidm_coordinateVector: = "[10,-18,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:7b3ef4930118f8730b06d784120ed132, niiri:5e385b701ab7f21285e4ab5006f3b0cc, -, -, -)
-    entity(niiri:2b60d3a424b67aec66f9f99b0fccbb0d,
+    wasDerivedFrom(niiri:5629d46077dec98c74dfbc8e049ea517, niiri:9c28e7c0288f5d8601280d59308426e4, -, -, -)
+    entity(niiri:0a467b6ecf94f5f6b8b6165d58bc65c5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0116" %% xsd:string,
-        prov:location = 'niiri:65f8612f3ec48ab25895d29bc35e3436',
+        prov:location = 'niiri:d4bc30138d04a5bbe3454b95ec405b94',
         prov:value = "0.895962595939636" %% xsd:float,
         nidm_equivalentZStatistic: = "1.8264044782252" %% xsd:float,
         nidm_pValueUncorrected: = "0.0338946789087741" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:65f8612f3ec48ab25895d29bc35e3436,
+    entity(niiri:d4bc30138d04a5bbe3454b95ec405b94,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0116" %% xsd:string,
         nidm_coordinateVector: = "[-42,-50,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:2b60d3a424b67aec66f9f99b0fccbb0d, niiri:9b4e4e9b57eb3e981b1ba74aae8a7114, -, -, -)
-    entity(niiri:1b85cec52ecc08fb6123be4911d70832,
+    wasDerivedFrom(niiri:0a467b6ecf94f5f6b8b6165d58bc65c5, niiri:49c7e8d7404b8a93cc2dc6a52274f6ef, -, -, -)
+    entity(niiri:9d771fa523b8607b56815b45270a4e93,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0117" %% xsd:string,
-        prov:location = 'niiri:87e9ae97ab2460fd67bf107c00b14f4d',
+        prov:location = 'niiri:82448dc2205297fdbefd6f106d891759',
         prov:value = "0.893008887767792" %% xsd:float,
         nidm_equivalentZStatistic: = "1.8226539056953" %% xsd:float,
         nidm_pValueUncorrected: = "0.0341779128567976" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:87e9ae97ab2460fd67bf107c00b14f4d,
+    entity(niiri:82448dc2205297fdbefd6f106d891759,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0117" %% xsd:string,
         nidm_coordinateVector: = "[-60,-32,46]" %% xsd:string])
-    wasDerivedFrom(niiri:1b85cec52ecc08fb6123be4911d70832, niiri:6d27ace5181c44103420a9d6058ab0d2, -, -, -)
-    entity(niiri:1d5890d8c4a830c8c8f1f464ee06b062,
+    wasDerivedFrom(niiri:9d771fa523b8607b56815b45270a4e93, niiri:5bc798e43cab1c880a412761cd0dabce, -, -, -)
+    entity(niiri:adb6b0a235ccc5b03f4e7c9f7dad9160,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0118" %% xsd:string,
-        prov:location = 'niiri:23b41b3bc0b16ebee53dd102abdb11d4',
+        prov:location = 'niiri:6f9fcf9029f665cf15d3412ed80b3a63',
         prov:value = "0.888202428817749" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81655281460242" %% xsd:float,
         nidm_pValueUncorrected: = "0.0346428070130568" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:23b41b3bc0b16ebee53dd102abdb11d4,
+    entity(niiri:6f9fcf9029f665cf15d3412ed80b3a63,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0118" %% xsd:string,
         nidm_coordinateVector: = "[56,-42,24]" %% xsd:string])
-    wasDerivedFrom(niiri:1d5890d8c4a830c8c8f1f464ee06b062, niiri:315d7b893c25221ef60daf1e43984066, -, -, -)
-    entity(niiri:2565e317445870947786d1813b8bf01d,
+    wasDerivedFrom(niiri:adb6b0a235ccc5b03f4e7c9f7dad9160, niiri:d5f0da3a07b3d47197bf039d8d42b58f, -, -, -)
+    entity(niiri:0024155386338cfcf3a295b23bf9be12,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0119" %% xsd:string,
-        prov:location = 'niiri:f0a8bf2c4bce9536b2e34cad8fad2f2e',
+        prov:location = 'niiri:366db76495f9bc35da783cfa4d85aaad',
         prov:value = "0.886661469936371" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81459734206643" %% xsd:float,
         nidm_pValueUncorrected: = "0.034792905633808" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f0a8bf2c4bce9536b2e34cad8fad2f2e,
+    entity(niiri:366db76495f9bc35da783cfa4d85aaad,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0119" %% xsd:string,
         nidm_coordinateVector: = "[-34,-90,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:2565e317445870947786d1813b8bf01d, niiri:34f88b9c2c80714dbe516b3f7ef092bb, -, -, -)
-    entity(niiri:e73954e3237244d481bbcd6dc6911176,
+    wasDerivedFrom(niiri:0024155386338cfcf3a295b23bf9be12, niiri:a57d901560addc33f414ddaed9a0c7fb, -, -, -)
+    entity(niiri:8a1311806bb1778b621397b5a41dfd96,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0120" %% xsd:string,
-        prov:location = 'niiri:d5854cc9ae10a2a740a4698cfa6ad761',
+        prov:location = 'niiri:b2b9b27d97fee31d70e759096f5c996a',
         prov:value = "0.88604724407196" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81381796560484" %% xsd:float,
         nidm_pValueUncorrected: = "0.0348528778271762" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d5854cc9ae10a2a740a4698cfa6ad761,
+    entity(niiri:b2b9b27d97fee31d70e759096f5c996a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0120" %% xsd:string,
         nidm_coordinateVector: = "[-6,-72,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:e73954e3237244d481bbcd6dc6911176, niiri:c07d0db5466c33ca960e3dd77f21333c, -, -, -)
-    entity(niiri:65e5e429d1c98e7a5de78ee327bfe175,
+    wasDerivedFrom(niiri:8a1311806bb1778b621397b5a41dfd96, niiri:01d84a7c8c63b90d178c8c7623156c7d, -, -, -)
+    entity(niiri:e2c16c6d913d0c2d6e9c5d0d27602288,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0121" %% xsd:string,
-        prov:location = 'niiri:9e7452e38b1a293e96d87620eeb74352',
+        prov:location = 'niiri:70af9ae3e7f3d4faa43eb79a9091469f',
         prov:value = "0.884565353393555" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81193780520014" %% xsd:float,
         nidm_pValueUncorrected: = "0.0349979035410456" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9e7452e38b1a293e96d87620eeb74352,
+    entity(niiri:70af9ae3e7f3d4faa43eb79a9091469f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0121" %% xsd:string,
         nidm_coordinateVector: = "[62,-24,46]" %% xsd:string])
-    wasDerivedFrom(niiri:65e5e429d1c98e7a5de78ee327bfe175, niiri:90645273f08ccfc7b9bf300a122cc2af, -, -, -)
-    entity(niiri:5eb9c920dba7f075a9df90020235c1a9,
+    wasDerivedFrom(niiri:e2c16c6d913d0c2d6e9c5d0d27602288, niiri:99056f1d754fd9f25d80632f06577e33, -, -, -)
+    entity(niiri:85d9117015506ddb0393f7b060018584,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0122" %% xsd:string,
-        prov:location = 'niiri:c6ecfbf5d1e362ea14e87e5b5f48caf5',
+        prov:location = 'niiri:a6e58394345941bac6a450ad0153b497',
         prov:value = "0.882052361965179" %% xsd:float,
         nidm_equivalentZStatistic: = "1.80874999534025" %% xsd:float,
         nidm_pValueUncorrected: = "0.0352449260120304" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c6ecfbf5d1e362ea14e87e5b5f48caf5,
+    entity(niiri:a6e58394345941bac6a450ad0153b497,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0122" %% xsd:string,
         nidm_coordinateVector: = "[-16,34,12]" %% xsd:string])
-    wasDerivedFrom(niiri:5eb9c920dba7f075a9df90020235c1a9, niiri:c12f0aee596eddb11ad8e3268c4eb077, -, -, -)
-    entity(niiri:506119698918e1fef046ce6c81d77ebe,
+    wasDerivedFrom(niiri:85d9117015506ddb0393f7b060018584, niiri:a0ee8183a98a000be01c4577a35a0d8c, -, -, -)
+    entity(niiri:cbd89dfc1ee38e3c17f96850cd7295e4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0123" %% xsd:string,
-        prov:location = 'niiri:09cff2c449ad605890a3ec72e7672784',
+        prov:location = 'niiri:5741a80cbff4ef218f24ec536bddbc1f',
         prov:value = "0.878161370754242" %% xsd:float,
         nidm_equivalentZStatistic: = "1.8038155651472" %% xsd:float,
         nidm_pValueUncorrected: = "0.0356301124625072" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:09cff2c449ad605890a3ec72e7672784,
+    entity(niiri:5741a80cbff4ef218f24ec536bddbc1f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0123" %% xsd:string,
         nidm_coordinateVector: = "[-20,-46,76]" %% xsd:string])
-    wasDerivedFrom(niiri:506119698918e1fef046ce6c81d77ebe, niiri:b74b40058d530ee5632e1df25f911065, -, -, -)
-    entity(niiri:d2d194c38029ea3cc730205928385128,
+    wasDerivedFrom(niiri:cbd89dfc1ee38e3c17f96850cd7295e4, niiri:40c9456923bb7d18a8a4ec203aeea09d, -, -, -)
+    entity(niiri:37d38fb5427bb518c234bcdb93146792,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0124" %% xsd:string,
-        prov:location = 'niiri:205f90e44f29beb0016b33f7cd420e9d',
+        prov:location = 'niiri:6ba75280f16989f0413cff07c5ae28d4',
         prov:value = "0.875840246677399" %% xsd:float,
         nidm_equivalentZStatistic: = "1.80087281439492" %% xsd:float,
         nidm_pValueUncorrected: = "0.0358614643888427" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:205f90e44f29beb0016b33f7cd420e9d,
+    entity(niiri:6ba75280f16989f0413cff07c5ae28d4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0124" %% xsd:string,
         nidm_coordinateVector: = "[-40,-6,34]" %% xsd:string])
-    wasDerivedFrom(niiri:d2d194c38029ea3cc730205928385128, niiri:169fad64b64219293f6c913c296583bc, -, -, -)
-    entity(niiri:743c6582a5009b8dc4efb633233a4535,
+    wasDerivedFrom(niiri:37d38fb5427bb518c234bcdb93146792, niiri:3cd64da8230af3c597bfb4e11e589670, -, -, -)
+    entity(niiri:4b5895493ed07bacb9952f039a51b8f6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0125" %% xsd:string,
-        prov:location = 'niiri:bcb2bb47914ac9215957ebf283630732',
+        prov:location = 'niiri:0edef54b9fb2741aebc7cda42a57bcf8',
         prov:value = "0.875353574752808" %% xsd:float,
         nidm_equivalentZStatistic: = "1.80025588397551" %% xsd:float,
         nidm_pValueUncorrected: = "0.0359101216845089" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:bcb2bb47914ac9215957ebf283630732,
+    entity(niiri:0edef54b9fb2741aebc7cda42a57bcf8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0125" %% xsd:string,
         nidm_coordinateVector: = "[-20,-12,8]" %% xsd:string])
-    wasDerivedFrom(niiri:743c6582a5009b8dc4efb633233a4535, niiri:c9ba05614242ea84b1cd6a9c5ec414e4, -, -, -)
-    entity(niiri:c71bc3fe49c5d5a474cc15dc6dffb62d,
+    wasDerivedFrom(niiri:4b5895493ed07bacb9952f039a51b8f6, niiri:32e5e0304b5a2c92b091fa83edcab359, -, -, -)
+    entity(niiri:5390aed5563081e77badfd3ed3e58844,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0126" %% xsd:string,
-        prov:location = 'niiri:b96787f5a81fc13105fb48a6fd5ea1a0',
+        prov:location = 'niiri:9fb7d9fa270614bdf589782a12b43645',
         prov:value = "0.87107241153717" %% xsd:float,
         nidm_equivalentZStatistic: = "1.79483003828998" %% xsd:float,
         nidm_pValueUncorrected: = "0.0363403916799833" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b96787f5a81fc13105fb48a6fd5ea1a0,
+    entity(niiri:9fb7d9fa270614bdf589782a12b43645,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0126" %% xsd:string,
         nidm_coordinateVector: = "[12,-44,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:c71bc3fe49c5d5a474cc15dc6dffb62d, niiri:be38e2f5b8c4edd116eb0a55684fdab2, -, -, -)
-    entity(niiri:f05e911e91200fba2a69c0dbec52ed46,
+    wasDerivedFrom(niiri:5390aed5563081e77badfd3ed3e58844, niiri:bf704e8aea1497f2136b7d0b3dde0bf6, -, -, -)
+    entity(niiri:6c566805e06c1caea5ba64a10caf0bd5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0127" %% xsd:string,
-        prov:location = 'niiri:2d89278f9562ee144eb9d57189b71a2e',
+        prov:location = 'niiri:7401db25a618931a21c1bd66336f51bb',
         prov:value = "0.865115165710449" %% xsd:float,
         nidm_equivalentZStatistic: = "1.78728350813392" %% xsd:float,
         nidm_pValueUncorrected: = "0.0369458390734643" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2d89278f9562ee144eb9d57189b71a2e,
+    entity(niiri:7401db25a618931a21c1bd66336f51bb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0127" %% xsd:string,
         nidm_coordinateVector: = "[2,56,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:f05e911e91200fba2a69c0dbec52ed46, niiri:9506dd108b62896cd6d8225dfc0e2e59, -, -, -)
-    entity(niiri:718114da93378acb4349a929b4418bb3,
+    wasDerivedFrom(niiri:6c566805e06c1caea5ba64a10caf0bd5, niiri:316701aef465a5778181dd76a5331844, -, -, -)
+    entity(niiri:6ab52d2779f2688ce41178fdd09b1849,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0128" %% xsd:string,
-        prov:location = 'niiri:76adcb2ddad656b23a665afa9087a907',
+        prov:location = 'niiri:3886ebad71d47a06506e87cdb3d33fee',
         prov:value = "0.864862859249115" %% xsd:float,
         nidm_equivalentZStatistic: = "1.78696398255915" %% xsd:float,
         nidm_pValueUncorrected: = "0.0369716550398422" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:76adcb2ddad656b23a665afa9087a907,
+    entity(niiri:3886ebad71d47a06506e87cdb3d33fee,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0128" %% xsd:string,
         nidm_coordinateVector: = "[-4,12,50]" %% xsd:string])
-    wasDerivedFrom(niiri:718114da93378acb4349a929b4418bb3, niiri:f404d574847ee68f9dc6bd08393bd9a1, -, -, -)
-    entity(niiri:03fc56b39e281ca8fbd18fd8b73b3a30,
+    wasDerivedFrom(niiri:6ab52d2779f2688ce41178fdd09b1849, niiri:90bdcb5fb7ef48121124edfe5e0439e6, -, -, -)
+    entity(niiri:49c821b0d9d061981dc68b1e3e6abfea,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0129" %% xsd:string,
-        prov:location = 'niiri:655c697c890d155ad920137ad8bbdd3a',
+        prov:location = 'niiri:050099abcdfa23d375e581da2db19230',
         prov:value = "0.864512741565704" %% xsd:float,
         nidm_equivalentZStatistic: = "1.78652059943143" %% xsd:float,
         nidm_pValueUncorrected: = "0.0370075024642879" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:655c697c890d155ad920137ad8bbdd3a,
+    entity(niiri:050099abcdfa23d375e581da2db19230,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0129" %% xsd:string,
         nidm_coordinateVector: = "[-30,-78,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:03fc56b39e281ca8fbd18fd8b73b3a30, niiri:99948f53ace7073cd3002a5850ecd361, -, -, -)
-    entity(niiri:9fe346931ab5bee817eaea36f0a39a81,
+    wasDerivedFrom(niiri:49c821b0d9d061981dc68b1e3e6abfea, niiri:d1db945756296f3d178c9d95312fcba1, -, -, -)
+    entity(niiri:d51ddcc544b96cfa8316116f60aeb9d7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0130" %% xsd:string,
-        prov:location = 'niiri:1a069cea9796d88418c354fa8b495668',
+        prov:location = 'niiri:577fa5fdf942816d72dee2d7adba9c04',
         prov:value = "0.860980033874512" %% xsd:float,
         nidm_equivalentZStatistic: = "1.7820476459466" %% xsd:float,
         nidm_pValueUncorrected: = "0.0373707311326116" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1a069cea9796d88418c354fa8b495668,
+    entity(niiri:577fa5fdf942816d72dee2d7adba9c04,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0130" %% xsd:string,
         nidm_coordinateVector: = "[12,-92,28]" %% xsd:string])
-    wasDerivedFrom(niiri:9fe346931ab5bee817eaea36f0a39a81, niiri:c8c7dba5be58cecd8f14593ccfb69e4b, -, -, -)
-    entity(niiri:1957ce020c99ce3df85faf2ec5078f77,
+    wasDerivedFrom(niiri:d51ddcc544b96cfa8316116f60aeb9d7, niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a, -, -, -)
+    entity(niiri:fa45d096c7906fe9ce12107ae864f03d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0131" %% xsd:string,
-        prov:location = 'niiri:98d11bc4b0ace2128270a5af1f3a8e18',
+        prov:location = 'niiri:c322d812103d8b149095968fc937209e',
         prov:value = "0.854242324829102" %% xsd:float,
         nidm_equivalentZStatistic: = "1.77352076998315" %% xsd:float,
         nidm_pValueUncorrected: = "0.0380712266728884" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:98d11bc4b0ace2128270a5af1f3a8e18,
+    entity(niiri:c322d812103d8b149095968fc937209e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0131" %% xsd:string,
         nidm_coordinateVector: = "[44,-50,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:1957ce020c99ce3df85faf2ec5078f77, niiri:a56ce0c60fde3ec8bf474d645a951d38, -, -, -)
-    entity(niiri:66c1e77cf01db1d64aa08bccb30f1ff7,
+    wasDerivedFrom(niiri:fa45d096c7906fe9ce12107ae864f03d, niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c, -, -, -)
+    entity(niiri:98d08117d5c59bca3961e8d0d91fb482,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0132" %% xsd:string,
-        prov:location = 'niiri:8f8663ded34d0a964fe049c0fc2e394e',
+        prov:location = 'niiri:17735795c02954ed333e3e53d28b146c',
         prov:value = "0.853475153446198" %% xsd:float,
         nidm_equivalentZStatistic: = "1.77255022378467" %% xsd:float,
         nidm_pValueUncorrected: = "0.0381516330201062" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8f8663ded34d0a964fe049c0fc2e394e,
+    entity(niiri:17735795c02954ed333e3e53d28b146c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0132" %% xsd:string,
         nidm_coordinateVector: = "[20,48,8]" %% xsd:string])
-    wasDerivedFrom(niiri:66c1e77cf01db1d64aa08bccb30f1ff7, niiri:82e02fb05b18c0c2a70d55d5e415aee5, -, -, -)
-    entity(niiri:b889d456c0879821e4ba3febfc7cbcc0,
+    wasDerivedFrom(niiri:98d08117d5c59bca3961e8d0d91fb482, niiri:9304b0681f39be2e136e7d42baff625c, -, -, -)
+    entity(niiri:99903325b32dacf464eb78e914073565,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0133" %% xsd:string,
-        prov:location = 'niiri:7dea8bfc01118debf10f84544e468a5c',
+        prov:location = 'niiri:4ac846381c96ad6a617444612779bfc0',
         prov:value = "0.848101913928986" %% xsd:float,
         nidm_equivalentZStatistic: = "1.76575454216401" %% xsd:float,
         nidm_pValueUncorrected: = "0.0387185189613873" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7dea8bfc01118debf10f84544e468a5c,
+    entity(niiri:4ac846381c96ad6a617444612779bfc0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0133" %% xsd:string,
         nidm_coordinateVector: = "[22,-10,68]" %% xsd:string])
-    wasDerivedFrom(niiri:b889d456c0879821e4ba3febfc7cbcc0, niiri:8d8ac9fae20babb989f7c367a4c4a609, -, -, -)
-    entity(niiri:97a3bf83baba0ea813905300ee82fe23,
+    wasDerivedFrom(niiri:99903325b32dacf464eb78e914073565, niiri:c4a9ab38a5b5faf27a110372a76b690b, -, -, -)
+    entity(niiri:d04d5d2d100ceb80264f8137772a93bb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0134" %% xsd:string,
-        prov:location = 'niiri:1b9230ed2c839aa6d24e8d83c79d5dd6',
+        prov:location = 'niiri:5ebd6bd9f56805b7a73b57e890d2c9d3',
         prov:value = "0.845535814762115" %% xsd:float,
         nidm_equivalentZStatistic: = "1.76251036116829" %% xsd:float,
         nidm_pValueUncorrected: = "0.038991553676096" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1b9230ed2c839aa6d24e8d83c79d5dd6,
+    entity(niiri:5ebd6bd9f56805b7a73b57e890d2c9d3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0134" %% xsd:string,
         nidm_coordinateVector: = "[10,16,62]" %% xsd:string])
-    wasDerivedFrom(niiri:97a3bf83baba0ea813905300ee82fe23, niiri:1a41584c1187bb4a87d3cc1af9993773, -, -, -)
-    entity(niiri:6fbe9b8954c9f730c642daa8c4847b4a,
+    wasDerivedFrom(niiri:d04d5d2d100ceb80264f8137772a93bb, niiri:b08c64db49c2acab9dde84fc5aaafee1, -, -, -)
+    entity(niiri:82bb09e80a51ba7c7cad776e0c839658,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0135" %% xsd:string,
-        prov:location = 'niiri:d1448e12a92a065f7e0cabf0e49e1ad3',
+        prov:location = 'niiri:8dfe0d34ef5e5740012a8bc214f3f619',
         prov:value = "0.845024406909943" %% xsd:float,
         nidm_equivalentZStatistic: = "1.76186391162221" %% xsd:float,
         nidm_pValueUncorrected: = "0.0390461466343727" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d1448e12a92a065f7e0cabf0e49e1ad3,
+    entity(niiri:8dfe0d34ef5e5740012a8bc214f3f619,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0135" %% xsd:string,
         nidm_coordinateVector: = "[-30,-60,-28]" %% xsd:string])
-    wasDerivedFrom(niiri:6fbe9b8954c9f730c642daa8c4847b4a, niiri:43ed38ee11c52db758569877faabd695, -, -, -)
-    entity(niiri:2549eeee38c0e38dc94943a1ee2e5a72,
+    wasDerivedFrom(niiri:82bb09e80a51ba7c7cad776e0c839658, niiri:a8f46a35300a709894debac1a5c7d877, -, -, -)
+    entity(niiri:ced019c79dabd92179f8a23ffb66322f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0136" %% xsd:string,
-        prov:location = 'niiri:c7735a5f5f10a0bd82c11474f8038741',
+        prov:location = 'niiri:b1f6f0554f2caf5a79e8f085d690f134',
         prov:value = "0.842050552368164" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75810541868522" %% xsd:float,
         nidm_pValueUncorrected: = "0.0393647869826912" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c7735a5f5f10a0bd82c11474f8038741,
+    entity(niiri:b1f6f0554f2caf5a79e8f085d690f134,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0136" %% xsd:string,
         nidm_coordinateVector: = "[20,6,44]" %% xsd:string])
-    wasDerivedFrom(niiri:2549eeee38c0e38dc94943a1ee2e5a72, niiri:ee629aca5d18e60c2724bfd2e1b3fc6b, -, -, -)
-    entity(niiri:b8cf304e8ace22648efb5f4a9981bb03,
+    wasDerivedFrom(niiri:ced019c79dabd92179f8a23ffb66322f, niiri:147fb623ae052dca9733d6d1d2297af8, -, -, -)
+    entity(niiri:8c53fc407776cbf3f06af1e7d0d3050b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0137" %% xsd:string,
-        prov:location = 'niiri:04749d474e0bfc0ede32e54c5c11feca',
+        prov:location = 'niiri:b14a5b57d07a5a949fbf0748f7fedeff',
         prov:value = "0.837220907211304" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75200380991823" %% xsd:float,
         nidm_pValueUncorrected: = "0.0398865764002145" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:04749d474e0bfc0ede32e54c5c11feca,
+    entity(niiri:b14a5b57d07a5a949fbf0748f7fedeff,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0137" %% xsd:string,
         nidm_coordinateVector: = "[-4,-100,4]" %% xsd:string])
-    wasDerivedFrom(niiri:b8cf304e8ace22648efb5f4a9981bb03, niiri:8b0a58d02f59556fa0151651c6d40cc0, -, -, -)
-    entity(niiri:95679c7d59594699386070848d7545e6,
+    wasDerivedFrom(niiri:8c53fc407776cbf3f06af1e7d0d3050b, niiri:eb257014e1b6b6961786c8543836a579, -, -, -)
+    entity(niiri:daa38cc1c0f9bbbca8083b6dc150874a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0138" %% xsd:string,
-        prov:location = 'niiri:55bb0fca7b0a040e7258ea87a9d4c539',
+        prov:location = 'niiri:d8a9aa94958b15cdbfa143422db3e409',
         prov:value = "0.83669376373291" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75133800938073" %% xsd:float,
         nidm_pValueUncorrected: = "0.0399438520830083" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:55bb0fca7b0a040e7258ea87a9d4c539,
+    entity(niiri:d8a9aa94958b15cdbfa143422db3e409,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0138" %% xsd:string,
         nidm_coordinateVector: = "[26,36,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:95679c7d59594699386070848d7545e6, niiri:eeb7c0ae3047601cda9c179c68e75d65, -, -, -)
-    entity(niiri:972eb6a3d099f2c00c6eb4bbaa70ac1b,
+    wasDerivedFrom(niiri:daa38cc1c0f9bbbca8083b6dc150874a, niiri:3c0db86cde8ac7aa1cb1f7b208b617e8, -, -, -)
+    entity(niiri:e6ccc430058b7e6f4734a533b0653ecd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0139" %% xsd:string,
-        prov:location = 'niiri:eeb8c0cd15d6d5c6bc694fdae27267b2',
+        prov:location = 'niiri:f7d532abb738d329ed77cfa4ca9d829d',
         prov:value = "0.835819184780121" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75023346183694" %% xsd:float,
         nidm_pValueUncorrected: = "0.0400390185167846" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:eeb8c0cd15d6d5c6bc694fdae27267b2,
+    entity(niiri:f7d532abb738d329ed77cfa4ca9d829d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0139" %% xsd:string,
         nidm_coordinateVector: = "[30,-36,28]" %% xsd:string])
-    wasDerivedFrom(niiri:972eb6a3d099f2c00c6eb4bbaa70ac1b, niiri:543214dac714341af8aeaa4b70f41266, -, -, -)
-    entity(niiri:5be765fc7b710cbdb2e1d4bd46ecce60,
+    wasDerivedFrom(niiri:e6ccc430058b7e6f4734a533b0653ecd, niiri:e578dd3a170f088e47efd39f45837f4e, -, -, -)
+    entity(niiri:c0c01149ce0c0a7325cb0911837c39c0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0140" %% xsd:string,
-        prov:location = 'niiri:60dea246d45afec73eaabe894de2e0d3',
+        prov:location = 'niiri:f81887eda1e93b996e6c64febcb68a9f',
         prov:value = "0.835755825042725" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75015344548878" %% xsd:float,
         nidm_pValueUncorrected: = "0.0400459197758659" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:60dea246d45afec73eaabe894de2e0d3,
+    entity(niiri:f81887eda1e93b996e6c64febcb68a9f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0140" %% xsd:string,
         nidm_coordinateVector: = "[16,48,10]" %% xsd:string])
-    wasDerivedFrom(niiri:5be765fc7b710cbdb2e1d4bd46ecce60, niiri:86191fa377232381128e79c2a57a4af6, -, -, -)
-    entity(niiri:af472b64871726e5127b3c3b9738e96f,
+    wasDerivedFrom(niiri:c0c01149ce0c0a7325cb0911837c39c0, niiri:ab7f882f69e9de3fd22bc39f3519003d, -, -, -)
+    entity(niiri:46a1c5dc61e2d7b3c894f451385aef85,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0141" %% xsd:string,
-        prov:location = 'niiri:1d48f9534397006412e809a8ce1f6646',
+        prov:location = 'niiri:0fd17548f87f46ceba800b4df8d45ffc',
         prov:value = "0.827520847320557" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73975784824994" %% xsd:float,
         nidm_pValueUncorrected: = "0.0409507734302569" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1d48f9534397006412e809a8ce1f6646,
+    entity(niiri:0fd17548f87f46ceba800b4df8d45ffc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0141" %% xsd:string,
         nidm_coordinateVector: = "[24,34,2]" %% xsd:string])
-    wasDerivedFrom(niiri:af472b64871726e5127b3c3b9738e96f, niiri:6f236184b94e16d3fb82cdd60cd19a6d, -, -, -)
-    entity(niiri:652faa5c53b766d8b0cf903c07dea641,
+    wasDerivedFrom(niiri:46a1c5dc61e2d7b3c894f451385aef85, niiri:ca827c13c9bc5f06b55e3bd1cd175793, -, -, -)
+    entity(niiri:82a28d110b435fed75bd1e9374b294b2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0142" %% xsd:string,
-        prov:location = 'niiri:74cfe0dca1f5419de1c3a172a2352d1c',
+        prov:location = 'niiri:9b4eccb2dece33b68e724e1fd45e6e19',
         prov:value = "0.825629651546478" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73737166192306" %% xsd:float,
         nidm_pValueUncorrected: = "0.0411607949360844" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:74cfe0dca1f5419de1c3a172a2352d1c,
+    entity(niiri:9b4eccb2dece33b68e724e1fd45e6e19,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0142" %% xsd:string,
         nidm_coordinateVector: = "[62,-42,44]" %% xsd:string])
-    wasDerivedFrom(niiri:652faa5c53b766d8b0cf903c07dea641, niiri:9ae54c5470ad002b7ae47f7b67b248ad, -, -, -)
-    entity(niiri:d26b4b3fb5276da558b2ded4146aecb4,
+    wasDerivedFrom(niiri:82a28d110b435fed75bd1e9374b294b2, niiri:8472115c12bd571d534dfe5bac960c80, -, -, -)
+    entity(niiri:2d3f5ec418b92bf3ca61148f66079396,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0143" %% xsd:string,
-        prov:location = 'niiri:88d33018c3f9dbc230683ee47c7f469a',
+        prov:location = 'niiri:3dbcf5a5ae42f6e1526aa0d8720cdb8a',
         prov:value = "0.82505863904953" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73665128497546" %% xsd:float,
         nidm_pValueUncorrected: = "0.0412243706597636" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:88d33018c3f9dbc230683ee47c7f469a,
+    entity(niiri:3dbcf5a5ae42f6e1526aa0d8720cdb8a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0143" %% xsd:string,
         nidm_coordinateVector: = "[-46,-40,38]" %% xsd:string])
-    wasDerivedFrom(niiri:d26b4b3fb5276da558b2ded4146aecb4, niiri:0104fa6d88bd50793a3b65b47635e2c6, -, -, -)
-    entity(niiri:5cc50ec6e00023b323ad96ff05dca350,
+    wasDerivedFrom(niiri:2d3f5ec418b92bf3ca61148f66079396, niiri:812c44e9a98ad090a6f8b72ffea8eb49, -, -, -)
+    entity(niiri:3514e869d053964fca5f28a8c09f4e91,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0144" %% xsd:string,
-        prov:location = 'niiri:b5c4ea65f2f942e5c79bd59f2797e844',
+        prov:location = 'niiri:fb4af523bacf868c90bee16373434943',
         prov:value = "0.824967801570892" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73653669020128" %% xsd:float,
         nidm_pValueUncorrected: = "0.0412344913749479" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b5c4ea65f2f942e5c79bd59f2797e844,
+    entity(niiri:fb4af523bacf868c90bee16373434943,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0144" %% xsd:string,
         nidm_coordinateVector: = "[-12,-58,-54]" %% xsd:string])
-    wasDerivedFrom(niiri:5cc50ec6e00023b323ad96ff05dca350, niiri:1ff5ea3ca56fb13894e4e43c39a861c9, -, -, -)
-    entity(niiri:9e195ae526df87602b1a5980eb32f1a3,
+    wasDerivedFrom(niiri:3514e869d053964fca5f28a8c09f4e91, niiri:eb1e036b54bfd5155015ad5c924a62ce, -, -, -)
+    entity(niiri:aee96554789220edfb0c2a5cb3e5dbcf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0145" %% xsd:string,
-        prov:location = 'niiri:09ab1d1db3cfbdd5ba683bbafc0a37e6',
+        prov:location = 'niiri:e3ed6f4e37e26c035620e0009be1898c',
         prov:value = "0.824692487716675" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73618937818564" %% xsd:float,
         nidm_pValueUncorrected: = "0.0412651773815628" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:09ab1d1db3cfbdd5ba683bbafc0a37e6,
+    entity(niiri:e3ed6f4e37e26c035620e0009be1898c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0145" %% xsd:string,
         nidm_coordinateVector: = "[26,-72,14]" %% xsd:string])
-    wasDerivedFrom(niiri:9e195ae526df87602b1a5980eb32f1a3, niiri:9e02c41cd62cc06c92b5e2b56a706886, -, -, -)
-    entity(niiri:9c93b5c306aacac5c321fe8b406ca25c,
+    wasDerivedFrom(niiri:aee96554789220edfb0c2a5cb3e5dbcf, niiri:8bac0f00c0d1f0f9f5c118004ab17321, -, -, -)
+    entity(niiri:cc8b982d26d7b3eda03f32ed426ee111,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0146" %% xsd:string,
-        prov:location = 'niiri:87a6b40994dc4f90c9f3ccee7834c6b4',
+        prov:location = 'niiri:ed883e8d69ce8310e32c0e8becfe841e',
         prov:value = "0.822546482086182" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73348249441809" %% xsd:float,
         nidm_pValueUncorrected: = "0.0415049731433188" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:87a6b40994dc4f90c9f3ccee7834c6b4,
+    entity(niiri:ed883e8d69ce8310e32c0e8becfe841e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0146" %% xsd:string,
         nidm_coordinateVector: = "[-40,-10,40]" %% xsd:string])
-    wasDerivedFrom(niiri:9c93b5c306aacac5c321fe8b406ca25c, niiri:a5e308239dff195e8c67ca5b964d553a, -, -, -)
-    entity(niiri:87be53fc52f329c31a4bbf852d8d96af,
+    wasDerivedFrom(niiri:cc8b982d26d7b3eda03f32ed426ee111, niiri:4f4b190235fbb136b1bb7467b78730d6, -, -, -)
+    entity(niiri:5f5a39c0ec9f402ad6c7b83cd3403cc8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0147" %% xsd:string,
-        prov:location = 'niiri:8a23632000b73752391bf7b0889bdc03',
+        prov:location = 'niiri:6f15a47567306fd72eb97be297c7405b',
         prov:value = "0.821757972240448" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73248804772578" %% xsd:float,
         nidm_pValueUncorrected: = "0.0415933516734939" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8a23632000b73752391bf7b0889bdc03,
+    entity(niiri:6f15a47567306fd72eb97be297c7405b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0147" %% xsd:string,
         nidm_coordinateVector: = "[54,-52,42]" %% xsd:string])
-    wasDerivedFrom(niiri:87be53fc52f329c31a4bbf852d8d96af, niiri:aeffc3536799596ea12e2467fc52bd65, -, -, -)
-    entity(niiri:522075dd68ebe791546a697684de5db9,
+    wasDerivedFrom(niiri:5f5a39c0ec9f402ad6c7b83cd3403cc8, niiri:d04d2676281bca09e8a782500650e993, -, -, -)
+    entity(niiri:21c2f0806b69f7a2007d792897684387,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0148" %% xsd:string,
-        prov:location = 'niiri:45539f048650428b2f89835fd4f28adf',
+        prov:location = 'niiri:8c75ae64ad9880eeb66c7dfdeca370d8',
         prov:value = "0.821538865566254" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73221173057204" %% xsd:float,
         nidm_pValueUncorrected: = "0.0416179355971084" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:45539f048650428b2f89835fd4f28adf,
+    entity(niiri:8c75ae64ad9880eeb66c7dfdeca370d8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0148" %% xsd:string,
         nidm_coordinateVector: = "[-10,-66,8]" %% xsd:string])
-    wasDerivedFrom(niiri:522075dd68ebe791546a697684de5db9, niiri:3e987521ad9deca092879412707ea491, -, -, -)
-    entity(niiri:322277ddac27387b3f1cf8caca630a5d,
+    wasDerivedFrom(niiri:21c2f0806b69f7a2007d792897684387, niiri:59c6e585fc56ebce5a5d95b959cc120d, -, -, -)
+    entity(niiri:4f107ffd42ea6e3a3e3d2968400fa620,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0149" %% xsd:string,
-        prov:location = 'niiri:dbba800ccf20410cbd8b17d4e7e3d71f',
+        prov:location = 'niiri:e296ec0027943c32f1d63187ca884faf',
         prov:value = "0.821337878704071" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73195826984928" %% xsd:float,
         nidm_pValueUncorrected: = "0.0416404963346692" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:dbba800ccf20410cbd8b17d4e7e3d71f,
+    entity(niiri:e296ec0027943c32f1d63187ca884faf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0149" %% xsd:string,
         nidm_coordinateVector: = "[20,-16,70]" %% xsd:string])
-    wasDerivedFrom(niiri:322277ddac27387b3f1cf8caca630a5d, niiri:f54f30ee52ac26f6dae0749e096ea6c1, -, -, -)
-    entity(niiri:c61ef0dd46c1c75dde8b0ff1cd46ff2a,
+    wasDerivedFrom(niiri:4f107ffd42ea6e3a3e3d2968400fa620, niiri:a4d82c21752d17f68b6fbf41caa89a4b, -, -, -)
+    entity(niiri:52953fe00c54e610f78c8e2bd72debb1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0150" %% xsd:string,
-        prov:location = 'niiri:e6913f677376e8f8d0cbf5768e2b2957',
+        prov:location = 'niiri:d4f42ae011a1b1bcdfd446d63c416728',
         prov:value = "0.821269989013672" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73187265661373" %% xsd:float,
         nidm_pValueUncorrected: = "0.0416481190738193" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e6913f677376e8f8d0cbf5768e2b2957,
+    entity(niiri:d4f42ae011a1b1bcdfd446d63c416728,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0150" %% xsd:string,
         nidm_coordinateVector: = "[34,-56,18]" %% xsd:string])
-    wasDerivedFrom(niiri:c61ef0dd46c1c75dde8b0ff1cd46ff2a, niiri:692bc9543cbfc2b98e06dde4c8e7603f, -, -, -)
-    entity(niiri:a80bb377de34b37212750ae3db10e20a,
+    wasDerivedFrom(niiri:52953fe00c54e610f78c8e2bd72debb1, niiri:9c09ac30035d9617daad1f111fa1b47f, -, -, -)
+    entity(niiri:b8bb24c25ece9a10c4a32995fda538dd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0151" %% xsd:string,
-        prov:location = 'niiri:0458d3c1e0559783e4029b2a4be03a14',
+        prov:location = 'niiri:48f70704159960814be91b72a9bd2859',
         prov:value = "0.82093757390976" %% xsd:float,
         nidm_equivalentZStatistic: = "1.7314534684428" %% xsd:float,
         nidm_pValueUncorrected: = "0.0416854586174026" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0458d3c1e0559783e4029b2a4be03a14,
+    entity(niiri:48f70704159960814be91b72a9bd2859,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0151" %% xsd:string,
         nidm_coordinateVector: = "[58,32,22]" %% xsd:string])
-    wasDerivedFrom(niiri:a80bb377de34b37212750ae3db10e20a, niiri:be235801557e66b2190c98cd649588c0, -, -, -)
-    entity(niiri:9fc68b058dc6ee748e78bc0342d26c9f,
+    wasDerivedFrom(niiri:b8bb24c25ece9a10c4a32995fda538dd, niiri:b5d02c34e634c7f52d94137fbd9f8813, -, -, -)
+    entity(niiri:553be5643aa7f566f5428ca1f18a7e99,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0152" %% xsd:string,
-        prov:location = 'niiri:243d348e8bb24e528c34f0f61a042268',
+        prov:location = 'niiri:793abb325ad9de1bede5b50108624f36',
         prov:value = "0.817427694797516" %% xsd:float,
         nidm_equivalentZStatistic: = "1.72702824070669" %% xsd:float,
         nidm_pValueUncorrected: = "0.0420812958690475" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:243d348e8bb24e528c34f0f61a042268,
+    entity(niiri:793abb325ad9de1bede5b50108624f36,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0152" %% xsd:string,
         nidm_coordinateVector: = "[-28,-74,18]" %% xsd:string])
-    wasDerivedFrom(niiri:9fc68b058dc6ee748e78bc0342d26c9f, niiri:baf9fc0b69478678bb8ed7430b24c094, -, -, -)
-    entity(niiri:b25ee7d26cd1e25affee2f1c6bc4278f,
+    wasDerivedFrom(niiri:553be5643aa7f566f5428ca1f18a7e99, niiri:fc91a408c252d8e2b7beb4005554eaf8, -, -, -)
+    entity(niiri:50446d0a8adcadede38bdf0d08c3a7c9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0153" %% xsd:string,
-        prov:location = 'niiri:f793261af421559e7bb8429a67afd216',
+        prov:location = 'niiri:4691db3191597b7338e7c95c4a8f87e2',
         prov:value = "0.816389560699463" %% xsd:float,
         nidm_equivalentZStatistic: = "1.72571967296696" %% xsd:float,
         nidm_pValueUncorrected: = "0.0421989285126135" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f793261af421559e7bb8429a67afd216,
+    entity(niiri:4691db3191597b7338e7c95c4a8f87e2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0153" %% xsd:string,
         nidm_coordinateVector: = "[28,-30,34]" %% xsd:string])
-    wasDerivedFrom(niiri:b25ee7d26cd1e25affee2f1c6bc4278f, niiri:27343a380f46da81b03903d4cf6193dc, -, -, -)
-    entity(niiri:b9cefb671f41cdcd2b2e4c69d6b7b359,
+    wasDerivedFrom(niiri:50446d0a8adcadede38bdf0d08c3a7c9, niiri:9b0591f2b854d2643aaf1afaa93cb549, -, -, -)
+    entity(niiri:65d8e0c0cee7cb9aedc8b05b70798526,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0154" %% xsd:string,
-        prov:location = 'niiri:e532ce509b03d476f34fbe3e3016c83c',
+        prov:location = 'niiri:a8791185dbb796dbe126d712ae2b55e4',
         prov:value = "0.810877442359924" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71877398514755" %% xsd:float,
         nidm_pValueUncorrected: = "0.0428277671196435" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e532ce509b03d476f34fbe3e3016c83c,
+    entity(niiri:a8791185dbb796dbe126d712ae2b55e4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0154" %% xsd:string,
         nidm_coordinateVector: = "[-4,-92,4]" %% xsd:string])
-    wasDerivedFrom(niiri:b9cefb671f41cdcd2b2e4c69d6b7b359, niiri:158f1d535951e2b7d78ea10b066c15f3, -, -, -)
-    entity(niiri:2ad984f6f188e95e289d863a3dc28223,
+    wasDerivedFrom(niiri:65d8e0c0cee7cb9aedc8b05b70798526, niiri:d54744a8017e84d7adb355fc9412fba3, -, -, -)
+    entity(niiri:ac42ea1cc64c6d5a7de30ab94c30ef98,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0155" %% xsd:string,
-        prov:location = 'niiri:9a5b03d3a41f3e346f8f366b062b7b4b',
+        prov:location = 'niiri:e8237ec0f9d80f45182261107f27d393',
         prov:value = "0.810260891914368" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71799733032142" %% xsd:float,
         nidm_pValueUncorrected: = "0.0428985511130971" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9a5b03d3a41f3e346f8f366b062b7b4b,
+    entity(niiri:e8237ec0f9d80f45182261107f27d393,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0155" %% xsd:string,
         nidm_coordinateVector: = "[-18,-22,44]" %% xsd:string])
-    wasDerivedFrom(niiri:2ad984f6f188e95e289d863a3dc28223, niiri:842d2062c93ff252780aae9939a20111, -, -, -)
-    entity(niiri:3271f178664f3539edaa018f6f207fa8,
+    wasDerivedFrom(niiri:ac42ea1cc64c6d5a7de30ab94c30ef98, niiri:e49a03f4d60a11688f798fc5bc43c1b2, -, -, -)
+    entity(niiri:69ee373828c471312b7a98ecd9d058a9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0156" %% xsd:string,
-        prov:location = 'niiri:90a5129a6c43a75a468beb3757198213',
+        prov:location = 'niiri:c8b68f98c5cfe0ac5c2cdefaedfdf163',
         prov:value = "0.809625387191772" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71719685114941" %% xsd:float,
         nidm_pValueUncorrected: = "0.042971605350922" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:90a5129a6c43a75a468beb3757198213,
+    entity(niiri:c8b68f98c5cfe0ac5c2cdefaedfdf163,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0156" %% xsd:string,
         nidm_coordinateVector: = "[-8,-88,-48]" %% xsd:string])
-    wasDerivedFrom(niiri:3271f178664f3539edaa018f6f207fa8, niiri:d27fbf9c8044e6b188c300c4990f6f54, -, -, -)
-    entity(niiri:e89619f00261dd896c5e6b49b91ad9fa,
+    wasDerivedFrom(niiri:69ee373828c471312b7a98ecd9d058a9, niiri:b04a187086857b7422c8096db14ee613, -, -, -)
+    entity(niiri:b43fdbd7e0791111185f3e004a40b90f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0157" %% xsd:string,
-        prov:location = 'niiri:cb30d0dcf44e480e9d546d120872d8b2',
+        prov:location = 'niiri:70a5abbded05158ae55374c9e47f8da2',
         prov:value = "0.807083547115326" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71399568809748" %% xsd:float,
         nidm_pValueUncorrected: = "0.0432647588890963" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:cb30d0dcf44e480e9d546d120872d8b2,
+    entity(niiri:70a5abbded05158ae55374c9e47f8da2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0157" %% xsd:string,
         nidm_coordinateVector: = "[-28,-90,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:e89619f00261dd896c5e6b49b91ad9fa, niiri:2a4965b8fc709556c2aa1abb6adf5441, -, -, -)
-    entity(niiri:d514e4693dd32deec29d4b4747f44ab2,
+    wasDerivedFrom(niiri:b43fdbd7e0791111185f3e004a40b90f, niiri:39ce93dd6abab662ab6da84a046a56bd, -, -, -)
+    entity(niiri:74b1e30b0b85916615db0f4c7da8ca2a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0158" %% xsd:string,
-        prov:location = 'niiri:b4bd0cc943eb4c6123bcaa4505ed1439',
+        prov:location = 'niiri:8b947c980b68849b563e6a600eb6f25e',
         prov:value = "0.804524898529053" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71077421355999" %% xsd:float,
         nidm_pValueUncorrected: = "0.0435614007800803" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b4bd0cc943eb4c6123bcaa4505ed1439,
+    entity(niiri:8b947c980b68849b563e6a600eb6f25e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0158" %% xsd:string,
         nidm_coordinateVector: = "[54,18,14]" %% xsd:string])
-    wasDerivedFrom(niiri:d514e4693dd32deec29d4b4747f44ab2, niiri:9cc63018305b210a50122f137d979802, -, -, -)
-    entity(niiri:56f159e4b339f215b07ab529dcb6afe5,
+    wasDerivedFrom(niiri:74b1e30b0b85916615db0f4c7da8ca2a, niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e, -, -, -)
+    entity(niiri:6630427441c8fc15cc3a64424eb38ad1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0159" %% xsd:string,
-        prov:location = 'niiri:0e2f64a7d2cf43118af0d523a1045abf',
+        prov:location = 'niiri:2352aa9bc768856664d6689721c07c97',
         prov:value = "0.801611304283142" %% xsd:float,
         nidm_equivalentZStatistic: = "1.70710689586196" %% xsd:float,
         nidm_pValueUncorrected: = "0.0439010928174099" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0e2f64a7d2cf43118af0d523a1045abf,
+    entity(niiri:2352aa9bc768856664d6689721c07c97,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0159" %% xsd:string,
         nidm_coordinateVector: = "[38,-48,18]" %% xsd:string])
-    wasDerivedFrom(niiri:56f159e4b339f215b07ab529dcb6afe5, niiri:965ac0d53ae837b608d6841eb6671ec5, -, -, -)
-    entity(niiri:3775e9935ca298404180c033594cef47,
+    wasDerivedFrom(niiri:6630427441c8fc15cc3a64424eb38ad1, niiri:ca20dee3ba6bf36049f99642c710470d, -, -, -)
+    entity(niiri:8292bd6d405860cc9e98ea0f6c90807b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0160" %% xsd:string,
-        prov:location = 'niiri:974a061454302498849b51020d3bcaf0',
+        prov:location = 'niiri:a2593a5375fecb7c266042738db0862e',
         prov:value = "0.801064372062683" %% xsd:float,
         nidm_equivalentZStatistic: = "1.70641860205681" %% xsd:float,
         nidm_pValueUncorrected: = "0.0439650847967754" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:974a061454302498849b51020d3bcaf0,
+    entity(niiri:a2593a5375fecb7c266042738db0862e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0160" %% xsd:string,
         nidm_coordinateVector: = "[-32,-70,28]" %% xsd:string])
-    wasDerivedFrom(niiri:3775e9935ca298404180c033594cef47, niiri:d20a800c34ef4ebbc2c9d064007ca5a5, -, -, -)
-    entity(niiri:67775b1fe689aac8a236bd5098ede3ac,
+    wasDerivedFrom(niiri:8292bd6d405860cc9e98ea0f6c90807b, niiri:26fa7a82c298f218eb7fd282cfbf7a81, -, -, -)
+    entity(niiri:40736270f2699f261bc17555c7292552,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0161" %% xsd:string,
-        prov:location = 'niiri:2c52525c383497b335b50a9120c734ec',
+        prov:location = 'niiri:f1dfb9a6e43d0bb924ebeb2df5b8754b',
         prov:value = "0.796977043151855" %% xsd:float,
         nidm_equivalentZStatistic: = "1.70127611195347" %% xsd:float,
         nidm_pValueUncorrected: = "0.0444455757271468" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2c52525c383497b335b50a9120c734ec,
+    entity(niiri:f1dfb9a6e43d0bb924ebeb2df5b8754b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0161" %% xsd:string,
         nidm_coordinateVector: = "[40,-8,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:67775b1fe689aac8a236bd5098ede3ac, niiri:0a26619869c6304390cf220d86997062, -, -, -)
-    entity(niiri:5338ab94ade7000ed4f4bdf7d9d76d2b,
+    wasDerivedFrom(niiri:40736270f2699f261bc17555c7292552, niiri:e518dd980ffdb694adcf472695d5a40a, -, -, -)
+    entity(niiri:0f9175ee5293a19900d9c265070230b1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0162" %% xsd:string,
-        prov:location = 'niiri:f70d129d0d7c22e30869fb59d6e5cc46',
+        prov:location = 'niiri:a2480bf60f7e38c86231bf76032bf596',
         prov:value = "0.795195400714874" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69903522990177" %% xsd:float,
         nidm_pValueUncorrected: = "0.044656272931023" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f70d129d0d7c22e30869fb59d6e5cc46,
+    entity(niiri:a2480bf60f7e38c86231bf76032bf596,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0162" %% xsd:string,
         nidm_coordinateVector: = "[10,-10,4]" %% xsd:string])
-    wasDerivedFrom(niiri:5338ab94ade7000ed4f4bdf7d9d76d2b, niiri:6a5b8fb86c67c0eb5b9c606e6b810510, -, -, -)
-    entity(niiri:47f63f9dd57bbc2ec925efae82f98e54,
+    wasDerivedFrom(niiri:0f9175ee5293a19900d9c265070230b1, niiri:5f278b6b11fae0c4b4f9690852a71d0c, -, -, -)
+    entity(niiri:9288e365e8e166d1d7201abdec31d34d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0163" %% xsd:string,
-        prov:location = 'niiri:f5fa7f06451efb337a56d65fce6310d4',
+        prov:location = 'niiri:360956c141f1348efb9ba6e9bda173e8',
         prov:value = "0.793771862983704" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69724506469093" %% xsd:float,
         nidm_pValueUncorrected: = "0.0448251692331177" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f5fa7f06451efb337a56d65fce6310d4,
+    entity(niiri:360956c141f1348efb9ba6e9bda173e8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0163" %% xsd:string,
         nidm_coordinateVector: = "[36,-38,16]" %% xsd:string])
-    wasDerivedFrom(niiri:47f63f9dd57bbc2ec925efae82f98e54, niiri:99f3a2d8e7661135dd74892e7227bd72, -, -, -)
-    entity(niiri:e057cf1a39f015eb9f597ecf60c28d8d,
+    wasDerivedFrom(niiri:9288e365e8e166d1d7201abdec31d34d, niiri:87f8233f1c48acf6ecdd7339055182ae, -, -, -)
+    entity(niiri:5eefd7306b4387e0f534121efebdd08c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0164" %% xsd:string,
-        prov:location = 'niiri:408e388806b9aac265fd41d04872e446',
+        prov:location = 'niiri:c6bbb6da467f04755510516c59db89cc',
         prov:value = "0.791125535964966" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69391791067376" %% xsd:float,
         nidm_pValueUncorrected: = "0.0451404415013222" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:408e388806b9aac265fd41d04872e446,
+    entity(niiri:c6bbb6da467f04755510516c59db89cc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0164" %% xsd:string,
         nidm_coordinateVector: = "[36,-58,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:e057cf1a39f015eb9f597ecf60c28d8d, niiri:64a5de9f75df294ee267e34b2597bc84, -, -, -)
-    entity(niiri:f4707b696468bcd21beacb40c56d4112,
+    wasDerivedFrom(niiri:5eefd7306b4387e0f534121efebdd08c, niiri:0189728b5aaa10d4eb4ff53d1fbc5843, -, -, -)
+    entity(niiri:0d043095f5b8ce7d202f6fc55b3238bc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0165" %% xsd:string,
-        prov:location = 'niiri:8770aec72d29d54ccbc74852e6556723',
+        prov:location = 'niiri:00bfef980e3b46b82577ed05a18e2998',
         prov:value = "0.790164232254028" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69270952448475" %% xsd:float,
         nidm_pValueUncorrected: = "0.0452553857167721" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8770aec72d29d54ccbc74852e6556723,
+    entity(niiri:00bfef980e3b46b82577ed05a18e2998,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0165" %% xsd:string,
         nidm_coordinateVector: = "[-24,-68,40]" %% xsd:string])
-    wasDerivedFrom(niiri:f4707b696468bcd21beacb40c56d4112, niiri:2c98abbba202c2ed1fa8e08549a97cb1, -, -, -)
-    entity(niiri:0855ebe4c0e33757d2de5fe5b72c3aa4,
+    wasDerivedFrom(niiri:0d043095f5b8ce7d202f6fc55b3238bc, niiri:453f1919d7df3d7e610709f6fdecbf62, -, -, -)
+    entity(niiri:d3837181ec2883710db3c1e102047902,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0166" %% xsd:string,
-        prov:location = 'niiri:1304b6c03fd823e5f08127fb56383466',
+        prov:location = 'niiri:6839436079db4de6e679f679c75a4c7e',
         prov:value = "0.789975047111511" %% xsd:float,
         nidm_equivalentZStatistic: = "1.6924717281141" %% xsd:float,
         nidm_pValueUncorrected: = "0.045278033108256" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1304b6c03fd823e5f08127fb56383466,
+    entity(niiri:6839436079db4de6e679f679c75a4c7e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0166" %% xsd:string,
         nidm_coordinateVector: = "[-32,-66,-54]" %% xsd:string])
-    wasDerivedFrom(niiri:0855ebe4c0e33757d2de5fe5b72c3aa4, niiri:35bfc5987aa4a1eba01be33e4c1ee7f2, -, -, -)
-    entity(niiri:767f2a4a4176e20fbe7980bfd92d4d37,
+    wasDerivedFrom(niiri:d3837181ec2883710db3c1e102047902, niiri:5b21dda7a2823d1c7efeff7947020767, -, -, -)
+    entity(niiri:7ada6738ac4a3476b738b4b0994fd916,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0167" %% xsd:string,
-        prov:location = 'niiri:48c823ec7d05b841c28208a512ace325',
+        prov:location = 'niiri:0e72b69c8d3905c21cb76f5d803a0e4d',
         prov:value = "0.785030126571655" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68625793462611" %% xsd:float,
         nidm_pValueUncorrected: = "0.0458730647233518" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:48c823ec7d05b841c28208a512ace325,
+    entity(niiri:0e72b69c8d3905c21cb76f5d803a0e4d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0167" %% xsd:string,
         nidm_coordinateVector: = "[-38,-4,36]" %% xsd:string])
-    wasDerivedFrom(niiri:767f2a4a4176e20fbe7980bfd92d4d37, niiri:33395b862a603ee1373735759fed1bcb, -, -, -)
-    entity(niiri:efc75d1d378ad8d8e290d9c8d692030e,
+    wasDerivedFrom(niiri:7ada6738ac4a3476b738b4b0994fd916, niiri:a6dc495a077e17aa8f96566659037e0b, -, -, -)
+    entity(niiri:9c5822f4331f39fcb128f71e39c9a258,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0168" %% xsd:string,
-        prov:location = 'niiri:cf847ee221aa1a3ba5ad8ab6ceda969c',
+        prov:location = 'niiri:ff06c430dadf64ca774b3086a78659e3',
         prov:value = "0.783349096775055" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68414631143602" %% xsd:float,
         nidm_pValueUncorrected: = "0.0460766980434556" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:cf847ee221aa1a3ba5ad8ab6ceda969c,
+    entity(niiri:ff06c430dadf64ca774b3086a78659e3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0168" %% xsd:string,
         nidm_coordinateVector: = "[-50,10,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:efc75d1d378ad8d8e290d9c8d692030e, niiri:635a4fc24d89b14d261b42d568e53ac8, -, -, -)
-    entity(niiri:f23899f7631f3a7071c3337dd7fc2238,
+    wasDerivedFrom(niiri:9c5822f4331f39fcb128f71e39c9a258, niiri:e5e5eeee288ec088072a80af972a3638, -, -, -)
+    entity(niiri:ccb323d69fd85ace7df2130c0f358f1e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0169" %% xsd:string,
-        prov:location = 'niiri:0bb4251c6e182321ff1b00b360bea5db',
+        prov:location = 'niiri:217b8e666093093f4b98080437a0d243',
         prov:value = "0.780271351337433" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68028121266012" %% xsd:float,
         nidm_pValueUncorrected: = "0.046451307319556" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0bb4251c6e182321ff1b00b360bea5db,
+    entity(niiri:217b8e666093093f4b98080437a0d243,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0169" %% xsd:string,
         nidm_coordinateVector: = "[-18,-22,34]" %% xsd:string])
-    wasDerivedFrom(niiri:f23899f7631f3a7071c3337dd7fc2238, niiri:55b4eeddb69bb03436464cf696dd593b, -, -, -)
-    entity(niiri:e0c716598553c866132acb9e00a99269,
+    wasDerivedFrom(niiri:ccb323d69fd85ace7df2130c0f358f1e, niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1, -, -, -)
+    entity(niiri:cf35bc5d34495239fdb3d14ae313539a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0170" %% xsd:string,
-        prov:location = 'niiri:bd016d0a131f74cd47766a37849f8af4',
+        prov:location = 'niiri:6a7144a67e64589dcd898f89b4f5a115',
         prov:value = "0.778013467788696" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67744654581037" %% xsd:float,
         nidm_pValueUncorrected: = "0.046727596979824" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:bd016d0a131f74cd47766a37849f8af4,
+    entity(niiri:6a7144a67e64589dcd898f89b4f5a115,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0170" %% xsd:string,
         nidm_coordinateVector: = "[-20,-22,38]" %% xsd:string])
-    wasDerivedFrom(niiri:e0c716598553c866132acb9e00a99269, niiri:493898a476d4ce4bf533682e007422c5, -, -, -)
-    entity(niiri:23993fd78665c8c8cea4bbea816aa847,
+    wasDerivedFrom(niiri:cf35bc5d34495239fdb3d14ae313539a, niiri:66cf0dbeb1aa03edbab1a35c2d527a55, -, -, -)
+    entity(niiri:8a057d875ec99d9bc03c3b517547b1ea,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0171" %% xsd:string,
-        prov:location = 'niiri:34c3f1555e908f480a1cd6c4105ace9b',
+        prov:location = 'niiri:074b47096ccc51be98dbe94fdd69bdea',
         prov:value = "0.775993704795837" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67491142741087" %% xsd:float,
         nidm_pValueUncorrected: = "0.0469758055929785" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:34c3f1555e908f480a1cd6c4105ace9b,
+    entity(niiri:074b47096ccc51be98dbe94fdd69bdea,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0171" %% xsd:string,
         nidm_coordinateVector: = "[12,-92,2]" %% xsd:string])
-    wasDerivedFrom(niiri:23993fd78665c8c8cea4bbea816aa847, niiri:b841eb2677ab2ad59ce73103265cdee0, -, -, -)
-    entity(niiri:2f0c7a7defde925468925744ec810146,
+    wasDerivedFrom(niiri:8a057d875ec99d9bc03c3b517547b1ea, niiri:09d8898196c5c40aec6f995a2b0c383d, -, -, -)
+    entity(niiri:136d5427f1933a243c7f06af362e36ee,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0172" %% xsd:string,
-        prov:location = 'niiri:da9b38041402957b6d2f062656d107ff',
+        prov:location = 'niiri:78b0fee3f9559ef3905e7bf963b53e38',
         prov:value = "0.774858772754669" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67348715940063" %% xsd:float,
         nidm_pValueUncorrected: = "0.0471157161396256" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:da9b38041402957b6d2f062656d107ff,
+    entity(niiri:78b0fee3f9559ef3905e7bf963b53e38,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0172" %% xsd:string,
         nidm_coordinateVector: = "[52,-44,58]" %% xsd:string])
-    wasDerivedFrom(niiri:2f0c7a7defde925468925744ec810146, niiri:4c7ec0be40515b0eae812fe9befe02f1, -, -, -)
-    entity(niiri:f05db93a343d1865fd10001c92a30d32,
+    wasDerivedFrom(niiri:136d5427f1933a243c7f06af362e36ee, niiri:bfe644ea717165d3b6b50431d8e57c87, -, -, -)
+    entity(niiri:f4fabce2608abd82f4cb41cc5b313112,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0173" %% xsd:string,
-        prov:location = 'niiri:5a77aafacf3c36dfd821f2078711b553',
+        prov:location = 'niiri:907619d79ece58eff1df517e0cbd5f78',
         prov:value = "0.766564428806305" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66308376386524" %% xsd:float,
         nidm_pValueUncorrected: = "0.0481478347201374" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5a77aafacf3c36dfd821f2078711b553,
+    entity(niiri:907619d79ece58eff1df517e0cbd5f78,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0173" %% xsd:string,
         nidm_coordinateVector: = "[46,30,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:f05db93a343d1865fd10001c92a30d32, niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22, -, -, -)
-    entity(niiri:8185514955cc636d4b50aa7fd9985960,
+    wasDerivedFrom(niiri:f4fabce2608abd82f4cb41cc5b313112, niiri:0d278ee0d105de3a7319a5acaa11c631, -, -, -)
+    entity(niiri:f47917da4ed2d8c7e7324d2c0d02a46d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0174" %% xsd:string,
-        prov:location = 'niiri:59906cc8f0c4f1ad9a16e5f64ecc97e9',
+        prov:location = 'niiri:4c0ec437ff4662e7d0eac4dcd51885cb',
         prov:value = "0.766485750675201" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66298512623431" %% xsd:float,
         nidm_pValueUncorrected: = "0.0481577064245639" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:59906cc8f0c4f1ad9a16e5f64ecc97e9,
+    entity(niiri:4c0ec437ff4662e7d0eac4dcd51885cb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0174" %% xsd:string,
         nidm_coordinateVector: = "[20,-72,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:8185514955cc636d4b50aa7fd9985960, niiri:9d494c09341573a6df3c044f6f353a5a, -, -, -)
-    entity(niiri:f82c4e460ed68891672a882b6ca47ce7,
+    wasDerivedFrom(niiri:f47917da4ed2d8c7e7324d2c0d02a46d, niiri:9a54b30308f71d0c474dab56acec5885, -, -, -)
+    entity(niiri:8e9351607907220ceb9c4d03fd181a94,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0175" %% xsd:string,
-        prov:location = 'niiri:6b08822f4f84a3704fb33481c32938e7',
+        prov:location = 'niiri:35e7e4f379992bd20464a3fd82e6925c',
         prov:value = "0.764753878116608" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66081412523685" %% xsd:float,
         nidm_pValueUncorrected: = "0.0483753916847881" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6b08822f4f84a3704fb33481c32938e7,
+    entity(niiri:35e7e4f379992bd20464a3fd82e6925c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0175" %% xsd:string,
         nidm_coordinateVector: = "[30,-32,14]" %% xsd:string])
-    wasDerivedFrom(niiri:f82c4e460ed68891672a882b6ca47ce7, niiri:630ac6074dee24b42295002659ee6cd4, -, -, -)
-    entity(niiri:085070c6b1c81a70c7d9316dc333c5af,
+    wasDerivedFrom(niiri:8e9351607907220ceb9c4d03fd181a94, niiri:f219989ec875846cc4815fffc10bd118, -, -, -)
+    entity(niiri:33b88df2af789585f536f999c5e3786b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0176" %% xsd:string,
-        prov:location = 'niiri:f2d70aea1159517722dc1f0e96049f7f',
+        prov:location = 'niiri:753a6ac393f5e043a90380ea38ab0569',
         prov:value = "0.764399468898773" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66036990560998" %% xsd:float,
         nidm_pValueUncorrected: = "0.0484200302267611" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f2d70aea1159517722dc1f0e96049f7f,
+    entity(niiri:753a6ac393f5e043a90380ea38ab0569,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0176" %% xsd:string,
         nidm_coordinateVector: = "[-8,-2,66]" %% xsd:string])
-    wasDerivedFrom(niiri:085070c6b1c81a70c7d9316dc333c5af, niiri:97f9982dca21f34e7ea0fcb977fcf50b, -, -, -)
-    entity(niiri:35df629079347c6c083f74c21c155794,
+    wasDerivedFrom(niiri:33b88df2af789585f536f999c5e3786b, niiri:4b37375a8d01d1d9009b430352062714, -, -, -)
+    entity(niiri:bb74269075716d4be58818314e11eb5f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0177" %% xsd:string,
-        prov:location = 'niiri:6c5f4e78e250aba08a965b5ca9cce21d',
+        prov:location = 'niiri:750f7b5e0fd142e4019c35e2387fbbba',
         prov:value = "0.763978481292725" %% xsd:float,
         nidm_equivalentZStatistic: = "1.65984225927592" %% xsd:float,
         nidm_pValueUncorrected: = "0.0484730949107541" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6c5f4e78e250aba08a965b5ca9cce21d,
+    entity(niiri:750f7b5e0fd142e4019c35e2387fbbba,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0177" %% xsd:string,
         nidm_coordinateVector: = "[-20,10,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:35df629079347c6c083f74c21c155794, niiri:b7588b8a823a7341bbdb4d3e8686e040, -, -, -)
-    entity(niiri:81ebc55180aab5f90eb8e98ffc27a319,
+    wasDerivedFrom(niiri:bb74269075716d4be58818314e11eb5f, niiri:0f0a4015dd42d89522302ce792b20d6d, -, -, -)
+    entity(niiri:3ad00aa4ff8a097302d4f9fa2f588f84,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0178" %% xsd:string,
-        prov:location = 'niiri:82ba696cda1e7d2d87bd5e1ac789e9b4',
+        prov:location = 'niiri:35bb5e6863e088834438d69e3f1e49f6',
         prov:value = "0.763044834136963" %% xsd:float,
         nidm_equivalentZStatistic: = "1.65867215934383" %% xsd:float,
         nidm_pValueUncorrected: = "0.0485909362055301" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:82ba696cda1e7d2d87bd5e1ac789e9b4,
+    entity(niiri:35bb5e6863e088834438d69e3f1e49f6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0178" %% xsd:string,
         nidm_coordinateVector: = "[-62,2,14]" %% xsd:string])
-    wasDerivedFrom(niiri:81ebc55180aab5f90eb8e98ffc27a319, niiri:31b704c584e2aae3b394c52754216fae, -, -, -)
-    entity(niiri:21c18d8c769fb0c198241386ba803d0e,
+    wasDerivedFrom(niiri:3ad00aa4ff8a097302d4f9fa2f588f84, niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a, -, -, -)
+    entity(niiri:fad858bb75eed0c28b072161552a6ba5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0179" %% xsd:string,
-        prov:location = 'niiri:38c7639cf73f14cd5fd84daa5a16b606',
+        prov:location = 'niiri:5bb50d8540759ebdbe65ef922e6b9009',
         prov:value = "0.762995421886444" %% xsd:float,
         nidm_equivalentZStatistic: = "1.65861023655314" %% xsd:float,
         nidm_pValueUncorrected: = "0.0485971788535396" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:38c7639cf73f14cd5fd84daa5a16b606,
+    entity(niiri:5bb50d8540759ebdbe65ef922e6b9009,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0179" %% xsd:string,
         nidm_coordinateVector: = "[-12,-28,80]" %% xsd:string])
-    wasDerivedFrom(niiri:21c18d8c769fb0c198241386ba803d0e, niiri:2eff95031f5301f6a29990e69708dce1, -, -, -)
+    wasDerivedFrom(niiri:fad858bb75eed0c28b072161552a6ba5, niiri:f6e36041fd68625d6c7813fe63387c51, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_partial_conjunction/nidm.provn
+++ b/spmexport/ex_spm_partial_conjunction/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:243ddea5e5dff3c37c34dba282896eea,
+  entity(niiri:53e129083d62a2ca94abd3ce77921782,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:25efcb2fdf89f72335565444747a8325,
+  agent(niiri:88c72fce53af7e51ed2ff12304fbd9ae,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:bc9474858aa89d5580813e5a520e15a8,
+  activity(niiri:edaedd7a6dd0f3ec41a2098624fa45c4,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:bc9474858aa89d5580813e5a520e15a8, niiri:25efcb2fdf89f72335565444747a8325, -)
-  wasGeneratedBy(niiri:243ddea5e5dff3c37c34dba282896eea, niiri:bc9474858aa89d5580813e5a520e15a8, 2016-01-11T10:34:17)
-  bundle niiri:243ddea5e5dff3c37c34dba282896eea
+  wasAssociatedWith(niiri:edaedd7a6dd0f3ec41a2098624fa45c4, niiri:88c72fce53af7e51ed2ff12304fbd9ae, -)
+  wasGeneratedBy(niiri:53e129083d62a2ca94abd3ce77921782, niiri:edaedd7a6dd0f3ec41a2098624fa45c4, 2016-01-11T10:45:00)
+  bundle niiri:53e129083d62a2ca94abd3ce77921782
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -126,12 +126,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:1d7e73278ccee95e211689d9de8f4d4a,
+    agent(niiri:4e80f2248e423bc7460bc30b328ae5d6,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:a56db6367efd1f7176e69f24b028de94,
+    entity(niiri:0cfe351ea2a996755a3dbf85a2ca844e,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -140,189 +140,189 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:03e7d0232ea5517ed14b6e2311b82699,
+    entity(niiri:638afc61f79794663d1226089c695924,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:df0cfe4ba2647dd9f372f5d3b73c6885,
+    entity(niiri:b35fb1f930f78d3d5e285a9136ef3b7b,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:1388e1cf368a92acbd46e47523c2061a,
+    entity(niiri:31585807d02b5a99ee20b72b3ab2bf1b,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:d17dbd59c5c8179a99d73392215c0c41',
+        dc:description = 'niiri:64eb05a859f67b223eb5213e85827912',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:df0cfe4ba2647dd9f372f5d3b73c6885',
+        nidm_hasDriftModel: = 'niiri:b35fb1f930f78d3d5e285a9136ef3b7b',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:d17dbd59c5c8179a99d73392215c0c41,
+    entity(niiri:64eb05a859f67b223eb5213e85827912,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:05be31167ef4404a70e4f0e58bd930aa,
+    entity(niiri:8f74b25b85dd7bbba6ad75fa25f658d0,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:8d051ec65c19e120a2e66d23f309c6e9,
+    activity(niiri:9a0a32dc2503c28d6779be4fd384e68b,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:8d051ec65c19e120a2e66d23f309c6e9, niiri:1d7e73278ccee95e211689d9de8f4d4a, -)
-    used(niiri:8d051ec65c19e120a2e66d23f309c6e9, niiri:1388e1cf368a92acbd46e47523c2061a, -)
-    used(niiri:8d051ec65c19e120a2e66d23f309c6e9, niiri:03e7d0232ea5517ed14b6e2311b82699, -)
-    used(niiri:8d051ec65c19e120a2e66d23f309c6e9, niiri:05be31167ef4404a70e4f0e58bd930aa, -)
-    entity(niiri:d17318e0fda06cc6303389a919cffce0,
+    wasAssociatedWith(niiri:9a0a32dc2503c28d6779be4fd384e68b, niiri:4e80f2248e423bc7460bc30b328ae5d6, -)
+    used(niiri:9a0a32dc2503c28d6779be4fd384e68b, niiri:31585807d02b5a99ee20b72b3ab2bf1b, -)
+    used(niiri:9a0a32dc2503c28d6779be4fd384e68b, niiri:638afc61f79794663d1226089c695924, -)
+    used(niiri:9a0a32dc2503c28d6779be4fd384e68b, niiri:8f74b25b85dd7bbba6ad75fa25f658d0, -)
+    entity(niiri:9f09276d756920c240534438990b34a9,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    entity(niiri:511e38d9f81db913e57cb2fda1bf7292,
+    entity(niiri:cb9a0e835164f4f8b37d523a8400d724,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b" %% xsd:string])
-    wasDerivedFrom(niiri:d17318e0fda06cc6303389a919cffce0, niiri:511e38d9f81db913e57cb2fda1bf7292, -, -, -)
-    wasGeneratedBy(niiri:d17318e0fda06cc6303389a919cffce0, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:b24768aaee9add9a163a13028ada6ac2,
+    wasDerivedFrom(niiri:9f09276d756920c240534438990b34a9, niiri:cb9a0e835164f4f8b37d523a8400d724, -, -, -)
+    wasGeneratedBy(niiri:9f09276d756920c240534438990b34a9, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:5da917d479c32c38ba8509a22d2b90c4,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "108.038318634033" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848" %% xsd:string])
-    wasGeneratedBy(niiri:b24768aaee9add9a163a13028ada6ac2, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:fbf0025dc56929ec686d1a867cba4ed9,
+    wasGeneratedBy(niiri:5da917d479c32c38ba8509a22d2b90c4, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
-    entity(niiri:c6f77d4608bf5adce440967ee6f38924,
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e'])
+    entity(niiri:ede52b072a350edb793f918d504fc8ca,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f" %% xsd:string])
-    wasDerivedFrom(niiri:fbf0025dc56929ec686d1a867cba4ed9, niiri:c6f77d4608bf5adce440967ee6f38924, -, -, -)
-    wasGeneratedBy(niiri:fbf0025dc56929ec686d1a867cba4ed9, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:b0bd46832f113e655723b654eb1eb6ad,
+    wasDerivedFrom(niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9, niiri:ede52b072a350edb793f918d504fc8ca, -, -, -)
+    wasGeneratedBy(niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:14112f18638a7370da3d3a355f94de50,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
-    entity(niiri:42e752fc06737a9878924396d3bfcce9,
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e'])
+    entity(niiri:bc4f0366eab13c36df4e113d393f9901,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b" %% xsd:string])
-    wasDerivedFrom(niiri:b0bd46832f113e655723b654eb1eb6ad, niiri:42e752fc06737a9878924396d3bfcce9, -, -, -)
-    wasGeneratedBy(niiri:b0bd46832f113e655723b654eb1eb6ad, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:09ee1b58f1cd2a34771305a61a8d1d32,
+    wasDerivedFrom(niiri:14112f18638a7370da3d3a355f94de50, niiri:bc4f0366eab13c36df4e113d393f9901, -, -, -)
+    wasGeneratedBy(niiri:14112f18638a7370da3d3a355f94de50, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:05e23b40e89003344a3dacbd46f567de,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
-    entity(niiri:a2c15aa0c4d45f52407ac5827bbf73bb,
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e'])
+    entity(niiri:3adf084caea6b7bfcdd869ed826a885e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb" %% xsd:string])
-    wasDerivedFrom(niiri:09ee1b58f1cd2a34771305a61a8d1d32, niiri:a2c15aa0c4d45f52407ac5827bbf73bb, -, -, -)
-    wasGeneratedBy(niiri:09ee1b58f1cd2a34771305a61a8d1d32, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:16ce2036a3b6f15ece6fc491d108ae37,
+    wasDerivedFrom(niiri:05e23b40e89003344a3dacbd46f567de, niiri:3adf084caea6b7bfcdd869ed826a885e, -, -, -)
+    wasGeneratedBy(niiri:05e23b40e89003344a3dacbd46f567de, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:37b5d50db4e958f60096d3793ca3fdf3,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
-    entity(niiri:ee716d14a7ac59b3c4521ed8cbff1e3a,
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e'])
+    entity(niiri:949afc6e785b9a3f221c178596a3bcf9,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6" %% xsd:string])
-    wasDerivedFrom(niiri:16ce2036a3b6f15ece6fc491d108ae37, niiri:ee716d14a7ac59b3c4521ed8cbff1e3a, -, -, -)
-    wasGeneratedBy(niiri:16ce2036a3b6f15ece6fc491d108ae37, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:c856b511969b2c541b07a88189532fa6,
+    wasDerivedFrom(niiri:37b5d50db4e958f60096d3793ca3fdf3, niiri:949afc6e785b9a3f221c178596a3bcf9, -, -, -)
+    wasGeneratedBy(niiri:37b5d50db4e958f60096d3793ca3fdf3, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:e951c223beee68af908d79eaaf52cd3d,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
-    entity(niiri:33afe3bb4683b8e28103d232fdf92af8,
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e'])
+    entity(niiri:3a6614401ac6a8441b9cb0233b7b7722,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff" %% xsd:string])
-    wasDerivedFrom(niiri:c856b511969b2c541b07a88189532fa6, niiri:33afe3bb4683b8e28103d232fdf92af8, -, -, -)
-    wasGeneratedBy(niiri:c856b511969b2c541b07a88189532fa6, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:e8f6f2e9821e3f9556f500048b8ae9b5,
+    wasDerivedFrom(niiri:e951c223beee68af908d79eaaf52cd3d, niiri:3a6614401ac6a8441b9cb0233b7b7722, -, -, -)
+    wasGeneratedBy(niiri:e951c223beee68af908d79eaaf52cd3d, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:40fd35a7356f9acff12bbe37c24ee5a6,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 6" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94'])
-    entity(niiri:8167c647e0923c3553c7c0ffc2d666d4,
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e'])
+    entity(niiri:31fb8c34052ae4e914aeecf4dc695a01,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0006.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c" %% xsd:string])
-    wasDerivedFrom(niiri:e8f6f2e9821e3f9556f500048b8ae9b5, niiri:8167c647e0923c3553c7c0ffc2d666d4, -, -, -)
-    wasGeneratedBy(niiri:e8f6f2e9821e3f9556f500048b8ae9b5, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:ecf064f9baf28d8f742bd2855558502d,
+    wasDerivedFrom(niiri:40fd35a7356f9acff12bbe37c24ee5a6, niiri:31fb8c34052ae4e914aeecf4dc695a01, -, -, -)
+    wasGeneratedBy(niiri:40fd35a7356f9acff12bbe37c24ee5a6, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:bb0227319e3db3da4111306100a7c129,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8" %% xsd:string])
-    entity(niiri:2cbf5c3625b82cb3fee7b9e869188b55,
+    entity(niiri:9e1d5161f7f086396aebbea3f1d66996,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81" %% xsd:string])
-    wasDerivedFrom(niiri:ecf064f9baf28d8f742bd2855558502d, niiri:2cbf5c3625b82cb3fee7b9e869188b55, -, -, -)
-    wasGeneratedBy(niiri:ecf064f9baf28d8f742bd2855558502d, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:0c0eb1d804cee8231e915a5fdfc5ab8b,
+    wasDerivedFrom(niiri:bb0227319e3db3da4111306100a7c129, niiri:9e1d5161f7f086396aebbea3f1d66996, -, -, -)
+    wasGeneratedBy(niiri:bb0227319e3db3da4111306100a7c129, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:f1d4f3ce5390393fe9ce15122e7a462e,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8" %% xsd:string])
-    entity(niiri:eeee4f9f7f0c1ed7696258b61716b549,
+    entity(niiri:14109ba534e31f1fcd5cf1a1c39e0277,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29" %% xsd:string])
-    wasDerivedFrom(niiri:0c0eb1d804cee8231e915a5fdfc5ab8b, niiri:eeee4f9f7f0c1ed7696258b61716b549, -, -, -)
-    wasGeneratedBy(niiri:0c0eb1d804cee8231e915a5fdfc5ab8b, niiri:8d051ec65c19e120a2e66d23f309c6e9, -)
-    entity(niiri:0e92041f1c22bfbe8b6d3bba28b3ce18,
+    wasDerivedFrom(niiri:f1d4f3ce5390393fe9ce15122e7a462e, niiri:14109ba534e31f1fcd5cf1a1c39e0277, -, -, -)
+    wasGeneratedBy(niiri:f1d4f3ce5390393fe9ce15122e7a462e, niiri:9a0a32dc2503c28d6779be4fd384e68b, -)
+    entity(niiri:c532578f9638b97cce706f745ab70822,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         prov:label = "Contrast: mr vs plain" %% xsd:string,
         prov:value = "[1, 1, -1, -1, 0, 0]" %% xsd:string])
-    activity(niiri:4ee8aaeabfe9f5181a4281676d9a033d,
+    activity(niiri:b8a53b0ddc7b238b0c822d8247668a2d,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation 1"])
-    wasAssociatedWith(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:1d7e73278ccee95e211689d9de8f4d4a, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:d17318e0fda06cc6303389a919cffce0, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:ecf064f9baf28d8f742bd2855558502d, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:1388e1cf368a92acbd46e47523c2061a, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:0e92041f1c22bfbe8b6d3bba28b3ce18, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:fbf0025dc56929ec686d1a867cba4ed9, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:b0bd46832f113e655723b654eb1eb6ad, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:09ee1b58f1cd2a34771305a61a8d1d32, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:16ce2036a3b6f15ece6fc491d108ae37, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:c856b511969b2c541b07a88189532fa6, -)
-    used(niiri:4ee8aaeabfe9f5181a4281676d9a033d, niiri:e8f6f2e9821e3f9556f500048b8ae9b5, -)
-    entity(niiri:3ccd77b3de962099cf8ce0c08029054a,
+    wasAssociatedWith(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:4e80f2248e423bc7460bc30b328ae5d6, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:9f09276d756920c240534438990b34a9, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:bb0227319e3db3da4111306100a7c129, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:31585807d02b5a99ee20b72b3ab2bf1b, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:c532578f9638b97cce706f745ab70822, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:14112f18638a7370da3d3a355f94de50, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:05e23b40e89003344a3dacbd46f567de, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:37b5d50db4e958f60096d3793ca3fdf3, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:e951c223beee68af908d79eaaf52cd3d, -)
+    used(niiri:b8a53b0ddc7b238b0c822d8247668a2d, niiri:40fd35a7356f9acff12bbe37c24ee5a6, -)
+    entity(niiri:9d7bfa4d0b9f9112e97374100868d499,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic_0001.nii.gz" %% xsd:string,
@@ -332,61 +332,61 @@ document
         nidm_contrastName: = "mr vs plain" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "3d222abce9f360902d01cb45ffaaa3d711c699c6771f36ee61630ccc2fec2275897a15dd31b846a074e20b59337bae8b171223c15f22d8f2168a1967e85b397a" %% xsd:string])
-    entity(niiri:f9a3461abe033c0b4194f4eb1324b723,
+    entity(niiri:a038302c53fddd4a98c7160cfbde7138,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782" %% xsd:string])
-    wasDerivedFrom(niiri:3ccd77b3de962099cf8ce0c08029054a, niiri:f9a3461abe033c0b4194f4eb1324b723, -, -, -)
-    wasGeneratedBy(niiri:3ccd77b3de962099cf8ce0c08029054a, niiri:4ee8aaeabfe9f5181a4281676d9a033d, -)
-    entity(niiri:8fec6cee88576b42702d9e1f7488e362,
+    wasDerivedFrom(niiri:9d7bfa4d0b9f9112e97374100868d499, niiri:a038302c53fddd4a98c7160cfbde7138, -, -, -)
+    wasGeneratedBy(niiri:9d7bfa4d0b9f9112e97374100868d499, niiri:b8a53b0ddc7b238b0c822d8247668a2d, -)
+    entity(niiri:d67127701e2842c7ad80371e04374f1c,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: mr vs plain" %% xsd:string,
         nidm_contrastName: = "mr vs plain" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5" %% xsd:string])
-    entity(niiri:3dcfcea6814505f9436e9dba6e69af0a,
+    entity(niiri:e5258d5b3277133b0419fa9783cb9dd2,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28" %% xsd:string])
-    wasDerivedFrom(niiri:8fec6cee88576b42702d9e1f7488e362, niiri:3dcfcea6814505f9436e9dba6e69af0a, -, -, -)
-    wasGeneratedBy(niiri:8fec6cee88576b42702d9e1f7488e362, niiri:4ee8aaeabfe9f5181a4281676d9a033d, -)
-    entity(niiri:4ad1bd5ff050ee049008dafae70fffb2,
+    wasDerivedFrom(niiri:d67127701e2842c7ad80371e04374f1c, niiri:e5258d5b3277133b0419fa9783cb9dd2, -, -, -)
+    wasGeneratedBy(niiri:d67127701e2842c7ad80371e04374f1c, niiri:b8a53b0ddc7b238b0c822d8247668a2d, -)
+    entity(niiri:810644c2421100536dbd030c23c92d8c,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError_0001.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError_0001.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b" %% xsd:string])
-    wasGeneratedBy(niiri:4ad1bd5ff050ee049008dafae70fffb2, niiri:4ee8aaeabfe9f5181a4281676d9a033d, -)
-    entity(niiri:13fb71f74ac2523fac8d4fe8ab7ecb1d,
+    wasGeneratedBy(niiri:810644c2421100536dbd030c23c92d8c, niiri:b8a53b0ddc7b238b0c822d8247668a2d, -)
+    entity(niiri:ded3bff3ce2da6fb2df69c3c171fd62b,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
         prov:label = "Contrast: switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
         prov:value = "[0.953151930124911, -1.04684806987509, 1.04684806987509, -0.953151930124911, 0, 0]" %% xsd:string])
-    activity(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08,
+    activity(niiri:87124f9d582147cec91df8f0e1c825f7,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation 2"])
-    wasAssociatedWith(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:1d7e73278ccee95e211689d9de8f4d4a, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:d17318e0fda06cc6303389a919cffce0, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:ecf064f9baf28d8f742bd2855558502d, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:1388e1cf368a92acbd46e47523c2061a, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:13fb71f74ac2523fac8d4fe8ab7ecb1d, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:fbf0025dc56929ec686d1a867cba4ed9, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:b0bd46832f113e655723b654eb1eb6ad, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:09ee1b58f1cd2a34771305a61a8d1d32, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:16ce2036a3b6f15ece6fc491d108ae37, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:c856b511969b2c541b07a88189532fa6, -)
-    used(niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, niiri:e8f6f2e9821e3f9556f500048b8ae9b5, -)
-    entity(niiri:406c820ff107488cd976836b2d5c6516,
+    wasAssociatedWith(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:4e80f2248e423bc7460bc30b328ae5d6, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:9f09276d756920c240534438990b34a9, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:bb0227319e3db3da4111306100a7c129, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:31585807d02b5a99ee20b72b3ab2bf1b, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:ded3bff3ce2da6fb2df69c3c171fd62b, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:14112f18638a7370da3d3a355f94de50, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:05e23b40e89003344a3dacbd46f567de, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:37b5d50db4e958f60096d3793ca3fdf3, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:e951c223beee68af908d79eaaf52cd3d, -)
+    used(niiri:87124f9d582147cec91df8f0e1c825f7, niiri:40fd35a7356f9acff12bbe37c24ee5a6, -)
+    entity(niiri:a66dbffb487a58bd067df5d6b5e3980b,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic_0002.nii.gz" %% xsd:string,
@@ -396,104 +396,104 @@ document
         nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "192.99999999965" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "0.999999999999999" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "ec2f61dbf28ab2256a374dc5e3a93ba3a54e520c6bccd089dfbd07421e445b4881154433ea31e32587c1fae170daa5dc0a21f6efc328b90727d8d25bbd524e2f" %% xsd:string])
-    entity(niiri:e928c1c55744b1fd90a0de8fa5ab64b3,
+    entity(niiri:19a7224c80d25fb724dee163a1e1dc8e,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "4a7d076c01440a170e048ebe9644f90193b2aaf1291f454bdc6be2cf17e11a66b1d177025f5ed77434afe780ff8dcba710ec41120246e38894f823eb0fd88621" %% xsd:string])
-    wasDerivedFrom(niiri:406c820ff107488cd976836b2d5c6516, niiri:e928c1c55744b1fd90a0de8fa5ab64b3, -, -, -)
-    wasGeneratedBy(niiri:406c820ff107488cd976836b2d5c6516, niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, -)
-    entity(niiri:769ec268b92ea35935ef54cff37b9b03,
+    wasDerivedFrom(niiri:a66dbffb487a58bd067df5d6b5e3980b, niiri:19a7224c80d25fb724dee163a1e1dc8e, -, -, -)
+    wasGeneratedBy(niiri:a66dbffb487a58bd067df5d6b5e3980b, niiri:87124f9d582147cec91df8f0e1c825f7, -)
+    entity(niiri:12d49f892703283c79a1a5df181e60aa,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast_0002.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
         nidm_contrastName: = "switch vs nonswitch (orth. w.r.t {1})" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "31a00f409f493fc214fe1f84fe2a799bb96d1e03d67f2ce5b8c5b5fdb934bb0005f1be68addb81934052af4643c3099542ea4944013e9346042a44c2ed8f3788" %% xsd:string])
-    entity(niiri:37d6e69cac2b0a5b938bfdfb712bf881,
+    entity(niiri:41374722583b15739e066d38b1129c99,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "6d92adc90c0045445b66064818fdae617474690e92e9cb332e73fa8bf27f6d1d18367c0648ffbc74196a5c2ce9f4af4186394628eed475a0e2866efe3d4eee9b" %% xsd:string])
-    wasDerivedFrom(niiri:769ec268b92ea35935ef54cff37b9b03, niiri:37d6e69cac2b0a5b938bfdfb712bf881, -, -, -)
-    wasGeneratedBy(niiri:769ec268b92ea35935ef54cff37b9b03, niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, -)
-    entity(niiri:791b2b0b99cd2c0794a3a2a508127afe,
+    wasDerivedFrom(niiri:12d49f892703283c79a1a5df181e60aa, niiri:41374722583b15739e066d38b1129c99, -, -, -)
+    wasGeneratedBy(niiri:12d49f892703283c79a1a5df181e60aa, niiri:87124f9d582147cec91df8f0e1c825f7, -)
+    entity(niiri:0a15259e1cb84af956c3d425f69b6a6d,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError_0002.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError_0002.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "ac87f548f0d92f929c05476d2aacbc7e5319da6d62a5585a72d714be836b1b86962a36c6d473ae84c17cd613d683976e9fc562d6d7692cb8e942966f71e34a08" %% xsd:string])
-    wasGeneratedBy(niiri:791b2b0b99cd2c0794a3a2a508127afe, niiri:f1caaf0c37a363ca6d9dba8a65ed8d08, -)
-    entity(niiri:926b152f947e98d6025b235c27f919b2,
+    wasGeneratedBy(niiri:0a15259e1cb84af956c3d425f69b6a6d, niiri:87124f9d582147cec91df8f0e1c825f7, -)
+    entity(niiri:f910459d8c9231bd403e71f9e88897d7,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.048771 (unc.)" %% xsd:string,
         prov:value = "0.0487705355732563" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:6c13a2215653fb5c58245ecb3124b723',
-        nidm_equivalentThreshold: = 'niiri:e14ba17059f36074630699f7fc00a61e'])
-    entity(niiri:6c13a2215653fb5c58245ecb3124b723,
+        nidm_equivalentThreshold: = 'niiri:b9cac449a762eda6c6944912d6bc5139',
+        nidm_equivalentThreshold: = 'niiri:e4f48690675c5e668fa0c4b1952e89f6'])
+    entity(niiri:b9cac449a762eda6c6944912d6bc5139,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.761625168301108" %% xsd:float])
-    entity(niiri:e14ba17059f36074630699f7fc00a61e,
+    entity(niiri:e4f48690675c5e668fa0c4b1952e89f6,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:57dbc4426669cb76ea05d5c255480994,
+    entity(niiri:3e9ab6b7ab94d21f2e2eb27edcd3e0b7,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:461720f2996e5344ac089e2cec429c07',
-        nidm_equivalentThreshold: = 'niiri:abec52af88c1f072dc3422a358ae41ff'])
-    entity(niiri:461720f2996e5344ac089e2cec429c07,
+        nidm_equivalentThreshold: = 'niiri:841c05662d34dd6394d93a67aab3944d',
+        nidm_equivalentThreshold: = 'niiri:896df8b6f3696a2566e797f4d5ca35d9'])
+    entity(niiri:841c05662d34dd6394d93a67aab3944d,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:abec52af88c1f072dc3422a358ae41ff,
+    entity(niiri:896df8b6f3696a2566e797f4d5ca35d9,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:3d219576930e0e1002fa5ad61a717666,
+    entity(niiri:e64dd9a3993e688a02e46f618db34698,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:a5a3ea39278acdf05599017327bbbab6,
+    entity(niiri:495c70d4ecfbcfc93cc3c1d386a10e84,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:8ca7abe146d9bd8a996b72f2d817f4e9,
+    activity(niiri:d51f5fd37ea92b55541c8f1c4a4c255e,
         [prov:type = "spm_PartialConjunctionInference",
         prov:label = " Partial Conjunction Inference",
         spm_partialConjunctionDegree: = "2" %% xsd:int])
-    wasAssociatedWith(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:1d7e73278ccee95e211689d9de8f4d4a, -)
-    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:926b152f947e98d6025b235c27f919b2, -)
-    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:57dbc4426669cb76ea05d5c255480994, -)
-    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:3ccd77b3de962099cf8ce0c08029054a, -)
-    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:406c820ff107488cd976836b2d5c6516, -)
-    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:0c0eb1d804cee8231e915a5fdfc5ab8b, -)
-    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:d17318e0fda06cc6303389a919cffce0, -)
-    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:3d219576930e0e1002fa5ad61a717666, -)
-    used(niiri:8ca7abe146d9bd8a996b72f2d817f4e9, niiri:a5a3ea39278acdf05599017327bbbab6, -)
-    entity(niiri:d31b1142c5902eeff2fda19317e15bea,
+    wasAssociatedWith(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:4e80f2248e423bc7460bc30b328ae5d6, -)
+    used(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:f910459d8c9231bd403e71f9e88897d7, -)
+    used(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:3e9ab6b7ab94d21f2e2eb27edcd3e0b7, -)
+    used(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:9d7bfa4d0b9f9112e97374100868d499, -)
+    used(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:a66dbffb487a58bd067df5d6b5e3980b, -)
+    used(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:f1d4f3ce5390393fe9ce15122e7a462e, -)
+    used(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:9f09276d756920c240534438990b34a9, -)
+    used(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:e64dd9a3993e688a02e46f618db34698, -)
+    used(niiri:d51f5fd37ea92b55541c8f1c4a4c255e, niiri:495c70d4ecfbcfc93cc3c1d386a10e84, -)
+    entity(niiri:fefe2eec48ef20facaab171162fdcdd4,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         nidm_searchVolumeInVoxels: = "207876" %% xsd:int,
         nidm_searchVolumeInUnits: = "1663008" %% xsd:float,
         nidm_reselSizeInVoxels: = "68.4409986586553" %% xsd:float,
@@ -509,8 +509,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "NaN" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "NaN" %% xsd:int,
         crypto:sha512 = "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8" %% xsd:string])
-    wasGeneratedBy(niiri:d31b1142c5902eeff2fda19317e15bea, niiri:8ca7abe146d9bd8a996b72f2d817f4e9, -)
-    entity(niiri:d4dd8ab29b5f9534a65e9a4b237ca312,
+    wasGeneratedBy(niiri:fefe2eec48ef20facaab171162fdcdd4, niiri:d51f5fd37ea92b55541c8f1c4a4c255e, -)
+    entity(niiri:3fd40489e0c7ad32d9dfa018bf86de4d,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -518,22 +518,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "150" %% xsd:int,
         nidm_pValue: = "1" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:216bc8b13e5d82e899e5c52cbb83016c',
-        nidm_hasMaximumIntensityProjection: = 'niiri:84d7cbdeb48144857ed31bb58c5ddc5b',
-        nidm_inCoordinateSpace: = 'niiri:a56db6367efd1f7176e69f24b028de94',
+        nidm_hasClusterLabelsMap: = 'niiri:a0313af9221db64a9d9558f02250653a',
+        nidm_hasMaximumIntensityProjection: = 'niiri:d02b883a417d3ce84e4591b2358cc8ef',
+        nidm_inCoordinateSpace: = 'niiri:0cfe351ea2a996755a3dbf85a2ca844e',
         crypto:sha512 = "662dfeb3cba04a6a6beda3e1e23ff90c951f3ffae3d379b8fbfef06307db3055236586cace653593957e67f60c9dbbaadb5f3cc87c0ecc9dcfb81727d86f177f" %% xsd:string])
-    entity(niiri:216bc8b13e5d82e899e5c52cbb83016c,
+    entity(niiri:a0313af9221db64a9d9558f02250653a,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:84d7cbdeb48144857ed31bb58c5ddc5b,
+    entity(niiri:d02b883a417d3ce84e4591b2358cc8ef,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:d4dd8ab29b5f9534a65e9a4b237ca312, niiri:8ca7abe146d9bd8a996b72f2d817f4e9, -)
-    entity(niiri:4362f5eac9972bf179ea49be33151c8e,
+    wasGeneratedBy(niiri:3fd40489e0c7ad32d9dfa018bf86de4d, niiri:d51f5fd37ea92b55541c8f1c4a4c255e, -)
+    entity(niiri:eaccd3ae3e22bfdca0eb19a7d8d32655,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2637" %% xsd:int,
@@ -542,8 +542,8 @@ document
         nidm_pValueFWER: = "2.1833083851952e-06" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:4362f5eac9972bf179ea49be33151c8e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:00f296730dd06a43e5f7334c226305c6,
+    wasDerivedFrom(niiri:eaccd3ae3e22bfdca0eb19a7d8d32655, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1415" %% xsd:int,
@@ -552,8 +552,8 @@ document
         nidm_pValueFWER: = "0.0013085566013008" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:00f296730dd06a43e5f7334c226305c6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:39a3babf6ed520d78e67263717ca5dbb,
+    wasDerivedFrom(niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:01caf6dcc4c07046ab44e8a119bab255,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "376" %% xsd:int,
@@ -562,8 +562,8 @@ document
         nidm_pValueFWER: = "0.854799051393012" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:39a3babf6ed520d78e67263717ca5dbb, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:26ed93f97118482ea99f750276db5700,
+    wasDerivedFrom(niiri:01caf6dcc4c07046ab44e8a119bab255, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:9a28574137dba928b957fda9013d355a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "128" %% xsd:int,
@@ -572,8 +572,8 @@ document
         nidm_pValueFWER: = "0.999999999997872" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:26ed93f97118482ea99f750276db5700, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:c0faffa954cb5edf1bd166b3c13b64b6,
+    wasDerivedFrom(niiri:9a28574137dba928b957fda9013d355a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:be0a079f2f0b4ba9e502f600a4b77251,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "31" %% xsd:int,
@@ -582,8 +582,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:c0faffa954cb5edf1bd166b3c13b64b6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:1baee1eea0758a922f6c4f1f12441da6,
+    wasDerivedFrom(niiri:be0a079f2f0b4ba9e502f600a4b77251, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:5c92eec2bb2da6800e461deccb3a6c17,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "482" %% xsd:int,
@@ -592,8 +592,8 @@ document
         nidm_pValueFWER: = "0.5345656346398" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:1baee1eea0758a922f6c4f1f12441da6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:1aa58b6ce0025b1ec01cb8a983388e1d,
+    wasDerivedFrom(niiri:5c92eec2bb2da6800e461deccb3a6c17, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:a87a039e7919a12304129d212230f18a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "31" %% xsd:int,
@@ -602,8 +602,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:1aa58b6ce0025b1ec01cb8a983388e1d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:3198b98e15c5c56654d8a4ffe4b44ce8,
+    wasDerivedFrom(niiri:a87a039e7919a12304129d212230f18a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:e274a3eaada08953bd1833b7c48506f2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "292" %% xsd:int,
@@ -612,8 +612,8 @@ document
         nidm_pValueFWER: = "0.986195307987511" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:3198b98e15c5c56654d8a4ffe4b44ce8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:7d6744d8bee9e326b4381ceb83e93c8d,
+    wasDerivedFrom(niiri:e274a3eaada08953bd1833b7c48506f2, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:245273ed130aa663dd8395923de7d766,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "454" %% xsd:int,
@@ -622,8 +622,8 @@ document
         nidm_pValueFWER: = "0.620742215844192" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:7d6744d8bee9e326b4381ceb83e93c8d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:1593dbfe6a27c4bfd6c7c865a55e6758,
+    wasDerivedFrom(niiri:245273ed130aa663dd8395923de7d766, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:d173e9e0c068ad3a55c343fddbeff960,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "30" %% xsd:int,
@@ -632,8 +632,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:1593dbfe6a27c4bfd6c7c865a55e6758, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:537cd4e035d031e1d96dcc9b62c35112,
+    wasDerivedFrom(niiri:d173e9e0c068ad3a55c343fddbeff960, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:26532b37abc532050b4bc4be92087a96,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "121" %% xsd:int,
@@ -642,8 +642,8 @@ document
         nidm_pValueFWER: = "0.999999999999841" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:537cd4e035d031e1d96dcc9b62c35112, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:3330f53a36ff5c9ef2f20b1290e9d286,
+    wasDerivedFrom(niiri:26532b37abc532050b4bc4be92087a96, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:aa0ecf58900f58c3045f470d5e5cd69a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "152" %% xsd:int,
@@ -652,8 +652,8 @@ document
         nidm_pValueFWER: = "0.999999997549602" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:3330f53a36ff5c9ef2f20b1290e9d286, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9c973b3443bcab76e6ce5b021d6b1a13,
+    wasDerivedFrom(niiri:aa0ecf58900f58c3045f470d5e5cd69a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:901b9fd9da6bf5e77628b338170d2e8d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "118" %% xsd:int,
@@ -662,8 +662,8 @@ document
         nidm_pValueFWER: = "0.999999999999952" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:9c973b3443bcab76e6ce5b021d6b1a13, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:27a3407fb41dee69924952963bf01095,
+    wasDerivedFrom(niiri:901b9fd9da6bf5e77628b338170d2e8d, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:54e9eacbd4a27d2bb3a673e3ecd6842c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "41" %% xsd:int,
@@ -672,8 +672,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:27a3407fb41dee69924952963bf01095, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9c3f0991818d487326255d5ca7862e30,
+    wasDerivedFrom(niiri:54e9eacbd4a27d2bb3a673e3ecd6842c, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:102bcff4159cf1d08e8b6d4fdfbaade6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "53" %% xsd:int,
@@ -682,8 +682,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:9c3f0991818d487326255d5ca7862e30, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:73094daa238696f8de11ef4e56a95c30,
+    wasDerivedFrom(niiri:102bcff4159cf1d08e8b6d4fdfbaade6, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:71589bd4c92a13b9d77db1a0f4dfe621,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "38" %% xsd:int,
@@ -692,8 +692,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:73094daa238696f8de11ef4e56a95c30, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:35af8997746066bb4be8d3a9cebf0640,
+    wasDerivedFrom(niiri:71589bd4c92a13b9d77db1a0f4dfe621, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:59224724a1e5e6aa2048738e448b7eb6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -702,8 +702,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:35af8997746066bb4be8d3a9cebf0640, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9d0b757e22fc3f0156790583744c1334,
+    wasDerivedFrom(niiri:59224724a1e5e6aa2048738e448b7eb6, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:6b72e4095c1f07ea4ea737f0c44371c4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "51" %% xsd:int,
@@ -712,8 +712,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:9d0b757e22fc3f0156790583744c1334, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8d3362f5850c9379377b0d1f0b1c2735,
+    wasDerivedFrom(niiri:6b72e4095c1f07ea4ea737f0c44371c4, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:adcf7702789aacaca259aab58c015a1b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -722,8 +722,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:8d3362f5850c9379377b0d1f0b1c2735, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:227019e17364687787db60a4a8267663,
+    wasDerivedFrom(niiri:adcf7702789aacaca259aab58c015a1b, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:9583432017e2a81f5dfd9ee21e31202e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -732,8 +732,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:227019e17364687787db60a4a8267663, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8669f380bd303fec5b169e636d626ce3,
+    wasDerivedFrom(niiri:9583432017e2a81f5dfd9ee21e31202e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:4d1c403da9e27b79352d1129d7d66218,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "23" %% xsd:int,
@@ -742,8 +742,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:8669f380bd303fec5b169e636d626ce3, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:f38934924fa68b3b9a71fb9c8171e8b6,
+    wasDerivedFrom(niiri:4d1c403da9e27b79352d1129d7d66218, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:7ac836ca3990ce9f1e31e9eb1801404a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -752,8 +752,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:f38934924fa68b3b9a71fb9c8171e8b6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:1793504b32e2869dcb2fbd3af062f8bc,
+    wasDerivedFrom(niiri:7ac836ca3990ce9f1e31e9eb1801404a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:fe6bad7c2c3cd88c5e91fc8c7f05871c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "20" %% xsd:int,
@@ -762,8 +762,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:1793504b32e2869dcb2fbd3af062f8bc, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:55aacac3d3863ecd2c5789acfd6b261d,
+    wasDerivedFrom(niiri:fe6bad7c2c3cd88c5e91fc8c7f05871c, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:af4a779ba8799ad0c9fe505505295a71,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -772,8 +772,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:55aacac3d3863ecd2c5789acfd6b261d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:03238c6a619b9f265421cbb7a0cda76e,
+    wasDerivedFrom(niiri:af4a779ba8799ad0c9fe505505295a71, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:034859fff2bec220b9605fe31c29e464,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "42" %% xsd:int,
@@ -782,8 +782,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:03238c6a619b9f265421cbb7a0cda76e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:bc83f4e59851c0ed8424e3172a378ee4,
+    wasDerivedFrom(niiri:034859fff2bec220b9605fe31c29e464, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:e4a8ed309e5dfdfbdd940912aa7b9917,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "34" %% xsd:int,
@@ -792,8 +792,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:bc83f4e59851c0ed8424e3172a378ee4, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:c340f3ccccc1a020f9aef989954e51fc,
+    wasDerivedFrom(niiri:e4a8ed309e5dfdfbdd940912aa7b9917, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:54cdf7b7e5fb6a712a9931f377c09dad,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -802,8 +802,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:c340f3ccccc1a020f9aef989954e51fc, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5,
+    wasDerivedFrom(niiri:54cdf7b7e5fb6a712a9931f377c09dad, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:f86480eb515c35553583815451053247,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "38" %% xsd:int,
@@ -812,8 +812,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:cb85dd1324b2d86671b2fe868f4dafc0,
+    wasDerivedFrom(niiri:f86480eb515c35553583815451053247, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:797c0d6ce89eec38f010854e7e38594b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -822,8 +822,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:cb85dd1324b2d86671b2fe868f4dafc0, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:0dc11dbfea7cb1fef76a1c48d7f8750f,
+    wasDerivedFrom(niiri:797c0d6ce89eec38f010854e7e38594b, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:223b74991051acba66efeafdae50f4c4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -832,8 +832,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:0dc11dbfea7cb1fef76a1c48d7f8750f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:6db75fb201d2decf706c9d2dd225cb5a,
+    wasDerivedFrom(niiri:223b74991051acba66efeafdae50f4c4, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:294fdb1b5bfd7e0473b8498bbe447111,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
         nidm_clusterSizeInVoxels: = "29" %% xsd:int,
@@ -842,8 +842,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "31" %% xsd:int])
-    wasDerivedFrom(niiri:6db75fb201d2decf706c9d2dd225cb5a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8fae62d51a220dbd34d1d3074ad97c80,
+    wasDerivedFrom(niiri:294fdb1b5bfd7e0473b8498bbe447111, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:317b26ee6683fc2d7e4152e9f21569d5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -852,8 +852,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "32" %% xsd:int])
-    wasDerivedFrom(niiri:8fae62d51a220dbd34d1d3074ad97c80, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:1b3f6a9bf76e54ad12539e190c7c838c,
+    wasDerivedFrom(niiri:317b26ee6683fc2d7e4152e9f21569d5, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:7a8231297a4abeb5308420c5bd8b95b0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
         nidm_clusterSizeInVoxels: = "37" %% xsd:int,
@@ -862,8 +862,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "33" %% xsd:int])
-    wasDerivedFrom(niiri:1b3f6a9bf76e54ad12539e190c7c838c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:dc2d50ba6c535742eed46213fc557f6a,
+    wasDerivedFrom(niiri:7a8231297a4abeb5308420c5bd8b95b0, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:6b7b56e17486f776bce05e82a97e5bb7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
         nidm_clusterSizeInVoxels: = "38" %% xsd:int,
@@ -872,8 +872,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "34" %% xsd:int])
-    wasDerivedFrom(niiri:dc2d50ba6c535742eed46213fc557f6a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:416dfaa44bb6a7fe97539c984a9173c3,
+    wasDerivedFrom(niiri:6b7b56e17486f776bce05e82a97e5bb7, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:dbaf33f41cd427af7e5a021f10031a6a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -882,8 +882,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "35" %% xsd:int])
-    wasDerivedFrom(niiri:416dfaa44bb6a7fe97539c984a9173c3, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:31033e543fb9492bc06e61625ca6b410,
+    wasDerivedFrom(niiri:dbaf33f41cd427af7e5a021f10031a6a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:2cb148daa680c4c53ffa5337fb86c905,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -892,8 +892,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "36" %% xsd:int])
-    wasDerivedFrom(niiri:31033e543fb9492bc06e61625ca6b410, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:7a8b21e9acaff0531c73c9fe0bfaeb53,
+    wasDerivedFrom(niiri:2cb148daa680c4c53ffa5337fb86c905, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:1d84285e01d49d904f7b5e9f0333287b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
         nidm_clusterSizeInVoxels: = "22" %% xsd:int,
@@ -902,8 +902,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "37" %% xsd:int])
-    wasDerivedFrom(niiri:7a8b21e9acaff0531c73c9fe0bfaeb53, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:5102964768a1c4313f8c0e48d48f8b40,
+    wasDerivedFrom(niiri:1d84285e01d49d904f7b5e9f0333287b, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8cb6b321e3922f27346febc1c617df72,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -912,8 +912,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "38" %% xsd:int])
-    wasDerivedFrom(niiri:5102964768a1c4313f8c0e48d48f8b40, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:256070c77a58b8b64913a5b6bfb81f60,
+    wasDerivedFrom(niiri:8cb6b321e3922f27346febc1c617df72, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:bd60388f21dba151ffa9b94fc56a76fc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -922,8 +922,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "39" %% xsd:int])
-    wasDerivedFrom(niiri:256070c77a58b8b64913a5b6bfb81f60, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:96604941a960daa1e224727cb5ba2d60,
+    wasDerivedFrom(niiri:bd60388f21dba151ffa9b94fc56a76fc, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:2634cefb56e62fe1daef544f6c3dc96a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
         nidm_clusterSizeInVoxels: = "23" %% xsd:int,
@@ -932,8 +932,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "40" %% xsd:int])
-    wasDerivedFrom(niiri:96604941a960daa1e224727cb5ba2d60, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:529af4aecda9065e5cce8adf4cdfd5c6,
+    wasDerivedFrom(niiri:2634cefb56e62fe1daef544f6c3dc96a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:eaf17770fa04ac0e839b538c792a3073,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -942,8 +942,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "41" %% xsd:int])
-    wasDerivedFrom(niiri:529af4aecda9065e5cce8adf4cdfd5c6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:bdef3fee2464d33f021c131ff78646c7,
+    wasDerivedFrom(niiri:eaf17770fa04ac0e839b538c792a3073, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:79667c98e94d775596ecebd364219144,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -952,8 +952,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "42" %% xsd:int])
-    wasDerivedFrom(niiri:bdef3fee2464d33f021c131ff78646c7, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:e8088392c69eb956afef92cedfa6aeb4,
+    wasDerivedFrom(niiri:79667c98e94d775596ecebd364219144, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:a9ca1d216068df228b4f56edb8974b0f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -962,8 +962,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "43" %% xsd:int])
-    wasDerivedFrom(niiri:e8088392c69eb956afef92cedfa6aeb4, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8b4322c153a15066be2583d11b23925c,
+    wasDerivedFrom(niiri:a9ca1d216068df228b4f56edb8974b0f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8bd946eb61909b953aeda01719f94d66,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
         nidm_clusterSizeInVoxels: = "21" %% xsd:int,
@@ -972,8 +972,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "44" %% xsd:int])
-    wasDerivedFrom(niiri:8b4322c153a15066be2583d11b23925c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:0c0e48a110ec2c20b75585b9e5372d67,
+    wasDerivedFrom(niiri:8bd946eb61909b953aeda01719f94d66, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:e49222f43a2c5f3b6f74b9eb9a47bd2f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -982,8 +982,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "45" %% xsd:int])
-    wasDerivedFrom(niiri:0c0e48a110ec2c20b75585b9e5372d67, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:1bf866f2d8a1a832a120aa9c02c60efd,
+    wasDerivedFrom(niiri:e49222f43a2c5f3b6f74b9eb9a47bd2f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:cccc8624875aafd03105dd4bd6af0ac3,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -992,8 +992,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "46" %% xsd:int])
-    wasDerivedFrom(niiri:1bf866f2d8a1a832a120aa9c02c60efd, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:a44aefad34ca2359e69bf6f9306bc2c6,
+    wasDerivedFrom(niiri:cccc8624875aafd03105dd4bd6af0ac3, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:c163699e2c590670b56fd1928fe502a8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -1002,8 +1002,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "47" %% xsd:int])
-    wasDerivedFrom(niiri:a44aefad34ca2359e69bf6f9306bc2c6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:ab78ea55fc7f212636dd2f73bdc99032,
+    wasDerivedFrom(niiri:c163699e2c590670b56fd1928fe502a8, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:4824d04f1a3ab526790824f893297a94,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1012,8 +1012,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "48" %% xsd:int])
-    wasDerivedFrom(niiri:ab78ea55fc7f212636dd2f73bdc99032, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:4128bacb45b84a2304aceeb9a3a06db7,
+    wasDerivedFrom(niiri:4824d04f1a3ab526790824f893297a94, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:64a8a8faea43eec16f564fc4aaeca53d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
         nidm_clusterSizeInVoxels: = "19" %% xsd:int,
@@ -1022,8 +1022,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "49" %% xsd:int])
-    wasDerivedFrom(niiri:4128bacb45b84a2304aceeb9a3a06db7, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:282d81c6243a1094abf4c4787764df02,
+    wasDerivedFrom(niiri:64a8a8faea43eec16f564fc4aaeca53d, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:0260356613cbea9c3fd0a42442707965,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -1032,8 +1032,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "50" %% xsd:int])
-    wasDerivedFrom(niiri:282d81c6243a1094abf4c4787764df02, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb,
+    wasDerivedFrom(niiri:0260356613cbea9c3fd0a42442707965, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:6c858d3255cb0a3570ef36dfad0fb623,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -1042,8 +1042,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "51" %% xsd:int])
-    wasDerivedFrom(niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:e58cf8e24a087d5746f02fb59416d367,
+    wasDerivedFrom(niiri:6c858d3255cb0a3570ef36dfad0fb623, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:073492dcf968ea0eb583396771e18cab,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
         nidm_clusterSizeInVoxels: = "17" %% xsd:int,
@@ -1052,8 +1052,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "52" %% xsd:int])
-    wasDerivedFrom(niiri:e58cf8e24a087d5746f02fb59416d367, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:47a95f63466991d3e681c4886347a76b,
+    wasDerivedFrom(niiri:073492dcf968ea0eb583396771e18cab, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:780d9b79f072e4bd50e8f0325a0fab9c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1062,8 +1062,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "53" %% xsd:int])
-    wasDerivedFrom(niiri:47a95f63466991d3e681c4886347a76b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:6a2d34c94894023a09a46d7ba699025b,
+    wasDerivedFrom(niiri:780d9b79f072e4bd50e8f0325a0fab9c, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:81f84bc9b5b654bad34cdaaac10ba1b6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -1072,8 +1072,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "54" %% xsd:int])
-    wasDerivedFrom(niiri:6a2d34c94894023a09a46d7ba699025b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:6ac7ce35dfb3dcf2c2696278c805c40a,
+    wasDerivedFrom(niiri:81f84bc9b5b654bad34cdaaac10ba1b6, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:90a20d94dc8e450298e631ead963f32b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -1082,8 +1082,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "55" %% xsd:int])
-    wasDerivedFrom(niiri:6ac7ce35dfb3dcf2c2696278c805c40a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:60e118fd5205eaa96f4b55808761eaf7,
+    wasDerivedFrom(niiri:90a20d94dc8e450298e631ead963f32b, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:f95655c375074857b8c6e69cc5aafd0f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -1092,8 +1092,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "56" %% xsd:int])
-    wasDerivedFrom(niiri:60e118fd5205eaa96f4b55808761eaf7, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:afff6750152337d325f510f877cd2b9c,
+    wasDerivedFrom(niiri:f95655c375074857b8c6e69cc5aafd0f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:af7629a171a38e8e209c4bfe5f604c75,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1102,8 +1102,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "57" %% xsd:int])
-    wasDerivedFrom(niiri:afff6750152337d325f510f877cd2b9c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:c87d05b7d28080150c45409119a926f8,
+    wasDerivedFrom(niiri:af7629a171a38e8e209c4bfe5f604c75, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:327ebdb7a1236038ee0a1c3dd96e5874,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0058" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -1112,8 +1112,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "58" %% xsd:int])
-    wasDerivedFrom(niiri:c87d05b7d28080150c45409119a926f8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:f1bb918000bbcdd8562fb7b7887a394d,
+    wasDerivedFrom(niiri:327ebdb7a1236038ee0a1c3dd96e5874, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:383ee7c40b6e148981f60c5244bc24eb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0059" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -1122,8 +1122,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "59" %% xsd:int])
-    wasDerivedFrom(niiri:f1bb918000bbcdd8562fb7b7887a394d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c,
+    wasDerivedFrom(niiri:383ee7c40b6e148981f60c5244bc24eb, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:7f19917cc657f479955495d0706a5e07,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0060" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1132,8 +1132,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "60" %% xsd:int])
-    wasDerivedFrom(niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f,
+    wasDerivedFrom(niiri:7f19917cc657f479955495d0706a5e07, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:df2a03c212f39fc884fa4c74b8f9861f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0061" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1142,8 +1142,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "61" %% xsd:int])
-    wasDerivedFrom(niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9e7cd816ef42776bf358bfe67f08f014,
+    wasDerivedFrom(niiri:df2a03c212f39fc884fa4c74b8f9861f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:d2f081110d405da4d574363c2c229683,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0062" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1152,8 +1152,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "62" %% xsd:int])
-    wasDerivedFrom(niiri:9e7cd816ef42776bf358bfe67f08f014, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:712375a17d0ff43c9dca459517dff9b2,
+    wasDerivedFrom(niiri:d2f081110d405da4d574363c2c229683, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:a9fda50c3e4479f40fb3419e04ad60e2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0063" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -1162,8 +1162,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "63" %% xsd:int])
-    wasDerivedFrom(niiri:712375a17d0ff43c9dca459517dff9b2, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:feddd730f38d65d4f1fd0e8616bcc9a5,
+    wasDerivedFrom(niiri:a9fda50c3e4479f40fb3419e04ad60e2, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:2bc33575bac46d2c46e0ab7793110244,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0064" %% xsd:string,
         nidm_clusterSizeInVoxels: = "7" %% xsd:int,
@@ -1172,8 +1172,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "64" %% xsd:int])
-    wasDerivedFrom(niiri:feddd730f38d65d4f1fd0e8616bcc9a5, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8041bc77682f50b65136018ca10c889c,
+    wasDerivedFrom(niiri:2bc33575bac46d2c46e0ab7793110244, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:ddb629f82c3dbdee2cea3fa27c6ff935,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0065" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1182,8 +1182,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "65" %% xsd:int])
-    wasDerivedFrom(niiri:8041bc77682f50b65136018ca10c889c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:e852e949acffc71ed6cce677c7be19d6,
+    wasDerivedFrom(niiri:ddb629f82c3dbdee2cea3fa27c6ff935, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:caa42f603185cae01bb9beafa64dc995,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0066" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1192,8 +1192,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "66" %% xsd:int])
-    wasDerivedFrom(niiri:e852e949acffc71ed6cce677c7be19d6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:0d099ee69c96416336f843fd890da4a0,
+    wasDerivedFrom(niiri:caa42f603185cae01bb9beafa64dc995, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:c445a9fb8be8c80d5df620717862bf5f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0067" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -1202,8 +1202,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "67" %% xsd:int])
-    wasDerivedFrom(niiri:0d099ee69c96416336f843fd890da4a0, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:6d0ee7f5877dfa2620f95f47e06e2a9a,
+    wasDerivedFrom(niiri:c445a9fb8be8c80d5df620717862bf5f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:44518bfa6ffcd022c48e2ccb2c04ed0a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0068" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1212,8 +1212,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "68" %% xsd:int])
-    wasDerivedFrom(niiri:6d0ee7f5877dfa2620f95f47e06e2a9a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:6ab419381418bd7fca0cb5bac6782b77,
+    wasDerivedFrom(niiri:44518bfa6ffcd022c48e2ccb2c04ed0a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:82a21597b08e98aa671123ebbede6579,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0069" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -1222,8 +1222,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "69" %% xsd:int])
-    wasDerivedFrom(niiri:6ab419381418bd7fca0cb5bac6782b77, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:b19325ccb6192dba58545cbeb7bc92e1,
+    wasDerivedFrom(niiri:82a21597b08e98aa671123ebbede6579, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:15cc5ee45c7553094b172ffcbfc6a579,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0070" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1232,8 +1232,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "70" %% xsd:int])
-    wasDerivedFrom(niiri:b19325ccb6192dba58545cbeb7bc92e1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:745fe95a68372701f2888393e817a23e,
+    wasDerivedFrom(niiri:15cc5ee45c7553094b172ffcbfc6a579, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:ff736f05be57ac9dd4cfdb8776f08af9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0071" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -1242,8 +1242,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "71" %% xsd:int])
-    wasDerivedFrom(niiri:745fe95a68372701f2888393e817a23e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:b1a5489610b480473aa63e95806df7d1,
+    wasDerivedFrom(niiri:ff736f05be57ac9dd4cfdb8776f08af9, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:08dde0ac9e0d585b26116508762ff9a0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0072" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1252,8 +1252,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "72" %% xsd:int])
-    wasDerivedFrom(niiri:b1a5489610b480473aa63e95806df7d1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:f6763487f8266f7e66acb49862c0bfa1,
+    wasDerivedFrom(niiri:08dde0ac9e0d585b26116508762ff9a0, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:0571f33be5ada80ea4b8808edaa7d20b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0073" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1262,8 +1262,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "73" %% xsd:int])
-    wasDerivedFrom(niiri:f6763487f8266f7e66acb49862c0bfa1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:f1b9cbe1f5cc757318e116f47537c68e,
+    wasDerivedFrom(niiri:0571f33be5ada80ea4b8808edaa7d20b, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:1ff90dcabb7242c8b1f78b63e5c5f98e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0074" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1272,8 +1272,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "74" %% xsd:int])
-    wasDerivedFrom(niiri:f1b9cbe1f5cc757318e116f47537c68e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:0299ab45ec018b51a01d2a8fe08bf4d0,
+    wasDerivedFrom(niiri:1ff90dcabb7242c8b1f78b63e5c5f98e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:fddfbb23e75434759d3265d89c552324,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0075" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1282,8 +1282,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "75" %% xsd:int])
-    wasDerivedFrom(niiri:0299ab45ec018b51a01d2a8fe08bf4d0, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:3bd0b694ec1e521a7072b15be74aa42c,
+    wasDerivedFrom(niiri:fddfbb23e75434759d3265d89c552324, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:225e575718bd5f927d7a41b6e9cdd96b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0076" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1292,8 +1292,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "76" %% xsd:int])
-    wasDerivedFrom(niiri:3bd0b694ec1e521a7072b15be74aa42c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:af9bee597f1e82856f732971c03e4ba5,
+    wasDerivedFrom(niiri:225e575718bd5f927d7a41b6e9cdd96b, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:eed1f93c005d2b4525f8eff9003cba5f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0077" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1302,8 +1302,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "77" %% xsd:int])
-    wasDerivedFrom(niiri:af9bee597f1e82856f732971c03e4ba5, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:7a01ea3f3b5332ecf281a7f277911529,
+    wasDerivedFrom(niiri:eed1f93c005d2b4525f8eff9003cba5f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:46a2cf3db4d3d8432ee134238328ee7d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0078" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1312,8 +1312,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "78" %% xsd:int])
-    wasDerivedFrom(niiri:7a01ea3f3b5332ecf281a7f277911529, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8d9244867124b8976a02c802025ebf7a,
+    wasDerivedFrom(niiri:46a2cf3db4d3d8432ee134238328ee7d, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:cb8b7a24533bb98686a08aa454cf3945,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0079" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1322,8 +1322,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "79" %% xsd:int])
-    wasDerivedFrom(niiri:8d9244867124b8976a02c802025ebf7a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:1acfcd5791fd893baf49e6750646bcbc,
+    wasDerivedFrom(niiri:cb8b7a24533bb98686a08aa454cf3945, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:ac46f34aa5d674ad08bca4f9e22cea59,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0080" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1332,8 +1332,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "80" %% xsd:int])
-    wasDerivedFrom(niiri:1acfcd5791fd893baf49e6750646bcbc, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:6bafc27afb06adc8274b4e85b0eb95cc,
+    wasDerivedFrom(niiri:ac46f34aa5d674ad08bca4f9e22cea59, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:dafb029bcb559a4294b48405b4710434,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0081" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -1342,8 +1342,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "81" %% xsd:int])
-    wasDerivedFrom(niiri:6bafc27afb06adc8274b4e85b0eb95cc, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:ee5baff089dc6387c53821c05a9e9154,
+    wasDerivedFrom(niiri:dafb029bcb559a4294b48405b4710434, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:99ae26cd919bcae015587fcb8e185e68,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0082" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1352,8 +1352,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "82" %% xsd:int])
-    wasDerivedFrom(niiri:ee5baff089dc6387c53821c05a9e9154, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:e4e0f746d182d60a55906480bc82791f,
+    wasDerivedFrom(niiri:99ae26cd919bcae015587fcb8e185e68, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:9f9bf96c341750df802f301ac988f4b0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0083" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1362,8 +1362,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "83" %% xsd:int])
-    wasDerivedFrom(niiri:e4e0f746d182d60a55906480bc82791f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:07ef8bc1f56adef8bb96bf2e4e871509,
+    wasDerivedFrom(niiri:9f9bf96c341750df802f301ac988f4b0, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:99e2b9de9821018fedc6a02eeea36eff,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0084" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1372,8 +1372,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "84" %% xsd:int])
-    wasDerivedFrom(niiri:07ef8bc1f56adef8bb96bf2e4e871509, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:4909c1eb824545b47aa0943b33200588,
+    wasDerivedFrom(niiri:99e2b9de9821018fedc6a02eeea36eff, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:19dd8817dc393deb5f3011d30203d171,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0085" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -1382,8 +1382,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "85" %% xsd:int])
-    wasDerivedFrom(niiri:4909c1eb824545b47aa0943b33200588, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9c28e7c0288f5d8601280d59308426e4,
+    wasDerivedFrom(niiri:19dd8817dc393deb5f3011d30203d171, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:f578ebe5aa3293c5670125665cd21221,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0086" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1392,8 +1392,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "86" %% xsd:int])
-    wasDerivedFrom(niiri:9c28e7c0288f5d8601280d59308426e4, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:49c7e8d7404b8a93cc2dc6a52274f6ef,
+    wasDerivedFrom(niiri:f578ebe5aa3293c5670125665cd21221, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:7166aa15d2e2b4eeab50316ce6eb7bff,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0087" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -1402,8 +1402,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "87" %% xsd:int])
-    wasDerivedFrom(niiri:49c7e8d7404b8a93cc2dc6a52274f6ef, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:5bc798e43cab1c880a412761cd0dabce,
+    wasDerivedFrom(niiri:7166aa15d2e2b4eeab50316ce6eb7bff, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:7c7ff9e10d9ed65989abad6706fb240e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0088" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1412,8 +1412,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "88" %% xsd:int])
-    wasDerivedFrom(niiri:5bc798e43cab1c880a412761cd0dabce, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:d5f0da3a07b3d47197bf039d8d42b58f,
+    wasDerivedFrom(niiri:7c7ff9e10d9ed65989abad6706fb240e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8134a1db611c7f7f2ed9c52d609bd453,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0089" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1422,8 +1422,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "89" %% xsd:int])
-    wasDerivedFrom(niiri:d5f0da3a07b3d47197bf039d8d42b58f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:a57d901560addc33f414ddaed9a0c7fb,
+    wasDerivedFrom(niiri:8134a1db611c7f7f2ed9c52d609bd453, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8a671f919525c9984fd7a67105748a9d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0090" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1432,8 +1432,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "90" %% xsd:int])
-    wasDerivedFrom(niiri:a57d901560addc33f414ddaed9a0c7fb, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:01d84a7c8c63b90d178c8c7623156c7d,
+    wasDerivedFrom(niiri:8a671f919525c9984fd7a67105748a9d, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:df8ccdbc007e7b001a7788aa3910f000,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0091" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1442,8 +1442,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "91" %% xsd:int])
-    wasDerivedFrom(niiri:01d84a7c8c63b90d178c8c7623156c7d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:99056f1d754fd9f25d80632f06577e33,
+    wasDerivedFrom(niiri:df8ccdbc007e7b001a7788aa3910f000, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8f423109f6452d8619bfc5cbabbcae4c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0092" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1452,8 +1452,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "92" %% xsd:int])
-    wasDerivedFrom(niiri:99056f1d754fd9f25d80632f06577e33, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:a0ee8183a98a000be01c4577a35a0d8c,
+    wasDerivedFrom(niiri:8f423109f6452d8619bfc5cbabbcae4c, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:059825f02c7e3a034dd438fe5e192ff5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0093" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1462,8 +1462,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "93" %% xsd:int])
-    wasDerivedFrom(niiri:a0ee8183a98a000be01c4577a35a0d8c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:40c9456923bb7d18a8a4ec203aeea09d,
+    wasDerivedFrom(niiri:059825f02c7e3a034dd438fe5e192ff5, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:3da0464bd78bb8c10fbf370ecd7a9476,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0094" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1472,8 +1472,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "94" %% xsd:int])
-    wasDerivedFrom(niiri:40c9456923bb7d18a8a4ec203aeea09d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:3cd64da8230af3c597bfb4e11e589670,
+    wasDerivedFrom(niiri:3da0464bd78bb8c10fbf370ecd7a9476, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8f8575f802002ae68576281bb473a96a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0095" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1482,8 +1482,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "95" %% xsd:int])
-    wasDerivedFrom(niiri:3cd64da8230af3c597bfb4e11e589670, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:32e5e0304b5a2c92b091fa83edcab359,
+    wasDerivedFrom(niiri:8f8575f802002ae68576281bb473a96a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:08bfdacca68fb28f9c006f7c77ce2d85,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0096" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1492,8 +1492,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "96" %% xsd:int])
-    wasDerivedFrom(niiri:32e5e0304b5a2c92b091fa83edcab359, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:bf704e8aea1497f2136b7d0b3dde0bf6,
+    wasDerivedFrom(niiri:08bfdacca68fb28f9c006f7c77ce2d85, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:6bb55a6a6929721f00e0951117b25f42,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0097" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1502,8 +1502,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "97" %% xsd:int])
-    wasDerivedFrom(niiri:bf704e8aea1497f2136b7d0b3dde0bf6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:316701aef465a5778181dd76a5331844,
+    wasDerivedFrom(niiri:6bb55a6a6929721f00e0951117b25f42, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:37af7d521a2b88cd58b24d8684f7fef9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0098" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1512,8 +1512,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "98" %% xsd:int])
-    wasDerivedFrom(niiri:316701aef465a5778181dd76a5331844, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:90bdcb5fb7ef48121124edfe5e0439e6,
+    wasDerivedFrom(niiri:37af7d521a2b88cd58b24d8684f7fef9, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:6fb39f850b88fc429c462810fc4c1cb0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0099" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -1522,8 +1522,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "99" %% xsd:int])
-    wasDerivedFrom(niiri:90bdcb5fb7ef48121124edfe5e0439e6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:d1db945756296f3d178c9d95312fcba1,
+    wasDerivedFrom(niiri:6fb39f850b88fc429c462810fc4c1cb0, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:3b4cc47fe21026a8ff3cc6cae8366e5a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0100" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1532,8 +1532,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "100" %% xsd:int])
-    wasDerivedFrom(niiri:d1db945756296f3d178c9d95312fcba1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a,
+    wasDerivedFrom(niiri:3b4cc47fe21026a8ff3cc6cae8366e5a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:cb21e315dda71865f3198bf3de5b7c55,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0101" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1542,8 +1542,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "101" %% xsd:int])
-    wasDerivedFrom(niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c,
+    wasDerivedFrom(niiri:cb21e315dda71865f3198bf3de5b7c55, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:2e5418c351f653b423462944edc63136,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0102" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1552,8 +1552,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "102" %% xsd:int])
-    wasDerivedFrom(niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9304b0681f39be2e136e7d42baff625c,
+    wasDerivedFrom(niiri:2e5418c351f653b423462944edc63136, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:f9e4a916c73e380e7f2b04ae24edb3eb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0103" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1562,8 +1562,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "103" %% xsd:int])
-    wasDerivedFrom(niiri:9304b0681f39be2e136e7d42baff625c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:c4a9ab38a5b5faf27a110372a76b690b,
+    wasDerivedFrom(niiri:f9e4a916c73e380e7f2b04ae24edb3eb, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:7154c13ca1ce907cde82a8d61810577c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0104" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -1572,8 +1572,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "104" %% xsd:int])
-    wasDerivedFrom(niiri:c4a9ab38a5b5faf27a110372a76b690b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:b08c64db49c2acab9dde84fc5aaafee1,
+    wasDerivedFrom(niiri:7154c13ca1ce907cde82a8d61810577c, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:79ad3466325804caf01c3623b06f85c5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0105" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1582,8 +1582,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "105" %% xsd:int])
-    wasDerivedFrom(niiri:b08c64db49c2acab9dde84fc5aaafee1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:a8f46a35300a709894debac1a5c7d877,
+    wasDerivedFrom(niiri:79ad3466325804caf01c3623b06f85c5, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:2e12076af378dbdca5de9e12404f5853,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0106" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1592,8 +1592,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "106" %% xsd:int])
-    wasDerivedFrom(niiri:a8f46a35300a709894debac1a5c7d877, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:147fb623ae052dca9733d6d1d2297af8,
+    wasDerivedFrom(niiri:2e12076af378dbdca5de9e12404f5853, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:88291e9044390a2d68e0e8f02afae64d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0107" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1602,8 +1602,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "107" %% xsd:int])
-    wasDerivedFrom(niiri:147fb623ae052dca9733d6d1d2297af8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:eb257014e1b6b6961786c8543836a579,
+    wasDerivedFrom(niiri:88291e9044390a2d68e0e8f02afae64d, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:9219dd196f709ade4b7d68bb82531ae9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0108" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1612,8 +1612,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "108" %% xsd:int])
-    wasDerivedFrom(niiri:eb257014e1b6b6961786c8543836a579, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:3c0db86cde8ac7aa1cb1f7b208b617e8,
+    wasDerivedFrom(niiri:9219dd196f709ade4b7d68bb82531ae9, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:b5869855e2ed1bde6084a419ce135245,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0109" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1622,8 +1622,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "109" %% xsd:int])
-    wasDerivedFrom(niiri:3c0db86cde8ac7aa1cb1f7b208b617e8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:e578dd3a170f088e47efd39f45837f4e,
+    wasDerivedFrom(niiri:b5869855e2ed1bde6084a419ce135245, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:3ed79923246b336ee14ba73c12fc89b8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0110" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1632,8 +1632,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "110" %% xsd:int])
-    wasDerivedFrom(niiri:e578dd3a170f088e47efd39f45837f4e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:ab7f882f69e9de3fd22bc39f3519003d,
+    wasDerivedFrom(niiri:3ed79923246b336ee14ba73c12fc89b8, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:12413ac997763f6fabc508fd21bfae38,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0111" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1642,8 +1642,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "111" %% xsd:int])
-    wasDerivedFrom(niiri:ab7f882f69e9de3fd22bc39f3519003d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:ca827c13c9bc5f06b55e3bd1cd175793,
+    wasDerivedFrom(niiri:12413ac997763f6fabc508fd21bfae38, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:f994daab5ee703f5c75c7c447254b288,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0112" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1652,8 +1652,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "112" %% xsd:int])
-    wasDerivedFrom(niiri:ca827c13c9bc5f06b55e3bd1cd175793, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8472115c12bd571d534dfe5bac960c80,
+    wasDerivedFrom(niiri:f994daab5ee703f5c75c7c447254b288, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:83cced094f39a6896a2e9e71f04942a7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0113" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1662,8 +1662,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "113" %% xsd:int])
-    wasDerivedFrom(niiri:8472115c12bd571d534dfe5bac960c80, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:812c44e9a98ad090a6f8b72ffea8eb49,
+    wasDerivedFrom(niiri:83cced094f39a6896a2e9e71f04942a7, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8cebbc59dd1e18a1762d12ca4d90e931,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0114" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1672,8 +1672,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "114" %% xsd:int])
-    wasDerivedFrom(niiri:812c44e9a98ad090a6f8b72ffea8eb49, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:eb1e036b54bfd5155015ad5c924a62ce,
+    wasDerivedFrom(niiri:8cebbc59dd1e18a1762d12ca4d90e931, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8c6f92e0a397a1c5c883eb79ede81691,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0115" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1682,8 +1682,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "115" %% xsd:int])
-    wasDerivedFrom(niiri:eb1e036b54bfd5155015ad5c924a62ce, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8bac0f00c0d1f0f9f5c118004ab17321,
+    wasDerivedFrom(niiri:8c6f92e0a397a1c5c883eb79ede81691, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:6e55a4195849427172678126ca78b28a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0116" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1692,8 +1692,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "116" %% xsd:int])
-    wasDerivedFrom(niiri:8bac0f00c0d1f0f9f5c118004ab17321, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:4f4b190235fbb136b1bb7467b78730d6,
+    wasDerivedFrom(niiri:6e55a4195849427172678126ca78b28a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:3d5e4a6eb5d78cc1ef178561e41ba9ee,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0117" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1702,8 +1702,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "117" %% xsd:int])
-    wasDerivedFrom(niiri:4f4b190235fbb136b1bb7467b78730d6, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:d04d2676281bca09e8a782500650e993,
+    wasDerivedFrom(niiri:3d5e4a6eb5d78cc1ef178561e41ba9ee, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:263da8c4eb7cf40aac1b2acc6184c451,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0118" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1712,8 +1712,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "118" %% xsd:int])
-    wasDerivedFrom(niiri:d04d2676281bca09e8a782500650e993, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:59c6e585fc56ebce5a5d95b959cc120d,
+    wasDerivedFrom(niiri:263da8c4eb7cf40aac1b2acc6184c451, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:d4fbe5cc673433a4ae33bce2f4d62046,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0119" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1722,8 +1722,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "119" %% xsd:int])
-    wasDerivedFrom(niiri:59c6e585fc56ebce5a5d95b959cc120d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:a4d82c21752d17f68b6fbf41caa89a4b,
+    wasDerivedFrom(niiri:d4fbe5cc673433a4ae33bce2f4d62046, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:92b2dd79b91691fa3fee9530c07ced7e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0120" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1732,8 +1732,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "120" %% xsd:int])
-    wasDerivedFrom(niiri:a4d82c21752d17f68b6fbf41caa89a4b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9c09ac30035d9617daad1f111fa1b47f,
+    wasDerivedFrom(niiri:92b2dd79b91691fa3fee9530c07ced7e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:0791bb16705c92dfa0eb9a2399ad7c01,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0121" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1742,8 +1742,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "121" %% xsd:int])
-    wasDerivedFrom(niiri:9c09ac30035d9617daad1f111fa1b47f, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:b5d02c34e634c7f52d94137fbd9f8813,
+    wasDerivedFrom(niiri:0791bb16705c92dfa0eb9a2399ad7c01, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:51393db8b7b8a6fffbbd81b5df93450e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0122" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1752,8 +1752,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "122" %% xsd:int])
-    wasDerivedFrom(niiri:b5d02c34e634c7f52d94137fbd9f8813, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:fc91a408c252d8e2b7beb4005554eaf8,
+    wasDerivedFrom(niiri:51393db8b7b8a6fffbbd81b5df93450e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:868dad72b2c68d3fbc6510a6d5cb9231,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0123" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1762,8 +1762,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "123" %% xsd:int])
-    wasDerivedFrom(niiri:fc91a408c252d8e2b7beb4005554eaf8, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9b0591f2b854d2643aaf1afaa93cb549,
+    wasDerivedFrom(niiri:868dad72b2c68d3fbc6510a6d5cb9231, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:f010113cde48b81f7b8ed0070c723116,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0124" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1772,8 +1772,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "124" %% xsd:int])
-    wasDerivedFrom(niiri:9b0591f2b854d2643aaf1afaa93cb549, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:d54744a8017e84d7adb355fc9412fba3,
+    wasDerivedFrom(niiri:f010113cde48b81f7b8ed0070c723116, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:0265995653f234724934abae5c95f7d7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0125" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1782,8 +1782,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "125" %% xsd:int])
-    wasDerivedFrom(niiri:d54744a8017e84d7adb355fc9412fba3, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:e49a03f4d60a11688f798fc5bc43c1b2,
+    wasDerivedFrom(niiri:0265995653f234724934abae5c95f7d7, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:f99e0a55aff25b99b4c4ccb40319fa7b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0126" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1792,8 +1792,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "126" %% xsd:int])
-    wasDerivedFrom(niiri:e49a03f4d60a11688f798fc5bc43c1b2, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:b04a187086857b7422c8096db14ee613,
+    wasDerivedFrom(niiri:f99e0a55aff25b99b4c4ccb40319fa7b, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:48a348ba7dc61a80c12ae68ab1b56cad,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0127" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1802,8 +1802,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "127" %% xsd:int])
-    wasDerivedFrom(niiri:b04a187086857b7422c8096db14ee613, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:39ce93dd6abab662ab6da84a046a56bd,
+    wasDerivedFrom(niiri:48a348ba7dc61a80c12ae68ab1b56cad, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:adc463abce824f98736aecdc0ef0fc44,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0128" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1812,8 +1812,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "128" %% xsd:int])
-    wasDerivedFrom(niiri:39ce93dd6abab662ab6da84a046a56bd, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e,
+    wasDerivedFrom(niiri:adc463abce824f98736aecdc0ef0fc44, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:2a0123807eeff74fec9051900072009a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0129" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -1822,8 +1822,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "129" %% xsd:int])
-    wasDerivedFrom(niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:ca20dee3ba6bf36049f99642c710470d,
+    wasDerivedFrom(niiri:2a0123807eeff74fec9051900072009a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:3c9c41ca803aea8e1aa376a37e7fd405,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0130" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1832,8 +1832,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "130" %% xsd:int])
-    wasDerivedFrom(niiri:ca20dee3ba6bf36049f99642c710470d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:26fa7a82c298f218eb7fd282cfbf7a81,
+    wasDerivedFrom(niiri:3c9c41ca803aea8e1aa376a37e7fd405, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:4ac51018dc7ac193d610d2175b143f4f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0131" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1842,8 +1842,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "131" %% xsd:int])
-    wasDerivedFrom(niiri:26fa7a82c298f218eb7fd282cfbf7a81, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:e518dd980ffdb694adcf472695d5a40a,
+    wasDerivedFrom(niiri:4ac51018dc7ac193d610d2175b143f4f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:9411d8ecf0144381e141c863accd8f82,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0132" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1852,8 +1852,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "132" %% xsd:int])
-    wasDerivedFrom(niiri:e518dd980ffdb694adcf472695d5a40a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:5f278b6b11fae0c4b4f9690852a71d0c,
+    wasDerivedFrom(niiri:9411d8ecf0144381e141c863accd8f82, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:58ff840b981e30971a46c0cdee9acc43,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0133" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1862,8 +1862,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "133" %% xsd:int])
-    wasDerivedFrom(niiri:5f278b6b11fae0c4b4f9690852a71d0c, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:87f8233f1c48acf6ecdd7339055182ae,
+    wasDerivedFrom(niiri:58ff840b981e30971a46c0cdee9acc43, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:81d9ad132a8f471d00cb8b3aef33836f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0134" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1872,8 +1872,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "134" %% xsd:int])
-    wasDerivedFrom(niiri:87f8233f1c48acf6ecdd7339055182ae, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:0189728b5aaa10d4eb4ff53d1fbc5843,
+    wasDerivedFrom(niiri:81d9ad132a8f471d00cb8b3aef33836f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:b85e89811d403dd797f7d9315b0c1779,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0135" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1882,8 +1882,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "135" %% xsd:int])
-    wasDerivedFrom(niiri:0189728b5aaa10d4eb4ff53d1fbc5843, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:453f1919d7df3d7e610709f6fdecbf62,
+    wasDerivedFrom(niiri:b85e89811d403dd797f7d9315b0c1779, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:559e52e372bf37a3bd9f89fe7d257b7f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0136" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -1892,8 +1892,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "136" %% xsd:int])
-    wasDerivedFrom(niiri:453f1919d7df3d7e610709f6fdecbf62, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:5b21dda7a2823d1c7efeff7947020767,
+    wasDerivedFrom(niiri:559e52e372bf37a3bd9f89fe7d257b7f, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:8675dcbc163828022ee916bae686b21e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0137" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1902,8 +1902,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "137" %% xsd:int])
-    wasDerivedFrom(niiri:5b21dda7a2823d1c7efeff7947020767, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:a6dc495a077e17aa8f96566659037e0b,
+    wasDerivedFrom(niiri:8675dcbc163828022ee916bae686b21e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:2ebb70aec77a1bb19cfa4bb0e86df28c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0138" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1912,8 +1912,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "138" %% xsd:int])
-    wasDerivedFrom(niiri:a6dc495a077e17aa8f96566659037e0b, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:e5e5eeee288ec088072a80af972a3638,
+    wasDerivedFrom(niiri:2ebb70aec77a1bb19cfa4bb0e86df28c, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:c3f909ea8341d2a928e08b183a5eb9b8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0139" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1922,8 +1922,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "139" %% xsd:int])
-    wasDerivedFrom(niiri:e5e5eeee288ec088072a80af972a3638, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1,
+    wasDerivedFrom(niiri:c3f909ea8341d2a928e08b183a5eb9b8, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:7da0c40e610d05ef5fcd5df75e03757e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0140" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -1932,8 +1932,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "140" %% xsd:int])
-    wasDerivedFrom(niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:66cf0dbeb1aa03edbab1a35c2d527a55,
+    wasDerivedFrom(niiri:7da0c40e610d05ef5fcd5df75e03757e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:88cc306d767adb94ebbccf9ff7621ad9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0141" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1942,8 +1942,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "141" %% xsd:int])
-    wasDerivedFrom(niiri:66cf0dbeb1aa03edbab1a35c2d527a55, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:09d8898196c5c40aec6f995a2b0c383d,
+    wasDerivedFrom(niiri:88cc306d767adb94ebbccf9ff7621ad9, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:74ee3d5df4f8c42807338247cfe92970,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0142" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1952,8 +1952,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "142" %% xsd:int])
-    wasDerivedFrom(niiri:09d8898196c5c40aec6f995a2b0c383d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:bfe644ea717165d3b6b50431d8e57c87,
+    wasDerivedFrom(niiri:74ee3d5df4f8c42807338247cfe92970, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:cdf3f858b94767540e52edcfccc91cae,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0143" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1962,8 +1962,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "143" %% xsd:int])
-    wasDerivedFrom(niiri:bfe644ea717165d3b6b50431d8e57c87, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:0d278ee0d105de3a7319a5acaa11c631,
+    wasDerivedFrom(niiri:cdf3f858b94767540e52edcfccc91cae, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:d47a915a52d84b041200dd225d0d123a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0144" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1972,8 +1972,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "144" %% xsd:int])
-    wasDerivedFrom(niiri:0d278ee0d105de3a7319a5acaa11c631, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:9a54b30308f71d0c474dab56acec5885,
+    wasDerivedFrom(niiri:d47a915a52d84b041200dd225d0d123a, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:a0b6cde2f07cadad11fae188db97aa3e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0145" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1982,8 +1982,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "145" %% xsd:int])
-    wasDerivedFrom(niiri:9a54b30308f71d0c474dab56acec5885, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:f219989ec875846cc4815fffc10bd118,
+    wasDerivedFrom(niiri:a0b6cde2f07cadad11fae188db97aa3e, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:28cf85781211b96d1afff400e743d8e0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0146" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -1992,8 +1992,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "146" %% xsd:int])
-    wasDerivedFrom(niiri:f219989ec875846cc4815fffc10bd118, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:4b37375a8d01d1d9009b430352062714,
+    wasDerivedFrom(niiri:28cf85781211b96d1afff400e743d8e0, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:3d1ef8f1229ad13d14520be973ee405c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0147" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -2002,8 +2002,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "147" %% xsd:int])
-    wasDerivedFrom(niiri:4b37375a8d01d1d9009b430352062714, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:0f0a4015dd42d89522302ce792b20d6d,
+    wasDerivedFrom(niiri:3d1ef8f1229ad13d14520be973ee405c, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:2960c762474a0ecebef6e8e066482105,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0148" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -2012,8 +2012,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "148" %% xsd:int])
-    wasDerivedFrom(niiri:0f0a4015dd42d89522302ce792b20d6d, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a,
+    wasDerivedFrom(niiri:2960c762474a0ecebef6e8e066482105, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:a86c5c480c3033b63bc45962d5c32c41,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0149" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -2022,8 +2022,8 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "149" %% xsd:int])
-    wasDerivedFrom(niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:f6e36041fd68625d6c7813fe63387c51,
+    wasDerivedFrom(niiri:a86c5c480c3033b63bc45962d5c32c41, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:9d76bd2f2d73c5dfd99aa453786bb3d2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0150" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -2032,2691 +2032,2691 @@ document
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "150" %% xsd:int])
-    wasDerivedFrom(niiri:f6e36041fd68625d6c7813fe63387c51, niiri:d4dd8ab29b5f9534a65e9a4b237ca312, -, -, -)
-    entity(niiri:442ae032432253444ea32f99f4dc387c,
+    wasDerivedFrom(niiri:9d76bd2f2d73c5dfd99aa453786bb3d2, niiri:3fd40489e0c7ad32d9dfa018bf86de4d, -, -, -)
+    entity(niiri:9b7a6f8fe35f2a47bcfd75c409f14815,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:a4693444c0135c8dfe9d5e4683a03a3a',
+        prov:location = 'niiri:c008cc59281fa7515bca5cbcc36458ba',
         prov:value = "2.18819689750671" %% xsd:float,
         nidm_equivalentZStatistic: = "3.5114661254844" %% xsd:float,
         nidm_pValueUncorrected: = "0.000222821126723893" %% xsd:float,
         nidm_pValueFWER: = "0.999999868311968" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a4693444c0135c8dfe9d5e4683a03a3a,
+    entity(niiri:c008cc59281fa7515bca5cbcc36458ba,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[-28,24,4]" %% xsd:string])
-    wasDerivedFrom(niiri:442ae032432253444ea32f99f4dc387c, niiri:4362f5eac9972bf179ea49be33151c8e, -, -, -)
-    entity(niiri:2cc0e4b46ef04062f76f3cd9f58335d7,
+    wasDerivedFrom(niiri:9b7a6f8fe35f2a47bcfd75c409f14815, niiri:eaccd3ae3e22bfdca0eb19a7d8d32655, -, -, -)
+    entity(niiri:e47bb82f7e55707630bbc40a4ee3aaf1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:21b2ec6e254ee0565b8270bfcfc0e2c7',
+        prov:location = 'niiri:19ecc7fec1ab9e465679a4c1330d1f70',
         prov:value = "2.07190132141113" %% xsd:float,
         nidm_equivalentZStatistic: = "3.35835159739265" %% xsd:float,
         nidm_pValueUncorrected: = "0.000392044053194152" %% xsd:float,
         nidm_pValueFWER: = "0.999999999969126" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:21b2ec6e254ee0565b8270bfcfc0e2c7,
+    entity(niiri:19ecc7fec1ab9e465679a4c1330d1f70,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[-28,26,12]" %% xsd:string])
-    wasDerivedFrom(niiri:2cc0e4b46ef04062f76f3cd9f58335d7, niiri:4362f5eac9972bf179ea49be33151c8e, -, -, -)
-    entity(niiri:bf2f05f6426d9b3de806efb87eb24421,
+    wasDerivedFrom(niiri:e47bb82f7e55707630bbc40a4ee3aaf1, niiri:eaccd3ae3e22bfdca0eb19a7d8d32655, -, -, -)
+    entity(niiri:020818951231889a14c8a658a2fb9afa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:63e78c482af8490d5dfa90d0a0e92669',
+        prov:location = 'niiri:0177753ae893aa15acf02da2338a4b6e',
         prov:value = "1.94285821914673" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18853089402481" %% xsd:float,
         nidm_pValueUncorrected: = "0.000714988643396364" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:63e78c482af8490d5dfa90d0a0e92669,
+    entity(niiri:0177753ae893aa15acf02da2338a4b6e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[-42,20,36]" %% xsd:string])
-    wasDerivedFrom(niiri:bf2f05f6426d9b3de806efb87eb24421, niiri:4362f5eac9972bf179ea49be33151c8e, -, -, -)
-    entity(niiri:6d4129ab6385c802707ca56c724df92f,
+    wasDerivedFrom(niiri:020818951231889a14c8a658a2fb9afa, niiri:eaccd3ae3e22bfdca0eb19a7d8d32655, -, -, -)
+    entity(niiri:3d036da0329b3609a9a6261f8555fd39,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:de746baa0f488d3bbadc409c300d1274',
+        prov:location = 'niiri:8d8393df7a5e35e7ad7f2394c4aa5d54',
         prov:value = "2.1167094707489" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41734061195353" %% xsd:float,
         nidm_pValueUncorrected: = "0.000316180548517564" %% xsd:float,
         nidm_pValueFWER: = "0.999999998897938" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:de746baa0f488d3bbadc409c300d1274,
+    entity(niiri:8d8393df7a5e35e7ad7f2394c4aa5d54,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[36,-84,2]" %% xsd:string])
-    wasDerivedFrom(niiri:6d4129ab6385c802707ca56c724df92f, niiri:00f296730dd06a43e5f7334c226305c6, -, -, -)
-    entity(niiri:3398d8202d4e93e898d65527617056fc,
+    wasDerivedFrom(niiri:3d036da0329b3609a9a6261f8555fd39, niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e, -, -, -)
+    entity(niiri:0098f2aeef861167067e9f9491ea1182,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:787673d51909fd4b7955adca6289845e',
+        prov:location = 'niiri:60ffd2d3a7a1286cd7710dc29c6f6d07',
         prov:value = "2.00524592399597" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27061943294259" %% xsd:float,
         nidm_pValueUncorrected: = "0.000536561087325027" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999994" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:787673d51909fd4b7955adca6289845e,
+    entity(niiri:60ffd2d3a7a1286cd7710dc29c6f6d07,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[34,-84,14]" %% xsd:string])
-    wasDerivedFrom(niiri:3398d8202d4e93e898d65527617056fc, niiri:00f296730dd06a43e5f7334c226305c6, -, -, -)
-    entity(niiri:d0c21323683c00398f1fe5b8cd2b1821,
+    wasDerivedFrom(niiri:0098f2aeef861167067e9f9491ea1182, niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e, -, -, -)
+    entity(niiri:e6739e9ae8332b314223bc21cd011d03,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:c2e490ac6fc0201797ed715401260ead',
+        prov:location = 'niiri:f04469bdfb14f7143a2944a5f25c8ae9',
         prov:value = "1.9834691286087" %% xsd:float,
         nidm_equivalentZStatistic: = "3.24196265203981" %% xsd:float,
         nidm_pValueUncorrected: = "0.000593547891254209" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999994" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c2e490ac6fc0201797ed715401260ead,
+    entity(niiri:f04469bdfb14f7143a2944a5f25c8ae9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[34,-78,36]" %% xsd:string])
-    wasDerivedFrom(niiri:d0c21323683c00398f1fe5b8cd2b1821, niiri:00f296730dd06a43e5f7334c226305c6, -, -, -)
-    entity(niiri:1f3d65d5c16aacc0308451722678f7de,
+    wasDerivedFrom(niiri:e6739e9ae8332b314223bc21cd011d03, niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e, -, -, -)
+    entity(niiri:325a9af4c986d5e88d093c8f57319bfc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:7291a001aa765929838e01ce77a9da57',
+        prov:location = 'niiri:85f2862ec8d073265d5d0d93ef5e63be',
         prov:value = "2.07622194290161" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36403923290147" %% xsd:float,
         nidm_pValueUncorrected: = "0.000384053116980865" %% xsd:float,
         nidm_pValueFWER: = "0.999999999955495" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7291a001aa765929838e01ce77a9da57,
+    entity(niiri:85f2862ec8d073265d5d0d93ef5e63be,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[52,48,12]" %% xsd:string])
-    wasDerivedFrom(niiri:1f3d65d5c16aacc0308451722678f7de, niiri:39a3babf6ed520d78e67263717ca5dbb, -, -, -)
-    entity(niiri:6c8bcca3f301b2525f53e90e5d2e044e,
+    wasDerivedFrom(niiri:325a9af4c986d5e88d093c8f57319bfc, niiri:01caf6dcc4c07046ab44e8a119bab255, -, -, -)
+    entity(niiri:808bcd026ac240ae9425800b48644b6d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:dcdc8cced1a70ed65194762748dd42f2',
+        prov:location = 'niiri:22cdaa124958cc1f12bf80546757ef10',
         prov:value = "2.0327205657959" %% xsd:float,
         nidm_equivalentZStatistic: = "3.306778623673" %% xsd:float,
         nidm_pValueUncorrected: = "0.000471877215462824" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999097" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:dcdc8cced1a70ed65194762748dd42f2,
+    entity(niiri:22cdaa124958cc1f12bf80546757ef10,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[30,68,12]" %% xsd:string])
-    wasDerivedFrom(niiri:6c8bcca3f301b2525f53e90e5d2e044e, niiri:39a3babf6ed520d78e67263717ca5dbb, -, -, -)
-    entity(niiri:dc9c09a94ef328a1469d800c80f6fc2f,
+    wasDerivedFrom(niiri:808bcd026ac240ae9425800b48644b6d, niiri:01caf6dcc4c07046ab44e8a119bab255, -, -, -)
+    entity(niiri:4db5e18b36a3e85181e92f727586a86f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:508dc677de99afa67c363c475a5c743e',
+        prov:location = 'niiri:cfd70f8eea67c129f7fa2224871f1827',
         prov:value = "1.63326919078827" %% xsd:float,
         nidm_equivalentZStatistic: = "2.78184273056811" %% xsd:float,
         nidm_pValueUncorrected: = "0.00270256128658664" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:508dc677de99afa67c363c475a5c743e,
+    entity(niiri:cfd70f8eea67c129f7fa2224871f1827,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[14,74,6]" %% xsd:string])
-    wasDerivedFrom(niiri:dc9c09a94ef328a1469d800c80f6fc2f, niiri:39a3babf6ed520d78e67263717ca5dbb, -, -, -)
-    entity(niiri:0445099b3ad94f2a7bffd17b72c32178,
+    wasDerivedFrom(niiri:4db5e18b36a3e85181e92f727586a86f, niiri:01caf6dcc4c07046ab44e8a119bab255, -, -, -)
+    entity(niiri:b160b4ecbdbbfda45b1aee101e93e903,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:d2747be6a82e62e1332bff6a58f4d7f5',
+        prov:location = 'niiri:8db786a8fb51025a0f98e6b8fea3043c',
         prov:value = "2.04988360404968" %% xsd:float,
         nidm_equivalentZStatistic: = "3.32936904595179" %% xsd:float,
         nidm_pValueUncorrected: = "0.000435214929046523" %% xsd:float,
         nidm_pValueFWER: = "0.999999999995547" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d2747be6a82e62e1332bff6a58f4d7f5,
+    entity(niiri:8db786a8fb51025a0f98e6b8fea3043c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[34,-54,52]" %% xsd:string])
-    wasDerivedFrom(niiri:0445099b3ad94f2a7bffd17b72c32178, niiri:26ed93f97118482ea99f750276db5700, -, -, -)
-    entity(niiri:6cf57566c63330551854cd41c76c7945,
+    wasDerivedFrom(niiri:b160b4ecbdbbfda45b1aee101e93e903, niiri:9a28574137dba928b957fda9013d355a, -, -, -)
+    entity(niiri:1000565e793f000cf9b2c8d2a289cbec,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:2e98c4783a911189aca09f35a6897677',
+        prov:location = 'niiri:7c521b4beb7f5ead8a32b666e19f1d1b',
         prov:value = "1.17590498924255" %% xsd:float,
         nidm_equivalentZStatistic: = "2.18553018514689" %% xsd:float,
         nidm_pValueUncorrected: = "0.0144249976129074" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2e98c4783a911189aca09f35a6897677,
+    entity(niiri:7c521b4beb7f5ead8a32b666e19f1d1b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[26,-48,50]" %% xsd:string])
-    wasDerivedFrom(niiri:6cf57566c63330551854cd41c76c7945, niiri:26ed93f97118482ea99f750276db5700, -, -, -)
-    entity(niiri:43ebe5004c0f1a88f50fa9cffeb58814,
+    wasDerivedFrom(niiri:1000565e793f000cf9b2c8d2a289cbec, niiri:9a28574137dba928b957fda9013d355a, -, -, -)
+    entity(niiri:dd0385d1a2c1edf101d66d2482f78a08,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:f2579430fdf3f2f8395d1d9fb3007977',
+        prov:location = 'niiri:7efe58cd9db4f5795487ee3bfda08304',
         prov:value = "1.17325437068939" %% xsd:float,
         nidm_equivalentZStatistic: = "2.18210185402812" %% xsd:float,
         nidm_pValueUncorrected: = "0.0145510082060974" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f2579430fdf3f2f8395d1d9fb3007977,
+    entity(niiri:7efe58cd9db4f5795487ee3bfda08304,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[32,-54,62]" %% xsd:string])
-    wasDerivedFrom(niiri:43ebe5004c0f1a88f50fa9cffeb58814, niiri:26ed93f97118482ea99f750276db5700, -, -, -)
-    entity(niiri:d5d5aad603484d20a1db3818d3e3212c,
+    wasDerivedFrom(niiri:dd0385d1a2c1edf101d66d2482f78a08, niiri:9a28574137dba928b957fda9013d355a, -, -, -)
+    entity(niiri:5c19ae6baeefcc74d9ced9a9372ca5eb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:0fa634cf4f8cd761e5a8e1556dae51af',
+        prov:location = 'niiri:f264d8cda2f387101ec768f5305a082f',
         prov:value = "1.69681537151337" %% xsd:float,
         nidm_equivalentZStatistic: = "2.86519802999163" %% xsd:float,
         nidm_pValueUncorrected: = "0.00208374267085354" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0fa634cf4f8cd761e5a8e1556dae51af,
+    entity(niiri:f264d8cda2f387101ec768f5305a082f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[-28,50,36]" %% xsd:string])
-    wasDerivedFrom(niiri:d5d5aad603484d20a1db3818d3e3212c, niiri:c0faffa954cb5edf1bd166b3c13b64b6, -, -, -)
-    entity(niiri:98d4353d19758293894ef727f5c50955,
+    wasDerivedFrom(niiri:5c19ae6baeefcc74d9ced9a9372ca5eb, niiri:be0a079f2f0b4ba9e502f600a4b77251, -, -, -)
+    entity(niiri:8a3985f227e111c7e8758ec46c529db0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:f1befc6625b08ba88efdc7f2bfff4a08',
+        prov:location = 'niiri:ef19a5fc9f128819eeacaa79f71a5237',
         prov:value = "0.933988809585571" %% xsd:float,
         nidm_equivalentZStatistic: = "1.8747737054388" %% xsd:float,
         nidm_pValueUncorrected: = "0.0304119310280364" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f1befc6625b08ba88efdc7f2bfff4a08,
+    entity(niiri:ef19a5fc9f128819eeacaa79f71a5237,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[-46,38,30]" %% xsd:string])
-    wasDerivedFrom(niiri:98d4353d19758293894ef727f5c50955, niiri:c0faffa954cb5edf1bd166b3c13b64b6, -, -, -)
-    entity(niiri:36a41856d01473f63c7c845ca39839d6,
+    wasDerivedFrom(niiri:8a3985f227e111c7e8758ec46c529db0, niiri:be0a079f2f0b4ba9e502f600a4b77251, -, -, -)
+    entity(niiri:e151d850eabe3ed6554330c51b7c4261,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:605d54e8c542405ec983a5d0a512106f',
+        prov:location = 'niiri:3b8ac2784ea06bbdd5f1e9c1d0514aa5',
         prov:value = "1.66940176486969" %% xsd:float,
         nidm_equivalentZStatistic: = "2.82922911554701" %% xsd:float,
         nidm_pValueUncorrected: = "0.00233301407977504" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:605d54e8c542405ec983a5d0a512106f,
+    entity(niiri:3b8ac2784ea06bbdd5f1e9c1d0514aa5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[16,-94,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:36a41856d01473f63c7c845ca39839d6, niiri:1baee1eea0758a922f6c4f1f12441da6, -, -, -)
-    entity(niiri:d8f65681bb1bfa31766963ffbe28cead,
+    wasDerivedFrom(niiri:e151d850eabe3ed6554330c51b7c4261, niiri:5c92eec2bb2da6800e461deccb3a6c17, -, -, -)
+    entity(niiri:32398273df940601469f78597544a3b0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:8e641bae5b55cb975397775ca4f1465e',
+        prov:location = 'niiri:57a11fb2f64ed51c5a756583086612db',
         prov:value = "1.5886458158493" %% xsd:float,
         nidm_equivalentZStatistic: = "2.72335979311329" %% xsd:float,
         nidm_pValueUncorrected: = "0.00323108192435606" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8e641bae5b55cb975397775ca4f1465e,
+    entity(niiri:57a11fb2f64ed51c5a756583086612db,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[24,-92,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:d8f65681bb1bfa31766963ffbe28cead, niiri:1baee1eea0758a922f6c4f1f12441da6, -, -, -)
-    entity(niiri:b277f286259eb04c946603cb6ba51822,
+    wasDerivedFrom(niiri:32398273df940601469f78597544a3b0, niiri:5c92eec2bb2da6800e461deccb3a6c17, -, -, -)
+    entity(niiri:5f0ffc888d7244cc8858761bbc7ad727,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:225f9a677dc138e3dd97c18cbf2884ef',
+        prov:location = 'niiri:9364bab6dc2738419beaf4eea7d5a29d',
         prov:value = "1.51174938678741" %% xsd:float,
         nidm_equivalentZStatistic: = "2.62269482082508" %% xsd:float,
         nidm_pValueUncorrected: = "0.00436186877852962" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:225f9a677dc138e3dd97c18cbf2884ef,
+    entity(niiri:9364bab6dc2738419beaf4eea7d5a29d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[34,-84,-48]" %% xsd:string])
-    wasDerivedFrom(niiri:b277f286259eb04c946603cb6ba51822, niiri:1baee1eea0758a922f6c4f1f12441da6, -, -, -)
-    entity(niiri:cee39f86215489cfd805b4d5f5dab3a2,
+    wasDerivedFrom(niiri:5f0ffc888d7244cc8858761bbc7ad727, niiri:5c92eec2bb2da6800e461deccb3a6c17, -, -, -)
+    entity(niiri:a65b728c7710923f24e0fc6ebd563120,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:9d6418747114ca65b24a6f9e53156964',
+        prov:location = 'niiri:a3811e5b29ae233e6e1b7dc3557dd2c8',
         prov:value = "1.6600536108017" %% xsd:float,
         nidm_equivalentZStatistic: = "2.81696686061887" %% xsd:float,
         nidm_pValueUncorrected: = "0.00242397637898328" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9d6418747114ca65b24a6f9e53156964,
+    entity(niiri:a3811e5b29ae233e6e1b7dc3557dd2c8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[-44,-56,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:cee39f86215489cfd805b4d5f5dab3a2, niiri:1aa58b6ce0025b1ec01cb8a983388e1d, -, -, -)
-    entity(niiri:10d3d3d8948f818e3d2670f3b08476f8,
+    wasDerivedFrom(niiri:a65b728c7710923f24e0fc6ebd563120, niiri:a87a039e7919a12304129d212230f18a, -, -, -)
+    entity(niiri:c972ef8c9922a6c6469238f35fa13b9f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:5c9455cedfce2a1f699bcd725ce4b27e',
+        prov:location = 'niiri:6fed42f8e866c5c1d7799ee58e8d8b35',
         prov:value = "1.5787501335144" %% xsd:float,
         nidm_equivalentZStatistic: = "2.71039687336073" %% xsd:float,
         nidm_pValueUncorrected: = "0.00336013715292427" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5c9455cedfce2a1f699bcd725ce4b27e,
+    entity(niiri:6fed42f8e866c5c1d7799ee58e8d8b35,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[-10,72,0]" %% xsd:string])
-    wasDerivedFrom(niiri:10d3d3d8948f818e3d2670f3b08476f8, niiri:3198b98e15c5c56654d8a4ffe4b44ce8, -, -, -)
-    entity(niiri:fb4201c849e6cb24fb95b4ccf6b6e5b3,
+    wasDerivedFrom(niiri:c972ef8c9922a6c6469238f35fa13b9f, niiri:e274a3eaada08953bd1833b7c48506f2, -, -, -)
+    entity(niiri:a425b12ef6a4f4de2fd7b5d75435f474,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:76b9f21dd86f54f4686cb3f8ad313ccc',
+        prov:location = 'niiri:de75b28ec25e88fbf3970e0deac065dd',
         prov:value = "1.37760043144226" %% xsd:float,
         nidm_equivalentZStatistic: = "2.44750858968075" %% xsd:float,
         nidm_pValueUncorrected: = "0.0071923848185762" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:76b9f21dd86f54f4686cb3f8ad313ccc,
+    entity(niiri:de75b28ec25e88fbf3970e0deac065dd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[-24,68,10]" %% xsd:string])
-    wasDerivedFrom(niiri:fb4201c849e6cb24fb95b4ccf6b6e5b3, niiri:3198b98e15c5c56654d8a4ffe4b44ce8, -, -, -)
-    entity(niiri:50e767c1e55c55fd6f705e63b8194c22,
+    wasDerivedFrom(niiri:a425b12ef6a4f4de2fd7b5d75435f474, niiri:e274a3eaada08953bd1833b7c48506f2, -, -, -)
+    entity(niiri:de53fffe0663909b6e3f958356870d95,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:200e07f7941deec2e3926a00d9c097f1',
+        prov:location = 'niiri:b5140c630fbb2dd4d49c35006d2f3132',
         prov:value = "1.35886359214783" %% xsd:float,
         nidm_equivalentZStatistic: = "2.42309168524595" %% xsd:float,
         nidm_pValueUncorrected: = "0.00769452108984159" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:200e07f7941deec2e3926a00d9c097f1,
+    entity(niiri:b5140c630fbb2dd4d49c35006d2f3132,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[-14,64,28]" %% xsd:string])
-    wasDerivedFrom(niiri:50e767c1e55c55fd6f705e63b8194c22, niiri:3198b98e15c5c56654d8a4ffe4b44ce8, -, -, -)
-    entity(niiri:651e85007a5f5536ec2697c8749ec5f0,
+    wasDerivedFrom(niiri:de53fffe0663909b6e3f958356870d95, niiri:e274a3eaada08953bd1833b7c48506f2, -, -, -)
+    entity(niiri:78c8a26930efa326681e90dff555fc77,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:a825a8bc763b96a41ba63085944a53f5',
+        prov:location = 'niiri:66be040da5c4acc0a89ea6b3e5f93b73',
         prov:value = "1.53290164470673" %% xsd:float,
         nidm_equivalentZStatistic: = "2.65036951622375" %% xsd:float,
         nidm_pValueUncorrected: = "0.00402018893002576" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a825a8bc763b96a41ba63085944a53f5,
+    entity(niiri:66be040da5c4acc0a89ea6b3e5f93b73,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[-32,-80,10]" %% xsd:string])
-    wasDerivedFrom(niiri:651e85007a5f5536ec2697c8749ec5f0, niiri:7d6744d8bee9e326b4381ceb83e93c8d, -, -, -)
-    entity(niiri:97da40b69bc71f2a3cbe9bddb8d74db7,
+    wasDerivedFrom(niiri:78c8a26930efa326681e90dff555fc77, niiri:245273ed130aa663dd8395923de7d766, -, -, -)
+    entity(niiri:e27450db030879526e2cd37f19b6068a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:92aaec6881a3d0f16d11925a7c0e8a35',
+        prov:location = 'niiri:9a134c4eb3f236a583bfeb4e2510100b',
         prov:value = "1.34681856632233" %% xsd:float,
         nidm_equivalentZStatistic: = "2.4074027844201" %% xsd:float,
         nidm_pValueUncorrected: = "0.00803321955273906" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:92aaec6881a3d0f16d11925a7c0e8a35,
+    entity(niiri:9a134c4eb3f236a583bfeb4e2510100b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-32,-88,8]" %% xsd:string])
-    wasDerivedFrom(niiri:97da40b69bc71f2a3cbe9bddb8d74db7, niiri:7d6744d8bee9e326b4381ceb83e93c8d, -, -, -)
-    entity(niiri:4a7114ba39dbababe80905fe47a8cbc5,
+    wasDerivedFrom(niiri:e27450db030879526e2cd37f19b6068a, niiri:245273ed130aa663dd8395923de7d766, -, -, -)
+    entity(niiri:61a1f119a58200fd0ce3b1e2fd682e00,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:a5814c8553718d88d2b132f5baa18703',
+        prov:location = 'niiri:f356a7d47e82f8102335f0556cb01595',
         prov:value = "1.31222748756409" %% xsd:float,
         nidm_equivalentZStatistic: = "2.36238178325093" %% xsd:float,
         nidm_pValueUncorrected: = "0.00907896581463363" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a5814c8553718d88d2b132f5baa18703,
+    entity(niiri:f356a7d47e82f8102335f0556cb01595,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[-30,-78,26]" %% xsd:string])
-    wasDerivedFrom(niiri:4a7114ba39dbababe80905fe47a8cbc5, niiri:7d6744d8bee9e326b4381ceb83e93c8d, -, -, -)
-    entity(niiri:891a014c9e49c38970fb24d2eaae740d,
+    wasDerivedFrom(niiri:61a1f119a58200fd0ce3b1e2fd682e00, niiri:245273ed130aa663dd8395923de7d766, -, -, -)
+    entity(niiri:229356d269942dce89a3a7c973961faa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:7d0bd7b1f39fd643840af9787a78ba95',
+        prov:location = 'niiri:744ef1cac9a60dbcaad14b0240043509',
         prov:value = "1.47698056697845" %% xsd:float,
         nidm_equivalentZStatistic: = "2.57723307746183" %% xsd:float,
         nidm_pValueUncorrected: = "0.00497973845037369" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7d0bd7b1f39fd643840af9787a78ba95,
+    entity(niiri:744ef1cac9a60dbcaad14b0240043509,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[24,-64,62]" %% xsd:string])
-    wasDerivedFrom(niiri:891a014c9e49c38970fb24d2eaae740d, niiri:1593dbfe6a27c4bfd6c7c865a55e6758, -, -, -)
-    entity(niiri:f4b89e59bc3ef696d8778bd6b6dea759,
+    wasDerivedFrom(niiri:229356d269942dce89a3a7c973961faa, niiri:d173e9e0c068ad3a55c343fddbeff960, -, -, -)
+    entity(niiri:579ab60fab49539d2dcc0aec8d3e6f1b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:1d699923abf53a3abefc6961b7996e12',
+        prov:location = 'niiri:bd285c68570a449ae738f6d1546377c9',
         prov:value = "1.47098410129547" %% xsd:float,
         nidm_equivalentZStatistic: = "2.56939616988394" %% xsd:float,
         nidm_pValueUncorrected: = "0.00509379579800051" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1d699923abf53a3abefc6961b7996e12,
+    entity(niiri:bd285c68570a449ae738f6d1546377c9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[42,2,42]" %% xsd:string])
-    wasDerivedFrom(niiri:f4b89e59bc3ef696d8778bd6b6dea759, niiri:537cd4e035d031e1d96dcc9b62c35112, -, -, -)
-    entity(niiri:6d3354cad50b2f85dd7cb7909270bbd9,
+    wasDerivedFrom(niiri:579ab60fab49539d2dcc0aec8d3e6f1b, niiri:26532b37abc532050b4bc4be92087a96, -, -, -)
+    entity(niiri:5d2f66f6ea92771fa62de13e4aaed7f3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:a0853cb3b872dd490c0e659c3b8de3c5',
+        prov:location = 'niiri:9ccf61688dd58507429dc35697a26efd',
         prov:value = "1.28529334068298" %% xsd:float,
         nidm_equivalentZStatistic: = "2.32736401858338" %% xsd:float,
         nidm_pValueUncorrected: = "0.00997294956075112" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a0853cb3b872dd490c0e659c3b8de3c5,
+    entity(niiri:9ccf61688dd58507429dc35697a26efd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[52,6,36]" %% xsd:string])
-    wasDerivedFrom(niiri:6d3354cad50b2f85dd7cb7909270bbd9, niiri:537cd4e035d031e1d96dcc9b62c35112, -, -, -)
-    entity(niiri:c9fd614181dc2572b186e5053efcd59d,
+    wasDerivedFrom(niiri:5d2f66f6ea92771fa62de13e4aaed7f3, niiri:26532b37abc532050b4bc4be92087a96, -, -, -)
+    entity(niiri:75ccce0f3228ed0ea90d8f61e6a628f9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:f39a7e048d6696e150550855cdb219a4',
+        prov:location = 'niiri:3d0c194e760a2dd9d0d578b8ebea83d7',
         prov:value = "1.46635723114014" %% xsd:float,
         nidm_equivalentZStatistic: = "2.56334999311601" %% xsd:float,
         nidm_pValueUncorrected: = "0.00518337435668992" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f39a7e048d6696e150550855cdb219a4,
+    entity(niiri:3d0c194e760a2dd9d0d578b8ebea83d7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[-28,-60,54]" %% xsd:string])
-    wasDerivedFrom(niiri:c9fd614181dc2572b186e5053efcd59d, niiri:3330f53a36ff5c9ef2f20b1290e9d286, -, -, -)
-    entity(niiri:a16bea998c35dc62efc05b93e35b430f,
+    wasDerivedFrom(niiri:75ccce0f3228ed0ea90d8f61e6a628f9, niiri:aa0ecf58900f58c3045f470d5e5cd69a, -, -, -)
+    entity(niiri:0a8f07ba5e6a270fb827db109ad495b3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:b2d449babe5545c90ba00fa714a59c65',
+        prov:location = 'niiri:a48160de56360c867ce27ffd993c3bbe',
         prov:value = "1.35919630527496" %% xsd:float,
         nidm_equivalentZStatistic: = "2.42352513638295" %% xsd:float,
         nidm_pValueUncorrected: = "0.00768534474692273" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b2d449babe5545c90ba00fa714a59c65,
+    entity(niiri:a48160de56360c867ce27ffd993c3bbe,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[-30,-56,62]" %% xsd:string])
-    wasDerivedFrom(niiri:a16bea998c35dc62efc05b93e35b430f, niiri:3330f53a36ff5c9ef2f20b1290e9d286, -, -, -)
-    entity(niiri:0103dbc26eaf007da3744695bb9e0aa0,
+    wasDerivedFrom(niiri:0a8f07ba5e6a270fb827db109ad495b3, niiri:aa0ecf58900f58c3045f470d5e5cd69a, -, -, -)
+    entity(niiri:2a16b9a23c54607f89ce1afaa023ee14,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:cba23a81a0efa6d0d2133678dd3ac39f',
+        prov:location = 'niiri:e8e1a406248262013c0b6a701696cc35',
         prov:value = "1.3043509721756" %% xsd:float,
         nidm_equivalentZStatistic: = "2.35213781333103" %% xsd:float,
         nidm_pValueUncorrected: = "0.00933292892535331" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:cba23a81a0efa6d0d2133678dd3ac39f,
+    entity(niiri:e8e1a406248262013c0b6a701696cc35,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[-18,-62,52]" %% xsd:string])
-    wasDerivedFrom(niiri:0103dbc26eaf007da3744695bb9e0aa0, niiri:3330f53a36ff5c9ef2f20b1290e9d286, -, -, -)
-    entity(niiri:f75194d50d0d5b9cd1dcdbd886ebd682,
+    wasDerivedFrom(niiri:2a16b9a23c54607f89ce1afaa023ee14, niiri:aa0ecf58900f58c3045f470d5e5cd69a, -, -, -)
+    entity(niiri:12302feaed198aa713f9e1c1f7af9c7e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:1adec05c4ab0624228a2752245a4ad8b',
+        prov:location = 'niiri:48dd2000662814bc84558738c5e24c54',
         prov:value = "1.45064067840576" %% xsd:float,
         nidm_equivalentZStatistic: = "2.54281750257153" %% xsd:float,
         nidm_pValueUncorrected: = "0.00549813229675677" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1adec05c4ab0624228a2752245a4ad8b,
+    entity(niiri:48dd2000662814bc84558738c5e24c54,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[-30,-84,-48]" %% xsd:string])
-    wasDerivedFrom(niiri:f75194d50d0d5b9cd1dcdbd886ebd682, niiri:9c973b3443bcab76e6ce5b021d6b1a13, -, -, -)
-    entity(niiri:acc4812fde8a87c23d34ba26b370d53f,
+    wasDerivedFrom(niiri:12302feaed198aa713f9e1c1f7af9c7e, niiri:901b9fd9da6bf5e77628b338170d2e8d, -, -, -)
+    entity(niiri:17a02fc314bca00a903267e8fe361e7c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:886a9d589ec63742ed0ea381ebb81a8f',
+        prov:location = 'niiri:83bac3dfa0ac2b0a2eeeecf18d99728a',
         prov:value = "1.37874686717987" %% xsd:float,
         nidm_equivalentZStatistic: = "2.44900302114624" %% xsd:float,
         nidm_pValueUncorrected: = "0.00716261232865922" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:886a9d589ec63742ed0ea381ebb81a8f,
+    entity(niiri:83bac3dfa0ac2b0a2eeeecf18d99728a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[-22,-84,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:acc4812fde8a87c23d34ba26b370d53f, niiri:9c973b3443bcab76e6ce5b021d6b1a13, -, -, -)
-    entity(niiri:15ccd6b0b7514b3584e9c6b60bb007cb,
+    wasDerivedFrom(niiri:17a02fc314bca00a903267e8fe361e7c, niiri:901b9fd9da6bf5e77628b338170d2e8d, -, -, -)
+    entity(niiri:664902a2909e45a871762350e07ff964,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0033" %% xsd:string,
-        prov:location = 'niiri:156b51e696a83a537ee4ec10986ac2ce',
+        prov:location = 'niiri:1d8b5ada3c9045bff9869305f2821f2f',
         prov:value = "1.1024569272995" %% xsd:float,
         nidm_equivalentZStatistic: = "2.09070134301333" %% xsd:float,
         nidm_pValueUncorrected: = "0.0182774222681363" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:156b51e696a83a537ee4ec10986ac2ce,
+    entity(niiri:1d8b5ada3c9045bff9869305f2821f2f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0033" %% xsd:string,
         nidm_coordinateVector: = "[-24,-90,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:15ccd6b0b7514b3584e9c6b60bb007cb, niiri:9c973b3443bcab76e6ce5b021d6b1a13, -, -, -)
-    entity(niiri:4777cf2071b7b41500a1f57022890df8,
+    wasDerivedFrom(niiri:664902a2909e45a871762350e07ff964, niiri:901b9fd9da6bf5e77628b338170d2e8d, -, -, -)
+    entity(niiri:24eaee863fcdfc204b0ce8fc5d61cd1d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0034" %% xsd:string,
-        prov:location = 'niiri:1af93548bf2bbf22f69bc6640b686613',
+        prov:location = 'niiri:61f3fe7972829fec8bde60e9d9f9e245',
         prov:value = "1.43723428249359" %% xsd:float,
         nidm_equivalentZStatistic: = "2.52530953068747" %% xsd:float,
         nidm_pValueUncorrected: = "0.00577982121839438" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1af93548bf2bbf22f69bc6640b686613,
+    entity(niiri:61f3fe7972829fec8bde60e9d9f9e245,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0034" %% xsd:string,
         nidm_coordinateVector: = "[-24,40,46]" %% xsd:string])
-    wasDerivedFrom(niiri:4777cf2071b7b41500a1f57022890df8, niiri:27a3407fb41dee69924952963bf01095, -, -, -)
-    entity(niiri:eacfb263b90cde13ef784658cf25eb48,
+    wasDerivedFrom(niiri:24eaee863fcdfc204b0ce8fc5d61cd1d, niiri:54e9eacbd4a27d2bb3a673e3ecd6842c, -, -, -)
+    entity(niiri:26343fd11572bb24257abcb3944a6ebe,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0035" %% xsd:string,
-        prov:location = 'niiri:7ac57d87a6011aa306f5300c51620b1f',
+        prov:location = 'niiri:cbf2928cfc607ea4fcba74676638f7e3',
         prov:value = "1.11286687850952" %% xsd:float,
         nidm_equivalentZStatistic: = "2.10411930550185" %% xsd:float,
         nidm_pValueUncorrected: = "0.0176840206088169" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7ac57d87a6011aa306f5300c51620b1f,
+    entity(niiri:cbf2928cfc607ea4fcba74676638f7e3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0035" %% xsd:string,
         nidm_coordinateVector: = "[-16,50,46]" %% xsd:string])
-    wasDerivedFrom(niiri:eacfb263b90cde13ef784658cf25eb48, niiri:27a3407fb41dee69924952963bf01095, -, -, -)
-    entity(niiri:f954f6180923bbe6c50483cd884c34cb,
+    wasDerivedFrom(niiri:26343fd11572bb24257abcb3944a6ebe, niiri:54e9eacbd4a27d2bb3a673e3ecd6842c, -, -, -)
+    entity(niiri:81d3cdeaca658f010af81a67520b4b89,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0036" %% xsd:string,
-        prov:location = 'niiri:7beb4ee855117da9771f3319e86d6926',
+        prov:location = 'niiri:d3e259c6333491ced7f35c96d536bb8d',
         prov:value = "1.42738270759583" %% xsd:float,
         nidm_equivalentZStatistic: = "2.51244786328393" %% xsd:float,
         nidm_pValueUncorrected: = "0.00599484099495173" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7beb4ee855117da9771f3319e86d6926,
+    entity(niiri:d3e259c6333491ced7f35c96d536bb8d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0036" %% xsd:string,
         nidm_coordinateVector: = "[40,32,42]" %% xsd:string])
-    wasDerivedFrom(niiri:f954f6180923bbe6c50483cd884c34cb, niiri:9c3f0991818d487326255d5ca7862e30, -, -, -)
-    entity(niiri:f04690c008db60f141bbb5f8963ea62f,
+    wasDerivedFrom(niiri:81d3cdeaca658f010af81a67520b4b89, niiri:102bcff4159cf1d08e8b6d4fdfbaade6, -, -, -)
+    entity(niiri:5b296736e349e0c0d6c37d50f3ce649a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0037" %% xsd:string,
-        prov:location = 'niiri:dc9d047e50802cd5dfea68f14c77fdb3',
+        prov:location = 'niiri:8ae8485dbc29c7d3d5cfb7b28efa1138',
         prov:value = "1.05634605884552" %% xsd:float,
         nidm_equivalentZStatistic: = "2.03136304442869" %% xsd:float,
         nidm_pValueUncorrected: = "0.0211090901815698" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:dc9d047e50802cd5dfea68f14c77fdb3,
+    entity(niiri:8ae8485dbc29c7d3d5cfb7b28efa1138,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0037" %% xsd:string,
         nidm_coordinateVector: = "[38,40,36]" %% xsd:string])
-    wasDerivedFrom(niiri:f04690c008db60f141bbb5f8963ea62f, niiri:9c3f0991818d487326255d5ca7862e30, -, -, -)
-    entity(niiri:f2927e668b305ce4095e4a1fae3d5ba5,
+    wasDerivedFrom(niiri:5b296736e349e0c0d6c37d50f3ce649a, niiri:102bcff4159cf1d08e8b6d4fdfbaade6, -, -, -)
+    entity(niiri:8cf4705ae6d69a2d312549186137f822,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0038" %% xsd:string,
-        prov:location = 'niiri:ee21681844ab92db1f554ed686e6cb97',
+        prov:location = 'niiri:70f5848935192c2f9c73c5bc880dce82',
         prov:value = "1.40870463848114" %% xsd:float,
         nidm_equivalentZStatistic: = "2.4880722231724" %% xsd:float,
         nidm_pValueUncorrected: = "0.00642188235953201" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ee21681844ab92db1f554ed686e6cb97,
+    entity(niiri:70f5848935192c2f9c73c5bc880dce82,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0038" %% xsd:string,
         nidm_coordinateVector: = "[-42,-84,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:f2927e668b305ce4095e4a1fae3d5ba5, niiri:73094daa238696f8de11ef4e56a95c30, -, -, -)
-    entity(niiri:402e0d4048e6d12f11de0e3c9bdf055c,
+    wasDerivedFrom(niiri:8cf4705ae6d69a2d312549186137f822, niiri:71589bd4c92a13b9d77db1a0f4dfe621, -, -, -)
+    entity(niiri:0dd3698237b6362f90b33d2433b0478e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0039" %% xsd:string,
-        prov:location = 'niiri:9e67d185caabdc161e0d312461d9cdd0',
+        prov:location = 'niiri:060e12f85e9cf56d29828d41b5de6eba',
         prov:value = "1.13220155239105" %% xsd:float,
         nidm_equivalentZStatistic: = "2.12906102075628" %% xsd:float,
         nidm_pValueUncorrected: = "0.0166246060871375" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9e67d185caabdc161e0d312461d9cdd0,
+    entity(niiri:060e12f85e9cf56d29828d41b5de6eba,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0039" %% xsd:string,
         nidm_coordinateVector: = "[-50,-78,0]" %% xsd:string])
-    wasDerivedFrom(niiri:402e0d4048e6d12f11de0e3c9bdf055c, niiri:73094daa238696f8de11ef4e56a95c30, -, -, -)
-    entity(niiri:ce6f3e2f152234ea375751cc54fa9c85,
+    wasDerivedFrom(niiri:0dd3698237b6362f90b33d2433b0478e, niiri:71589bd4c92a13b9d77db1a0f4dfe621, -, -, -)
+    entity(niiri:1e54eee3467b7fb8f7b3d6f4f6a52ee0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0040" %% xsd:string,
-        prov:location = 'niiri:93fdcdaf5f69c6e135d078d6217da497',
+        prov:location = 'niiri:2cfbace584ca70fa07c72dace3b804e0',
         prov:value = "1.34917068481445" %% xsd:float,
         nidm_equivalentZStatistic: = "2.41046599292312" %% xsd:float,
         nidm_pValueUncorrected: = "0.00796607827138629" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:93fdcdaf5f69c6e135d078d6217da497,
+    entity(niiri:2cfbace584ca70fa07c72dace3b804e0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0040" %% xsd:string,
         nidm_coordinateVector: = "[12,-20,80]" %% xsd:string])
-    wasDerivedFrom(niiri:ce6f3e2f152234ea375751cc54fa9c85, niiri:35af8997746066bb4be8d3a9cebf0640, -, -, -)
-    entity(niiri:b988b89ef13b4938653637ed36c2bc4d,
+    wasDerivedFrom(niiri:1e54eee3467b7fb8f7b3d6f4f6a52ee0, niiri:59224724a1e5e6aa2048738e448b7eb6, -, -, -)
+    entity(niiri:5d2341704a7e536bbc30a147b3fdb40e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0041" %% xsd:string,
-        prov:location = 'niiri:8bc4c3b0a3463c5ccd6748b60c01b1b7',
+        prov:location = 'niiri:7b320bcd0aea26dd35055afdae5821d2',
         prov:value = "1.34354746341705" %% xsd:float,
         nidm_equivalentZStatistic: = "2.40314315325023" %% xsd:float,
         nidm_pValueUncorrected: = "0.0081274114265858" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8bc4c3b0a3463c5ccd6748b60c01b1b7,
+    entity(niiri:7b320bcd0aea26dd35055afdae5821d2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0041" %% xsd:string,
         nidm_coordinateVector: = "[18,48,44]" %% xsd:string])
-    wasDerivedFrom(niiri:b988b89ef13b4938653637ed36c2bc4d, niiri:9d0b757e22fc3f0156790583744c1334, -, -, -)
-    entity(niiri:1d5df79c27d668272e122666fca002b8,
+    wasDerivedFrom(niiri:5d2341704a7e536bbc30a147b3fdb40e, niiri:6b72e4095c1f07ea4ea737f0c44371c4, -, -, -)
+    entity(niiri:43ed1491cc19f7e7aff955c8842cbc4f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0042" %% xsd:string,
-        prov:location = 'niiri:6429c604174465ae78baf35ecfc017c4',
+        prov:location = 'niiri:fa685a13be0595595616be60e9c54c60',
         prov:value = "1.14962959289551" %% xsd:float,
         nidm_equivalentZStatistic: = "2.15156492154198" %% xsd:float,
         nidm_pValueUncorrected: = "0.015715818709074" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6429c604174465ae78baf35ecfc017c4,
+    entity(niiri:fa685a13be0595595616be60e9c54c60,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0042" %% xsd:string,
         nidm_coordinateVector: = "[8,52,46]" %% xsd:string])
-    wasDerivedFrom(niiri:1d5df79c27d668272e122666fca002b8, niiri:9d0b757e22fc3f0156790583744c1334, -, -, -)
-    entity(niiri:3141b4c6e901f4ec1f5e0352c6d0360d,
+    wasDerivedFrom(niiri:43ed1491cc19f7e7aff955c8842cbc4f, niiri:6b72e4095c1f07ea4ea737f0c44371c4, -, -, -)
+    entity(niiri:459ed47a48d1df07a89f83b8f1ac0c69,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0043" %% xsd:string,
-        prov:location = 'niiri:65ae40d69c72f6ee264d19c45986f3b4',
+        prov:location = 'niiri:0fc5888e3b443b2a1df816962b2fc3dd',
         prov:value = "1.33556091785431" %% xsd:float,
         nidm_equivalentZStatistic: = "2.39274498818401" %% xsd:float,
         nidm_pValueUncorrected: = "0.00836142979663967" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:65ae40d69c72f6ee264d19c45986f3b4,
+    entity(niiri:0fc5888e3b443b2a1df816962b2fc3dd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0043" %% xsd:string,
         nidm_coordinateVector: = "[64,-52,2]" %% xsd:string])
-    wasDerivedFrom(niiri:3141b4c6e901f4ec1f5e0352c6d0360d, niiri:8d3362f5850c9379377b0d1f0b1c2735, -, -, -)
-    entity(niiri:469e72c7f14e92f86f0ec5262a435c39,
+    wasDerivedFrom(niiri:459ed47a48d1df07a89f83b8f1ac0c69, niiri:adcf7702789aacaca259aab58c015a1b, -, -, -)
+    entity(niiri:14d7a1850581b6956488a368f171e3cf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0044" %% xsd:string,
-        prov:location = 'niiri:a51b4e8c46bf9aa3e74eadca19ad0968',
+        prov:location = 'niiri:836f43e4e1f3e9f4635c5ddfe843e3e3',
         prov:value = "1.30518817901611" %% xsd:float,
         nidm_equivalentZStatistic: = "2.35322652463791" %% xsd:float,
         nidm_pValueUncorrected: = "0.00930564616578244" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a51b4e8c46bf9aa3e74eadca19ad0968,
+    entity(niiri:836f43e4e1f3e9f4635c5ddfe843e3e3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0044" %% xsd:string,
         nidm_coordinateVector: = "[26,-74,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:469e72c7f14e92f86f0ec5262a435c39, niiri:227019e17364687787db60a4a8267663, -, -, -)
-    entity(niiri:99a673bf7bd432cda404ddae34a3c146,
+    wasDerivedFrom(niiri:14d7a1850581b6956488a368f171e3cf, niiri:9583432017e2a81f5dfd9ee21e31202e, -, -, -)
+    entity(niiri:1302b9300cedb561929231efc9492a17,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0045" %% xsd:string,
-        prov:location = 'niiri:85071e33199bbf64537a2df42a3a1673',
+        prov:location = 'niiri:80bda3ee5f37298b4b39cb791e126ae9',
         prov:value = "1.30020189285278" %% xsd:float,
         nidm_equivalentZStatistic: = "2.34674279460019" %% xsd:float,
         nidm_pValueUncorrected: = "0.00946916148556731" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:85071e33199bbf64537a2df42a3a1673,
+    entity(niiri:80bda3ee5f37298b4b39cb791e126ae9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0045" %% xsd:string,
         nidm_coordinateVector: = "[-44,-82,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:99a673bf7bd432cda404ddae34a3c146, niiri:8669f380bd303fec5b169e636d626ce3, -, -, -)
-    entity(niiri:09715737634975b7e4a53926319b1bee,
+    wasDerivedFrom(niiri:1302b9300cedb561929231efc9492a17, niiri:4d1c403da9e27b79352d1129d7d66218, -, -, -)
+    entity(niiri:928c7de4a7c271559d39f39ca6ad73a3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0046" %% xsd:string,
-        prov:location = 'niiri:b8520f4b473a7db7a8a22098c02388df',
+        prov:location = 'niiri:3826704f625e88111646a8c9959f204c',
         prov:value = "1.2840074300766" %% xsd:float,
         nidm_equivalentZStatistic: = "2.32569303609441" %% xsd:float,
         nidm_pValueUncorrected: = "0.0100174661332294" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b8520f4b473a7db7a8a22098c02388df,
+    entity(niiri:3826704f625e88111646a8c9959f204c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0046" %% xsd:string,
         nidm_coordinateVector: = "[-6,62,36]" %% xsd:string])
-    wasDerivedFrom(niiri:09715737634975b7e4a53926319b1bee, niiri:f38934924fa68b3b9a71fb9c8171e8b6, -, -, -)
-    entity(niiri:a950180a6b2d1ba6bd0c8453f6aa57c6,
+    wasDerivedFrom(niiri:928c7de4a7c271559d39f39ca6ad73a3, niiri:7ac836ca3990ce9f1e31e9eb1801404a, -, -, -)
+    entity(niiri:2ad53ef72da7feef4241d530910c3059,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0047" %% xsd:string,
-        prov:location = 'niiri:1f3bac07c06f6c4da947941a3e0d40d2',
+        prov:location = 'niiri:95fe8a40c4c4abb8182e888bc8731540',
         prov:value = "1.26505351066589" %% xsd:float,
         nidm_equivalentZStatistic: = "2.30107272004429" %% xsd:float,
         nidm_pValueUncorrected: = "0.0106937605017341" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1f3bac07c06f6c4da947941a3e0d40d2,
+    entity(niiri:95fe8a40c4c4abb8182e888bc8731540,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0047" %% xsd:string,
         nidm_coordinateVector: = "[-50,-2,50]" %% xsd:string])
-    wasDerivedFrom(niiri:a950180a6b2d1ba6bd0c8453f6aa57c6, niiri:1793504b32e2869dcb2fbd3af062f8bc, -, -, -)
-    entity(niiri:a59a5d4bd11645916f5cb26b0edecf9d,
+    wasDerivedFrom(niiri:2ad53ef72da7feef4241d530910c3059, niiri:fe6bad7c2c3cd88c5e91fc8c7f05871c, -, -, -)
+    entity(niiri:3931e7effd25e2bca692d42cb4be7fdf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0048" %% xsd:string,
-        prov:location = 'niiri:686f5e6308163bd9a97c3148f494b7b8',
+        prov:location = 'niiri:4320b94b260e1ab5e9bf6ae2ce37ec21',
         prov:value = "1.24030959606171" %% xsd:float,
         nidm_equivalentZStatistic: = "2.26895897281379" %% xsd:float,
         nidm_pValueUncorrected: = "0.0116354104606456" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:686f5e6308163bd9a97c3148f494b7b8,
+    entity(niiri:4320b94b260e1ab5e9bf6ae2ce37ec21,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0048" %% xsd:string,
         nidm_coordinateVector: = "[-18,6,32]" %% xsd:string])
-    wasDerivedFrom(niiri:a59a5d4bd11645916f5cb26b0edecf9d, niiri:55aacac3d3863ecd2c5789acfd6b261d, -, -, -)
-    entity(niiri:fb31a7b6c3f653a71eb02bc199c1c87d,
+    wasDerivedFrom(niiri:3931e7effd25e2bca692d42cb4be7fdf, niiri:af4a779ba8799ad0c9fe505505295a71, -, -, -)
+    entity(niiri:d3d4be6c2db0dbdcc7b2d8f9dba10557,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0049" %% xsd:string,
-        prov:location = 'niiri:86d95b0aaa548888f11ac1f3260b8a14',
+        prov:location = 'niiri:b6308ae0f236e4a1c0a36b987dae355b',
         prov:value = "1.23086047172546" %% xsd:float,
         nidm_equivalentZStatistic: = "2.25670403369037" %% xsd:float,
         nidm_pValueUncorrected: = "0.0120132873197203" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:86d95b0aaa548888f11ac1f3260b8a14,
+    entity(niiri:b6308ae0f236e4a1c0a36b987dae355b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0049" %% xsd:string,
         nidm_coordinateVector: = "[32,-44,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:fb31a7b6c3f653a71eb02bc199c1c87d, niiri:03238c6a619b9f265421cbb7a0cda76e, -, -, -)
-    entity(niiri:573a177d63d9c9f2fb4fa151422f89eb,
+    wasDerivedFrom(niiri:d3d4be6c2db0dbdcc7b2d8f9dba10557, niiri:034859fff2bec220b9605fe31c29e464, -, -, -)
+    entity(niiri:5946f3ffe932cd7089f09585f0ea10ab,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0050" %% xsd:string,
-        prov:location = 'niiri:d21d8383c2ef494476f34cb7efde4323',
+        prov:location = 'niiri:f6a9e6f3d876bef6da1f25ca40fcea8f',
         prov:value = "1.22944271564484" %% xsd:float,
         nidm_equivalentZStatistic: = "2.25486570897048" %% xsd:float,
         nidm_pValueUncorrected: = "0.012070879644426" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d21d8383c2ef494476f34cb7efde4323,
+    entity(niiri:f6a9e6f3d876bef6da1f25ca40fcea8f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0050" %% xsd:string,
         nidm_coordinateVector: = "[-46,-10,58]" %% xsd:string])
-    wasDerivedFrom(niiri:573a177d63d9c9f2fb4fa151422f89eb, niiri:bc83f4e59851c0ed8424e3172a378ee4, -, -, -)
-    entity(niiri:9fac645dbbfbce2fe558862574fd138e,
+    wasDerivedFrom(niiri:5946f3ffe932cd7089f09585f0ea10ab, niiri:e4a8ed309e5dfdfbdd940912aa7b9917, -, -, -)
+    entity(niiri:11570b8227fe008a9ad3e7f235166414,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0051" %% xsd:string,
-        prov:location = 'niiri:df5af951356032bbf21dae5e4eafe818',
+        prov:location = 'niiri:dab3f47042b08489e32b41af5dc6d145',
         prov:value = "1.22471487522125" %% xsd:float,
         nidm_equivalentZStatistic: = "2.24873618228261" %% xsd:float,
         nidm_pValueUncorrected: = "0.0122646428654261" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:df5af951356032bbf21dae5e4eafe818,
+    entity(niiri:dab3f47042b08489e32b41af5dc6d145,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0051" %% xsd:string,
         nidm_coordinateVector: = "[-22,-94,26]" %% xsd:string])
-    wasDerivedFrom(niiri:9fac645dbbfbce2fe558862574fd138e, niiri:c340f3ccccc1a020f9aef989954e51fc, -, -, -)
-    entity(niiri:85c21df54812854d9dcc91de1c9501e3,
+    wasDerivedFrom(niiri:11570b8227fe008a9ad3e7f235166414, niiri:54cdf7b7e5fb6a712a9931f377c09dad, -, -, -)
+    entity(niiri:f77468942763f8e191e11dddee19d43a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0052" %% xsd:string,
-        prov:location = 'niiri:b1d19ddb93361faaef7a254dcfaf85f5',
+        prov:location = 'niiri:213a51e4d0cd0916770b07505d60d6cb',
         prov:value = "1.21706402301788" %% xsd:float,
         nidm_equivalentZStatistic: = "2.23881967357295" %% xsd:float,
         nidm_pValueUncorrected: = "0.0125838258304741" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b1d19ddb93361faaef7a254dcfaf85f5,
+    entity(niiri:213a51e4d0cd0916770b07505d60d6cb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0052" %% xsd:string,
         nidm_coordinateVector: = "[36,32,8]" %% xsd:string])
-    wasDerivedFrom(niiri:85c21df54812854d9dcc91de1c9501e3, niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5, -, -, -)
-    entity(niiri:419edd7ae0533f67f4b514cad51a7e40,
+    wasDerivedFrom(niiri:f77468942763f8e191e11dddee19d43a, niiri:f86480eb515c35553583815451053247, -, -, -)
+    entity(niiri:2bb7a0ae8224d3d87a2d1e162463a80f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0053" %% xsd:string,
-        prov:location = 'niiri:9e821e6d86a5b665b7128c83d0b55b57',
+        prov:location = 'niiri:246a5f68eb203f6e3f9476c5929534b1',
         prov:value = "1.1321427822113" %% xsd:float,
         nidm_equivalentZStatistic: = "2.12898516834439" %% xsd:float,
         nidm_pValueUncorrected: = "0.0166277437596988" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9e821e6d86a5b665b7128c83d0b55b57,
+    entity(niiri:246a5f68eb203f6e3f9476c5929534b1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0053" %% xsd:string,
         nidm_coordinateVector: = "[32,28,2]" %% xsd:string])
-    wasDerivedFrom(niiri:419edd7ae0533f67f4b514cad51a7e40, niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5, -, -, -)
-    entity(niiri:cbe78a0c214f75fee02b8f4215a8d050,
+    wasDerivedFrom(niiri:2bb7a0ae8224d3d87a2d1e162463a80f, niiri:f86480eb515c35553583815451053247, -, -, -)
+    entity(niiri:b69bbb0f81f95850657d5352879fb5ab,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0054" %% xsd:string,
-        prov:location = 'niiri:61ea3aa03f07e52544d1f2c561b325f5',
+        prov:location = 'niiri:9f0de39e9fe7f38ddad952a0d7bccc8f',
         prov:value = "1.21668255329132" %% xsd:float,
         nidm_equivalentZStatistic: = "2.23832532460858" %% xsd:float,
         nidm_pValueUncorrected: = "0.0125999239065135" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:61ea3aa03f07e52544d1f2c561b325f5,
+    entity(niiri:9f0de39e9fe7f38ddad952a0d7bccc8f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0054" %% xsd:string,
         nidm_coordinateVector: = "[-36,-42,38]" %% xsd:string])
-    wasDerivedFrom(niiri:cbe78a0c214f75fee02b8f4215a8d050, niiri:cb85dd1324b2d86671b2fe868f4dafc0, -, -, -)
-    entity(niiri:0a98388a34991d9fe59b4a9cf396642c,
+    wasDerivedFrom(niiri:b69bbb0f81f95850657d5352879fb5ab, niiri:797c0d6ce89eec38f010854e7e38594b, -, -, -)
+    entity(niiri:1c99fba420ab95e54f5e82f1c2a767db,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0055" %% xsd:string,
-        prov:location = 'niiri:ef543ad68b3140441251e0efe0af7cd1',
+        prov:location = 'niiri:4dfa41027eded7653e2d6ff0fbd63da3',
         prov:value = "1.19720852375031" %% xsd:float,
         nidm_equivalentZStatistic: = "2.21309986746215" %% xsd:float,
         nidm_pValueUncorrected: = "0.0134453806257753" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ef543ad68b3140441251e0efe0af7cd1,
+    entity(niiri:4dfa41027eded7653e2d6ff0fbd63da3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0055" %% xsd:string,
         nidm_coordinateVector: = "[2,68,26]" %% xsd:string])
-    wasDerivedFrom(niiri:0a98388a34991d9fe59b4a9cf396642c, niiri:0dc11dbfea7cb1fef76a1c48d7f8750f, -, -, -)
-    entity(niiri:acf1658fdc834ef5f68e881f5de034af,
+    wasDerivedFrom(niiri:1c99fba420ab95e54f5e82f1c2a767db, niiri:223b74991051acba66efeafdae50f4c4, -, -, -)
+    entity(niiri:6a6243c36daeead679e5dc9b4b70fc84,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0056" %% xsd:string,
-        prov:location = 'niiri:ba2d9a0c93e36c103ea6c6300ded5fa8',
+        prov:location = 'niiri:6dad428dc18a6069931ebbf2fcba9dcf',
         prov:value = "1.1896378993988" %% xsd:float,
         nidm_equivalentZStatistic: = "2.20329932117063" %% xsd:float,
         nidm_pValueUncorrected: = "0.013786829398946" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ba2d9a0c93e36c103ea6c6300ded5fa8,
+    entity(niiri:6dad428dc18a6069931ebbf2fcba9dcf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0056" %% xsd:string,
         nidm_coordinateVector: = "[46,14,2]" %% xsd:string])
-    wasDerivedFrom(niiri:acf1658fdc834ef5f68e881f5de034af, niiri:6db75fb201d2decf706c9d2dd225cb5a, -, -, -)
-    entity(niiri:82118381b7674f736b0f0cd125544fe3,
+    wasDerivedFrom(niiri:6a6243c36daeead679e5dc9b4b70fc84, niiri:294fdb1b5bfd7e0473b8498bbe447111, -, -, -)
+    entity(niiri:df04715790f66448d96cbbc580c69445,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0057" %% xsd:string,
-        prov:location = 'niiri:d8f27c43af5b906ba5f0b6da34c9df35',
+        prov:location = 'niiri:84731f87155885fd75a8ffe0e64d7f6a',
         prov:value = "0.84699684381485" %% xsd:float,
         nidm_equivalentZStatistic: = "1.76435736331002" %% xsd:float,
         nidm_pValueUncorrected: = "0.0388359158916027" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d8f27c43af5b906ba5f0b6da34c9df35,
+    entity(niiri:84731f87155885fd75a8ffe0e64d7f6a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0057" %% xsd:string,
         nidm_coordinateVector: = "[40,10,10]" %% xsd:string])
-    wasDerivedFrom(niiri:82118381b7674f736b0f0cd125544fe3, niiri:6db75fb201d2decf706c9d2dd225cb5a, -, -, -)
-    entity(niiri:71125be49af0dc99c2e40193fb5e66b2,
+    wasDerivedFrom(niiri:df04715790f66448d96cbbc580c69445, niiri:294fdb1b5bfd7e0473b8498bbe447111, -, -, -)
+    entity(niiri:ae975e66ecc6bc89e61cc1c6ba62c79d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0058" %% xsd:string,
-        prov:location = 'niiri:fdf68d1a3ec000d7fa998a7c58e56d5d',
+        prov:location = 'niiri:8bedce252c2de48da69a3b37443ed2a4',
         prov:value = "1.18655109405518" %% xsd:float,
         nidm_equivalentZStatistic: = "2.19930428061828" %% xsd:float,
         nidm_pValueUncorrected: = "0.0139281467706139" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:fdf68d1a3ec000d7fa998a7c58e56d5d,
+    entity(niiri:8bedce252c2de48da69a3b37443ed2a4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0058" %% xsd:string,
         nidm_coordinateVector: = "[-32,-28,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:71125be49af0dc99c2e40193fb5e66b2, niiri:8fae62d51a220dbd34d1d3074ad97c80, -, -, -)
-    entity(niiri:4e602b57e82d39a3379ea0238f2f065a,
+    wasDerivedFrom(niiri:ae975e66ecc6bc89e61cc1c6ba62c79d, niiri:317b26ee6683fc2d7e4152e9f21569d5, -, -, -)
+    entity(niiri:65cce8abcbb33fd2c8c6a019e9bb7038,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0059" %% xsd:string,
-        prov:location = 'niiri:2f57e4ad9e363502818b5b7af383279e',
+        prov:location = 'niiri:00c23da14f9cf7988bcbc63d84fe0d88',
         prov:value = "1.17589449882507" %% xsd:float,
         nidm_equivalentZStatistic: = "2.18551661590201" %% xsd:float,
         nidm_pValueUncorrected: = "0.0144254945017301" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2f57e4ad9e363502818b5b7af383279e,
+    entity(niiri:00c23da14f9cf7988bcbc63d84fe0d88,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0059" %% xsd:string,
         nidm_coordinateVector: = "[-18,30,50]" %% xsd:string])
-    wasDerivedFrom(niiri:4e602b57e82d39a3379ea0238f2f065a, niiri:1b3f6a9bf76e54ad12539e190c7c838c, -, -, -)
-    entity(niiri:127254d5f8144e53a6000f178ba9832f,
+    wasDerivedFrom(niiri:65cce8abcbb33fd2c8c6a019e9bb7038, niiri:7a8231297a4abeb5308420c5bd8b95b0, -, -, -)
+    entity(niiri:3b9f724439a601a2217386ee517c26d1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0060" %% xsd:string,
-        prov:location = 'niiri:f78dbb802d360f040867d01f91280a3e',
+        prov:location = 'niiri:61b8ab33a1b0f17d66c8c98888b7aa6d',
         prov:value = "1.17159426212311" %% xsd:float,
         nidm_equivalentZStatistic: = "2.17995487813573" %% xsd:float,
         nidm_pValueUncorrected: = "0.0146304032058477" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f78dbb802d360f040867d01f91280a3e,
+    entity(niiri:61b8ab33a1b0f17d66c8c98888b7aa6d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0060" %% xsd:string,
         nidm_coordinateVector: = "[-14,-26,66]" %% xsd:string])
-    wasDerivedFrom(niiri:127254d5f8144e53a6000f178ba9832f, niiri:dc2d50ba6c535742eed46213fc557f6a, -, -, -)
-    entity(niiri:323e53e57a73eedef512b5baa864925b,
+    wasDerivedFrom(niiri:3b9f724439a601a2217386ee517c26d1, niiri:6b7b56e17486f776bce05e82a97e5bb7, -, -, -)
+    entity(niiri:92731d2fdb3968c2064b6892b4a6c735,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0061" %% xsd:string,
-        prov:location = 'niiri:e99f8650eabbc3b1cd1432e8b2374a82',
+        prov:location = 'niiri:c9b930c22d2863c88d596a347430fb43',
         prov:value = "1.1714745759964" %% xsd:float,
         nidm_equivalentZStatistic: = "2.17980009775463" %% xsd:float,
         nidm_pValueUncorrected: = "0.0146361413495164" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e99f8650eabbc3b1cd1432e8b2374a82,
+    entity(niiri:c9b930c22d2863c88d596a347430fb43,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0061" %% xsd:string,
         nidm_coordinateVector: = "[18,60,34]" %% xsd:string])
-    wasDerivedFrom(niiri:323e53e57a73eedef512b5baa864925b, niiri:416dfaa44bb6a7fe97539c984a9173c3, -, -, -)
-    entity(niiri:617a5f940f4b8fb780b2b0fba6f13c31,
+    wasDerivedFrom(niiri:92731d2fdb3968c2064b6892b4a6c735, niiri:dbaf33f41cd427af7e5a021f10031a6a, -, -, -)
+    entity(niiri:5764da2697fce92e5bdd83dfee44f500,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0062" %% xsd:string,
-        prov:location = 'niiri:45d2e869fd9ca2ba349709e3128b5308',
+        prov:location = 'niiri:3497a1d298e28ded5637bf48b84d5733',
         prov:value = "1.17128801345825" %% xsd:float,
         nidm_equivalentZStatistic: = "2.17955883330163" %% xsd:float,
         nidm_pValueUncorrected: = "0.0146450895624214" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:45d2e869fd9ca2ba349709e3128b5308,
+    entity(niiri:3497a1d298e28ded5637bf48b84d5733,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0062" %% xsd:string,
         nidm_coordinateVector: = "[-30,-72,-50]" %% xsd:string])
-    wasDerivedFrom(niiri:617a5f940f4b8fb780b2b0fba6f13c31, niiri:31033e543fb9492bc06e61625ca6b410, -, -, -)
-    entity(niiri:14ae1fa9257e4c53338274fcc108384b,
+    wasDerivedFrom(niiri:5764da2697fce92e5bdd83dfee44f500, niiri:2cb148daa680c4c53ffa5337fb86c905, -, -, -)
+    entity(niiri:3dc749ec7b2f059a8b5376f0602ce80c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0063" %% xsd:string,
-        prov:location = 'niiri:f5920a1ad34f8b842af3e79ef81c8e61',
+        prov:location = 'niiri:53765155d8a469d9d77032055bf2673b',
         prov:value = "1.15287852287292" %% xsd:float,
         nidm_equivalentZStatistic: = "2.15576230673889" %% xsd:float,
         nidm_pValueUncorrected: = "0.0155511150762138" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f5920a1ad34f8b842af3e79ef81c8e61,
+    entity(niiri:53765155d8a469d9d77032055bf2673b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0063" %% xsd:string,
         nidm_coordinateVector: = "[10,6,74]" %% xsd:string])
-    wasDerivedFrom(niiri:14ae1fa9257e4c53338274fcc108384b, niiri:7a8b21e9acaff0531c73c9fe0bfaeb53, -, -, -)
-    entity(niiri:7eb75ab35a0ed1f5c8a184d8d88a9b5c,
+    wasDerivedFrom(niiri:3dc749ec7b2f059a8b5376f0602ce80c, niiri:1d84285e01d49d904f7b5e9f0333287b, -, -, -)
+    entity(niiri:494fcc7b0e2ed566e5f8a2478f2485a1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0064" %% xsd:string,
-        prov:location = 'niiri:7e6b90a96f7d814724fd0f217cbe1716',
+        prov:location = 'niiri:c5a39b376cec940e5b6f5e749210ca95',
         prov:value = "1.14964759349823" %% xsd:float,
         nidm_equivalentZStatistic: = "2.15158817513994" %% xsd:float,
         nidm_pValueUncorrected: = "0.0157149021414998" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7e6b90a96f7d814724fd0f217cbe1716,
+    entity(niiri:c5a39b376cec940e5b6f5e749210ca95,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0064" %% xsd:string,
         nidm_coordinateVector: = "[-40,48,22]" %% xsd:string])
-    wasDerivedFrom(niiri:7eb75ab35a0ed1f5c8a184d8d88a9b5c, niiri:5102964768a1c4313f8c0e48d48f8b40, -, -, -)
-    entity(niiri:23a04d6d64ae1555176652a69477cb6e,
+    wasDerivedFrom(niiri:494fcc7b0e2ed566e5f8a2478f2485a1, niiri:8cb6b321e3922f27346febc1c617df72, -, -, -)
+    entity(niiri:761a60caff966c3e9100c61d125e846c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0065" %% xsd:string,
-        prov:location = 'niiri:ceee7ccdc7c470b175dedd001c1ea7f6',
+        prov:location = 'niiri:d9c29a8c9776b18525935ece2a275428',
         prov:value = "1.14813911914825" %% xsd:float,
         nidm_equivalentZStatistic: = "2.14963956628403" %% xsd:float,
         nidm_pValueUncorrected: = "0.0157918680840622" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ceee7ccdc7c470b175dedd001c1ea7f6,
+    entity(niiri:d9c29a8c9776b18525935ece2a275428,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0065" %% xsd:string,
         nidm_coordinateVector: = "[10,-78,-40]" %% xsd:string])
-    wasDerivedFrom(niiri:23a04d6d64ae1555176652a69477cb6e, niiri:256070c77a58b8b64913a5b6bfb81f60, -, -, -)
-    entity(niiri:cf610736c17264f136dfe0eb89ee2a05,
+    wasDerivedFrom(niiri:761a60caff966c3e9100c61d125e846c, niiri:bd60388f21dba151ffa9b94fc56a76fc, -, -, -)
+    entity(niiri:bed8d5d8fa75f809069ec2833a81f4ea,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0066" %% xsd:string,
-        prov:location = 'niiri:279a6a11962ed1f111fb8d7a02bb5d8a',
+        prov:location = 'niiri:7236907b7bfecfe0ada496a13aa8158d',
         prov:value = "1.14065408706665" %% xsd:float,
         nidm_equivalentZStatistic: = "2.13997280538058" %% xsd:float,
         nidm_pValueUncorrected: = "0.0161784822721924" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:279a6a11962ed1f111fb8d7a02bb5d8a,
+    entity(niiri:7236907b7bfecfe0ada496a13aa8158d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0066" %% xsd:string,
         nidm_coordinateVector: = "[-12,2,70]" %% xsd:string])
-    wasDerivedFrom(niiri:cf610736c17264f136dfe0eb89ee2a05, niiri:96604941a960daa1e224727cb5ba2d60, -, -, -)
-    entity(niiri:515a57e55082e7aaafd8054cc4375e77,
+    wasDerivedFrom(niiri:bed8d5d8fa75f809069ec2833a81f4ea, niiri:2634cefb56e62fe1daef544f6c3dc96a, -, -, -)
+    entity(niiri:c65e794da990db696a73c27b821aa5bb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0067" %% xsd:string,
-        prov:location = 'niiri:fe98447baa6baac51db022671fc048f4',
+        prov:location = 'niiri:c8be43b69b65fd7bd6fcfe9003806301',
         prov:value = "1.1338312625885" %% xsd:float,
         nidm_equivalentZStatistic: = "2.13116451819532" %% xsd:float,
         nidm_pValueUncorrected: = "0.0165377954988448" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:fe98447baa6baac51db022671fc048f4,
+    entity(niiri:c8be43b69b65fd7bd6fcfe9003806301,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0067" %% xsd:string,
         nidm_coordinateVector: = "[22,-18,48]" %% xsd:string])
-    wasDerivedFrom(niiri:515a57e55082e7aaafd8054cc4375e77, niiri:529af4aecda9065e5cce8adf4cdfd5c6, -, -, -)
-    entity(niiri:7d5fd522914b718d895ca04f556b7437,
+    wasDerivedFrom(niiri:c65e794da990db696a73c27b821aa5bb, niiri:eaf17770fa04ac0e839b538c792a3073, -, -, -)
+    entity(niiri:c5fe85ea37711b9210d10755ac8c11e1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0068" %% xsd:string,
-        prov:location = 'niiri:966a95b3241bbaf0d187fd1e341c79bf',
+        prov:location = 'niiri:e2973e9fea14c5a99804e786bf6fc076',
         prov:value = "1.11546647548676" %% xsd:float,
         nidm_equivalentZStatistic: = "2.10747127106409" %% xsd:float,
         nidm_pValueUncorrected: = "0.0175383747043093" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:966a95b3241bbaf0d187fd1e341c79bf,
+    entity(niiri:e2973e9fea14c5a99804e786bf6fc076,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0068" %% xsd:string,
         nidm_coordinateVector: = "[30,-18,16]" %% xsd:string])
-    wasDerivedFrom(niiri:7d5fd522914b718d895ca04f556b7437, niiri:bdef3fee2464d33f021c131ff78646c7, -, -, -)
-    entity(niiri:3eefe07ca12961dd4d03965206e8cb06,
+    wasDerivedFrom(niiri:c5fe85ea37711b9210d10755ac8c11e1, niiri:79667c98e94d775596ecebd364219144, -, -, -)
+    entity(niiri:8ac8469c9dcf83f4841a272192fc0c34,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0069" %% xsd:string,
-        prov:location = 'niiri:a233e11baaca31ed80be42d76e85c346',
+        prov:location = 'niiri:2b70ceb182df8bebc9f8c76761a4cc1a',
         prov:value = "1.11363661289215" %% xsd:float,
         nidm_equivalentZStatistic: = "2.10511176477938" %% xsd:float,
         nidm_pValueUncorrected: = "0.0176407901931581" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a233e11baaca31ed80be42d76e85c346,
+    entity(niiri:2b70ceb182df8bebc9f8c76761a4cc1a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0069" %% xsd:string,
         nidm_coordinateVector: = "[16,2,56]" %% xsd:string])
-    wasDerivedFrom(niiri:3eefe07ca12961dd4d03965206e8cb06, niiri:e8088392c69eb956afef92cedfa6aeb4, -, -, -)
-    entity(niiri:ec714042c4c04e8a27fea498c29a9f63,
+    wasDerivedFrom(niiri:8ac8469c9dcf83f4841a272192fc0c34, niiri:a9ca1d216068df228b4f56edb8974b0f, -, -, -)
+    entity(niiri:998f850a75eb862538438d7c67c9746f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0070" %% xsd:string,
-        prov:location = 'niiri:9467ed32fd2aaef55d31182b82d68662',
+        prov:location = 'niiri:66e6a864e1379db647d5020c3ede2fa8',
         prov:value = "1.10444390773773" %% xsd:float,
         nidm_equivalentZStatistic: = "2.09326187305734" %% xsd:float,
         nidm_pValueUncorrected: = "0.0181628920812176" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9467ed32fd2aaef55d31182b82d68662,
+    entity(niiri:66e6a864e1379db647d5020c3ede2fa8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0070" %% xsd:string,
         nidm_coordinateVector: = "[-32,-52,14]" %% xsd:string])
-    wasDerivedFrom(niiri:ec714042c4c04e8a27fea498c29a9f63, niiri:8b4322c153a15066be2583d11b23925c, -, -, -)
-    entity(niiri:b5ad2afffcf7769dff075c2ad1bcfb1d,
+    wasDerivedFrom(niiri:998f850a75eb862538438d7c67c9746f, niiri:8bd946eb61909b953aeda01719f94d66, -, -, -)
+    entity(niiri:b14ce44894b188593156f60c6d6febea,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0071" %% xsd:string,
-        prov:location = 'niiri:1e589a760119fa51b33a0aee5879a1c9',
+        prov:location = 'niiri:429f05522c8c9ea8849a7f284cabadfc',
         prov:value = "1.01987111568451" %% xsd:float,
         nidm_equivalentZStatistic: = "1.98454402904349" %% xsd:float,
         nidm_pValueUncorrected: = "0.0235976124289208" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:1e589a760119fa51b33a0aee5879a1c9,
+    entity(niiri:429f05522c8c9ea8849a7f284cabadfc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0071" %% xsd:string,
         nidm_coordinateVector: = "[-32,-60,18]" %% xsd:string])
-    wasDerivedFrom(niiri:b5ad2afffcf7769dff075c2ad1bcfb1d, niiri:8b4322c153a15066be2583d11b23925c, -, -, -)
-    entity(niiri:82ce4d65f10bc5c571a676520fb3526a,
+    wasDerivedFrom(niiri:b14ce44894b188593156f60c6d6febea, niiri:8bd946eb61909b953aeda01719f94d66, -, -, -)
+    entity(niiri:360dab51259c713e829b994ba8824f4f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0072" %% xsd:string,
-        prov:location = 'niiri:7edb55b74d2a34760e50cf1502d58c54',
+        prov:location = 'niiri:da24a94414680a235f8c03368fc7a6fa',
         prov:value = "0.951668322086334" %% xsd:float,
         nidm_equivalentZStatistic: = "1.89731313030669" %% xsd:float,
         nidm_pValueUncorrected: = "0.0288933115272303" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7edb55b74d2a34760e50cf1502d58c54,
+    entity(niiri:da24a94414680a235f8c03368fc7a6fa,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0072" %% xsd:string,
         nidm_coordinateVector: = "[-24,-50,20]" %% xsd:string])
-    wasDerivedFrom(niiri:82ce4d65f10bc5c571a676520fb3526a, niiri:8b4322c153a15066be2583d11b23925c, -, -, -)
-    entity(niiri:51c84dd2b7a652dbbe29eec2ec10da45,
+    wasDerivedFrom(niiri:360dab51259c713e829b994ba8824f4f, niiri:8bd946eb61909b953aeda01719f94d66, -, -, -)
+    entity(niiri:e5475d3cadc57811178268faabdde254,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0073" %% xsd:string,
-        prov:location = 'niiri:42bd98c846ed3e6b2f8267e9e359b51c',
+        prov:location = 'niiri:b09818ac6236576063ffd0e16d44009e',
         prov:value = "1.10060369968414" %% xsd:float,
         nidm_equivalentZStatistic: = "2.08831343102831" %% xsd:float,
         nidm_pValueUncorrected: = "0.0183847853440164" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:42bd98c846ed3e6b2f8267e9e359b51c,
+    entity(niiri:b09818ac6236576063ffd0e16d44009e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0073" %% xsd:string,
         nidm_coordinateVector: = "[10,50,18]" %% xsd:string])
-    wasDerivedFrom(niiri:51c84dd2b7a652dbbe29eec2ec10da45, niiri:0c0e48a110ec2c20b75585b9e5372d67, -, -, -)
-    entity(niiri:4c431af959a928867e01e3773e1b88b0,
+    wasDerivedFrom(niiri:e5475d3cadc57811178268faabdde254, niiri:e49222f43a2c5f3b6f74b9eb9a47bd2f, -, -, -)
+    entity(niiri:e8319110e20edbd00beee44e2faa7150,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0074" %% xsd:string,
-        prov:location = 'niiri:84ebd2f1bc394a77f0212ac8234096da',
+        prov:location = 'niiri:416e73485c421b4f8e221cd6755977d2',
         prov:value = "1.09576165676117" %% xsd:float,
         nidm_equivalentZStatistic: = "2.08207556282094" %% xsd:float,
         nidm_pValueUncorrected: = "0.0186677841332979" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:84ebd2f1bc394a77f0212ac8234096da,
+    entity(niiri:416e73485c421b4f8e221cd6755977d2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0074" %% xsd:string,
         nidm_coordinateVector: = "[-46,6,34]" %% xsd:string])
-    wasDerivedFrom(niiri:4c431af959a928867e01e3773e1b88b0, niiri:1bf866f2d8a1a832a120aa9c02c60efd, -, -, -)
-    entity(niiri:35a5c8c115f0abfbfa3d921633f364a7,
+    wasDerivedFrom(niiri:e8319110e20edbd00beee44e2faa7150, niiri:cccc8624875aafd03105dd4bd6af0ac3, -, -, -)
+    entity(niiri:a7f5bb980c1234c0b6a4202a36c25405,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0075" %% xsd:string,
-        prov:location = 'niiri:3018cf0b63274458035abe5fb99ee859',
+        prov:location = 'niiri:3e607638a1673e2c3095f2dc73f95698',
         prov:value = "1.09575474262238" %% xsd:float,
         nidm_equivalentZStatistic: = "2.08206665675352" %% xsd:float,
         nidm_pValueUncorrected: = "0.0186681908185171" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:3018cf0b63274458035abe5fb99ee859,
+    entity(niiri:3e607638a1673e2c3095f2dc73f95698,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0075" %% xsd:string,
         nidm_coordinateVector: = "[28,-8,70]" %% xsd:string])
-    wasDerivedFrom(niiri:35a5c8c115f0abfbfa3d921633f364a7, niiri:a44aefad34ca2359e69bf6f9306bc2c6, -, -, -)
-    entity(niiri:d9f041fefa100fdb8132c7a4b6108de0,
+    wasDerivedFrom(niiri:a7f5bb980c1234c0b6a4202a36c25405, niiri:c163699e2c590670b56fd1928fe502a8, -, -, -)
+    entity(niiri:df76b0971b4b5de66f8c278de97ee3c7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0076" %% xsd:string,
-        prov:location = 'niiri:b4abdf84c2b011481d11ad3d94001873',
+        prov:location = 'niiri:2f8b006298b7ec9f1ed1f7b8311e90ca',
         prov:value = "1.07974576950073" %% xsd:float,
         nidm_equivalentZStatistic: = "2.06145507795256" %% xsd:float,
         nidm_pValueUncorrected: = "0.019629822462089" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b4abdf84c2b011481d11ad3d94001873,
+    entity(niiri:2f8b006298b7ec9f1ed1f7b8311e90ca,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0076" %% xsd:string,
         nidm_coordinateVector: = "[-58,18,30]" %% xsd:string])
-    wasDerivedFrom(niiri:d9f041fefa100fdb8132c7a4b6108de0, niiri:ab78ea55fc7f212636dd2f73bdc99032, -, -, -)
-    entity(niiri:b1760aaa8500b6832a7af07d81d63e5d,
+    wasDerivedFrom(niiri:df76b0971b4b5de66f8c278de97ee3c7, niiri:4824d04f1a3ab526790824f893297a94, -, -, -)
+    entity(niiri:f79befe504bc7cf2d60a0bc41882c1f9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0077" %% xsd:string,
-        prov:location = 'niiri:285bc9cc2ba32db7f5e98cd91fb2cfdc',
+        prov:location = 'niiri:2293ee429f376629915b7d742c9deaa6',
         prov:value = "1.07930290699005" %% xsd:float,
         nidm_equivalentZStatistic: = "2.06088516484109" %% xsd:float,
         nidm_pValueUncorrected: = "0.019656998463677" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:285bc9cc2ba32db7f5e98cd91fb2cfdc,
+    entity(niiri:2293ee429f376629915b7d742c9deaa6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0077" %% xsd:string,
         nidm_coordinateVector: = "[-24,-66,24]" %% xsd:string])
-    wasDerivedFrom(niiri:b1760aaa8500b6832a7af07d81d63e5d, niiri:4128bacb45b84a2304aceeb9a3a06db7, -, -, -)
-    entity(niiri:7e3b976cef84740109d0eb1268357e83,
+    wasDerivedFrom(niiri:f79befe504bc7cf2d60a0bc41882c1f9, niiri:64a8a8faea43eec16f564fc4aaeca53d, -, -, -)
+    entity(niiri:a3c279a10d848e11e97ebef3f2d73123,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0078" %% xsd:string,
-        prov:location = 'niiri:926d256b539273b87002cdf595c1f8fd',
+        prov:location = 'niiri:d154a29c693d212b9dbbe2088571b958',
         prov:value = "1.07559859752655" %% xsd:float,
         nidm_equivalentZStatistic: = "2.05611872869022" %% xsd:float,
         nidm_pValueUncorrected: = "0.0198855367075194" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:926d256b539273b87002cdf595c1f8fd,
+    entity(niiri:d154a29c693d212b9dbbe2088571b958,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0078" %% xsd:string,
         nidm_coordinateVector: = "[34,34,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:7e3b976cef84740109d0eb1268357e83, niiri:282d81c6243a1094abf4c4787764df02, -, -, -)
-    entity(niiri:73165ed86c4c250a74adde2ee20f14b8,
+    wasDerivedFrom(niiri:a3c279a10d848e11e97ebef3f2d73123, niiri:0260356613cbea9c3fd0a42442707965, -, -, -)
+    entity(niiri:35e6e74115a2d1d1ffb378ec9262eeeb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0079" %% xsd:string,
-        prov:location = 'niiri:c0f34ced902e532fff9b867f315ddc89',
+        prov:location = 'niiri:6d90736d00550882400a7cbe20af36fa',
         prov:value = "1.07552266120911" %% xsd:float,
         nidm_equivalentZStatistic: = "2.05602103030259" %% xsd:float,
         nidm_pValueUncorrected: = "0.0198902445740951" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c0f34ced902e532fff9b867f315ddc89,
+    entity(niiri:6d90736d00550882400a7cbe20af36fa,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0079" %% xsd:string,
         nidm_coordinateVector: = "[-32,-10,4]" %% xsd:string])
-    wasDerivedFrom(niiri:73165ed86c4c250a74adde2ee20f14b8, niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb, -, -, -)
-    entity(niiri:9aafe36d107ae7055a61332c58a0078a,
+    wasDerivedFrom(niiri:35e6e74115a2d1d1ffb378ec9262eeeb, niiri:6c858d3255cb0a3570ef36dfad0fb623, -, -, -)
+    entity(niiri:d4c192c1569dc83d9ffdb7912bb5c3c3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0080" %% xsd:string,
-        prov:location = 'niiri:8884d81ec71e104a0c484f8f5375a98f',
+        prov:location = 'niiri:b9ba086df52dccdb9ac91cc8f89c41cf',
         prov:value = "1.06592130661011" %% xsd:float,
         nidm_equivalentZStatistic: = "2.04367166566034" %% xsd:float,
         nidm_pValueUncorrected: = "0.0204929970846689" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8884d81ec71e104a0c484f8f5375a98f,
+    entity(niiri:b9ba086df52dccdb9ac91cc8f89c41cf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0080" %% xsd:string,
         nidm_coordinateVector: = "[8,-70,-18]" %% xsd:string])
-    wasDerivedFrom(niiri:9aafe36d107ae7055a61332c58a0078a, niiri:e58cf8e24a087d5746f02fb59416d367, -, -, -)
-    entity(niiri:05e6dc235f43178bc7d691271ff32879,
+    wasDerivedFrom(niiri:d4c192c1569dc83d9ffdb7912bb5c3c3, niiri:073492dcf968ea0eb583396771e18cab, -, -, -)
+    entity(niiri:5fe5d0e93a3f396e39624e767f2a9a61,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0081" %% xsd:string,
-        prov:location = 'niiri:35353ef550e7b9afa6ef357536b0eef1',
+        prov:location = 'niiri:88daac370d1820736e40f7cdc0e04a89',
         prov:value = "1.05881226062775" %% xsd:float,
         nidm_equivalentZStatistic: = "2.03453256202328" %% xsd:float,
         nidm_pValueUncorrected: = "0.0209489644915043" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:35353ef550e7b9afa6ef357536b0eef1,
+    entity(niiri:88daac370d1820736e40f7cdc0e04a89,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0081" %% xsd:string,
         nidm_coordinateVector: = "[18,-56,74]" %% xsd:string])
-    wasDerivedFrom(niiri:05e6dc235f43178bc7d691271ff32879, niiri:47a95f63466991d3e681c4886347a76b, -, -, -)
-    entity(niiri:9dcb3cd8472b6b25eb1fbcfcb93000f6,
+    wasDerivedFrom(niiri:5fe5d0e93a3f396e39624e767f2a9a61, niiri:780d9b79f072e4bd50e8f0325a0fab9c, -, -, -)
+    entity(niiri:42a52210a53d06ae32d6780e566dd401,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0082" %% xsd:string,
-        prov:location = 'niiri:f3eeefc4c0d3dd27751aef22dbdb7c8c',
+        prov:location = 'niiri:28efcf6e1b05b157050c26f376336d49',
         prov:value = "1.05682730674744" %% xsd:float,
         nidm_equivalentZStatistic: = "2.03198149751153" %% xsd:float,
         nidm_pValueUncorrected: = "0.0210777645475412" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f3eeefc4c0d3dd27751aef22dbdb7c8c,
+    entity(niiri:28efcf6e1b05b157050c26f376336d49,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0082" %% xsd:string,
         nidm_coordinateVector: = "[28,-2,6]" %% xsd:string])
-    wasDerivedFrom(niiri:9dcb3cd8472b6b25eb1fbcfcb93000f6, niiri:6a2d34c94894023a09a46d7ba699025b, -, -, -)
-    entity(niiri:e9806207a16169f3be4d10f35b194c85,
+    wasDerivedFrom(niiri:42a52210a53d06ae32d6780e566dd401, niiri:81f84bc9b5b654bad34cdaaac10ba1b6, -, -, -)
+    entity(niiri:ad76f527b91ba78b206d32c7f100894a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0083" %% xsd:string,
-        prov:location = 'niiri:766104bfba8f24878b83241025cb8ce1',
+        prov:location = 'niiri:335dcb194bd2015598fc3583680cdbc3',
         prov:value = "1.05488443374634" %% xsd:float,
         nidm_equivalentZStatistic: = "2.02948481888272" %% xsd:float,
         nidm_pValueUncorrected: = "0.0212044668522343" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:766104bfba8f24878b83241025cb8ce1,
+    entity(niiri:335dcb194bd2015598fc3583680cdbc3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0083" %% xsd:string,
         nidm_coordinateVector: = "[12,-58,-26]" %% xsd:string])
-    wasDerivedFrom(niiri:e9806207a16169f3be4d10f35b194c85, niiri:6ac7ce35dfb3dcf2c2696278c805c40a, -, -, -)
-    entity(niiri:6c0046aab9a8b299190ccc8aaedee47d,
+    wasDerivedFrom(niiri:ad76f527b91ba78b206d32c7f100894a, niiri:90a20d94dc8e450298e631ead963f32b, -, -, -)
+    entity(niiri:c79e2a88c4292efb789de4859de56d08,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0084" %% xsd:string,
-        prov:location = 'niiri:d186aa78992fc5d9cfe80768c6680e50',
+        prov:location = 'niiri:6a17b23b0a6d433f3dfc23c8c524da9a',
         prov:value = "1.05219066143036" %% xsd:float,
         nidm_equivalentZStatistic: = "2.02602370012315" %% xsd:float,
         nidm_pValueUncorrected: = "0.0213811780074668" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d186aa78992fc5d9cfe80768c6680e50,
+    entity(niiri:6a17b23b0a6d433f3dfc23c8c524da9a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0084" %% xsd:string,
         nidm_coordinateVector: = "[46,-60,-36]" %% xsd:string])
-    wasDerivedFrom(niiri:6c0046aab9a8b299190ccc8aaedee47d, niiri:60e118fd5205eaa96f4b55808761eaf7, -, -, -)
-    entity(niiri:08ed1b983e3a1203b8770d31cb409572,
+    wasDerivedFrom(niiri:c79e2a88c4292efb789de4859de56d08, niiri:f95655c375074857b8c6e69cc5aafd0f, -, -, -)
+    entity(niiri:ebd4a27d8bf566022e64d373894404d5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0085" %% xsd:string,
-        prov:location = 'niiri:c6cce78c32c1be7e581a855e903919a1',
+        prov:location = 'niiri:de95505d9e319af70e99cce4b0dbc76b',
         prov:value = "1.02921843528748" %% xsd:float,
         nidm_equivalentZStatistic: = "1.9965316371229" %% xsd:float,
         nidm_pValueUncorrected: = "0.0229380428256576" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c6cce78c32c1be7e581a855e903919a1,
+    entity(niiri:de95505d9e319af70e99cce4b0dbc76b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0085" %% xsd:string,
         nidm_coordinateVector: = "[56,10,22]" %% xsd:string])
-    wasDerivedFrom(niiri:08ed1b983e3a1203b8770d31cb409572, niiri:afff6750152337d325f510f877cd2b9c, -, -, -)
-    entity(niiri:c3a91a1145ae795e0275567c7afd4153,
+    wasDerivedFrom(niiri:ebd4a27d8bf566022e64d373894404d5, niiri:af7629a171a38e8e209c4bfe5f604c75, -, -, -)
+    entity(niiri:f5915df818a315f89559dab93e544fc7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0086" %% xsd:string,
-        prov:location = 'niiri:3f578a0866ace4a3d5417fd1bda419bc',
+        prov:location = 'niiri:dba053991ca17c094fb424c234b541eb',
         prov:value = "1.02376317977905" %% xsd:float,
         nidm_equivalentZStatistic: = "1.98953456023084" %% xsd:float,
         nidm_pValueUncorrected: = "0.0233211155368704" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:3f578a0866ace4a3d5417fd1bda419bc,
+    entity(niiri:dba053991ca17c094fb424c234b541eb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0086" %% xsd:string,
         nidm_coordinateVector: = "[48,-40,48]" %% xsd:string])
-    wasDerivedFrom(niiri:c3a91a1145ae795e0275567c7afd4153, niiri:c87d05b7d28080150c45409119a926f8, -, -, -)
-    entity(niiri:b4d3685e07ada48df1c6167a6925950e,
+    wasDerivedFrom(niiri:f5915df818a315f89559dab93e544fc7, niiri:327ebdb7a1236038ee0a1c3dd96e5874, -, -, -)
+    entity(niiri:7bb7989b699ac7fa7008bbe5bb854acc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0087" %% xsd:string,
-        prov:location = 'niiri:795be4dc59029fec477cb821024b0305',
+        prov:location = 'niiri:dcbbded9fea2dd6b1364026922e60cfb',
         prov:value = "1.01926970481873" %% xsd:float,
         nidm_equivalentZStatistic: = "1.98377299631032" %% xsd:float,
         nidm_pValueUncorrected: = "0.0236405758837211" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:795be4dc59029fec477cb821024b0305,
+    entity(niiri:dcbbded9fea2dd6b1364026922e60cfb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0087" %% xsd:string,
         nidm_coordinateVector: = "[-6,-74,6]" %% xsd:string])
-    wasDerivedFrom(niiri:b4d3685e07ada48df1c6167a6925950e, niiri:f1bb918000bbcdd8562fb7b7887a394d, -, -, -)
-    entity(niiri:f80228783e894278ef084da2baf7ed31,
+    wasDerivedFrom(niiri:7bb7989b699ac7fa7008bbe5bb854acc, niiri:383ee7c40b6e148981f60c5244bc24eb, -, -, -)
+    entity(niiri:1ad10c296ccb6b3d01aa87dc5249331a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0088" %% xsd:string,
-        prov:location = 'niiri:2ca83eae786b7fda7e22a5a70371af3d',
+        prov:location = 'niiri:32f775be0b42ac144b9528fceeae29e1',
         prov:value = "1.01770269870758" %% xsd:float,
         nidm_equivalentZStatistic: = "1.9817641782018" %% xsd:float,
         nidm_pValueUncorrected: = "0.0237528202287247" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2ca83eae786b7fda7e22a5a70371af3d,
+    entity(niiri:32f775be0b42ac144b9528fceeae29e1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0088" %% xsd:string,
         nidm_coordinateVector: = "[20,60,-18]" %% xsd:string])
-    wasDerivedFrom(niiri:f80228783e894278ef084da2baf7ed31, niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c, -, -, -)
-    entity(niiri:d9eeefbbebdab2ca09c4160ffbf3de45,
+    wasDerivedFrom(niiri:1ad10c296ccb6b3d01aa87dc5249331a, niiri:7f19917cc657f479955495d0706a5e07, -, -, -)
+    entity(niiri:d1fe1137f09b0626f4c83b9eddcb166a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0089" %% xsd:string,
-        prov:location = 'niiri:53f418da90a8fac39b172895c357d44a',
+        prov:location = 'niiri:0523fa71436283c95d0ceb61b239edac',
         prov:value = "0.994811475276947" %% xsd:float,
         nidm_equivalentZStatistic: = "1.95244337576045" %% xsd:float,
         nidm_pValueUncorrected: = "0.0254427937463042" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:53f418da90a8fac39b172895c357d44a,
+    entity(niiri:0523fa71436283c95d0ceb61b239edac,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0089" %% xsd:string,
         nidm_coordinateVector: = "[6,-2,60]" %% xsd:string])
-    wasDerivedFrom(niiri:d9eeefbbebdab2ca09c4160ffbf3de45, niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f, -, -, -)
-    entity(niiri:48c043bcf9f7016d4422cd1eb0275f46,
+    wasDerivedFrom(niiri:d1fe1137f09b0626f4c83b9eddcb166a, niiri:df2a03c212f39fc884fa4c74b8f9861f, -, -, -)
+    entity(niiri:d57a6c6df91f1e8ed6c3a2ec9c71f15d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0090" %% xsd:string,
-        prov:location = 'niiri:6077c53ec3ce7550b6798aee6404ca8b',
+        prov:location = 'niiri:350ed7a0adbfad41ab7bf60ddf292e4f',
         prov:value = "0.99255907535553" %% xsd:float,
         nidm_equivalentZStatistic: = "1.94956085899435" %% xsd:float,
         nidm_pValueUncorrected: = "0.0256142412083677" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6077c53ec3ce7550b6798aee6404ca8b,
+    entity(niiri:350ed7a0adbfad41ab7bf60ddf292e4f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0090" %% xsd:string,
         nidm_coordinateVector: = "[10,-42,48]" %% xsd:string])
-    wasDerivedFrom(niiri:48c043bcf9f7016d4422cd1eb0275f46, niiri:9e7cd816ef42776bf358bfe67f08f014, -, -, -)
-    entity(niiri:3cfe0ff468e6f850a19584472f45a4ca,
+    wasDerivedFrom(niiri:d57a6c6df91f1e8ed6c3a2ec9c71f15d, niiri:d2f081110d405da4d574363c2c229683, -, -, -)
+    entity(niiri:276f0c85068fe253b02d9c93aff123ac,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0091" %% xsd:string,
-        prov:location = 'niiri:64683e1e79d133f97706c9c14ce1de9a',
+        prov:location = 'niiri:8c385aab9767fb464d437e8b648f313b',
         prov:value = "0.984159111976624" %% xsd:float,
         nidm_equivalentZStatistic: = "1.93881506095718" %% xsd:float,
         nidm_pValueUncorrected: = "0.0262619307677786" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:64683e1e79d133f97706c9c14ce1de9a,
+    entity(niiri:8c385aab9767fb464d437e8b648f313b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0091" %% xsd:string,
         nidm_coordinateVector: = "[44,-2,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:3cfe0ff468e6f850a19584472f45a4ca, niiri:712375a17d0ff43c9dca459517dff9b2, -, -, -)
-    entity(niiri:4cbbdabb6d9ca2894ccd7d8bf83c4b92,
+    wasDerivedFrom(niiri:276f0c85068fe253b02d9c93aff123ac, niiri:a9fda50c3e4479f40fb3419e04ad60e2, -, -, -)
+    entity(niiri:3062094ae125936adc6f8e1677e03e37,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0092" %% xsd:string,
-        prov:location = 'niiri:057307222fb1d6a12be4aac362eeba79',
+        prov:location = 'niiri:b46169f62390c6f8268b141fcaa6158a',
         prov:value = "0.981177926063538" %% xsd:float,
         nidm_equivalentZStatistic: = "1.93500289088164" %% xsd:float,
         nidm_pValueUncorrected: = "0.0264949704670242" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:057307222fb1d6a12be4aac362eeba79,
+    entity(niiri:b46169f62390c6f8268b141fcaa6158a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0092" %% xsd:string,
         nidm_coordinateVector: = "[-16,-98,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:4cbbdabb6d9ca2894ccd7d8bf83c4b92, niiri:feddd730f38d65d4f1fd0e8616bcc9a5, -, -, -)
-    entity(niiri:a8d461e1b05a579974c9fa442ca95335,
+    wasDerivedFrom(niiri:3062094ae125936adc6f8e1677e03e37, niiri:2bc33575bac46d2c46e0ab7793110244, -, -, -)
+    entity(niiri:2f981e6bb474e96b3ff279ee010df619,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0093" %% xsd:string,
-        prov:location = 'niiri:f56cb3f0f78382ca1667d4c9cb2a5fa9',
+        prov:location = 'niiri:f2652fba249b9e66acb7995fdac6415d',
         prov:value = "0.979127943515778" %% xsd:float,
         nidm_equivalentZStatistic: = "1.93238197004834" %% xsd:float,
         nidm_pValueUncorrected: = "0.026656188878889" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f56cb3f0f78382ca1667d4c9cb2a5fa9,
+    entity(niiri:f2652fba249b9e66acb7995fdac6415d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0093" %% xsd:string,
         nidm_coordinateVector: = "[18,-54,-16]" %% xsd:string])
-    wasDerivedFrom(niiri:a8d461e1b05a579974c9fa442ca95335, niiri:8041bc77682f50b65136018ca10c889c, -, -, -)
-    entity(niiri:422e9504c658a0894198e2bc2af7dc45,
+    wasDerivedFrom(niiri:2f981e6bb474e96b3ff279ee010df619, niiri:ddb629f82c3dbdee2cea3fa27c6ff935, -, -, -)
+    entity(niiri:7731dd838fe87d9cc58300c17db9fc02,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0094" %% xsd:string,
-        prov:location = 'niiri:85068ba7ad3e2344be6218dbd67be2d4',
+        prov:location = 'niiri:8348066e2ea0d600e90b3c5790500bbd',
         prov:value = "0.971426725387573" %% xsd:float,
         nidm_equivalentZStatistic: = "1.92253941721557" %% xsd:float,
         nidm_pValueUncorrected: = "0.0272689593644924" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:85068ba7ad3e2344be6218dbd67be2d4,
+    entity(niiri:8348066e2ea0d600e90b3c5790500bbd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0094" %% xsd:string,
         nidm_coordinateVector: = "[4,60,38]" %% xsd:string])
-    wasDerivedFrom(niiri:422e9504c658a0894198e2bc2af7dc45, niiri:e852e949acffc71ed6cce677c7be19d6, -, -, -)
-    entity(niiri:5f72f791f7614242b4b6ad4e858c999a,
+    wasDerivedFrom(niiri:7731dd838fe87d9cc58300c17db9fc02, niiri:caa42f603185cae01bb9beafa64dc995, -, -, -)
+    entity(niiri:346bb89a5cb51ea237c8d4e3ae61e598,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0095" %% xsd:string,
-        prov:location = 'niiri:dbc6a1f63f9fa825746e17ef6fa5f72a',
+        prov:location = 'niiri:b57aec85d53cee2b2f7e6a1394ca5271',
         prov:value = "0.967807769775391" %% xsd:float,
         nidm_equivalentZStatistic: = "1.91791614515868" %% xsd:float,
         nidm_pValueUncorrected: = "0.0275608223501947" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:dbc6a1f63f9fa825746e17ef6fa5f72a,
+    entity(niiri:b57aec85d53cee2b2f7e6a1394ca5271,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0095" %% xsd:string,
         nidm_coordinateVector: = "[20,18,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:5f72f791f7614242b4b6ad4e858c999a, niiri:0d099ee69c96416336f843fd890da4a0, -, -, -)
-    entity(niiri:de1fef4fc7d400efc2f44d0c30039c86,
+    wasDerivedFrom(niiri:346bb89a5cb51ea237c8d4e3ae61e598, niiri:c445a9fb8be8c80d5df620717862bf5f, -, -, -)
+    entity(niiri:0b3f328e53640174c17e513ebc52cc58,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0096" %% xsd:string,
-        prov:location = 'niiri:c12b5e9466736ae0a4035530d53f806a',
+        prov:location = 'niiri:758f735a56d8fbaac97129a45913bc0d',
         prov:value = "0.959724724292755" %% xsd:float,
         nidm_equivalentZStatistic: = "1.90759446601654" %% xsd:float,
         nidm_pValueUncorrected: = "0.0282218254783678" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c12b5e9466736ae0a4035530d53f806a,
+    entity(niiri:758f735a56d8fbaac97129a45913bc0d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0096" %% xsd:string,
         nidm_coordinateVector: = "[30,-32,10]" %% xsd:string])
-    wasDerivedFrom(niiri:de1fef4fc7d400efc2f44d0c30039c86, niiri:6d0ee7f5877dfa2620f95f47e06e2a9a, -, -, -)
-    entity(niiri:b8e4a8666a562187b667fd0000d52335,
+    wasDerivedFrom(niiri:0b3f328e53640174c17e513ebc52cc58, niiri:44518bfa6ffcd022c48e2ccb2c04ed0a, -, -, -)
+    entity(niiri:cd3217ce17598e712e7491aeb85abdf0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0097" %% xsd:string,
-        prov:location = 'niiri:bfa0701f0eb2a5270ae3e9b16ebfc296',
+        prov:location = 'niiri:3855635f168a3bdaaaee9486acb9a661',
         prov:value = "0.957907795906067" %% xsd:float,
         nidm_equivalentZStatistic: = "1.90527520238565" %% xsd:float,
         nidm_pValueUncorrected: = "0.0283721535699227" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:bfa0701f0eb2a5270ae3e9b16ebfc296,
+    entity(niiri:3855635f168a3bdaaaee9486acb9a661,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0097" %% xsd:string,
         nidm_coordinateVector: = "[10,12,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:b8e4a8666a562187b667fd0000d52335, niiri:6ab419381418bd7fca0cb5bac6782b77, -, -, -)
-    entity(niiri:d331e521291249d8ba1e2d26ee0d6359,
+    wasDerivedFrom(niiri:cd3217ce17598e712e7491aeb85abdf0, niiri:82a21597b08e98aa671123ebbede6579, -, -, -)
+    entity(niiri:ef3f68546abf3df170c641c28001dd1a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0098" %% xsd:string,
-        prov:location = 'niiri:2b7cd0cd9952e2971cceba9068ca4224',
+        prov:location = 'niiri:50283c7f660364e245a75b11e6636fea',
         prov:value = "0.95493882894516" %% xsd:float,
         nidm_equivalentZStatistic: = "1.90148608420821" %% xsd:float,
         nidm_pValueUncorrected: = "0.0286191867597474" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2b7cd0cd9952e2971cceba9068ca4224,
+    entity(niiri:50283c7f660364e245a75b11e6636fea,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0098" %% xsd:string,
         nidm_coordinateVector: = "[-26,-94,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:d331e521291249d8ba1e2d26ee0d6359, niiri:b19325ccb6192dba58545cbeb7bc92e1, -, -, -)
-    entity(niiri:8d11278149ef3ed6c1be32712cecb870,
+    wasDerivedFrom(niiri:ef3f68546abf3df170c641c28001dd1a, niiri:15cc5ee45c7553094b172ffcbfc6a579, -, -, -)
+    entity(niiri:43c393bbdc2304cbf9d4016430aa4598,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0099" %% xsd:string,
-        prov:location = 'niiri:444c6e0d2d8dae8e91a8b6fec5449cd8',
+        prov:location = 'niiri:bb6687543dca84c795dbc87e991f59e4',
         prov:value = "0.950750410556793" %% xsd:float,
         nidm_equivalentZStatistic: = "1.89614212461773" %% xsd:float,
         nidm_pValueUncorrected: = "0.0289706268368529" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:444c6e0d2d8dae8e91a8b6fec5449cd8,
+    entity(niiri:bb6687543dca84c795dbc87e991f59e4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0099" %% xsd:string,
         nidm_coordinateVector: = "[-50,-18,0]" %% xsd:string])
-    wasDerivedFrom(niiri:8d11278149ef3ed6c1be32712cecb870, niiri:745fe95a68372701f2888393e817a23e, -, -, -)
-    entity(niiri:2c0d2607032810a81675ff4225065850,
+    wasDerivedFrom(niiri:43c393bbdc2304cbf9d4016430aa4598, niiri:ff736f05be57ac9dd4cfdb8776f08af9, -, -, -)
+    entity(niiri:cf51c47582d2b2b05386f382a3d21c63,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0100" %% xsd:string,
-        prov:location = 'niiri:3e68989f6a6b2152794e95703c55559c',
+        prov:location = 'niiri:599a85124187847d9c9c19579e6b2646',
         prov:value = "0.949834227561951" %% xsd:float,
         nidm_equivalentZStatistic: = "1.89497340726092" %% xsd:float,
         nidm_pValueUncorrected: = "0.0290479624174936" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:3e68989f6a6b2152794e95703c55559c,
+    entity(niiri:599a85124187847d9c9c19579e6b2646,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0100" %% xsd:string,
         nidm_coordinateVector: = "[42,36,18]" %% xsd:string])
-    wasDerivedFrom(niiri:2c0d2607032810a81675ff4225065850, niiri:b1a5489610b480473aa63e95806df7d1, -, -, -)
-    entity(niiri:47b2ce9b5be41d91dfa11f100ed3ad82,
+    wasDerivedFrom(niiri:cf51c47582d2b2b05386f382a3d21c63, niiri:08dde0ac9e0d585b26116508762ff9a0, -, -, -)
+    entity(niiri:4dfd61566964ab64b7fa9261c635a341,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0101" %% xsd:string,
-        prov:location = 'niiri:eb5106a605d1357f4af29aa54137b817',
+        prov:location = 'niiri:036505a852d46704d9f5c80f04831b2a',
         prov:value = "0.949459254741669" %% xsd:float,
         nidm_equivalentZStatistic: = "1.89449510188639" %% xsd:float,
         nidm_pValueUncorrected: = "0.0290796619499293" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:eb5106a605d1357f4af29aa54137b817,
+    entity(niiri:036505a852d46704d9f5c80f04831b2a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0101" %% xsd:string,
         nidm_coordinateVector: = "[46,-78,16]" %% xsd:string])
-    wasDerivedFrom(niiri:47b2ce9b5be41d91dfa11f100ed3ad82, niiri:f6763487f8266f7e66acb49862c0bfa1, -, -, -)
-    entity(niiri:bffc483b3f0c4050ac78cd4ff4a4338e,
+    wasDerivedFrom(niiri:4dfd61566964ab64b7fa9261c635a341, niiri:0571f33be5ada80ea4b8808edaa7d20b, -, -, -)
+    entity(niiri:c2126c0dd023e90eef0335f2fc52f7f4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0102" %% xsd:string,
-        prov:location = 'niiri:0cf2044fea597c136be141a7d8a4de31',
+        prov:location = 'niiri:775577aaed49524eee4f16b91353fbac',
         prov:value = "0.942987263202667" %% xsd:float,
         nidm_equivalentZStatistic: = "1.88624180999136" %% xsd:float,
         nidm_pValueUncorrected: = "0.0296311883673402" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0cf2044fea597c136be141a7d8a4de31,
+    entity(niiri:775577aaed49524eee4f16b91353fbac,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0102" %% xsd:string,
         nidm_coordinateVector: = "[-52,40,8]" %% xsd:string])
-    wasDerivedFrom(niiri:bffc483b3f0c4050ac78cd4ff4a4338e, niiri:f1b9cbe1f5cc757318e116f47537c68e, -, -, -)
-    entity(niiri:b2f0952d4932beebb348b8767e1b15d6,
+    wasDerivedFrom(niiri:c2126c0dd023e90eef0335f2fc52f7f4, niiri:1ff90dcabb7242c8b1f78b63e5c5f98e, -, -, -)
+    entity(niiri:ff903cea33e06ff766789de7140112dc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0103" %% xsd:string,
-        prov:location = 'niiri:7bb01c321a9f81f207675da840baca24',
+        prov:location = 'niiri:444609ca222121a7843273bd2c36928c',
         prov:value = "0.937418699264526" %% xsd:float,
         nidm_equivalentZStatistic: = "1.87914396799602" %% xsd:float,
         nidm_pValueUncorrected: = "0.0301124189915838" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7bb01c321a9f81f207675da840baca24,
+    entity(niiri:444609ca222121a7843273bd2c36928c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0103" %% xsd:string,
         nidm_coordinateVector: = "[-12,42,48]" %% xsd:string])
-    wasDerivedFrom(niiri:b2f0952d4932beebb348b8767e1b15d6, niiri:0299ab45ec018b51a01d2a8fe08bf4d0, -, -, -)
-    entity(niiri:6bbcdf18aa971f01e2cb61e2a276a0c1,
+    wasDerivedFrom(niiri:ff903cea33e06ff766789de7140112dc, niiri:fddfbb23e75434759d3265d89c552324, -, -, -)
+    entity(niiri:7fb34d039923fe763e04aeb0c5892346,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0104" %% xsd:string,
-        prov:location = 'niiri:2cce387756fae768863a2b909443a366',
+        prov:location = 'niiri:b0cb3c750ba113e0dc29395267e8927d',
         prov:value = "0.933299362659454" %% xsd:float,
         nidm_equivalentZStatistic: = "1.87389537802186" %% xsd:float,
         nidm_pValueUncorrected: = "0.0304724233227471" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2cce387756fae768863a2b909443a366,
+    entity(niiri:b0cb3c750ba113e0dc29395267e8927d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0104" %% xsd:string,
         nidm_coordinateVector: = "[44,40,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:6bbcdf18aa971f01e2cb61e2a276a0c1, niiri:3bd0b694ec1e521a7072b15be74aa42c, -, -, -)
-    entity(niiri:e76b9afc8d6f8323f6709346e8342328,
+    wasDerivedFrom(niiri:7fb34d039923fe763e04aeb0c5892346, niiri:225e575718bd5f927d7a41b6e9cdd96b, -, -, -)
+    entity(niiri:95559a426e44487074969ba865235e01,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0105" %% xsd:string,
-        prov:location = 'niiri:6b6cd0eb3c448196f54b71c1dba6e4d6',
+        prov:location = 'niiri:c098ca2d9c3ffa6a78302faf76b61c96',
         prov:value = "0.931596636772156" %% xsd:float,
         nidm_equivalentZStatistic: = "1.87172638333963" %% xsd:float,
         nidm_pValueUncorrected: = "0.0306222337565211" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6b6cd0eb3c448196f54b71c1dba6e4d6,
+    entity(niiri:c098ca2d9c3ffa6a78302faf76b61c96,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0105" %% xsd:string,
         nidm_coordinateVector: = "[-20,-74,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:e76b9afc8d6f8323f6709346e8342328, niiri:af9bee597f1e82856f732971c03e4ba5, -, -, -)
-    entity(niiri:731e7e0e8812977914ca201d6ec12be9,
+    wasDerivedFrom(niiri:95559a426e44487074969ba865235e01, niiri:eed1f93c005d2b4525f8eff9003cba5f, -, -, -)
+    entity(niiri:2dd07750a017279a7abffa5eb950bebe,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0106" %% xsd:string,
-        prov:location = 'niiri:b7cc5c0755b7af3c315c2d00ee88a4d2',
+        prov:location = 'niiri:ac52f2233df7136ec2dbaff1d0f4f0d7',
         prov:value = "0.921256303787231" %% xsd:float,
         nidm_equivalentZStatistic: = "1.85856093332641" %% xsd:float,
         nidm_pValueUncorrected: = "0.031544699452275" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b7cc5c0755b7af3c315c2d00ee88a4d2,
+    entity(niiri:ac52f2233df7136ec2dbaff1d0f4f0d7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0106" %% xsd:string,
         nidm_coordinateVector: = "[-10,-26,78]" %% xsd:string])
-    wasDerivedFrom(niiri:731e7e0e8812977914ca201d6ec12be9, niiri:7a01ea3f3b5332ecf281a7f277911529, -, -, -)
-    entity(niiri:d920f5295c82c34ffdb61a212ac97bda,
+    wasDerivedFrom(niiri:2dd07750a017279a7abffa5eb950bebe, niiri:46a2cf3db4d3d8432ee134238328ee7d, -, -, -)
+    entity(niiri:343eddd0b158ae01001ed5a519b906a5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0107" %% xsd:string,
-        prov:location = 'niiri:b9e3cdf7fa9c85cc1bd3ef2b223e5f10',
+        prov:location = 'niiri:4c794f29969754faf39304545d9ed9a8',
         prov:value = "0.913095474243164" %% xsd:float,
         nidm_equivalentZStatistic: = "1.84817837718658" %% xsd:float,
         nidm_pValueUncorrected: = "0.0322882711892066" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b9e3cdf7fa9c85cc1bd3ef2b223e5f10,
+    entity(niiri:4c794f29969754faf39304545d9ed9a8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0107" %% xsd:string,
         nidm_coordinateVector: = "[-22,-34,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:d920f5295c82c34ffdb61a212ac97bda, niiri:8d9244867124b8976a02c802025ebf7a, -, -, -)
-    entity(niiri:60cd8b72aba218010406e59a4d283f22,
+    wasDerivedFrom(niiri:343eddd0b158ae01001ed5a519b906a5, niiri:cb8b7a24533bb98686a08aa454cf3945, -, -, -)
+    entity(niiri:2e550bb4b78ea76d79f4118f9ea5091e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0108" %% xsd:string,
-        prov:location = 'niiri:83348a06a08a490ee2ad27ad5f88b837',
+        prov:location = 'niiri:7c8e057832544f8166b50372b453b020',
         prov:value = "0.910208523273468" %% xsd:float,
         nidm_equivalentZStatistic: = "1.84450717202411" %% xsd:float,
         nidm_pValueUncorrected: = "0.0325546307872665" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:83348a06a08a490ee2ad27ad5f88b837,
+    entity(niiri:7c8e057832544f8166b50372b453b020,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0108" %% xsd:string,
         nidm_coordinateVector: = "[-34,-52,40]" %% xsd:string])
-    wasDerivedFrom(niiri:60cd8b72aba218010406e59a4d283f22, niiri:1acfcd5791fd893baf49e6750646bcbc, -, -, -)
-    entity(niiri:598d2ba06bdf7b67f6b54a339b88c029,
+    wasDerivedFrom(niiri:2e550bb4b78ea76d79f4118f9ea5091e, niiri:ac46f34aa5d674ad08bca4f9e22cea59, -, -, -)
+    entity(niiri:183f025599eb15195c17433da3bba50e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0109" %% xsd:string,
-        prov:location = 'niiri:df28a935119bc1a9fe922acf6abc9791',
+        prov:location = 'niiri:c41e0496eb80d24f4ca478bfc993d607',
         prov:value = "0.909155905246735" %% xsd:float,
         nidm_equivalentZStatistic: = "1.84316882767473" %% xsd:float,
         nidm_pValueUncorrected: = "0.0326521823346975" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:df28a935119bc1a9fe922acf6abc9791,
+    entity(niiri:c41e0496eb80d24f4ca478bfc993d607,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0109" %% xsd:string,
         nidm_coordinateVector: = "[12,-70,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:598d2ba06bdf7b67f6b54a339b88c029, niiri:6bafc27afb06adc8274b4e85b0eb95cc, -, -, -)
-    entity(niiri:a6db2f879c2f570c76c4c4fd60f93003,
+    wasDerivedFrom(niiri:183f025599eb15195c17433da3bba50e, niiri:dafb029bcb559a4294b48405b4710434, -, -, -)
+    entity(niiri:1f1fcde3a8b79f3a49244050d94a15da,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0110" %% xsd:string,
-        prov:location = 'niiri:040670c2a1baf229dd4a840108736964',
+        prov:location = 'niiri:11089bcdb82ac977f5d5ae239b636ce9',
         prov:value = "0.907121956348419" %% xsd:float,
         nidm_equivalentZStatistic: = "1.84058311467862" %% xsd:float,
         nidm_pValueUncorrected: = "0.0328413370266359" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:040670c2a1baf229dd4a840108736964,
+    entity(niiri:11089bcdb82ac977f5d5ae239b636ce9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0110" %% xsd:string,
         nidm_coordinateVector: = "[56,-36,52]" %% xsd:string])
-    wasDerivedFrom(niiri:a6db2f879c2f570c76c4c4fd60f93003, niiri:ee5baff089dc6387c53821c05a9e9154, -, -, -)
-    entity(niiri:069b63564a99aa9ff6d1ddb584fbf1db,
+    wasDerivedFrom(niiri:1f1fcde3a8b79f3a49244050d94a15da, niiri:99ae26cd919bcae015587fcb8e185e68, -, -, -)
+    entity(niiri:eb7839e6ba258340734103354dd2b8b4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0111" %% xsd:string,
-        prov:location = 'niiri:bfd62b4d2231ff667c215ff1fe989844',
+        prov:location = 'niiri:7b86b4f1c392283ae44a1f8806042f1f',
         prov:value = "0.904614567756653" %% xsd:float,
         nidm_equivalentZStatistic: = "1.83739614411337" %% xsd:float,
         nidm_pValueUncorrected: = "0.0330757178223472" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:bfd62b4d2231ff667c215ff1fe989844,
+    entity(niiri:7b86b4f1c392283ae44a1f8806042f1f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0111" %% xsd:string,
         nidm_coordinateVector: = "[36,-54,16]" %% xsd:string])
-    wasDerivedFrom(niiri:069b63564a99aa9ff6d1ddb584fbf1db, niiri:e4e0f746d182d60a55906480bc82791f, -, -, -)
-    entity(niiri:ac8fabc6b095c00007fab8d02fe6ad74,
+    wasDerivedFrom(niiri:eb7839e6ba258340734103354dd2b8b4, niiri:9f9bf96c341750df802f301ac988f4b0, -, -, -)
+    entity(niiri:d260832806e1c25bc3d0d77ae5bf48c5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0112" %% xsd:string,
-        prov:location = 'niiri:fc4540b0a0db5dceda1b71fe564a0d94',
+        prov:location = 'niiri:50b00dbb1eefad016d2ac5427a043778',
         prov:value = "0.902757167816162" %% xsd:float,
         nidm_equivalentZStatistic: = "1.83503576989372" %% xsd:float,
         nidm_pValueUncorrected: = "0.0332501948262349" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:fc4540b0a0db5dceda1b71fe564a0d94,
+    entity(niiri:50b00dbb1eefad016d2ac5427a043778,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0112" %% xsd:string,
         nidm_coordinateVector: = "[14,50,12]" %% xsd:string])
-    wasDerivedFrom(niiri:ac8fabc6b095c00007fab8d02fe6ad74, niiri:07ef8bc1f56adef8bb96bf2e4e871509, -, -, -)
-    entity(niiri:28e9ce4572be1966c1b7c8d5fcec989e,
+    wasDerivedFrom(niiri:d260832806e1c25bc3d0d77ae5bf48c5, niiri:99e2b9de9821018fedc6a02eeea36eff, -, -, -)
+    entity(niiri:1cc2bab8d89be3d79fcdb3439982f4f4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0113" %% xsd:string,
-        prov:location = 'niiri:4b30382d1e4ea48108691076704ac047',
+        prov:location = 'niiri:ff2691dba21009263cbebce34c551c69',
         prov:value = "0.901206791400909" %% xsd:float,
         nidm_equivalentZStatistic: = "1.83306584752486" %% xsd:float,
         nidm_pValueUncorrected: = "0.0333963896408318" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4b30382d1e4ea48108691076704ac047,
+    entity(niiri:ff2691dba21009263cbebce34c551c69,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0113" %% xsd:string,
         nidm_coordinateVector: = "[-10,-70,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:28e9ce4572be1966c1b7c8d5fcec989e, niiri:4909c1eb824545b47aa0943b33200588, -, -, -)
-    entity(niiri:9b95918d4848aaeb3e55a87a62ab7a3e,
+    wasDerivedFrom(niiri:1cc2bab8d89be3d79fcdb3439982f4f4, niiri:19dd8817dc393deb5f3011d30203d171, -, -, -)
+    entity(niiri:3f8ad4b7b6912679ab10b2fb4fd84763,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0114" %% xsd:string,
-        prov:location = 'niiri:fa0cc76b071f87753c14060810d31dfe',
+        prov:location = 'niiri:0d210a5a8d997c4cc1342133bed723a2',
         prov:value = "0.797126054763794" %% xsd:float,
         nidm_equivalentZStatistic: = "1.70146355236453" %% xsd:float,
         nidm_pValueUncorrected: = "0.0444279881500879" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:fa0cc76b071f87753c14060810d31dfe,
+    entity(niiri:0d210a5a8d997c4cc1342133bed723a2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0114" %% xsd:string,
         nidm_coordinateVector: = "[-16,-64,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:9b95918d4848aaeb3e55a87a62ab7a3e, niiri:4909c1eb824545b47aa0943b33200588, -, -, -)
-    entity(niiri:5629d46077dec98c74dfbc8e049ea517,
+    wasDerivedFrom(niiri:3f8ad4b7b6912679ab10b2fb4fd84763, niiri:19dd8817dc393deb5f3011d30203d171, -, -, -)
+    entity(niiri:269952645645cd8baa0eb2f26a246253,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0115" %% xsd:string,
-        prov:location = 'niiri:55609d261623909025c92a20fcf0610b',
+        prov:location = 'niiri:8b9e35fbd9f5fde24d4211d278f00c74',
         prov:value = "0.899936437606812" %% xsd:float,
         nidm_equivalentZStatistic: = "1.83145192034408" %% xsd:float,
         nidm_pValueUncorrected: = "0.0335165588882574" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:55609d261623909025c92a20fcf0610b,
+    entity(niiri:8b9e35fbd9f5fde24d4211d278f00c74,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0115" %% xsd:string,
         nidm_coordinateVector: = "[10,-18,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:5629d46077dec98c74dfbc8e049ea517, niiri:9c28e7c0288f5d8601280d59308426e4, -, -, -)
-    entity(niiri:0a467b6ecf94f5f6b8b6165d58bc65c5,
+    wasDerivedFrom(niiri:269952645645cd8baa0eb2f26a246253, niiri:f578ebe5aa3293c5670125665cd21221, -, -, -)
+    entity(niiri:9eb3d60d7bc801da2ef325b6f1f84772,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0116" %% xsd:string,
-        prov:location = 'niiri:d4bc30138d04a5bbe3454b95ec405b94',
+        prov:location = 'niiri:697e76778687af351371482f7f313f99',
         prov:value = "0.895962595939636" %% xsd:float,
         nidm_equivalentZStatistic: = "1.8264044782252" %% xsd:float,
         nidm_pValueUncorrected: = "0.0338946789087741" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d4bc30138d04a5bbe3454b95ec405b94,
+    entity(niiri:697e76778687af351371482f7f313f99,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0116" %% xsd:string,
         nidm_coordinateVector: = "[-42,-50,-42]" %% xsd:string])
-    wasDerivedFrom(niiri:0a467b6ecf94f5f6b8b6165d58bc65c5, niiri:49c7e8d7404b8a93cc2dc6a52274f6ef, -, -, -)
-    entity(niiri:9d771fa523b8607b56815b45270a4e93,
+    wasDerivedFrom(niiri:9eb3d60d7bc801da2ef325b6f1f84772, niiri:7166aa15d2e2b4eeab50316ce6eb7bff, -, -, -)
+    entity(niiri:e6d56476400c2eda2bb12ea8573a604d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0117" %% xsd:string,
-        prov:location = 'niiri:82448dc2205297fdbefd6f106d891759',
+        prov:location = 'niiri:93b14541b6f6b7bebc32dbe2481caf9f',
         prov:value = "0.893008887767792" %% xsd:float,
         nidm_equivalentZStatistic: = "1.8226539056953" %% xsd:float,
         nidm_pValueUncorrected: = "0.0341779128567976" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:82448dc2205297fdbefd6f106d891759,
+    entity(niiri:93b14541b6f6b7bebc32dbe2481caf9f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0117" %% xsd:string,
         nidm_coordinateVector: = "[-60,-32,46]" %% xsd:string])
-    wasDerivedFrom(niiri:9d771fa523b8607b56815b45270a4e93, niiri:5bc798e43cab1c880a412761cd0dabce, -, -, -)
-    entity(niiri:adb6b0a235ccc5b03f4e7c9f7dad9160,
+    wasDerivedFrom(niiri:e6d56476400c2eda2bb12ea8573a604d, niiri:7c7ff9e10d9ed65989abad6706fb240e, -, -, -)
+    entity(niiri:9117835199b6871927a5258f349f17ef,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0118" %% xsd:string,
-        prov:location = 'niiri:6f9fcf9029f665cf15d3412ed80b3a63',
+        prov:location = 'niiri:b00280726430f31e237be43c95b9cadf',
         prov:value = "0.888202428817749" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81655281460242" %% xsd:float,
         nidm_pValueUncorrected: = "0.0346428070130568" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6f9fcf9029f665cf15d3412ed80b3a63,
+    entity(niiri:b00280726430f31e237be43c95b9cadf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0118" %% xsd:string,
         nidm_coordinateVector: = "[56,-42,24]" %% xsd:string])
-    wasDerivedFrom(niiri:adb6b0a235ccc5b03f4e7c9f7dad9160, niiri:d5f0da3a07b3d47197bf039d8d42b58f, -, -, -)
-    entity(niiri:0024155386338cfcf3a295b23bf9be12,
+    wasDerivedFrom(niiri:9117835199b6871927a5258f349f17ef, niiri:8134a1db611c7f7f2ed9c52d609bd453, -, -, -)
+    entity(niiri:4b50fca0c97d713c79d41fbc1e04e85d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0119" %% xsd:string,
-        prov:location = 'niiri:366db76495f9bc35da783cfa4d85aaad',
+        prov:location = 'niiri:5ead31a014ab6206f353fa4aeb59222f',
         prov:value = "0.886661469936371" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81459734206643" %% xsd:float,
         nidm_pValueUncorrected: = "0.034792905633808" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:366db76495f9bc35da783cfa4d85aaad,
+    entity(niiri:5ead31a014ab6206f353fa4aeb59222f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0119" %% xsd:string,
         nidm_coordinateVector: = "[-34,-90,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:0024155386338cfcf3a295b23bf9be12, niiri:a57d901560addc33f414ddaed9a0c7fb, -, -, -)
-    entity(niiri:8a1311806bb1778b621397b5a41dfd96,
+    wasDerivedFrom(niiri:4b50fca0c97d713c79d41fbc1e04e85d, niiri:8a671f919525c9984fd7a67105748a9d, -, -, -)
+    entity(niiri:534a3ccb005e5e1093fbb4026c43c313,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0120" %% xsd:string,
-        prov:location = 'niiri:b2b9b27d97fee31d70e759096f5c996a',
+        prov:location = 'niiri:4866cdfd47e85855dccc46f53ad50b46',
         prov:value = "0.88604724407196" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81381796560484" %% xsd:float,
         nidm_pValueUncorrected: = "0.0348528778271762" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b2b9b27d97fee31d70e759096f5c996a,
+    entity(niiri:4866cdfd47e85855dccc46f53ad50b46,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0120" %% xsd:string,
         nidm_coordinateVector: = "[-6,-72,-20]" %% xsd:string])
-    wasDerivedFrom(niiri:8a1311806bb1778b621397b5a41dfd96, niiri:01d84a7c8c63b90d178c8c7623156c7d, -, -, -)
-    entity(niiri:e2c16c6d913d0c2d6e9c5d0d27602288,
+    wasDerivedFrom(niiri:534a3ccb005e5e1093fbb4026c43c313, niiri:df8ccdbc007e7b001a7788aa3910f000, -, -, -)
+    entity(niiri:578560195be338aa8ecf191250fb731a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0121" %% xsd:string,
-        prov:location = 'niiri:70af9ae3e7f3d4faa43eb79a9091469f',
+        prov:location = 'niiri:8ab727aa442e8af16f5a419e9cce99bf',
         prov:value = "0.884565353393555" %% xsd:float,
         nidm_equivalentZStatistic: = "1.81193780520014" %% xsd:float,
         nidm_pValueUncorrected: = "0.0349979035410456" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:70af9ae3e7f3d4faa43eb79a9091469f,
+    entity(niiri:8ab727aa442e8af16f5a419e9cce99bf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0121" %% xsd:string,
         nidm_coordinateVector: = "[62,-24,46]" %% xsd:string])
-    wasDerivedFrom(niiri:e2c16c6d913d0c2d6e9c5d0d27602288, niiri:99056f1d754fd9f25d80632f06577e33, -, -, -)
-    entity(niiri:85d9117015506ddb0393f7b060018584,
+    wasDerivedFrom(niiri:578560195be338aa8ecf191250fb731a, niiri:8f423109f6452d8619bfc5cbabbcae4c, -, -, -)
+    entity(niiri:9662c3bacc953b09a8de8d20a89c562c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0122" %% xsd:string,
-        prov:location = 'niiri:a6e58394345941bac6a450ad0153b497',
+        prov:location = 'niiri:8bd961ce1f150069823abeeb7af6d3d4',
         prov:value = "0.882052361965179" %% xsd:float,
         nidm_equivalentZStatistic: = "1.80874999534025" %% xsd:float,
         nidm_pValueUncorrected: = "0.0352449260120304" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a6e58394345941bac6a450ad0153b497,
+    entity(niiri:8bd961ce1f150069823abeeb7af6d3d4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0122" %% xsd:string,
         nidm_coordinateVector: = "[-16,34,12]" %% xsd:string])
-    wasDerivedFrom(niiri:85d9117015506ddb0393f7b060018584, niiri:a0ee8183a98a000be01c4577a35a0d8c, -, -, -)
-    entity(niiri:cbd89dfc1ee38e3c17f96850cd7295e4,
+    wasDerivedFrom(niiri:9662c3bacc953b09a8de8d20a89c562c, niiri:059825f02c7e3a034dd438fe5e192ff5, -, -, -)
+    entity(niiri:3f60e68e7e4cf37d5f2137f9a45555f2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0123" %% xsd:string,
-        prov:location = 'niiri:5741a80cbff4ef218f24ec536bddbc1f',
+        prov:location = 'niiri:98ebc36cf1b3185fdeb2c243b898105d',
         prov:value = "0.878161370754242" %% xsd:float,
         nidm_equivalentZStatistic: = "1.8038155651472" %% xsd:float,
         nidm_pValueUncorrected: = "0.0356301124625072" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5741a80cbff4ef218f24ec536bddbc1f,
+    entity(niiri:98ebc36cf1b3185fdeb2c243b898105d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0123" %% xsd:string,
         nidm_coordinateVector: = "[-20,-46,76]" %% xsd:string])
-    wasDerivedFrom(niiri:cbd89dfc1ee38e3c17f96850cd7295e4, niiri:40c9456923bb7d18a8a4ec203aeea09d, -, -, -)
-    entity(niiri:37d38fb5427bb518c234bcdb93146792,
+    wasDerivedFrom(niiri:3f60e68e7e4cf37d5f2137f9a45555f2, niiri:3da0464bd78bb8c10fbf370ecd7a9476, -, -, -)
+    entity(niiri:7664ae686a3d486e9acec8560806a3c6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0124" %% xsd:string,
-        prov:location = 'niiri:6ba75280f16989f0413cff07c5ae28d4',
+        prov:location = 'niiri:4bbf40a82cf0536de16d095ce55c07f0',
         prov:value = "0.875840246677399" %% xsd:float,
         nidm_equivalentZStatistic: = "1.80087281439492" %% xsd:float,
         nidm_pValueUncorrected: = "0.0358614643888427" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6ba75280f16989f0413cff07c5ae28d4,
+    entity(niiri:4bbf40a82cf0536de16d095ce55c07f0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0124" %% xsd:string,
         nidm_coordinateVector: = "[-40,-6,34]" %% xsd:string])
-    wasDerivedFrom(niiri:37d38fb5427bb518c234bcdb93146792, niiri:3cd64da8230af3c597bfb4e11e589670, -, -, -)
-    entity(niiri:4b5895493ed07bacb9952f039a51b8f6,
+    wasDerivedFrom(niiri:7664ae686a3d486e9acec8560806a3c6, niiri:8f8575f802002ae68576281bb473a96a, -, -, -)
+    entity(niiri:d306012bf92eb74af9b7cecf10a666d1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0125" %% xsd:string,
-        prov:location = 'niiri:0edef54b9fb2741aebc7cda42a57bcf8',
+        prov:location = 'niiri:614801535ffe5f4c55d2531f004ac363',
         prov:value = "0.875353574752808" %% xsd:float,
         nidm_equivalentZStatistic: = "1.80025588397551" %% xsd:float,
         nidm_pValueUncorrected: = "0.0359101216845089" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0edef54b9fb2741aebc7cda42a57bcf8,
+    entity(niiri:614801535ffe5f4c55d2531f004ac363,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0125" %% xsd:string,
         nidm_coordinateVector: = "[-20,-12,8]" %% xsd:string])
-    wasDerivedFrom(niiri:4b5895493ed07bacb9952f039a51b8f6, niiri:32e5e0304b5a2c92b091fa83edcab359, -, -, -)
-    entity(niiri:5390aed5563081e77badfd3ed3e58844,
+    wasDerivedFrom(niiri:d306012bf92eb74af9b7cecf10a666d1, niiri:08bfdacca68fb28f9c006f7c77ce2d85, -, -, -)
+    entity(niiri:ae03667aceb7cbf14b4b9e2dc82bb138,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0126" %% xsd:string,
-        prov:location = 'niiri:9fb7d9fa270614bdf589782a12b43645',
+        prov:location = 'niiri:7cf301e9c3da7d19484a4a83b2d77938',
         prov:value = "0.87107241153717" %% xsd:float,
         nidm_equivalentZStatistic: = "1.79483003828998" %% xsd:float,
         nidm_pValueUncorrected: = "0.0363403916799833" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9fb7d9fa270614bdf589782a12b43645,
+    entity(niiri:7cf301e9c3da7d19484a4a83b2d77938,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0126" %% xsd:string,
         nidm_coordinateVector: = "[12,-44,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:5390aed5563081e77badfd3ed3e58844, niiri:bf704e8aea1497f2136b7d0b3dde0bf6, -, -, -)
-    entity(niiri:6c566805e06c1caea5ba64a10caf0bd5,
+    wasDerivedFrom(niiri:ae03667aceb7cbf14b4b9e2dc82bb138, niiri:6bb55a6a6929721f00e0951117b25f42, -, -, -)
+    entity(niiri:2f189ccf478c1f7803a99294add6d13b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0127" %% xsd:string,
-        prov:location = 'niiri:7401db25a618931a21c1bd66336f51bb',
+        prov:location = 'niiri:67f64698e8253ef928d17d99e92099ca',
         prov:value = "0.865115165710449" %% xsd:float,
         nidm_equivalentZStatistic: = "1.78728350813392" %% xsd:float,
         nidm_pValueUncorrected: = "0.0369458390734643" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:7401db25a618931a21c1bd66336f51bb,
+    entity(niiri:67f64698e8253ef928d17d99e92099ca,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0127" %% xsd:string,
         nidm_coordinateVector: = "[2,56,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:6c566805e06c1caea5ba64a10caf0bd5, niiri:316701aef465a5778181dd76a5331844, -, -, -)
-    entity(niiri:6ab52d2779f2688ce41178fdd09b1849,
+    wasDerivedFrom(niiri:2f189ccf478c1f7803a99294add6d13b, niiri:37af7d521a2b88cd58b24d8684f7fef9, -, -, -)
+    entity(niiri:6b41f34b6d11482d641fbf6e724b14b9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0128" %% xsd:string,
-        prov:location = 'niiri:3886ebad71d47a06506e87cdb3d33fee',
+        prov:location = 'niiri:dc37a81ea4668eecf38e1163432a2364',
         prov:value = "0.864862859249115" %% xsd:float,
         nidm_equivalentZStatistic: = "1.78696398255915" %% xsd:float,
         nidm_pValueUncorrected: = "0.0369716550398422" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:3886ebad71d47a06506e87cdb3d33fee,
+    entity(niiri:dc37a81ea4668eecf38e1163432a2364,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0128" %% xsd:string,
         nidm_coordinateVector: = "[-4,12,50]" %% xsd:string])
-    wasDerivedFrom(niiri:6ab52d2779f2688ce41178fdd09b1849, niiri:90bdcb5fb7ef48121124edfe5e0439e6, -, -, -)
-    entity(niiri:49c821b0d9d061981dc68b1e3e6abfea,
+    wasDerivedFrom(niiri:6b41f34b6d11482d641fbf6e724b14b9, niiri:6fb39f850b88fc429c462810fc4c1cb0, -, -, -)
+    entity(niiri:c5151588d7538e4fe417cc06b8b41a04,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0129" %% xsd:string,
-        prov:location = 'niiri:050099abcdfa23d375e581da2db19230',
+        prov:location = 'niiri:cde16f243d8a750921ee9b21a71d953e',
         prov:value = "0.864512741565704" %% xsd:float,
         nidm_equivalentZStatistic: = "1.78652059943143" %% xsd:float,
         nidm_pValueUncorrected: = "0.0370075024642879" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:050099abcdfa23d375e581da2db19230,
+    entity(niiri:cde16f243d8a750921ee9b21a71d953e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0129" %% xsd:string,
         nidm_coordinateVector: = "[-30,-78,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:49c821b0d9d061981dc68b1e3e6abfea, niiri:d1db945756296f3d178c9d95312fcba1, -, -, -)
-    entity(niiri:d51ddcc544b96cfa8316116f60aeb9d7,
+    wasDerivedFrom(niiri:c5151588d7538e4fe417cc06b8b41a04, niiri:3b4cc47fe21026a8ff3cc6cae8366e5a, -, -, -)
+    entity(niiri:492919352e3d47c6173bffe5d9b359e9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0130" %% xsd:string,
-        prov:location = 'niiri:577fa5fdf942816d72dee2d7adba9c04',
+        prov:location = 'niiri:9254ca8c360e7c8c32935f3c76dbbdad',
         prov:value = "0.860980033874512" %% xsd:float,
         nidm_equivalentZStatistic: = "1.7820476459466" %% xsd:float,
         nidm_pValueUncorrected: = "0.0373707311326116" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:577fa5fdf942816d72dee2d7adba9c04,
+    entity(niiri:9254ca8c360e7c8c32935f3c76dbbdad,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0130" %% xsd:string,
         nidm_coordinateVector: = "[12,-92,28]" %% xsd:string])
-    wasDerivedFrom(niiri:d51ddcc544b96cfa8316116f60aeb9d7, niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a, -, -, -)
-    entity(niiri:fa45d096c7906fe9ce12107ae864f03d,
+    wasDerivedFrom(niiri:492919352e3d47c6173bffe5d9b359e9, niiri:cb21e315dda71865f3198bf3de5b7c55, -, -, -)
+    entity(niiri:3bfe16f27ba2a0b79f505be203d7e68f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0131" %% xsd:string,
-        prov:location = 'niiri:c322d812103d8b149095968fc937209e',
+        prov:location = 'niiri:f245d5153fe44fb6c38cd4e34efe9d5b',
         prov:value = "0.854242324829102" %% xsd:float,
         nidm_equivalentZStatistic: = "1.77352076998315" %% xsd:float,
         nidm_pValueUncorrected: = "0.0380712266728884" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c322d812103d8b149095968fc937209e,
+    entity(niiri:f245d5153fe44fb6c38cd4e34efe9d5b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0131" %% xsd:string,
         nidm_coordinateVector: = "[44,-50,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:fa45d096c7906fe9ce12107ae864f03d, niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c, -, -, -)
-    entity(niiri:98d08117d5c59bca3961e8d0d91fb482,
+    wasDerivedFrom(niiri:3bfe16f27ba2a0b79f505be203d7e68f, niiri:2e5418c351f653b423462944edc63136, -, -, -)
+    entity(niiri:6c76e471c03533bb1f5987a45db39955,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0132" %% xsd:string,
-        prov:location = 'niiri:17735795c02954ed333e3e53d28b146c',
+        prov:location = 'niiri:fc53fd234d50c6fb7191d72517b75b67',
         prov:value = "0.853475153446198" %% xsd:float,
         nidm_equivalentZStatistic: = "1.77255022378467" %% xsd:float,
         nidm_pValueUncorrected: = "0.0381516330201062" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:17735795c02954ed333e3e53d28b146c,
+    entity(niiri:fc53fd234d50c6fb7191d72517b75b67,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0132" %% xsd:string,
         nidm_coordinateVector: = "[20,48,8]" %% xsd:string])
-    wasDerivedFrom(niiri:98d08117d5c59bca3961e8d0d91fb482, niiri:9304b0681f39be2e136e7d42baff625c, -, -, -)
-    entity(niiri:99903325b32dacf464eb78e914073565,
+    wasDerivedFrom(niiri:6c76e471c03533bb1f5987a45db39955, niiri:f9e4a916c73e380e7f2b04ae24edb3eb, -, -, -)
+    entity(niiri:514a728f700d8eae9a4d01bef97ce699,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0133" %% xsd:string,
-        prov:location = 'niiri:4ac846381c96ad6a617444612779bfc0',
+        prov:location = 'niiri:8e9d52e803698afa10541fc835c58053',
         prov:value = "0.848101913928986" %% xsd:float,
         nidm_equivalentZStatistic: = "1.76575454216401" %% xsd:float,
         nidm_pValueUncorrected: = "0.0387185189613873" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4ac846381c96ad6a617444612779bfc0,
+    entity(niiri:8e9d52e803698afa10541fc835c58053,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0133" %% xsd:string,
         nidm_coordinateVector: = "[22,-10,68]" %% xsd:string])
-    wasDerivedFrom(niiri:99903325b32dacf464eb78e914073565, niiri:c4a9ab38a5b5faf27a110372a76b690b, -, -, -)
-    entity(niiri:d04d5d2d100ceb80264f8137772a93bb,
+    wasDerivedFrom(niiri:514a728f700d8eae9a4d01bef97ce699, niiri:7154c13ca1ce907cde82a8d61810577c, -, -, -)
+    entity(niiri:b58b30fb101bfb1709c7cca394569751,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0134" %% xsd:string,
-        prov:location = 'niiri:5ebd6bd9f56805b7a73b57e890d2c9d3',
+        prov:location = 'niiri:d50eaca1969dea2ee978843abe1497b6',
         prov:value = "0.845535814762115" %% xsd:float,
         nidm_equivalentZStatistic: = "1.76251036116829" %% xsd:float,
         nidm_pValueUncorrected: = "0.038991553676096" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5ebd6bd9f56805b7a73b57e890d2c9d3,
+    entity(niiri:d50eaca1969dea2ee978843abe1497b6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0134" %% xsd:string,
         nidm_coordinateVector: = "[10,16,62]" %% xsd:string])
-    wasDerivedFrom(niiri:d04d5d2d100ceb80264f8137772a93bb, niiri:b08c64db49c2acab9dde84fc5aaafee1, -, -, -)
-    entity(niiri:82bb09e80a51ba7c7cad776e0c839658,
+    wasDerivedFrom(niiri:b58b30fb101bfb1709c7cca394569751, niiri:79ad3466325804caf01c3623b06f85c5, -, -, -)
+    entity(niiri:23ed43ecc179ab2c90d8fdb998591666,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0135" %% xsd:string,
-        prov:location = 'niiri:8dfe0d34ef5e5740012a8bc214f3f619',
+        prov:location = 'niiri:ee67ae6fa60ae225aba88ea4a11eebbd',
         prov:value = "0.845024406909943" %% xsd:float,
         nidm_equivalentZStatistic: = "1.76186391162221" %% xsd:float,
         nidm_pValueUncorrected: = "0.0390461466343727" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8dfe0d34ef5e5740012a8bc214f3f619,
+    entity(niiri:ee67ae6fa60ae225aba88ea4a11eebbd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0135" %% xsd:string,
         nidm_coordinateVector: = "[-30,-60,-28]" %% xsd:string])
-    wasDerivedFrom(niiri:82bb09e80a51ba7c7cad776e0c839658, niiri:a8f46a35300a709894debac1a5c7d877, -, -, -)
-    entity(niiri:ced019c79dabd92179f8a23ffb66322f,
+    wasDerivedFrom(niiri:23ed43ecc179ab2c90d8fdb998591666, niiri:2e12076af378dbdca5de9e12404f5853, -, -, -)
+    entity(niiri:6235312dbe0a50495db71d1cbcef370d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0136" %% xsd:string,
-        prov:location = 'niiri:b1f6f0554f2caf5a79e8f085d690f134',
+        prov:location = 'niiri:ac1addae966f13ce0b52a9768b4836fd',
         prov:value = "0.842050552368164" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75810541868522" %% xsd:float,
         nidm_pValueUncorrected: = "0.0393647869826912" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b1f6f0554f2caf5a79e8f085d690f134,
+    entity(niiri:ac1addae966f13ce0b52a9768b4836fd,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0136" %% xsd:string,
         nidm_coordinateVector: = "[20,6,44]" %% xsd:string])
-    wasDerivedFrom(niiri:ced019c79dabd92179f8a23ffb66322f, niiri:147fb623ae052dca9733d6d1d2297af8, -, -, -)
-    entity(niiri:8c53fc407776cbf3f06af1e7d0d3050b,
+    wasDerivedFrom(niiri:6235312dbe0a50495db71d1cbcef370d, niiri:88291e9044390a2d68e0e8f02afae64d, -, -, -)
+    entity(niiri:d47b337e440883382de4fab28e6d94f8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0137" %% xsd:string,
-        prov:location = 'niiri:b14a5b57d07a5a949fbf0748f7fedeff',
+        prov:location = 'niiri:ee184cacdde8de299e33532df8b43683',
         prov:value = "0.837220907211304" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75200380991823" %% xsd:float,
         nidm_pValueUncorrected: = "0.0398865764002145" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:b14a5b57d07a5a949fbf0748f7fedeff,
+    entity(niiri:ee184cacdde8de299e33532df8b43683,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0137" %% xsd:string,
         nidm_coordinateVector: = "[-4,-100,4]" %% xsd:string])
-    wasDerivedFrom(niiri:8c53fc407776cbf3f06af1e7d0d3050b, niiri:eb257014e1b6b6961786c8543836a579, -, -, -)
-    entity(niiri:daa38cc1c0f9bbbca8083b6dc150874a,
+    wasDerivedFrom(niiri:d47b337e440883382de4fab28e6d94f8, niiri:9219dd196f709ade4b7d68bb82531ae9, -, -, -)
+    entity(niiri:1a81f2b791ccebb1e9c0bde558a466c0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0138" %% xsd:string,
-        prov:location = 'niiri:d8a9aa94958b15cdbfa143422db3e409',
+        prov:location = 'niiri:d3c9d34e7b4bd20b7efc87ab3f4a7ae1',
         prov:value = "0.83669376373291" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75133800938073" %% xsd:float,
         nidm_pValueUncorrected: = "0.0399438520830083" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d8a9aa94958b15cdbfa143422db3e409,
+    entity(niiri:d3c9d34e7b4bd20b7efc87ab3f4a7ae1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0138" %% xsd:string,
         nidm_coordinateVector: = "[26,36,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:daa38cc1c0f9bbbca8083b6dc150874a, niiri:3c0db86cde8ac7aa1cb1f7b208b617e8, -, -, -)
-    entity(niiri:e6ccc430058b7e6f4734a533b0653ecd,
+    wasDerivedFrom(niiri:1a81f2b791ccebb1e9c0bde558a466c0, niiri:b5869855e2ed1bde6084a419ce135245, -, -, -)
+    entity(niiri:729704c4f052081f1863d33a4e9f9f30,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0139" %% xsd:string,
-        prov:location = 'niiri:f7d532abb738d329ed77cfa4ca9d829d',
+        prov:location = 'niiri:8e1d0f1031cd834986592fe31edb44e9',
         prov:value = "0.835819184780121" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75023346183694" %% xsd:float,
         nidm_pValueUncorrected: = "0.0400390185167846" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f7d532abb738d329ed77cfa4ca9d829d,
+    entity(niiri:8e1d0f1031cd834986592fe31edb44e9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0139" %% xsd:string,
         nidm_coordinateVector: = "[30,-36,28]" %% xsd:string])
-    wasDerivedFrom(niiri:e6ccc430058b7e6f4734a533b0653ecd, niiri:e578dd3a170f088e47efd39f45837f4e, -, -, -)
-    entity(niiri:c0c01149ce0c0a7325cb0911837c39c0,
+    wasDerivedFrom(niiri:729704c4f052081f1863d33a4e9f9f30, niiri:3ed79923246b336ee14ba73c12fc89b8, -, -, -)
+    entity(niiri:ff2e059e98e36207411765ac32b8f7d0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0140" %% xsd:string,
-        prov:location = 'niiri:f81887eda1e93b996e6c64febcb68a9f',
+        prov:location = 'niiri:bec436ba508234eb75e5a5465c872720',
         prov:value = "0.835755825042725" %% xsd:float,
         nidm_equivalentZStatistic: = "1.75015344548878" %% xsd:float,
         nidm_pValueUncorrected: = "0.0400459197758659" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f81887eda1e93b996e6c64febcb68a9f,
+    entity(niiri:bec436ba508234eb75e5a5465c872720,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0140" %% xsd:string,
         nidm_coordinateVector: = "[16,48,10]" %% xsd:string])
-    wasDerivedFrom(niiri:c0c01149ce0c0a7325cb0911837c39c0, niiri:ab7f882f69e9de3fd22bc39f3519003d, -, -, -)
-    entity(niiri:46a1c5dc61e2d7b3c894f451385aef85,
+    wasDerivedFrom(niiri:ff2e059e98e36207411765ac32b8f7d0, niiri:12413ac997763f6fabc508fd21bfae38, -, -, -)
+    entity(niiri:6d0a5e28cb7df9eee3b154f98efd90ea,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0141" %% xsd:string,
-        prov:location = 'niiri:0fd17548f87f46ceba800b4df8d45ffc',
+        prov:location = 'niiri:765adf84ddd52eb6e5d694ba6cec47a0',
         prov:value = "0.827520847320557" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73975784824994" %% xsd:float,
         nidm_pValueUncorrected: = "0.0409507734302569" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0fd17548f87f46ceba800b4df8d45ffc,
+    entity(niiri:765adf84ddd52eb6e5d694ba6cec47a0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0141" %% xsd:string,
         nidm_coordinateVector: = "[24,34,2]" %% xsd:string])
-    wasDerivedFrom(niiri:46a1c5dc61e2d7b3c894f451385aef85, niiri:ca827c13c9bc5f06b55e3bd1cd175793, -, -, -)
-    entity(niiri:82a28d110b435fed75bd1e9374b294b2,
+    wasDerivedFrom(niiri:6d0a5e28cb7df9eee3b154f98efd90ea, niiri:f994daab5ee703f5c75c7c447254b288, -, -, -)
+    entity(niiri:e902209feaeb13aa59e67a7f3977bf1a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0142" %% xsd:string,
-        prov:location = 'niiri:9b4eccb2dece33b68e724e1fd45e6e19',
+        prov:location = 'niiri:22a252c18b9fc266e8b32326dc729ee3',
         prov:value = "0.825629651546478" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73737166192306" %% xsd:float,
         nidm_pValueUncorrected: = "0.0411607949360844" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:9b4eccb2dece33b68e724e1fd45e6e19,
+    entity(niiri:22a252c18b9fc266e8b32326dc729ee3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0142" %% xsd:string,
         nidm_coordinateVector: = "[62,-42,44]" %% xsd:string])
-    wasDerivedFrom(niiri:82a28d110b435fed75bd1e9374b294b2, niiri:8472115c12bd571d534dfe5bac960c80, -, -, -)
-    entity(niiri:2d3f5ec418b92bf3ca61148f66079396,
+    wasDerivedFrom(niiri:e902209feaeb13aa59e67a7f3977bf1a, niiri:83cced094f39a6896a2e9e71f04942a7, -, -, -)
+    entity(niiri:937ca91b092a9615108e156d006cd75f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0143" %% xsd:string,
-        prov:location = 'niiri:3dbcf5a5ae42f6e1526aa0d8720cdb8a',
+        prov:location = 'niiri:0c7268ae1b298870e210c38e71475db6',
         prov:value = "0.82505863904953" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73665128497546" %% xsd:float,
         nidm_pValueUncorrected: = "0.0412243706597636" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:3dbcf5a5ae42f6e1526aa0d8720cdb8a,
+    entity(niiri:0c7268ae1b298870e210c38e71475db6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0143" %% xsd:string,
         nidm_coordinateVector: = "[-46,-40,38]" %% xsd:string])
-    wasDerivedFrom(niiri:2d3f5ec418b92bf3ca61148f66079396, niiri:812c44e9a98ad090a6f8b72ffea8eb49, -, -, -)
-    entity(niiri:3514e869d053964fca5f28a8c09f4e91,
+    wasDerivedFrom(niiri:937ca91b092a9615108e156d006cd75f, niiri:8cebbc59dd1e18a1762d12ca4d90e931, -, -, -)
+    entity(niiri:e4e5e8bf127576928bc51c913aa4738e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0144" %% xsd:string,
-        prov:location = 'niiri:fb4af523bacf868c90bee16373434943',
+        prov:location = 'niiri:86dfaeee85a3c20d3fa1895f256886ae',
         prov:value = "0.824967801570892" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73653669020128" %% xsd:float,
         nidm_pValueUncorrected: = "0.0412344913749479" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:fb4af523bacf868c90bee16373434943,
+    entity(niiri:86dfaeee85a3c20d3fa1895f256886ae,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0144" %% xsd:string,
         nidm_coordinateVector: = "[-12,-58,-54]" %% xsd:string])
-    wasDerivedFrom(niiri:3514e869d053964fca5f28a8c09f4e91, niiri:eb1e036b54bfd5155015ad5c924a62ce, -, -, -)
-    entity(niiri:aee96554789220edfb0c2a5cb3e5dbcf,
+    wasDerivedFrom(niiri:e4e5e8bf127576928bc51c913aa4738e, niiri:8c6f92e0a397a1c5c883eb79ede81691, -, -, -)
+    entity(niiri:348213d7436248cd56fb0d8e6f9b70d4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0145" %% xsd:string,
-        prov:location = 'niiri:e3ed6f4e37e26c035620e0009be1898c',
+        prov:location = 'niiri:b7883e9d90d471712abd8c90c1a5dd3c',
         prov:value = "0.824692487716675" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73618937818564" %% xsd:float,
         nidm_pValueUncorrected: = "0.0412651773815628" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e3ed6f4e37e26c035620e0009be1898c,
+    entity(niiri:b7883e9d90d471712abd8c90c1a5dd3c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0145" %% xsd:string,
         nidm_coordinateVector: = "[26,-72,14]" %% xsd:string])
-    wasDerivedFrom(niiri:aee96554789220edfb0c2a5cb3e5dbcf, niiri:8bac0f00c0d1f0f9f5c118004ab17321, -, -, -)
-    entity(niiri:cc8b982d26d7b3eda03f32ed426ee111,
+    wasDerivedFrom(niiri:348213d7436248cd56fb0d8e6f9b70d4, niiri:6e55a4195849427172678126ca78b28a, -, -, -)
+    entity(niiri:6ed89be12666768ddd7761719af22822,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0146" %% xsd:string,
-        prov:location = 'niiri:ed883e8d69ce8310e32c0e8becfe841e',
+        prov:location = 'niiri:0ec8e7e416617b5bb2a8ca07a2c32fd3',
         prov:value = "0.822546482086182" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73348249441809" %% xsd:float,
         nidm_pValueUncorrected: = "0.0415049731433188" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ed883e8d69ce8310e32c0e8becfe841e,
+    entity(niiri:0ec8e7e416617b5bb2a8ca07a2c32fd3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0146" %% xsd:string,
         nidm_coordinateVector: = "[-40,-10,40]" %% xsd:string])
-    wasDerivedFrom(niiri:cc8b982d26d7b3eda03f32ed426ee111, niiri:4f4b190235fbb136b1bb7467b78730d6, -, -, -)
-    entity(niiri:5f5a39c0ec9f402ad6c7b83cd3403cc8,
+    wasDerivedFrom(niiri:6ed89be12666768ddd7761719af22822, niiri:3d5e4a6eb5d78cc1ef178561e41ba9ee, -, -, -)
+    entity(niiri:8d954dfe5cc3c1744ec9b69c893a4ce7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0147" %% xsd:string,
-        prov:location = 'niiri:6f15a47567306fd72eb97be297c7405b',
+        prov:location = 'niiri:c99de1733407f9b917d2fcf6f18107c7',
         prov:value = "0.821757972240448" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73248804772578" %% xsd:float,
         nidm_pValueUncorrected: = "0.0415933516734939" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6f15a47567306fd72eb97be297c7405b,
+    entity(niiri:c99de1733407f9b917d2fcf6f18107c7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0147" %% xsd:string,
         nidm_coordinateVector: = "[54,-52,42]" %% xsd:string])
-    wasDerivedFrom(niiri:5f5a39c0ec9f402ad6c7b83cd3403cc8, niiri:d04d2676281bca09e8a782500650e993, -, -, -)
-    entity(niiri:21c2f0806b69f7a2007d792897684387,
+    wasDerivedFrom(niiri:8d954dfe5cc3c1744ec9b69c893a4ce7, niiri:263da8c4eb7cf40aac1b2acc6184c451, -, -, -)
+    entity(niiri:f720acd422ca543f3b9d91c8bad1ff84,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0148" %% xsd:string,
-        prov:location = 'niiri:8c75ae64ad9880eeb66c7dfdeca370d8',
+        prov:location = 'niiri:86e21b78f8bbaad1b5d369b817045f62',
         prov:value = "0.821538865566254" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73221173057204" %% xsd:float,
         nidm_pValueUncorrected: = "0.0416179355971084" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8c75ae64ad9880eeb66c7dfdeca370d8,
+    entity(niiri:86e21b78f8bbaad1b5d369b817045f62,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0148" %% xsd:string,
         nidm_coordinateVector: = "[-10,-66,8]" %% xsd:string])
-    wasDerivedFrom(niiri:21c2f0806b69f7a2007d792897684387, niiri:59c6e585fc56ebce5a5d95b959cc120d, -, -, -)
-    entity(niiri:4f107ffd42ea6e3a3e3d2968400fa620,
+    wasDerivedFrom(niiri:f720acd422ca543f3b9d91c8bad1ff84, niiri:d4fbe5cc673433a4ae33bce2f4d62046, -, -, -)
+    entity(niiri:6dc851372d8e3e27d41d97f6dab1a12b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0149" %% xsd:string,
-        prov:location = 'niiri:e296ec0027943c32f1d63187ca884faf',
+        prov:location = 'niiri:6496c51bd773c1ae0b6d90ee2114dba0',
         prov:value = "0.821337878704071" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73195826984928" %% xsd:float,
         nidm_pValueUncorrected: = "0.0416404963346692" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e296ec0027943c32f1d63187ca884faf,
+    entity(niiri:6496c51bd773c1ae0b6d90ee2114dba0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0149" %% xsd:string,
         nidm_coordinateVector: = "[20,-16,70]" %% xsd:string])
-    wasDerivedFrom(niiri:4f107ffd42ea6e3a3e3d2968400fa620, niiri:a4d82c21752d17f68b6fbf41caa89a4b, -, -, -)
-    entity(niiri:52953fe00c54e610f78c8e2bd72debb1,
+    wasDerivedFrom(niiri:6dc851372d8e3e27d41d97f6dab1a12b, niiri:92b2dd79b91691fa3fee9530c07ced7e, -, -, -)
+    entity(niiri:eacb189a4f6aad7ba7991ec7e8ee4a64,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0150" %% xsd:string,
-        prov:location = 'niiri:d4f42ae011a1b1bcdfd446d63c416728',
+        prov:location = 'niiri:6b1547bb95fed435e85d0b37e1ae174c',
         prov:value = "0.821269989013672" %% xsd:float,
         nidm_equivalentZStatistic: = "1.73187265661373" %% xsd:float,
         nidm_pValueUncorrected: = "0.0416481190738193" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:d4f42ae011a1b1bcdfd446d63c416728,
+    entity(niiri:6b1547bb95fed435e85d0b37e1ae174c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0150" %% xsd:string,
         nidm_coordinateVector: = "[34,-56,18]" %% xsd:string])
-    wasDerivedFrom(niiri:52953fe00c54e610f78c8e2bd72debb1, niiri:9c09ac30035d9617daad1f111fa1b47f, -, -, -)
-    entity(niiri:b8bb24c25ece9a10c4a32995fda538dd,
+    wasDerivedFrom(niiri:eacb189a4f6aad7ba7991ec7e8ee4a64, niiri:0791bb16705c92dfa0eb9a2399ad7c01, -, -, -)
+    entity(niiri:0abc45dfbb89620780d8de5664cb5010,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0151" %% xsd:string,
-        prov:location = 'niiri:48f70704159960814be91b72a9bd2859',
+        prov:location = 'niiri:3dc38b67bdfcc504dc6cec93875d1d6b',
         prov:value = "0.82093757390976" %% xsd:float,
         nidm_equivalentZStatistic: = "1.7314534684428" %% xsd:float,
         nidm_pValueUncorrected: = "0.0416854586174026" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:48f70704159960814be91b72a9bd2859,
+    entity(niiri:3dc38b67bdfcc504dc6cec93875d1d6b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0151" %% xsd:string,
         nidm_coordinateVector: = "[58,32,22]" %% xsd:string])
-    wasDerivedFrom(niiri:b8bb24c25ece9a10c4a32995fda538dd, niiri:b5d02c34e634c7f52d94137fbd9f8813, -, -, -)
-    entity(niiri:553be5643aa7f566f5428ca1f18a7e99,
+    wasDerivedFrom(niiri:0abc45dfbb89620780d8de5664cb5010, niiri:51393db8b7b8a6fffbbd81b5df93450e, -, -, -)
+    entity(niiri:af431788e35f94f8cb37bdfbd4f460da,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0152" %% xsd:string,
-        prov:location = 'niiri:793abb325ad9de1bede5b50108624f36',
+        prov:location = 'niiri:cd30e79318ec8a11a5787534f3a9030c',
         prov:value = "0.817427694797516" %% xsd:float,
         nidm_equivalentZStatistic: = "1.72702824070669" %% xsd:float,
         nidm_pValueUncorrected: = "0.0420812958690475" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:793abb325ad9de1bede5b50108624f36,
+    entity(niiri:cd30e79318ec8a11a5787534f3a9030c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0152" %% xsd:string,
         nidm_coordinateVector: = "[-28,-74,18]" %% xsd:string])
-    wasDerivedFrom(niiri:553be5643aa7f566f5428ca1f18a7e99, niiri:fc91a408c252d8e2b7beb4005554eaf8, -, -, -)
-    entity(niiri:50446d0a8adcadede38bdf0d08c3a7c9,
+    wasDerivedFrom(niiri:af431788e35f94f8cb37bdfbd4f460da, niiri:868dad72b2c68d3fbc6510a6d5cb9231, -, -, -)
+    entity(niiri:1a8f2ea7a45f2075e9f9f34168c9ff29,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0153" %% xsd:string,
-        prov:location = 'niiri:4691db3191597b7338e7c95c4a8f87e2',
+        prov:location = 'niiri:9df19e189040f4843e39f4748baf9672',
         prov:value = "0.816389560699463" %% xsd:float,
         nidm_equivalentZStatistic: = "1.72571967296696" %% xsd:float,
         nidm_pValueUncorrected: = "0.0421989285126135" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4691db3191597b7338e7c95c4a8f87e2,
+    entity(niiri:9df19e189040f4843e39f4748baf9672,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0153" %% xsd:string,
         nidm_coordinateVector: = "[28,-30,34]" %% xsd:string])
-    wasDerivedFrom(niiri:50446d0a8adcadede38bdf0d08c3a7c9, niiri:9b0591f2b854d2643aaf1afaa93cb549, -, -, -)
-    entity(niiri:65d8e0c0cee7cb9aedc8b05b70798526,
+    wasDerivedFrom(niiri:1a8f2ea7a45f2075e9f9f34168c9ff29, niiri:f010113cde48b81f7b8ed0070c723116, -, -, -)
+    entity(niiri:54183cc34e3e6967db364d7904a9e52d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0154" %% xsd:string,
-        prov:location = 'niiri:a8791185dbb796dbe126d712ae2b55e4',
+        prov:location = 'niiri:008e78402e17c38602734ce16c5f22d8',
         prov:value = "0.810877442359924" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71877398514755" %% xsd:float,
         nidm_pValueUncorrected: = "0.0428277671196435" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a8791185dbb796dbe126d712ae2b55e4,
+    entity(niiri:008e78402e17c38602734ce16c5f22d8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0154" %% xsd:string,
         nidm_coordinateVector: = "[-4,-92,4]" %% xsd:string])
-    wasDerivedFrom(niiri:65d8e0c0cee7cb9aedc8b05b70798526, niiri:d54744a8017e84d7adb355fc9412fba3, -, -, -)
-    entity(niiri:ac42ea1cc64c6d5a7de30ab94c30ef98,
+    wasDerivedFrom(niiri:54183cc34e3e6967db364d7904a9e52d, niiri:0265995653f234724934abae5c95f7d7, -, -, -)
+    entity(niiri:46f6b44a41e9e8cb3de0ec11f8a393f6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0155" %% xsd:string,
-        prov:location = 'niiri:e8237ec0f9d80f45182261107f27d393',
+        prov:location = 'niiri:149ba67b614148cadebeb33b2cb01bb7',
         prov:value = "0.810260891914368" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71799733032142" %% xsd:float,
         nidm_pValueUncorrected: = "0.0428985511130971" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:e8237ec0f9d80f45182261107f27d393,
+    entity(niiri:149ba67b614148cadebeb33b2cb01bb7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0155" %% xsd:string,
         nidm_coordinateVector: = "[-18,-22,44]" %% xsd:string])
-    wasDerivedFrom(niiri:ac42ea1cc64c6d5a7de30ab94c30ef98, niiri:e49a03f4d60a11688f798fc5bc43c1b2, -, -, -)
-    entity(niiri:69ee373828c471312b7a98ecd9d058a9,
+    wasDerivedFrom(niiri:46f6b44a41e9e8cb3de0ec11f8a393f6, niiri:f99e0a55aff25b99b4c4ccb40319fa7b, -, -, -)
+    entity(niiri:46adeac017faa4c69a20028b6f8e63c6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0156" %% xsd:string,
-        prov:location = 'niiri:c8b68f98c5cfe0ac5c2cdefaedfdf163',
+        prov:location = 'niiri:2773eefe6180cc14e7a7960b97901f27',
         prov:value = "0.809625387191772" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71719685114941" %% xsd:float,
         nidm_pValueUncorrected: = "0.042971605350922" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c8b68f98c5cfe0ac5c2cdefaedfdf163,
+    entity(niiri:2773eefe6180cc14e7a7960b97901f27,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0156" %% xsd:string,
         nidm_coordinateVector: = "[-8,-88,-48]" %% xsd:string])
-    wasDerivedFrom(niiri:69ee373828c471312b7a98ecd9d058a9, niiri:b04a187086857b7422c8096db14ee613, -, -, -)
-    entity(niiri:b43fdbd7e0791111185f3e004a40b90f,
+    wasDerivedFrom(niiri:46adeac017faa4c69a20028b6f8e63c6, niiri:48a348ba7dc61a80c12ae68ab1b56cad, -, -, -)
+    entity(niiri:5100c19d55a2cc622e67db8f475de925,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0157" %% xsd:string,
-        prov:location = 'niiri:70a5abbded05158ae55374c9e47f8da2',
+        prov:location = 'niiri:5a8af079332b887b04f7005a6595a20c',
         prov:value = "0.807083547115326" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71399568809748" %% xsd:float,
         nidm_pValueUncorrected: = "0.0432647588890963" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:70a5abbded05158ae55374c9e47f8da2,
+    entity(niiri:5a8af079332b887b04f7005a6595a20c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0157" %% xsd:string,
         nidm_coordinateVector: = "[-28,-90,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:b43fdbd7e0791111185f3e004a40b90f, niiri:39ce93dd6abab662ab6da84a046a56bd, -, -, -)
-    entity(niiri:74b1e30b0b85916615db0f4c7da8ca2a,
+    wasDerivedFrom(niiri:5100c19d55a2cc622e67db8f475de925, niiri:adc463abce824f98736aecdc0ef0fc44, -, -, -)
+    entity(niiri:8c8a82f24104d341825f45a98d5506eb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0158" %% xsd:string,
-        prov:location = 'niiri:8b947c980b68849b563e6a600eb6f25e',
+        prov:location = 'niiri:7359bf2ba1fa3b8608e099d2f80da1d0',
         prov:value = "0.804524898529053" %% xsd:float,
         nidm_equivalentZStatistic: = "1.71077421355999" %% xsd:float,
         nidm_pValueUncorrected: = "0.0435614007800803" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:8b947c980b68849b563e6a600eb6f25e,
+    entity(niiri:7359bf2ba1fa3b8608e099d2f80da1d0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0158" %% xsd:string,
         nidm_coordinateVector: = "[54,18,14]" %% xsd:string])
-    wasDerivedFrom(niiri:74b1e30b0b85916615db0f4c7da8ca2a, niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e, -, -, -)
-    entity(niiri:6630427441c8fc15cc3a64424eb38ad1,
+    wasDerivedFrom(niiri:8c8a82f24104d341825f45a98d5506eb, niiri:2a0123807eeff74fec9051900072009a, -, -, -)
+    entity(niiri:599fe24d4e0a62c0a4539e2b34d200da,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0159" %% xsd:string,
-        prov:location = 'niiri:2352aa9bc768856664d6689721c07c97',
+        prov:location = 'niiri:d905430746f831b8f4d4d82f144d3ea7',
         prov:value = "0.801611304283142" %% xsd:float,
         nidm_equivalentZStatistic: = "1.70710689586196" %% xsd:float,
         nidm_pValueUncorrected: = "0.0439010928174099" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:2352aa9bc768856664d6689721c07c97,
+    entity(niiri:d905430746f831b8f4d4d82f144d3ea7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0159" %% xsd:string,
         nidm_coordinateVector: = "[38,-48,18]" %% xsd:string])
-    wasDerivedFrom(niiri:6630427441c8fc15cc3a64424eb38ad1, niiri:ca20dee3ba6bf36049f99642c710470d, -, -, -)
-    entity(niiri:8292bd6d405860cc9e98ea0f6c90807b,
+    wasDerivedFrom(niiri:599fe24d4e0a62c0a4539e2b34d200da, niiri:3c9c41ca803aea8e1aa376a37e7fd405, -, -, -)
+    entity(niiri:3c0e3d6e7514eaa237950debc30b47fd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0160" %% xsd:string,
-        prov:location = 'niiri:a2593a5375fecb7c266042738db0862e',
+        prov:location = 'niiri:4cf1c35d95d7b5dd244c47e4c2790de2',
         prov:value = "0.801064372062683" %% xsd:float,
         nidm_equivalentZStatistic: = "1.70641860205681" %% xsd:float,
         nidm_pValueUncorrected: = "0.0439650847967754" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a2593a5375fecb7c266042738db0862e,
+    entity(niiri:4cf1c35d95d7b5dd244c47e4c2790de2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0160" %% xsd:string,
         nidm_coordinateVector: = "[-32,-70,28]" %% xsd:string])
-    wasDerivedFrom(niiri:8292bd6d405860cc9e98ea0f6c90807b, niiri:26fa7a82c298f218eb7fd282cfbf7a81, -, -, -)
-    entity(niiri:40736270f2699f261bc17555c7292552,
+    wasDerivedFrom(niiri:3c0e3d6e7514eaa237950debc30b47fd, niiri:4ac51018dc7ac193d610d2175b143f4f, -, -, -)
+    entity(niiri:9bef5b0ca963e53070a3a99033f87f38,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0161" %% xsd:string,
-        prov:location = 'niiri:f1dfb9a6e43d0bb924ebeb2df5b8754b',
+        prov:location = 'niiri:2d34e4b441f7b135e77d543d9f66dadb',
         prov:value = "0.796977043151855" %% xsd:float,
         nidm_equivalentZStatistic: = "1.70127611195347" %% xsd:float,
         nidm_pValueUncorrected: = "0.0444455757271468" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:f1dfb9a6e43d0bb924ebeb2df5b8754b,
+    entity(niiri:2d34e4b441f7b135e77d543d9f66dadb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0161" %% xsd:string,
         nidm_coordinateVector: = "[40,-8,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:40736270f2699f261bc17555c7292552, niiri:e518dd980ffdb694adcf472695d5a40a, -, -, -)
-    entity(niiri:0f9175ee5293a19900d9c265070230b1,
+    wasDerivedFrom(niiri:9bef5b0ca963e53070a3a99033f87f38, niiri:9411d8ecf0144381e141c863accd8f82, -, -, -)
+    entity(niiri:f6d4c9131d22036aec030e09ab39c6dd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0162" %% xsd:string,
-        prov:location = 'niiri:a2480bf60f7e38c86231bf76032bf596',
+        prov:location = 'niiri:6aa2fbb29246a07a9badf57a76c05ab5',
         prov:value = "0.795195400714874" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69903522990177" %% xsd:float,
         nidm_pValueUncorrected: = "0.044656272931023" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:a2480bf60f7e38c86231bf76032bf596,
+    entity(niiri:6aa2fbb29246a07a9badf57a76c05ab5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0162" %% xsd:string,
         nidm_coordinateVector: = "[10,-10,4]" %% xsd:string])
-    wasDerivedFrom(niiri:0f9175ee5293a19900d9c265070230b1, niiri:5f278b6b11fae0c4b4f9690852a71d0c, -, -, -)
-    entity(niiri:9288e365e8e166d1d7201abdec31d34d,
+    wasDerivedFrom(niiri:f6d4c9131d22036aec030e09ab39c6dd, niiri:58ff840b981e30971a46c0cdee9acc43, -, -, -)
+    entity(niiri:0a6dd43a51f3ce9c34de2142af6b02e6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0163" %% xsd:string,
-        prov:location = 'niiri:360956c141f1348efb9ba6e9bda173e8',
+        prov:location = 'niiri:da7303ac72bc02c9cd855044756c5de5',
         prov:value = "0.793771862983704" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69724506469093" %% xsd:float,
         nidm_pValueUncorrected: = "0.0448251692331177" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:360956c141f1348efb9ba6e9bda173e8,
+    entity(niiri:da7303ac72bc02c9cd855044756c5de5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0163" %% xsd:string,
         nidm_coordinateVector: = "[36,-38,16]" %% xsd:string])
-    wasDerivedFrom(niiri:9288e365e8e166d1d7201abdec31d34d, niiri:87f8233f1c48acf6ecdd7339055182ae, -, -, -)
-    entity(niiri:5eefd7306b4387e0f534121efebdd08c,
+    wasDerivedFrom(niiri:0a6dd43a51f3ce9c34de2142af6b02e6, niiri:81d9ad132a8f471d00cb8b3aef33836f, -, -, -)
+    entity(niiri:9a78a0f7476ba56a9df1ed696f78fe77,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0164" %% xsd:string,
-        prov:location = 'niiri:c6bbb6da467f04755510516c59db89cc',
+        prov:location = 'niiri:3b43899302ca56905cfe7f84b26615cf',
         prov:value = "0.791125535964966" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69391791067376" %% xsd:float,
         nidm_pValueUncorrected: = "0.0451404415013222" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:c6bbb6da467f04755510516c59db89cc,
+    entity(niiri:3b43899302ca56905cfe7f84b26615cf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0164" %% xsd:string,
         nidm_coordinateVector: = "[36,-58,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:5eefd7306b4387e0f534121efebdd08c, niiri:0189728b5aaa10d4eb4ff53d1fbc5843, -, -, -)
-    entity(niiri:0d043095f5b8ce7d202f6fc55b3238bc,
+    wasDerivedFrom(niiri:9a78a0f7476ba56a9df1ed696f78fe77, niiri:b85e89811d403dd797f7d9315b0c1779, -, -, -)
+    entity(niiri:2cb31cb7b093dad502997f78c9a4e430,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0165" %% xsd:string,
-        prov:location = 'niiri:00bfef980e3b46b82577ed05a18e2998',
+        prov:location = 'niiri:0c6294ba2898494ddcc11332935ee7b8',
         prov:value = "0.790164232254028" %% xsd:float,
         nidm_equivalentZStatistic: = "1.69270952448475" %% xsd:float,
         nidm_pValueUncorrected: = "0.0452553857167721" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:00bfef980e3b46b82577ed05a18e2998,
+    entity(niiri:0c6294ba2898494ddcc11332935ee7b8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0165" %% xsd:string,
         nidm_coordinateVector: = "[-24,-68,40]" %% xsd:string])
-    wasDerivedFrom(niiri:0d043095f5b8ce7d202f6fc55b3238bc, niiri:453f1919d7df3d7e610709f6fdecbf62, -, -, -)
-    entity(niiri:d3837181ec2883710db3c1e102047902,
+    wasDerivedFrom(niiri:2cb31cb7b093dad502997f78c9a4e430, niiri:559e52e372bf37a3bd9f89fe7d257b7f, -, -, -)
+    entity(niiri:51c2f67a4825f1b51311539b25ee7829,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0166" %% xsd:string,
-        prov:location = 'niiri:6839436079db4de6e679f679c75a4c7e',
+        prov:location = 'niiri:3ea5e74a42e56df9c591de50df3e57a3',
         prov:value = "0.789975047111511" %% xsd:float,
         nidm_equivalentZStatistic: = "1.6924717281141" %% xsd:float,
         nidm_pValueUncorrected: = "0.045278033108256" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6839436079db4de6e679f679c75a4c7e,
+    entity(niiri:3ea5e74a42e56df9c591de50df3e57a3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0166" %% xsd:string,
         nidm_coordinateVector: = "[-32,-66,-54]" %% xsd:string])
-    wasDerivedFrom(niiri:d3837181ec2883710db3c1e102047902, niiri:5b21dda7a2823d1c7efeff7947020767, -, -, -)
-    entity(niiri:7ada6738ac4a3476b738b4b0994fd916,
+    wasDerivedFrom(niiri:51c2f67a4825f1b51311539b25ee7829, niiri:8675dcbc163828022ee916bae686b21e, -, -, -)
+    entity(niiri:d572a9f3f060da98ea22bc80c122a357,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0167" %% xsd:string,
-        prov:location = 'niiri:0e72b69c8d3905c21cb76f5d803a0e4d',
+        prov:location = 'niiri:de264a5f790a2be83bd78daa8fa8bde4',
         prov:value = "0.785030126571655" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68625793462611" %% xsd:float,
         nidm_pValueUncorrected: = "0.0458730647233518" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:0e72b69c8d3905c21cb76f5d803a0e4d,
+    entity(niiri:de264a5f790a2be83bd78daa8fa8bde4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0167" %% xsd:string,
         nidm_coordinateVector: = "[-38,-4,36]" %% xsd:string])
-    wasDerivedFrom(niiri:7ada6738ac4a3476b738b4b0994fd916, niiri:a6dc495a077e17aa8f96566659037e0b, -, -, -)
-    entity(niiri:9c5822f4331f39fcb128f71e39c9a258,
+    wasDerivedFrom(niiri:d572a9f3f060da98ea22bc80c122a357, niiri:2ebb70aec77a1bb19cfa4bb0e86df28c, -, -, -)
+    entity(niiri:57888f359906dd4ad43ceadb5ca1aaf2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0168" %% xsd:string,
-        prov:location = 'niiri:ff06c430dadf64ca774b3086a78659e3',
+        prov:location = 'niiri:50211b7729f84e2eee954df78ae7c694',
         prov:value = "0.783349096775055" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68414631143602" %% xsd:float,
         nidm_pValueUncorrected: = "0.0460766980434556" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:ff06c430dadf64ca774b3086a78659e3,
+    entity(niiri:50211b7729f84e2eee954df78ae7c694,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0168" %% xsd:string,
         nidm_coordinateVector: = "[-50,10,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:9c5822f4331f39fcb128f71e39c9a258, niiri:e5e5eeee288ec088072a80af972a3638, -, -, -)
-    entity(niiri:ccb323d69fd85ace7df2130c0f358f1e,
+    wasDerivedFrom(niiri:57888f359906dd4ad43ceadb5ca1aaf2, niiri:c3f909ea8341d2a928e08b183a5eb9b8, -, -, -)
+    entity(niiri:b2bf188e739b8f5d5cead545d7bd3a14,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0169" %% xsd:string,
-        prov:location = 'niiri:217b8e666093093f4b98080437a0d243',
+        prov:location = 'niiri:78cd9a9cdaed3e069d100845a7bfd965',
         prov:value = "0.780271351337433" %% xsd:float,
         nidm_equivalentZStatistic: = "1.68028121266012" %% xsd:float,
         nidm_pValueUncorrected: = "0.046451307319556" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:217b8e666093093f4b98080437a0d243,
+    entity(niiri:78cd9a9cdaed3e069d100845a7bfd965,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0169" %% xsd:string,
         nidm_coordinateVector: = "[-18,-22,34]" %% xsd:string])
-    wasDerivedFrom(niiri:ccb323d69fd85ace7df2130c0f358f1e, niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1, -, -, -)
-    entity(niiri:cf35bc5d34495239fdb3d14ae313539a,
+    wasDerivedFrom(niiri:b2bf188e739b8f5d5cead545d7bd3a14, niiri:7da0c40e610d05ef5fcd5df75e03757e, -, -, -)
+    entity(niiri:0233592a88bd1be7e7a031f75ae13813,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0170" %% xsd:string,
-        prov:location = 'niiri:6a7144a67e64589dcd898f89b4f5a115',
+        prov:location = 'niiri:ba73c9d83c778237f47a9adf18f1fb7d',
         prov:value = "0.778013467788696" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67744654581037" %% xsd:float,
         nidm_pValueUncorrected: = "0.046727596979824" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:6a7144a67e64589dcd898f89b4f5a115,
+    entity(niiri:ba73c9d83c778237f47a9adf18f1fb7d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0170" %% xsd:string,
         nidm_coordinateVector: = "[-20,-22,38]" %% xsd:string])
-    wasDerivedFrom(niiri:cf35bc5d34495239fdb3d14ae313539a, niiri:66cf0dbeb1aa03edbab1a35c2d527a55, -, -, -)
-    entity(niiri:8a057d875ec99d9bc03c3b517547b1ea,
+    wasDerivedFrom(niiri:0233592a88bd1be7e7a031f75ae13813, niiri:88cc306d767adb94ebbccf9ff7621ad9, -, -, -)
+    entity(niiri:d69c50de58f7fd7a1f64ba4b4fd99d9d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0171" %% xsd:string,
-        prov:location = 'niiri:074b47096ccc51be98dbe94fdd69bdea',
+        prov:location = 'niiri:37454513b78e9abdf3a0cc61d7e5c7be',
         prov:value = "0.775993704795837" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67491142741087" %% xsd:float,
         nidm_pValueUncorrected: = "0.0469758055929785" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:074b47096ccc51be98dbe94fdd69bdea,
+    entity(niiri:37454513b78e9abdf3a0cc61d7e5c7be,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0171" %% xsd:string,
         nidm_coordinateVector: = "[12,-92,2]" %% xsd:string])
-    wasDerivedFrom(niiri:8a057d875ec99d9bc03c3b517547b1ea, niiri:09d8898196c5c40aec6f995a2b0c383d, -, -, -)
-    entity(niiri:136d5427f1933a243c7f06af362e36ee,
+    wasDerivedFrom(niiri:d69c50de58f7fd7a1f64ba4b4fd99d9d, niiri:74ee3d5df4f8c42807338247cfe92970, -, -, -)
+    entity(niiri:7c59dea47bc9bb0c6e1644fc44dbec4a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0172" %% xsd:string,
-        prov:location = 'niiri:78b0fee3f9559ef3905e7bf963b53e38',
+        prov:location = 'niiri:1c18bf474c8f011148fe77f34b1c8d4b',
         prov:value = "0.774858772754669" %% xsd:float,
         nidm_equivalentZStatistic: = "1.67348715940063" %% xsd:float,
         nidm_pValueUncorrected: = "0.0471157161396256" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:78b0fee3f9559ef3905e7bf963b53e38,
+    entity(niiri:1c18bf474c8f011148fe77f34b1c8d4b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0172" %% xsd:string,
         nidm_coordinateVector: = "[52,-44,58]" %% xsd:string])
-    wasDerivedFrom(niiri:136d5427f1933a243c7f06af362e36ee, niiri:bfe644ea717165d3b6b50431d8e57c87, -, -, -)
-    entity(niiri:f4fabce2608abd82f4cb41cc5b313112,
+    wasDerivedFrom(niiri:7c59dea47bc9bb0c6e1644fc44dbec4a, niiri:cdf3f858b94767540e52edcfccc91cae, -, -, -)
+    entity(niiri:570b7b59ff44fc705fdaa803ba38b444,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0173" %% xsd:string,
-        prov:location = 'niiri:907619d79ece58eff1df517e0cbd5f78',
+        prov:location = 'niiri:5235c98b2b9af63a0b7f146548cf6c9d',
         prov:value = "0.766564428806305" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66308376386524" %% xsd:float,
         nidm_pValueUncorrected: = "0.0481478347201374" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:907619d79ece58eff1df517e0cbd5f78,
+    entity(niiri:5235c98b2b9af63a0b7f146548cf6c9d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0173" %% xsd:string,
         nidm_coordinateVector: = "[46,30,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:f4fabce2608abd82f4cb41cc5b313112, niiri:0d278ee0d105de3a7319a5acaa11c631, -, -, -)
-    entity(niiri:f47917da4ed2d8c7e7324d2c0d02a46d,
+    wasDerivedFrom(niiri:570b7b59ff44fc705fdaa803ba38b444, niiri:d47a915a52d84b041200dd225d0d123a, -, -, -)
+    entity(niiri:80def1f8a0731234b7509b9b4f521a78,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0174" %% xsd:string,
-        prov:location = 'niiri:4c0ec437ff4662e7d0eac4dcd51885cb',
+        prov:location = 'niiri:4df3c96aa2621e41fa961300b05f4c73',
         prov:value = "0.766485750675201" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66298512623431" %% xsd:float,
         nidm_pValueUncorrected: = "0.0481577064245639" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:4c0ec437ff4662e7d0eac4dcd51885cb,
+    entity(niiri:4df3c96aa2621e41fa961300b05f4c73,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0174" %% xsd:string,
         nidm_coordinateVector: = "[20,-72,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:f47917da4ed2d8c7e7324d2c0d02a46d, niiri:9a54b30308f71d0c474dab56acec5885, -, -, -)
-    entity(niiri:8e9351607907220ceb9c4d03fd181a94,
+    wasDerivedFrom(niiri:80def1f8a0731234b7509b9b4f521a78, niiri:a0b6cde2f07cadad11fae188db97aa3e, -, -, -)
+    entity(niiri:f2b4c8fde8e4f84a6a4912601523b7df,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0175" %% xsd:string,
-        prov:location = 'niiri:35e7e4f379992bd20464a3fd82e6925c',
+        prov:location = 'niiri:84d153ca4a1304647807d3be47f7888a',
         prov:value = "0.764753878116608" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66081412523685" %% xsd:float,
         nidm_pValueUncorrected: = "0.0483753916847881" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:35e7e4f379992bd20464a3fd82e6925c,
+    entity(niiri:84d153ca4a1304647807d3be47f7888a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0175" %% xsd:string,
         nidm_coordinateVector: = "[30,-32,14]" %% xsd:string])
-    wasDerivedFrom(niiri:8e9351607907220ceb9c4d03fd181a94, niiri:f219989ec875846cc4815fffc10bd118, -, -, -)
-    entity(niiri:33b88df2af789585f536f999c5e3786b,
+    wasDerivedFrom(niiri:f2b4c8fde8e4f84a6a4912601523b7df, niiri:28cf85781211b96d1afff400e743d8e0, -, -, -)
+    entity(niiri:757185c9fd95e6316258dfd8ad5f1ff6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0176" %% xsd:string,
-        prov:location = 'niiri:753a6ac393f5e043a90380ea38ab0569',
+        prov:location = 'niiri:6acd7d3913ce7522e14fde1e44943e73',
         prov:value = "0.764399468898773" %% xsd:float,
         nidm_equivalentZStatistic: = "1.66036990560998" %% xsd:float,
         nidm_pValueUncorrected: = "0.0484200302267611" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:753a6ac393f5e043a90380ea38ab0569,
+    entity(niiri:6acd7d3913ce7522e14fde1e44943e73,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0176" %% xsd:string,
         nidm_coordinateVector: = "[-8,-2,66]" %% xsd:string])
-    wasDerivedFrom(niiri:33b88df2af789585f536f999c5e3786b, niiri:4b37375a8d01d1d9009b430352062714, -, -, -)
-    entity(niiri:bb74269075716d4be58818314e11eb5f,
+    wasDerivedFrom(niiri:757185c9fd95e6316258dfd8ad5f1ff6, niiri:3d1ef8f1229ad13d14520be973ee405c, -, -, -)
+    entity(niiri:e0f17b2441dc69b87cdd45e8ca4ee7c7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0177" %% xsd:string,
-        prov:location = 'niiri:750f7b5e0fd142e4019c35e2387fbbba',
+        prov:location = 'niiri:3617ff6ee179b8c6a14ac8eba47e10fe',
         prov:value = "0.763978481292725" %% xsd:float,
         nidm_equivalentZStatistic: = "1.65984225927592" %% xsd:float,
         nidm_pValueUncorrected: = "0.0484730949107541" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:750f7b5e0fd142e4019c35e2387fbbba,
+    entity(niiri:3617ff6ee179b8c6a14ac8eba47e10fe,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0177" %% xsd:string,
         nidm_coordinateVector: = "[-20,10,-22]" %% xsd:string])
-    wasDerivedFrom(niiri:bb74269075716d4be58818314e11eb5f, niiri:0f0a4015dd42d89522302ce792b20d6d, -, -, -)
-    entity(niiri:3ad00aa4ff8a097302d4f9fa2f588f84,
+    wasDerivedFrom(niiri:e0f17b2441dc69b87cdd45e8ca4ee7c7, niiri:2960c762474a0ecebef6e8e066482105, -, -, -)
+    entity(niiri:4df33de97684a17b10e203e3c302d01c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0178" %% xsd:string,
-        prov:location = 'niiri:35bb5e6863e088834438d69e3f1e49f6',
+        prov:location = 'niiri:1879b473543bd6074c1745df6f3c6cdc',
         prov:value = "0.763044834136963" %% xsd:float,
         nidm_equivalentZStatistic: = "1.65867215934383" %% xsd:float,
         nidm_pValueUncorrected: = "0.0485909362055301" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:35bb5e6863e088834438d69e3f1e49f6,
+    entity(niiri:1879b473543bd6074c1745df6f3c6cdc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0178" %% xsd:string,
         nidm_coordinateVector: = "[-62,2,14]" %% xsd:string])
-    wasDerivedFrom(niiri:3ad00aa4ff8a097302d4f9fa2f588f84, niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a, -, -, -)
-    entity(niiri:fad858bb75eed0c28b072161552a6ba5,
+    wasDerivedFrom(niiri:4df33de97684a17b10e203e3c302d01c, niiri:a86c5c480c3033b63bc45962d5c32c41, -, -, -)
+    entity(niiri:954abdec09c8dd4a4898bbfe748cfcd9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0179" %% xsd:string,
-        prov:location = 'niiri:5bb50d8540759ebdbe65ef922e6b9009',
+        prov:location = 'niiri:19eeb0792f31b2212bb6d81c0bab4b01',
         prov:value = "0.762995421886444" %% xsd:float,
         nidm_equivalentZStatistic: = "1.65861023655314" %% xsd:float,
         nidm_pValueUncorrected: = "0.0485971788535396" %% xsd:float,
         nidm_pValueFWER: = "1" %% xsd:float,
         nidm_qValueFDR: = "0.928284605381944" %% xsd:float])
-    entity(niiri:5bb50d8540759ebdbe65ef922e6b9009,
+    entity(niiri:19eeb0792f31b2212bb6d81c0bab4b01,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0179" %% xsd:string,
         nidm_coordinateVector: = "[-12,-28,80]" %% xsd:string])
-    wasDerivedFrom(niiri:fad858bb75eed0c28b072161552a6ba5, niiri:f6e36041fd68625d6c7813fe63387c51, -, -, -)
+    wasDerivedFrom(niiri:954abdec09c8dd4a4898bbfe748cfcd9, niiri:9d76bd2f2d73c5dfd99aa453786bb3d2, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_partial_conjunction/nidm.ttl
+++ b/spmexport/ex_spm_partial_conjunction/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:243ddea5e5dff3c37c34dba282896eea
+niiri:53e129083d62a2ca94abd3ce77921782
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:25efcb2fdf89f72335565444747a8325
+niiri:88c72fce53af7e51ed2ff12304fbd9ae
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:bc9474858aa89d5580813e5a520e15a8
+niiri:edaedd7a6dd0f3ec41a2098624fa45c4
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:bc9474858aa89d5580813e5a520e15a8 prov:wasAssociatedWith niiri:25efcb2fdf89f72335565444747a8325 .
+niiri:edaedd7a6dd0f3ec41a2098624fa45c4 prov:wasAssociatedWith niiri:88c72fce53af7e51ed2ff12304fbd9ae .
 
 _:blank5 a prov:Generation .
 
-niiri:243ddea5e5dff3c37c34dba282896eea prov:qualifiedGeneration _:blank5 .
+niiri:53e129083d62a2ca94abd3ce77921782 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:34:17"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:45:00"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -136,12 +136,12 @@ _:blank5 prov:atTime "2016-01-11T10:34:17"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:1d7e73278ccee95e211689d9de8f4d4a
+niiri:4e80f2248e423bc7460bc30b328ae5d6
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:a56db6367efd1f7176e69f24b028de94
+niiri:0cfe351ea2a996755a3dbf85a2ca844e
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -151,35 +151,35 @@ niiri:a56db6367efd1f7176e69f24b028de94
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:03e7d0232ea5517ed14b6e2311b82699
+niiri:638afc61f79794663d1226089c695924
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:df0cfe4ba2647dd9f372f5d3b73c6885
+niiri:b35fb1f930f78d3d5e285a9136ef3b7b
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:1388e1cf368a92acbd46e47523c2061a
+niiri:31585807d02b5a99ee20b72b3ab2bf1b
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:d17dbd59c5c8179a99d73392215c0c41 ;
+    dc:description niiri:64eb05a859f67b223eb5213e85827912 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:df0cfe4ba2647dd9f372f5d3b73c6885 ;
+    nidm_hasDriftModel: niiri:b35fb1f930f78d3d5e285a9136ef3b7b ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:d17dbd59c5c8179a99d73392215c0c41
+niiri:64eb05a859f67b223eb5213e85827912
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:05be31167ef4404a70e4f0e58bd930aa
+niiri:8f74b25b85dd7bbba6ad75fa25f658d0
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -187,213 +187,213 @@ niiri:05be31167ef4404a70e4f0e58bd930aa
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:8d051ec65c19e120a2e66d23f309c6e9
+niiri:9a0a32dc2503c28d6779be4fd384e68b
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:8d051ec65c19e120a2e66d23f309c6e9 prov:wasAssociatedWith niiri:1d7e73278ccee95e211689d9de8f4d4a .
+niiri:9a0a32dc2503c28d6779be4fd384e68b prov:wasAssociatedWith niiri:4e80f2248e423bc7460bc30b328ae5d6 .
 
-niiri:8d051ec65c19e120a2e66d23f309c6e9 prov:used niiri:1388e1cf368a92acbd46e47523c2061a .
+niiri:9a0a32dc2503c28d6779be4fd384e68b prov:used niiri:31585807d02b5a99ee20b72b3ab2bf1b .
 
-niiri:8d051ec65c19e120a2e66d23f309c6e9 prov:used niiri:03e7d0232ea5517ed14b6e2311b82699 .
+niiri:9a0a32dc2503c28d6779be4fd384e68b prov:used niiri:638afc61f79794663d1226089c695924 .
 
-niiri:8d051ec65c19e120a2e66d23f309c6e9 prov:used niiri:05be31167ef4404a70e4f0e58bd930aa .
+niiri:9a0a32dc2503c28d6779be4fd384e68b prov:used niiri:8f74b25b85dd7bbba6ad75fa25f658d0 .
 
-niiri:d17318e0fda06cc6303389a919cffce0
+niiri:9f09276d756920c240534438990b34a9
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:511e38d9f81db913e57cb2fda1bf7292
+niiri:cb9a0e835164f4f8b37d523a8400d724
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
 
-niiri:d17318e0fda06cc6303389a919cffce0 prov:wasDerivedFrom niiri:511e38d9f81db913e57cb2fda1bf7292 .
+niiri:9f09276d756920c240534438990b34a9 prov:wasDerivedFrom niiri:cb9a0e835164f4f8b37d523a8400d724 .
 
-niiri:d17318e0fda06cc6303389a919cffce0 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:9f09276d756920c240534438990b34a9 prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:b24768aaee9add9a163a13028ada6ac2
+niiri:5da917d479c32c38ba8509a22d2b90c4
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "108.038318634033"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
 
-niiri:b24768aaee9add9a163a13028ada6ac2 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:5da917d479c32c38ba8509a22d2b90c4 prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:fbf0025dc56929ec686d1a867cba4ed9
+niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e .
 
-niiri:c6f77d4608bf5adce440967ee6f38924
+niiri:ede52b072a350edb793f918d504fc8ca
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f"^^xsd:string .
 
-niiri:fbf0025dc56929ec686d1a867cba4ed9 prov:wasDerivedFrom niiri:c6f77d4608bf5adce440967ee6f38924 .
+niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9 prov:wasDerivedFrom niiri:ede52b072a350edb793f918d504fc8ca .
 
-niiri:fbf0025dc56929ec686d1a867cba4ed9 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9 prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:b0bd46832f113e655723b654eb1eb6ad
+niiri:14112f18638a7370da3d3a355f94de50
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e .
 
-niiri:42e752fc06737a9878924396d3bfcce9
+niiri:bc4f0366eab13c36df4e113d393f9901
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
 
-niiri:b0bd46832f113e655723b654eb1eb6ad prov:wasDerivedFrom niiri:42e752fc06737a9878924396d3bfcce9 .
+niiri:14112f18638a7370da3d3a355f94de50 prov:wasDerivedFrom niiri:bc4f0366eab13c36df4e113d393f9901 .
 
-niiri:b0bd46832f113e655723b654eb1eb6ad prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:14112f18638a7370da3d3a355f94de50 prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:09ee1b58f1cd2a34771305a61a8d1d32
+niiri:05e23b40e89003344a3dacbd46f567de
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e .
 
-niiri:a2c15aa0c4d45f52407ac5827bbf73bb
+niiri:3adf084caea6b7bfcdd869ed826a885e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb"^^xsd:string .
 
-niiri:09ee1b58f1cd2a34771305a61a8d1d32 prov:wasDerivedFrom niiri:a2c15aa0c4d45f52407ac5827bbf73bb .
+niiri:05e23b40e89003344a3dacbd46f567de prov:wasDerivedFrom niiri:3adf084caea6b7bfcdd869ed826a885e .
 
-niiri:09ee1b58f1cd2a34771305a61a8d1d32 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:05e23b40e89003344a3dacbd46f567de prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:16ce2036a3b6f15ece6fc491d108ae37
+niiri:37b5d50db4e958f60096d3793ca3fdf3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e .
 
-niiri:ee716d14a7ac59b3c4521ed8cbff1e3a
+niiri:949afc6e785b9a3f221c178596a3bcf9
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6"^^xsd:string .
 
-niiri:16ce2036a3b6f15ece6fc491d108ae37 prov:wasDerivedFrom niiri:ee716d14a7ac59b3c4521ed8cbff1e3a .
+niiri:37b5d50db4e958f60096d3793ca3fdf3 prov:wasDerivedFrom niiri:949afc6e785b9a3f221c178596a3bcf9 .
 
-niiri:16ce2036a3b6f15ece6fc491d108ae37 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:37b5d50db4e958f60096d3793ca3fdf3 prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:c856b511969b2c541b07a88189532fa6
+niiri:e951c223beee68af908d79eaaf52cd3d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e .
 
-niiri:33afe3bb4683b8e28103d232fdf92af8
+niiri:3a6614401ac6a8441b9cb0233b7b7722
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff"^^xsd:string .
 
-niiri:c856b511969b2c541b07a88189532fa6 prov:wasDerivedFrom niiri:33afe3bb4683b8e28103d232fdf92af8 .
+niiri:e951c223beee68af908d79eaaf52cd3d prov:wasDerivedFrom niiri:3a6614401ac6a8441b9cb0233b7b7722 .
 
-niiri:c856b511969b2c541b07a88189532fa6 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:e951c223beee68af908d79eaaf52cd3d prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:e8f6f2e9821e3f9556f500048b8ae9b5
+niiri:40fd35a7356f9acff12bbe37c24ee5a6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 6" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e .
 
-niiri:8167c647e0923c3553c7c0ffc2d666d4
+niiri:31fb8c34052ae4e914aeecf4dc695a01
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
 
-niiri:e8f6f2e9821e3f9556f500048b8ae9b5 prov:wasDerivedFrom niiri:8167c647e0923c3553c7c0ffc2d666d4 .
+niiri:40fd35a7356f9acff12bbe37c24ee5a6 prov:wasDerivedFrom niiri:31fb8c34052ae4e914aeecf4dc695a01 .
 
-niiri:e8f6f2e9821e3f9556f500048b8ae9b5 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:40fd35a7356f9acff12bbe37c24ee5a6 prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:ecf064f9baf28d8f742bd2855558502d
+niiri:bb0227319e3db3da4111306100a7c129
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8"^^xsd:string .
 
-niiri:2cbf5c3625b82cb3fee7b9e869188b55
+niiri:9e1d5161f7f086396aebbea3f1d66996
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81"^^xsd:string .
 
-niiri:ecf064f9baf28d8f742bd2855558502d prov:wasDerivedFrom niiri:2cbf5c3625b82cb3fee7b9e869188b55 .
+niiri:bb0227319e3db3da4111306100a7c129 prov:wasDerivedFrom niiri:9e1d5161f7f086396aebbea3f1d66996 .
 
-niiri:ecf064f9baf28d8f742bd2855558502d prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:bb0227319e3db3da4111306100a7c129 prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:0c0eb1d804cee8231e915a5fdfc5ab8b
+niiri:f1d4f3ce5390393fe9ce15122e7a462e
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8"^^xsd:string .
 
-niiri:eeee4f9f7f0c1ed7696258b61716b549
+niiri:14109ba534e31f1fcd5cf1a1c39e0277
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29"^^xsd:string .
 
-niiri:0c0eb1d804cee8231e915a5fdfc5ab8b prov:wasDerivedFrom niiri:eeee4f9f7f0c1ed7696258b61716b549 .
+niiri:f1d4f3ce5390393fe9ce15122e7a462e prov:wasDerivedFrom niiri:14109ba534e31f1fcd5cf1a1c39e0277 .
 
-niiri:0c0eb1d804cee8231e915a5fdfc5ab8b prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
+niiri:f1d4f3ce5390393fe9ce15122e7a462e prov:wasGeneratedBy niiri:9a0a32dc2503c28d6779be4fd384e68b .
 
-niiri:0e92041f1c22bfbe8b6d3bba28b3ce18
+niiri:c532578f9638b97cce706f745ab70822
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     rdfs:label "Contrast: mr vs plain" ;
     prov:value "[1, 1, -1, -1, 0, 0]"^^xsd:string .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d
+niiri:b8a53b0ddc7b238b0c822d8247668a2d
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 1" .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:wasAssociatedWith niiri:1d7e73278ccee95e211689d9de8f4d4a .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:wasAssociatedWith niiri:4e80f2248e423bc7460bc30b328ae5d6 .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:d17318e0fda06cc6303389a919cffce0 .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:9f09276d756920c240534438990b34a9 .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:ecf064f9baf28d8f742bd2855558502d .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:bb0227319e3db3da4111306100a7c129 .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:1388e1cf368a92acbd46e47523c2061a .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:31585807d02b5a99ee20b72b3ab2bf1b .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:0e92041f1c22bfbe8b6d3bba28b3ce18 .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:c532578f9638b97cce706f745ab70822 .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:fbf0025dc56929ec686d1a867cba4ed9 .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9 .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:b0bd46832f113e655723b654eb1eb6ad .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:14112f18638a7370da3d3a355f94de50 .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:09ee1b58f1cd2a34771305a61a8d1d32 .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:05e23b40e89003344a3dacbd46f567de .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:16ce2036a3b6f15ece6fc491d108ae37 .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:37b5d50db4e958f60096d3793ca3fdf3 .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:c856b511969b2c541b07a88189532fa6 .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:e951c223beee68af908d79eaaf52cd3d .
 
-niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:e8f6f2e9821e3f9556f500048b8ae9b5 .
+niiri:b8a53b0ddc7b238b0c822d8247668a2d prov:used niiri:40fd35a7356f9acff12bbe37c24ee5a6 .
 
-niiri:3ccd77b3de962099cf8ce0c08029054a
+niiri:9d7bfa4d0b9f9112e97374100868d499
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0001.nii.gz"^^xsd:string ;
@@ -403,84 +403,84 @@ niiri:3ccd77b3de962099cf8ce0c08029054a
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "3d222abce9f360902d01cb45ffaaa3d711c699c6771f36ee61630ccc2fec2275897a15dd31b846a074e20b59337bae8b171223c15f22d8f2168a1967e85b397a"^^xsd:string .
 
-niiri:f9a3461abe033c0b4194f4eb1324b723
+niiri:a038302c53fddd4a98c7160cfbde7138
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782"^^xsd:string .
 
-niiri:3ccd77b3de962099cf8ce0c08029054a prov:wasDerivedFrom niiri:f9a3461abe033c0b4194f4eb1324b723 .
+niiri:9d7bfa4d0b9f9112e97374100868d499 prov:wasDerivedFrom niiri:a038302c53fddd4a98c7160cfbde7138 .
 
-niiri:3ccd77b3de962099cf8ce0c08029054a prov:wasGeneratedBy niiri:4ee8aaeabfe9f5181a4281676d9a033d .
+niiri:9d7bfa4d0b9f9112e97374100868d499 prov:wasGeneratedBy niiri:b8a53b0ddc7b238b0c822d8247668a2d .
 
-niiri:8fec6cee88576b42702d9e1f7488e362
+niiri:d67127701e2842c7ad80371e04374f1c
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: mr vs plain" ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5"^^xsd:string .
 
-niiri:3dcfcea6814505f9436e9dba6e69af0a
+niiri:e5258d5b3277133b0419fa9783cb9dd2
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28"^^xsd:string .
 
-niiri:8fec6cee88576b42702d9e1f7488e362 prov:wasDerivedFrom niiri:3dcfcea6814505f9436e9dba6e69af0a .
+niiri:d67127701e2842c7ad80371e04374f1c prov:wasDerivedFrom niiri:e5258d5b3277133b0419fa9783cb9dd2 .
 
-niiri:8fec6cee88576b42702d9e1f7488e362 prov:wasGeneratedBy niiri:4ee8aaeabfe9f5181a4281676d9a033d .
+niiri:d67127701e2842c7ad80371e04374f1c prov:wasGeneratedBy niiri:b8a53b0ddc7b238b0c822d8247668a2d .
 
-niiri:4ad1bd5ff050ee049008dafae70fffb2
+niiri:810644c2421100536dbd030c23c92d8c
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b"^^xsd:string .
 
-niiri:4ad1bd5ff050ee049008dafae70fffb2 prov:wasGeneratedBy niiri:4ee8aaeabfe9f5181a4281676d9a033d .
+niiri:810644c2421100536dbd030c23c92d8c prov:wasGeneratedBy niiri:b8a53b0ddc7b238b0c822d8247668a2d .
 
-niiri:13fb71f74ac2523fac8d4fe8ab7ecb1d
+niiri:ded3bff3ce2da6fb2df69c3c171fd62b
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
     rdfs:label "Contrast: switch vs nonswitch (orth. w.r.t {1})" ;
     prov:value "[0.953151930124911, -1.04684806987509, 1.04684806987509, -0.953151930124911, 0, 0]"^^xsd:string .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08
+niiri:87124f9d582147cec91df8f0e1c825f7
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 2" .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:wasAssociatedWith niiri:1d7e73278ccee95e211689d9de8f4d4a .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:wasAssociatedWith niiri:4e80f2248e423bc7460bc30b328ae5d6 .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:d17318e0fda06cc6303389a919cffce0 .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:9f09276d756920c240534438990b34a9 .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:ecf064f9baf28d8f742bd2855558502d .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:bb0227319e3db3da4111306100a7c129 .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:1388e1cf368a92acbd46e47523c2061a .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:31585807d02b5a99ee20b72b3ab2bf1b .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:13fb71f74ac2523fac8d4fe8ab7ecb1d .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:ded3bff3ce2da6fb2df69c3c171fd62b .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:fbf0025dc56929ec686d1a867cba4ed9 .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:4e3a06b069cc20b2ad0b2c31cd5dc9d9 .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:b0bd46832f113e655723b654eb1eb6ad .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:14112f18638a7370da3d3a355f94de50 .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:09ee1b58f1cd2a34771305a61a8d1d32 .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:05e23b40e89003344a3dacbd46f567de .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:16ce2036a3b6f15ece6fc491d108ae37 .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:37b5d50db4e958f60096d3793ca3fdf3 .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:c856b511969b2c541b07a88189532fa6 .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:e951c223beee68af908d79eaaf52cd3d .
 
-niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:e8f6f2e9821e3f9556f500048b8ae9b5 .
+niiri:87124f9d582147cec91df8f0e1c825f7 prov:used niiri:40fd35a7356f9acff12bbe37c24ee5a6 .
 
-niiri:406c820ff107488cd976836b2d5c6516
+niiri:a66dbffb487a58bd067df5d6b5e3980b
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0002.nii.gz"^^xsd:string ;
@@ -490,126 +490,126 @@ niiri:406c820ff107488cd976836b2d5c6516
     nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "ec2f61dbf28ab2256a374dc5e3a93ba3a54e520c6bccd089dfbd07421e445b4881154433ea31e32587c1fae170daa5dc0a21f6efc328b90727d8d25bbd524e2f"^^xsd:string .
 
-niiri:e928c1c55744b1fd90a0de8fa5ab64b3
+niiri:19a7224c80d25fb724dee163a1e1dc8e
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4a7d076c01440a170e048ebe9644f90193b2aaf1291f454bdc6be2cf17e11a66b1d177025f5ed77434afe780ff8dcba710ec41120246e38894f823eb0fd88621"^^xsd:string .
 
-niiri:406c820ff107488cd976836b2d5c6516 prov:wasDerivedFrom niiri:e928c1c55744b1fd90a0de8fa5ab64b3 .
+niiri:a66dbffb487a58bd067df5d6b5e3980b prov:wasDerivedFrom niiri:19a7224c80d25fb724dee163a1e1dc8e .
 
-niiri:406c820ff107488cd976836b2d5c6516 prov:wasGeneratedBy niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 .
+niiri:a66dbffb487a58bd067df5d6b5e3980b prov:wasGeneratedBy niiri:87124f9d582147cec91df8f0e1c825f7 .
 
-niiri:769ec268b92ea35935ef54cff37b9b03
+niiri:12d49f892703283c79a1a5df181e60aa
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: switch vs nonswitch (orth. w.r.t {1})" ;
     nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "31a00f409f493fc214fe1f84fe2a799bb96d1e03d67f2ce5b8c5b5fdb934bb0005f1be68addb81934052af4643c3099542ea4944013e9346042a44c2ed8f3788"^^xsd:string .
 
-niiri:37d6e69cac2b0a5b938bfdfb712bf881
+niiri:41374722583b15739e066d38b1129c99
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "6d92adc90c0045445b66064818fdae617474690e92e9cb332e73fa8bf27f6d1d18367c0648ffbc74196a5c2ce9f4af4186394628eed475a0e2866efe3d4eee9b"^^xsd:string .
 
-niiri:769ec268b92ea35935ef54cff37b9b03 prov:wasDerivedFrom niiri:37d6e69cac2b0a5b938bfdfb712bf881 .
+niiri:12d49f892703283c79a1a5df181e60aa prov:wasDerivedFrom niiri:41374722583b15739e066d38b1129c99 .
 
-niiri:769ec268b92ea35935ef54cff37b9b03 prov:wasGeneratedBy niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 .
+niiri:12d49f892703283c79a1a5df181e60aa prov:wasGeneratedBy niiri:87124f9d582147cec91df8f0e1c825f7 .
 
-niiri:791b2b0b99cd2c0794a3a2a508127afe
+niiri:0a15259e1cb84af956c3d425f69b6a6d
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "ac87f548f0d92f929c05476d2aacbc7e5319da6d62a5585a72d714be836b1b86962a36c6d473ae84c17cd613d683976e9fc562d6d7692cb8e942966f71e34a08"^^xsd:string .
 
-niiri:791b2b0b99cd2c0794a3a2a508127afe prov:wasGeneratedBy niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 .
+niiri:0a15259e1cb84af956c3d425f69b6a6d prov:wasGeneratedBy niiri:87124f9d582147cec91df8f0e1c825f7 .
 
-niiri:926b152f947e98d6025b235c27f919b2
+niiri:f910459d8c9231bd403e71f9e88897d7
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.048771 (unc.)" ;
     prov:value "0.0487705355732563"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:6c13a2215653fb5c58245ecb3124b723 ;
-    nidm_equivalentThreshold: niiri:e14ba17059f36074630699f7fc00a61e .
+    nidm_equivalentThreshold: niiri:b9cac449a762eda6c6944912d6bc5139 ;
+    nidm_equivalentThreshold: niiri:e4f48690675c5e668fa0c4b1952e89f6 .
 
-niiri:6c13a2215653fb5c58245ecb3124b723
+niiri:b9cac449a762eda6c6944912d6bc5139
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.761625168301108"^^xsd:float .
 
-niiri:e14ba17059f36074630699f7fc00a61e
+niiri:e4f48690675c5e668fa0c4b1952e89f6
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:57dbc4426669cb76ea05d5c255480994
+niiri:3e9ab6b7ab94d21f2e2eb27edcd3e0b7
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:461720f2996e5344ac089e2cec429c07 ;
-    nidm_equivalentThreshold: niiri:abec52af88c1f072dc3422a358ae41ff .
+    nidm_equivalentThreshold: niiri:841c05662d34dd6394d93a67aab3944d ;
+    nidm_equivalentThreshold: niiri:896df8b6f3696a2566e797f4d5ca35d9 .
 
-niiri:461720f2996e5344ac089e2cec429c07
+niiri:841c05662d34dd6394d93a67aab3944d
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:abec52af88c1f072dc3422a358ae41ff
+niiri:896df8b6f3696a2566e797f4d5ca35d9
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:3d219576930e0e1002fa5ad61a717666
+niiri:e64dd9a3993e688a02e46f618db34698
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:a5a3ea39278acdf05599017327bbbab6
+niiri:495c70d4ecfbcfc93cc3c1d386a10e84
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e
     a prov:Activity, spm_PartialConjunctionInference ; 
     rdfs:label " Partial Conjunction Inference" ;
     spm_partialConjunctionDegree: "2"^^xsd:int .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:wasAssociatedWith niiri:1d7e73278ccee95e211689d9de8f4d4a .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:wasAssociatedWith niiri:4e80f2248e423bc7460bc30b328ae5d6 .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:926b152f947e98d6025b235c27f919b2 .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:used niiri:f910459d8c9231bd403e71f9e88897d7 .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:57dbc4426669cb76ea05d5c255480994 .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:used niiri:3e9ab6b7ab94d21f2e2eb27edcd3e0b7 .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:3ccd77b3de962099cf8ce0c08029054a .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:used niiri:9d7bfa4d0b9f9112e97374100868d499 .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:406c820ff107488cd976836b2d5c6516 .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:used niiri:a66dbffb487a58bd067df5d6b5e3980b .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:0c0eb1d804cee8231e915a5fdfc5ab8b .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:used niiri:f1d4f3ce5390393fe9ce15122e7a462e .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:d17318e0fda06cc6303389a919cffce0 .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:used niiri:9f09276d756920c240534438990b34a9 .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:3d219576930e0e1002fa5ad61a717666 .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:used niiri:e64dd9a3993e688a02e46f618db34698 .
 
-niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:a5a3ea39278acdf05599017327bbbab6 .
+niiri:d51f5fd37ea92b55541c8f1c4a4c255e prov:used niiri:495c70d4ecfbcfc93cc3c1d386a10e84 .
 
-niiri:d31b1142c5902eeff2fda19317e15bea
+niiri:fefe2eec48ef20facaab171162fdcdd4
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
     nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.4409986586553"^^xsd:float ;
@@ -626,9 +626,9 @@ niiri:d31b1142c5902eeff2fda19317e15bea
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "NaN"^^xsd:int ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:d31b1142c5902eeff2fda19317e15bea prov:wasGeneratedBy niiri:8ca7abe146d9bd8a996b72f2d817f4e9 .
+niiri:fefe2eec48ef20facaab171162fdcdd4 prov:wasGeneratedBy niiri:d51f5fd37ea92b55541c8f1c4a4c255e .
 
-niiri:d4dd8ab29b5f9534a65e9a4b237ca312
+niiri:3fd40489e0c7ad32d9dfa018bf86de4d
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -636,26 +636,26 @@ niiri:d4dd8ab29b5f9534a65e9a4b237ca312
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "150"^^xsd:int ;
     nidm_pValue: "1"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:216bc8b13e5d82e899e5c52cbb83016c ;
-    nidm_hasMaximumIntensityProjection: niiri:84d7cbdeb48144857ed31bb58c5ddc5b ;
-    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
+    nidm_hasClusterLabelsMap: niiri:a0313af9221db64a9d9558f02250653a ;
+    nidm_hasMaximumIntensityProjection: niiri:d02b883a417d3ce84e4591b2358cc8ef ;
+    nidm_inCoordinateSpace: niiri:0cfe351ea2a996755a3dbf85a2ca844e ;
     crypto:sha512 "662dfeb3cba04a6a6beda3e1e23ff90c951f3ffae3d379b8fbfef06307db3055236586cace653593957e67f60c9dbbaadb5f3cc87c0ecc9dcfb81727d86f177f"^^xsd:string .
 
-niiri:216bc8b13e5d82e899e5c52cbb83016c
+niiri:a0313af9221db64a9d9558f02250653a
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:84d7cbdeb48144857ed31bb58c5ddc5b
+niiri:d02b883a417d3ce84e4591b2358cc8ef
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:d4dd8ab29b5f9534a65e9a4b237ca312 prov:wasGeneratedBy niiri:8ca7abe146d9bd8a996b72f2d817f4e9 .
+niiri:3fd40489e0c7ad32d9dfa018bf86de4d prov:wasGeneratedBy niiri:d51f5fd37ea92b55541c8f1c4a4c255e .
 
-niiri:4362f5eac9972bf179ea49be33151c8e
+niiri:eaccd3ae3e22bfdca0eb19a7d8d32655
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "2637"^^xsd:int ;
@@ -665,9 +665,9 @@ niiri:4362f5eac9972bf179ea49be33151c8e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:4362f5eac9972bf179ea49be33151c8e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:eaccd3ae3e22bfdca0eb19a7d8d32655 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:00f296730dd06a43e5f7334c226305c6
+niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "1415"^^xsd:int ;
@@ -677,9 +677,9 @@ niiri:00f296730dd06a43e5f7334c226305c6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:00f296730dd06a43e5f7334c226305c6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:39a3babf6ed520d78e67263717ca5dbb
+niiri:01caf6dcc4c07046ab44e8a119bab255
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "376"^^xsd:int ;
@@ -689,9 +689,9 @@ niiri:39a3babf6ed520d78e67263717ca5dbb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:39a3babf6ed520d78e67263717ca5dbb prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:01caf6dcc4c07046ab44e8a119bab255 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:26ed93f97118482ea99f750276db5700
+niiri:9a28574137dba928b957fda9013d355a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "128"^^xsd:int ;
@@ -701,9 +701,9 @@ niiri:26ed93f97118482ea99f750276db5700
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:26ed93f97118482ea99f750276db5700 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:9a28574137dba928b957fda9013d355a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:c0faffa954cb5edf1bd166b3c13b64b6
+niiri:be0a079f2f0b4ba9e502f600a4b77251
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -713,9 +713,9 @@ niiri:c0faffa954cb5edf1bd166b3c13b64b6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:c0faffa954cb5edf1bd166b3c13b64b6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:be0a079f2f0b4ba9e502f600a4b77251 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:1baee1eea0758a922f6c4f1f12441da6
+niiri:5c92eec2bb2da6800e461deccb3a6c17
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "482"^^xsd:int ;
@@ -725,9 +725,9 @@ niiri:1baee1eea0758a922f6c4f1f12441da6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:1baee1eea0758a922f6c4f1f12441da6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:5c92eec2bb2da6800e461deccb3a6c17 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:1aa58b6ce0025b1ec01cb8a983388e1d
+niiri:a87a039e7919a12304129d212230f18a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -737,9 +737,9 @@ niiri:1aa58b6ce0025b1ec01cb8a983388e1d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:1aa58b6ce0025b1ec01cb8a983388e1d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:a87a039e7919a12304129d212230f18a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:3198b98e15c5c56654d8a4ffe4b44ce8
+niiri:e274a3eaada08953bd1833b7c48506f2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "292"^^xsd:int ;
@@ -749,9 +749,9 @@ niiri:3198b98e15c5c56654d8a4ffe4b44ce8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:3198b98e15c5c56654d8a4ffe4b44ce8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:e274a3eaada08953bd1833b7c48506f2 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:7d6744d8bee9e326b4381ceb83e93c8d
+niiri:245273ed130aa663dd8395923de7d766
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "454"^^xsd:int ;
@@ -761,9 +761,9 @@ niiri:7d6744d8bee9e326b4381ceb83e93c8d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:7d6744d8bee9e326b4381ceb83e93c8d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:245273ed130aa663dd8395923de7d766 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:1593dbfe6a27c4bfd6c7c865a55e6758
+niiri:d173e9e0c068ad3a55c343fddbeff960
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -773,9 +773,9 @@ niiri:1593dbfe6a27c4bfd6c7c865a55e6758
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:1593dbfe6a27c4bfd6c7c865a55e6758 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:d173e9e0c068ad3a55c343fddbeff960 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:537cd4e035d031e1d96dcc9b62c35112
+niiri:26532b37abc532050b4bc4be92087a96
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "121"^^xsd:int ;
@@ -785,9 +785,9 @@ niiri:537cd4e035d031e1d96dcc9b62c35112
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:537cd4e035d031e1d96dcc9b62c35112 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:26532b37abc532050b4bc4be92087a96 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:3330f53a36ff5c9ef2f20b1290e9d286
+niiri:aa0ecf58900f58c3045f470d5e5cd69a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "152"^^xsd:int ;
@@ -797,9 +797,9 @@ niiri:3330f53a36ff5c9ef2f20b1290e9d286
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:3330f53a36ff5c9ef2f20b1290e9d286 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:aa0ecf58900f58c3045f470d5e5cd69a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9c973b3443bcab76e6ce5b021d6b1a13
+niiri:901b9fd9da6bf5e77628b338170d2e8d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "118"^^xsd:int ;
@@ -809,9 +809,9 @@ niiri:9c973b3443bcab76e6ce5b021d6b1a13
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:9c973b3443bcab76e6ce5b021d6b1a13 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:901b9fd9da6bf5e77628b338170d2e8d prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:27a3407fb41dee69924952963bf01095
+niiri:54e9eacbd4a27d2bb3a673e3ecd6842c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -821,9 +821,9 @@ niiri:27a3407fb41dee69924952963bf01095
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:27a3407fb41dee69924952963bf01095 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:54e9eacbd4a27d2bb3a673e3ecd6842c prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9c3f0991818d487326255d5ca7862e30
+niiri:102bcff4159cf1d08e8b6d4fdfbaade6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "53"^^xsd:int ;
@@ -833,9 +833,9 @@ niiri:9c3f0991818d487326255d5ca7862e30
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:9c3f0991818d487326255d5ca7862e30 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:102bcff4159cf1d08e8b6d4fdfbaade6 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:73094daa238696f8de11ef4e56a95c30
+niiri:71589bd4c92a13b9d77db1a0f4dfe621
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -845,9 +845,9 @@ niiri:73094daa238696f8de11ef4e56a95c30
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:73094daa238696f8de11ef4e56a95c30 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:71589bd4c92a13b9d77db1a0f4dfe621 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:35af8997746066bb4be8d3a9cebf0640
+niiri:59224724a1e5e6aa2048738e448b7eb6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -857,9 +857,9 @@ niiri:35af8997746066bb4be8d3a9cebf0640
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:35af8997746066bb4be8d3a9cebf0640 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:59224724a1e5e6aa2048738e448b7eb6 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9d0b757e22fc3f0156790583744c1334
+niiri:6b72e4095c1f07ea4ea737f0c44371c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "51"^^xsd:int ;
@@ -869,9 +869,9 @@ niiri:9d0b757e22fc3f0156790583744c1334
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:9d0b757e22fc3f0156790583744c1334 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:6b72e4095c1f07ea4ea737f0c44371c4 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8d3362f5850c9379377b0d1f0b1c2735
+niiri:adcf7702789aacaca259aab58c015a1b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -881,9 +881,9 @@ niiri:8d3362f5850c9379377b0d1f0b1c2735
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:8d3362f5850c9379377b0d1f0b1c2735 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:adcf7702789aacaca259aab58c015a1b prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:227019e17364687787db60a4a8267663
+niiri:9583432017e2a81f5dfd9ee21e31202e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -893,9 +893,9 @@ niiri:227019e17364687787db60a4a8267663
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:227019e17364687787db60a4a8267663 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:9583432017e2a81f5dfd9ee21e31202e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8669f380bd303fec5b169e636d626ce3
+niiri:4d1c403da9e27b79352d1129d7d66218
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -905,9 +905,9 @@ niiri:8669f380bd303fec5b169e636d626ce3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:8669f380bd303fec5b169e636d626ce3 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:4d1c403da9e27b79352d1129d7d66218 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:f38934924fa68b3b9a71fb9c8171e8b6
+niiri:7ac836ca3990ce9f1e31e9eb1801404a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -917,9 +917,9 @@ niiri:f38934924fa68b3b9a71fb9c8171e8b6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:f38934924fa68b3b9a71fb9c8171e8b6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:7ac836ca3990ce9f1e31e9eb1801404a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:1793504b32e2869dcb2fbd3af062f8bc
+niiri:fe6bad7c2c3cd88c5e91fc8c7f05871c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -929,9 +929,9 @@ niiri:1793504b32e2869dcb2fbd3af062f8bc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:1793504b32e2869dcb2fbd3af062f8bc prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:fe6bad7c2c3cd88c5e91fc8c7f05871c prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:55aacac3d3863ecd2c5789acfd6b261d
+niiri:af4a779ba8799ad0c9fe505505295a71
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -941,9 +941,9 @@ niiri:55aacac3d3863ecd2c5789acfd6b261d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:55aacac3d3863ecd2c5789acfd6b261d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:af4a779ba8799ad0c9fe505505295a71 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:03238c6a619b9f265421cbb7a0cda76e
+niiri:034859fff2bec220b9605fe31c29e464
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "42"^^xsd:int ;
@@ -953,9 +953,9 @@ niiri:03238c6a619b9f265421cbb7a0cda76e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:03238c6a619b9f265421cbb7a0cda76e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:034859fff2bec220b9605fe31c29e464 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:bc83f4e59851c0ed8424e3172a378ee4
+niiri:e4a8ed309e5dfdfbdd940912aa7b9917
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "34"^^xsd:int ;
@@ -965,9 +965,9 @@ niiri:bc83f4e59851c0ed8424e3172a378ee4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:bc83f4e59851c0ed8424e3172a378ee4 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:e4a8ed309e5dfdfbdd940912aa7b9917 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:c340f3ccccc1a020f9aef989954e51fc
+niiri:54cdf7b7e5fb6a712a9931f377c09dad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -977,9 +977,9 @@ niiri:c340f3ccccc1a020f9aef989954e51fc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:c340f3ccccc1a020f9aef989954e51fc prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:54cdf7b7e5fb6a712a9931f377c09dad prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5
+niiri:f86480eb515c35553583815451053247
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -989,9 +989,9 @@ niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:f86480eb515c35553583815451053247 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:cb85dd1324b2d86671b2fe868f4dafc0
+niiri:797c0d6ce89eec38f010854e7e38594b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1001,9 +1001,9 @@ niiri:cb85dd1324b2d86671b2fe868f4dafc0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:cb85dd1324b2d86671b2fe868f4dafc0 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:797c0d6ce89eec38f010854e7e38594b prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:0dc11dbfea7cb1fef76a1c48d7f8750f
+niiri:223b74991051acba66efeafdae50f4c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1013,9 +1013,9 @@ niiri:0dc11dbfea7cb1fef76a1c48d7f8750f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:0dc11dbfea7cb1fef76a1c48d7f8750f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:223b74991051acba66efeafdae50f4c4 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:6db75fb201d2decf706c9d2dd225cb5a
+niiri:294fdb1b5bfd7e0473b8498bbe447111
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -1025,9 +1025,9 @@ niiri:6db75fb201d2decf706c9d2dd225cb5a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:6db75fb201d2decf706c9d2dd225cb5a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:294fdb1b5bfd7e0473b8498bbe447111 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8fae62d51a220dbd34d1d3074ad97c80
+niiri:317b26ee6683fc2d7e4152e9f21569d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1037,9 +1037,9 @@ niiri:8fae62d51a220dbd34d1d3074ad97c80
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:8fae62d51a220dbd34d1d3074ad97c80 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:317b26ee6683fc2d7e4152e9f21569d5 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:1b3f6a9bf76e54ad12539e190c7c838c
+niiri:7a8231297a4abeb5308420c5bd8b95b0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -1049,9 +1049,9 @@ niiri:1b3f6a9bf76e54ad12539e190c7c838c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:1b3f6a9bf76e54ad12539e190c7c838c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:7a8231297a4abeb5308420c5bd8b95b0 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:dc2d50ba6c535742eed46213fc557f6a
+niiri:6b7b56e17486f776bce05e82a97e5bb7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -1061,9 +1061,9 @@ niiri:dc2d50ba6c535742eed46213fc557f6a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:dc2d50ba6c535742eed46213fc557f6a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:6b7b56e17486f776bce05e82a97e5bb7 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:416dfaa44bb6a7fe97539c984a9173c3
+niiri:dbaf33f41cd427af7e5a021f10031a6a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1073,9 +1073,9 @@ niiri:416dfaa44bb6a7fe97539c984a9173c3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:416dfaa44bb6a7fe97539c984a9173c3 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:dbaf33f41cd427af7e5a021f10031a6a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:31033e543fb9492bc06e61625ca6b410
+niiri:2cb148daa680c4c53ffa5337fb86c905
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1085,9 +1085,9 @@ niiri:31033e543fb9492bc06e61625ca6b410
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:31033e543fb9492bc06e61625ca6b410 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:2cb148daa680c4c53ffa5337fb86c905 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:7a8b21e9acaff0531c73c9fe0bfaeb53
+niiri:1d84285e01d49d904f7b5e9f0333287b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1097,9 +1097,9 @@ niiri:7a8b21e9acaff0531c73c9fe0bfaeb53
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:7a8b21e9acaff0531c73c9fe0bfaeb53 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:1d84285e01d49d904f7b5e9f0333287b prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:5102964768a1c4313f8c0e48d48f8b40
+niiri:8cb6b321e3922f27346febc1c617df72
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1109,9 +1109,9 @@ niiri:5102964768a1c4313f8c0e48d48f8b40
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:5102964768a1c4313f8c0e48d48f8b40 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8cb6b321e3922f27346febc1c617df72 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:256070c77a58b8b64913a5b6bfb81f60
+niiri:bd60388f21dba151ffa9b94fc56a76fc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1121,9 +1121,9 @@ niiri:256070c77a58b8b64913a5b6bfb81f60
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:256070c77a58b8b64913a5b6bfb81f60 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:bd60388f21dba151ffa9b94fc56a76fc prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:96604941a960daa1e224727cb5ba2d60
+niiri:2634cefb56e62fe1daef544f6c3dc96a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -1133,9 +1133,9 @@ niiri:96604941a960daa1e224727cb5ba2d60
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:96604941a960daa1e224727cb5ba2d60 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:2634cefb56e62fe1daef544f6c3dc96a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:529af4aecda9065e5cce8adf4cdfd5c6
+niiri:eaf17770fa04ac0e839b538c792a3073
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1145,9 +1145,9 @@ niiri:529af4aecda9065e5cce8adf4cdfd5c6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:529af4aecda9065e5cce8adf4cdfd5c6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:eaf17770fa04ac0e839b538c792a3073 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:bdef3fee2464d33f021c131ff78646c7
+niiri:79667c98e94d775596ecebd364219144
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1157,9 +1157,9 @@ niiri:bdef3fee2464d33f021c131ff78646c7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:bdef3fee2464d33f021c131ff78646c7 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:79667c98e94d775596ecebd364219144 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:e8088392c69eb956afef92cedfa6aeb4
+niiri:a9ca1d216068df228b4f56edb8974b0f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1169,9 +1169,9 @@ niiri:e8088392c69eb956afef92cedfa6aeb4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:e8088392c69eb956afef92cedfa6aeb4 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:a9ca1d216068df228b4f56edb8974b0f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8b4322c153a15066be2583d11b23925c
+niiri:8bd946eb61909b953aeda01719f94d66
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -1181,9 +1181,9 @@ niiri:8b4322c153a15066be2583d11b23925c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:8b4322c153a15066be2583d11b23925c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8bd946eb61909b953aeda01719f94d66 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:0c0e48a110ec2c20b75585b9e5372d67
+niiri:e49222f43a2c5f3b6f74b9eb9a47bd2f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1193,9 +1193,9 @@ niiri:0c0e48a110ec2c20b75585b9e5372d67
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:0c0e48a110ec2c20b75585b9e5372d67 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:e49222f43a2c5f3b6f74b9eb9a47bd2f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:1bf866f2d8a1a832a120aa9c02c60efd
+niiri:cccc8624875aafd03105dd4bd6af0ac3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -1205,9 +1205,9 @@ niiri:1bf866f2d8a1a832a120aa9c02c60efd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:1bf866f2d8a1a832a120aa9c02c60efd prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:cccc8624875aafd03105dd4bd6af0ac3 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:a44aefad34ca2359e69bf6f9306bc2c6
+niiri:c163699e2c590670b56fd1928fe502a8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1217,9 +1217,9 @@ niiri:a44aefad34ca2359e69bf6f9306bc2c6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:a44aefad34ca2359e69bf6f9306bc2c6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:c163699e2c590670b56fd1928fe502a8 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:ab78ea55fc7f212636dd2f73bdc99032
+niiri:4824d04f1a3ab526790824f893297a94
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1229,9 +1229,9 @@ niiri:ab78ea55fc7f212636dd2f73bdc99032
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:ab78ea55fc7f212636dd2f73bdc99032 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:4824d04f1a3ab526790824f893297a94 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:4128bacb45b84a2304aceeb9a3a06db7
+niiri:64a8a8faea43eec16f564fc4aaeca53d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1241,9 +1241,9 @@ niiri:4128bacb45b84a2304aceeb9a3a06db7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:4128bacb45b84a2304aceeb9a3a06db7 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:64a8a8faea43eec16f564fc4aaeca53d prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:282d81c6243a1094abf4c4787764df02
+niiri:0260356613cbea9c3fd0a42442707965
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1253,9 +1253,9 @@ niiri:282d81c6243a1094abf4c4787764df02
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:282d81c6243a1094abf4c4787764df02 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:0260356613cbea9c3fd0a42442707965 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb
+niiri:6c858d3255cb0a3570ef36dfad0fb623
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1265,9 +1265,9 @@ niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:6c858d3255cb0a3570ef36dfad0fb623 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:e58cf8e24a087d5746f02fb59416d367
+niiri:073492dcf968ea0eb583396771e18cab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1277,9 +1277,9 @@ niiri:e58cf8e24a087d5746f02fb59416d367
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:e58cf8e24a087d5746f02fb59416d367 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:073492dcf968ea0eb583396771e18cab prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:47a95f63466991d3e681c4886347a76b
+niiri:780d9b79f072e4bd50e8f0325a0fab9c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1289,9 +1289,9 @@ niiri:47a95f63466991d3e681c4886347a76b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:47a95f63466991d3e681c4886347a76b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:780d9b79f072e4bd50e8f0325a0fab9c prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:6a2d34c94894023a09a46d7ba699025b
+niiri:81f84bc9b5b654bad34cdaaac10ba1b6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1301,9 +1301,9 @@ niiri:6a2d34c94894023a09a46d7ba699025b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:6a2d34c94894023a09a46d7ba699025b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:81f84bc9b5b654bad34cdaaac10ba1b6 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:6ac7ce35dfb3dcf2c2696278c805c40a
+niiri:90a20d94dc8e450298e631ead963f32b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1313,9 +1313,9 @@ niiri:6ac7ce35dfb3dcf2c2696278c805c40a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:6ac7ce35dfb3dcf2c2696278c805c40a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:90a20d94dc8e450298e631ead963f32b prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:60e118fd5205eaa96f4b55808761eaf7
+niiri:f95655c375074857b8c6e69cc5aafd0f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1325,9 +1325,9 @@ niiri:60e118fd5205eaa96f4b55808761eaf7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:60e118fd5205eaa96f4b55808761eaf7 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:f95655c375074857b8c6e69cc5aafd0f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:afff6750152337d325f510f877cd2b9c
+niiri:af7629a171a38e8e209c4bfe5f604c75
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1337,9 +1337,9 @@ niiri:afff6750152337d325f510f877cd2b9c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:afff6750152337d325f510f877cd2b9c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:af7629a171a38e8e209c4bfe5f604c75 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:c87d05b7d28080150c45409119a926f8
+niiri:327ebdb7a1236038ee0a1c3dd96e5874
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1349,9 +1349,9 @@ niiri:c87d05b7d28080150c45409119a926f8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:c87d05b7d28080150c45409119a926f8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:327ebdb7a1236038ee0a1c3dd96e5874 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:f1bb918000bbcdd8562fb7b7887a394d
+niiri:383ee7c40b6e148981f60c5244bc24eb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1361,9 +1361,9 @@ niiri:f1bb918000bbcdd8562fb7b7887a394d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:f1bb918000bbcdd8562fb7b7887a394d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:383ee7c40b6e148981f60c5244bc24eb prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c
+niiri:7f19917cc657f479955495d0706a5e07
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1373,9 +1373,9 @@ niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:7f19917cc657f479955495d0706a5e07 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f
+niiri:df2a03c212f39fc884fa4c74b8f9861f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1385,9 +1385,9 @@ niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:df2a03c212f39fc884fa4c74b8f9861f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9e7cd816ef42776bf358bfe67f08f014
+niiri:d2f081110d405da4d574363c2c229683
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1397,9 +1397,9 @@ niiri:9e7cd816ef42776bf358bfe67f08f014
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:9e7cd816ef42776bf358bfe67f08f014 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:d2f081110d405da4d574363c2c229683 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:712375a17d0ff43c9dca459517dff9b2
+niiri:a9fda50c3e4479f40fb3419e04ad60e2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1409,9 +1409,9 @@ niiri:712375a17d0ff43c9dca459517dff9b2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:712375a17d0ff43c9dca459517dff9b2 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:a9fda50c3e4479f40fb3419e04ad60e2 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:feddd730f38d65d4f1fd0e8616bcc9a5
+niiri:2bc33575bac46d2c46e0ab7793110244
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1421,9 +1421,9 @@ niiri:feddd730f38d65d4f1fd0e8616bcc9a5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:feddd730f38d65d4f1fd0e8616bcc9a5 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:2bc33575bac46d2c46e0ab7793110244 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8041bc77682f50b65136018ca10c889c
+niiri:ddb629f82c3dbdee2cea3fa27c6ff935
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1433,9 +1433,9 @@ niiri:8041bc77682f50b65136018ca10c889c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:8041bc77682f50b65136018ca10c889c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:ddb629f82c3dbdee2cea3fa27c6ff935 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:e852e949acffc71ed6cce677c7be19d6
+niiri:caa42f603185cae01bb9beafa64dc995
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1445,9 +1445,9 @@ niiri:e852e949acffc71ed6cce677c7be19d6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:e852e949acffc71ed6cce677c7be19d6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:caa42f603185cae01bb9beafa64dc995 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:0d099ee69c96416336f843fd890da4a0
+niiri:c445a9fb8be8c80d5df620717862bf5f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1457,9 +1457,9 @@ niiri:0d099ee69c96416336f843fd890da4a0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:0d099ee69c96416336f843fd890da4a0 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:c445a9fb8be8c80d5df620717862bf5f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:6d0ee7f5877dfa2620f95f47e06e2a9a
+niiri:44518bfa6ffcd022c48e2ccb2c04ed0a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1469,9 +1469,9 @@ niiri:6d0ee7f5877dfa2620f95f47e06e2a9a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:6d0ee7f5877dfa2620f95f47e06e2a9a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:44518bfa6ffcd022c48e2ccb2c04ed0a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:6ab419381418bd7fca0cb5bac6782b77
+niiri:82a21597b08e98aa671123ebbede6579
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1481,9 +1481,9 @@ niiri:6ab419381418bd7fca0cb5bac6782b77
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:6ab419381418bd7fca0cb5bac6782b77 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:82a21597b08e98aa671123ebbede6579 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:b19325ccb6192dba58545cbeb7bc92e1
+niiri:15cc5ee45c7553094b172ffcbfc6a579
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1493,9 +1493,9 @@ niiri:b19325ccb6192dba58545cbeb7bc92e1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:b19325ccb6192dba58545cbeb7bc92e1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:15cc5ee45c7553094b172ffcbfc6a579 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:745fe95a68372701f2888393e817a23e
+niiri:ff736f05be57ac9dd4cfdb8776f08af9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1505,9 +1505,9 @@ niiri:745fe95a68372701f2888393e817a23e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:745fe95a68372701f2888393e817a23e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:ff736f05be57ac9dd4cfdb8776f08af9 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:b1a5489610b480473aa63e95806df7d1
+niiri:08dde0ac9e0d585b26116508762ff9a0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1517,9 +1517,9 @@ niiri:b1a5489610b480473aa63e95806df7d1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:b1a5489610b480473aa63e95806df7d1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:08dde0ac9e0d585b26116508762ff9a0 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:f6763487f8266f7e66acb49862c0bfa1
+niiri:0571f33be5ada80ea4b8808edaa7d20b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1529,9 +1529,9 @@ niiri:f6763487f8266f7e66acb49862c0bfa1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:f6763487f8266f7e66acb49862c0bfa1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:0571f33be5ada80ea4b8808edaa7d20b prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:f1b9cbe1f5cc757318e116f47537c68e
+niiri:1ff90dcabb7242c8b1f78b63e5c5f98e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1541,9 +1541,9 @@ niiri:f1b9cbe1f5cc757318e116f47537c68e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:f1b9cbe1f5cc757318e116f47537c68e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:1ff90dcabb7242c8b1f78b63e5c5f98e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:0299ab45ec018b51a01d2a8fe08bf4d0
+niiri:fddfbb23e75434759d3265d89c552324
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1553,9 +1553,9 @@ niiri:0299ab45ec018b51a01d2a8fe08bf4d0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:0299ab45ec018b51a01d2a8fe08bf4d0 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:fddfbb23e75434759d3265d89c552324 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:3bd0b694ec1e521a7072b15be74aa42c
+niiri:225e575718bd5f927d7a41b6e9cdd96b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1565,9 +1565,9 @@ niiri:3bd0b694ec1e521a7072b15be74aa42c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:3bd0b694ec1e521a7072b15be74aa42c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:225e575718bd5f927d7a41b6e9cdd96b prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:af9bee597f1e82856f732971c03e4ba5
+niiri:eed1f93c005d2b4525f8eff9003cba5f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1577,9 +1577,9 @@ niiri:af9bee597f1e82856f732971c03e4ba5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:af9bee597f1e82856f732971c03e4ba5 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:eed1f93c005d2b4525f8eff9003cba5f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:7a01ea3f3b5332ecf281a7f277911529
+niiri:46a2cf3db4d3d8432ee134238328ee7d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1589,9 +1589,9 @@ niiri:7a01ea3f3b5332ecf281a7f277911529
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:7a01ea3f3b5332ecf281a7f277911529 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:46a2cf3db4d3d8432ee134238328ee7d prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8d9244867124b8976a02c802025ebf7a
+niiri:cb8b7a24533bb98686a08aa454cf3945
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1601,9 +1601,9 @@ niiri:8d9244867124b8976a02c802025ebf7a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:8d9244867124b8976a02c802025ebf7a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:cb8b7a24533bb98686a08aa454cf3945 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:1acfcd5791fd893baf49e6750646bcbc
+niiri:ac46f34aa5d674ad08bca4f9e22cea59
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1613,9 +1613,9 @@ niiri:1acfcd5791fd893baf49e6750646bcbc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:1acfcd5791fd893baf49e6750646bcbc prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:ac46f34aa5d674ad08bca4f9e22cea59 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:6bafc27afb06adc8274b4e85b0eb95cc
+niiri:dafb029bcb559a4294b48405b4710434
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1625,9 +1625,9 @@ niiri:6bafc27afb06adc8274b4e85b0eb95cc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:6bafc27afb06adc8274b4e85b0eb95cc prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:dafb029bcb559a4294b48405b4710434 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:ee5baff089dc6387c53821c05a9e9154
+niiri:99ae26cd919bcae015587fcb8e185e68
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1637,9 +1637,9 @@ niiri:ee5baff089dc6387c53821c05a9e9154
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:ee5baff089dc6387c53821c05a9e9154 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:99ae26cd919bcae015587fcb8e185e68 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:e4e0f746d182d60a55906480bc82791f
+niiri:9f9bf96c341750df802f301ac988f4b0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1649,9 +1649,9 @@ niiri:e4e0f746d182d60a55906480bc82791f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:e4e0f746d182d60a55906480bc82791f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:9f9bf96c341750df802f301ac988f4b0 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:07ef8bc1f56adef8bb96bf2e4e871509
+niiri:99e2b9de9821018fedc6a02eeea36eff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1661,9 +1661,9 @@ niiri:07ef8bc1f56adef8bb96bf2e4e871509
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:07ef8bc1f56adef8bb96bf2e4e871509 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:99e2b9de9821018fedc6a02eeea36eff prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:4909c1eb824545b47aa0943b33200588
+niiri:19dd8817dc393deb5f3011d30203d171
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0085" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1673,9 +1673,9 @@ niiri:4909c1eb824545b47aa0943b33200588
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "85"^^xsd:int .
 
-niiri:4909c1eb824545b47aa0943b33200588 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:19dd8817dc393deb5f3011d30203d171 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9c28e7c0288f5d8601280d59308426e4
+niiri:f578ebe5aa3293c5670125665cd21221
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0086" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1685,9 +1685,9 @@ niiri:9c28e7c0288f5d8601280d59308426e4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "86"^^xsd:int .
 
-niiri:9c28e7c0288f5d8601280d59308426e4 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:f578ebe5aa3293c5670125665cd21221 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:49c7e8d7404b8a93cc2dc6a52274f6ef
+niiri:7166aa15d2e2b4eeab50316ce6eb7bff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0087" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1697,9 +1697,9 @@ niiri:49c7e8d7404b8a93cc2dc6a52274f6ef
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "87"^^xsd:int .
 
-niiri:49c7e8d7404b8a93cc2dc6a52274f6ef prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:7166aa15d2e2b4eeab50316ce6eb7bff prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:5bc798e43cab1c880a412761cd0dabce
+niiri:7c7ff9e10d9ed65989abad6706fb240e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0088" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1709,9 +1709,9 @@ niiri:5bc798e43cab1c880a412761cd0dabce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "88"^^xsd:int .
 
-niiri:5bc798e43cab1c880a412761cd0dabce prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:7c7ff9e10d9ed65989abad6706fb240e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:d5f0da3a07b3d47197bf039d8d42b58f
+niiri:8134a1db611c7f7f2ed9c52d609bd453
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0089" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1721,9 +1721,9 @@ niiri:d5f0da3a07b3d47197bf039d8d42b58f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "89"^^xsd:int .
 
-niiri:d5f0da3a07b3d47197bf039d8d42b58f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8134a1db611c7f7f2ed9c52d609bd453 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:a57d901560addc33f414ddaed9a0c7fb
+niiri:8a671f919525c9984fd7a67105748a9d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0090" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1733,9 +1733,9 @@ niiri:a57d901560addc33f414ddaed9a0c7fb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "90"^^xsd:int .
 
-niiri:a57d901560addc33f414ddaed9a0c7fb prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8a671f919525c9984fd7a67105748a9d prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:01d84a7c8c63b90d178c8c7623156c7d
+niiri:df8ccdbc007e7b001a7788aa3910f000
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0091" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1745,9 +1745,9 @@ niiri:01d84a7c8c63b90d178c8c7623156c7d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "91"^^xsd:int .
 
-niiri:01d84a7c8c63b90d178c8c7623156c7d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:df8ccdbc007e7b001a7788aa3910f000 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:99056f1d754fd9f25d80632f06577e33
+niiri:8f423109f6452d8619bfc5cbabbcae4c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0092" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1757,9 +1757,9 @@ niiri:99056f1d754fd9f25d80632f06577e33
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "92"^^xsd:int .
 
-niiri:99056f1d754fd9f25d80632f06577e33 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8f423109f6452d8619bfc5cbabbcae4c prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:a0ee8183a98a000be01c4577a35a0d8c
+niiri:059825f02c7e3a034dd438fe5e192ff5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0093" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1769,9 +1769,9 @@ niiri:a0ee8183a98a000be01c4577a35a0d8c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "93"^^xsd:int .
 
-niiri:a0ee8183a98a000be01c4577a35a0d8c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:059825f02c7e3a034dd438fe5e192ff5 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:40c9456923bb7d18a8a4ec203aeea09d
+niiri:3da0464bd78bb8c10fbf370ecd7a9476
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0094" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1781,9 +1781,9 @@ niiri:40c9456923bb7d18a8a4ec203aeea09d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "94"^^xsd:int .
 
-niiri:40c9456923bb7d18a8a4ec203aeea09d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:3da0464bd78bb8c10fbf370ecd7a9476 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:3cd64da8230af3c597bfb4e11e589670
+niiri:8f8575f802002ae68576281bb473a96a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0095" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1793,9 +1793,9 @@ niiri:3cd64da8230af3c597bfb4e11e589670
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "95"^^xsd:int .
 
-niiri:3cd64da8230af3c597bfb4e11e589670 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8f8575f802002ae68576281bb473a96a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:32e5e0304b5a2c92b091fa83edcab359
+niiri:08bfdacca68fb28f9c006f7c77ce2d85
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0096" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1805,9 +1805,9 @@ niiri:32e5e0304b5a2c92b091fa83edcab359
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "96"^^xsd:int .
 
-niiri:32e5e0304b5a2c92b091fa83edcab359 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:08bfdacca68fb28f9c006f7c77ce2d85 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:bf704e8aea1497f2136b7d0b3dde0bf6
+niiri:6bb55a6a6929721f00e0951117b25f42
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0097" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1817,9 +1817,9 @@ niiri:bf704e8aea1497f2136b7d0b3dde0bf6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "97"^^xsd:int .
 
-niiri:bf704e8aea1497f2136b7d0b3dde0bf6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:6bb55a6a6929721f00e0951117b25f42 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:316701aef465a5778181dd76a5331844
+niiri:37af7d521a2b88cd58b24d8684f7fef9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0098" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1829,9 +1829,9 @@ niiri:316701aef465a5778181dd76a5331844
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "98"^^xsd:int .
 
-niiri:316701aef465a5778181dd76a5331844 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:37af7d521a2b88cd58b24d8684f7fef9 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:90bdcb5fb7ef48121124edfe5e0439e6
+niiri:6fb39f850b88fc429c462810fc4c1cb0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0099" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1841,9 +1841,9 @@ niiri:90bdcb5fb7ef48121124edfe5e0439e6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "99"^^xsd:int .
 
-niiri:90bdcb5fb7ef48121124edfe5e0439e6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:6fb39f850b88fc429c462810fc4c1cb0 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:d1db945756296f3d178c9d95312fcba1
+niiri:3b4cc47fe21026a8ff3cc6cae8366e5a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0100" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1853,9 +1853,9 @@ niiri:d1db945756296f3d178c9d95312fcba1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "100"^^xsd:int .
 
-niiri:d1db945756296f3d178c9d95312fcba1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:3b4cc47fe21026a8ff3cc6cae8366e5a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a
+niiri:cb21e315dda71865f3198bf3de5b7c55
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0101" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1865,9 +1865,9 @@ niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "101"^^xsd:int .
 
-niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:cb21e315dda71865f3198bf3de5b7c55 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c
+niiri:2e5418c351f653b423462944edc63136
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0102" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1877,9 +1877,9 @@ niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "102"^^xsd:int .
 
-niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:2e5418c351f653b423462944edc63136 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9304b0681f39be2e136e7d42baff625c
+niiri:f9e4a916c73e380e7f2b04ae24edb3eb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0103" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1889,9 +1889,9 @@ niiri:9304b0681f39be2e136e7d42baff625c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "103"^^xsd:int .
 
-niiri:9304b0681f39be2e136e7d42baff625c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:f9e4a916c73e380e7f2b04ae24edb3eb prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:c4a9ab38a5b5faf27a110372a76b690b
+niiri:7154c13ca1ce907cde82a8d61810577c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0104" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1901,9 +1901,9 @@ niiri:c4a9ab38a5b5faf27a110372a76b690b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "104"^^xsd:int .
 
-niiri:c4a9ab38a5b5faf27a110372a76b690b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:7154c13ca1ce907cde82a8d61810577c prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:b08c64db49c2acab9dde84fc5aaafee1
+niiri:79ad3466325804caf01c3623b06f85c5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0105" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1913,9 +1913,9 @@ niiri:b08c64db49c2acab9dde84fc5aaafee1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "105"^^xsd:int .
 
-niiri:b08c64db49c2acab9dde84fc5aaafee1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:79ad3466325804caf01c3623b06f85c5 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:a8f46a35300a709894debac1a5c7d877
+niiri:2e12076af378dbdca5de9e12404f5853
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0106" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1925,9 +1925,9 @@ niiri:a8f46a35300a709894debac1a5c7d877
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "106"^^xsd:int .
 
-niiri:a8f46a35300a709894debac1a5c7d877 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:2e12076af378dbdca5de9e12404f5853 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:147fb623ae052dca9733d6d1d2297af8
+niiri:88291e9044390a2d68e0e8f02afae64d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0107" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1937,9 +1937,9 @@ niiri:147fb623ae052dca9733d6d1d2297af8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "107"^^xsd:int .
 
-niiri:147fb623ae052dca9733d6d1d2297af8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:88291e9044390a2d68e0e8f02afae64d prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:eb257014e1b6b6961786c8543836a579
+niiri:9219dd196f709ade4b7d68bb82531ae9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0108" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1949,9 +1949,9 @@ niiri:eb257014e1b6b6961786c8543836a579
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "108"^^xsd:int .
 
-niiri:eb257014e1b6b6961786c8543836a579 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:9219dd196f709ade4b7d68bb82531ae9 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:3c0db86cde8ac7aa1cb1f7b208b617e8
+niiri:b5869855e2ed1bde6084a419ce135245
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0109" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1961,9 +1961,9 @@ niiri:3c0db86cde8ac7aa1cb1f7b208b617e8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "109"^^xsd:int .
 
-niiri:3c0db86cde8ac7aa1cb1f7b208b617e8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:b5869855e2ed1bde6084a419ce135245 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:e578dd3a170f088e47efd39f45837f4e
+niiri:3ed79923246b336ee14ba73c12fc89b8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0110" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1973,9 +1973,9 @@ niiri:e578dd3a170f088e47efd39f45837f4e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "110"^^xsd:int .
 
-niiri:e578dd3a170f088e47efd39f45837f4e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:3ed79923246b336ee14ba73c12fc89b8 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:ab7f882f69e9de3fd22bc39f3519003d
+niiri:12413ac997763f6fabc508fd21bfae38
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0111" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1985,9 +1985,9 @@ niiri:ab7f882f69e9de3fd22bc39f3519003d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "111"^^xsd:int .
 
-niiri:ab7f882f69e9de3fd22bc39f3519003d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:12413ac997763f6fabc508fd21bfae38 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:ca827c13c9bc5f06b55e3bd1cd175793
+niiri:f994daab5ee703f5c75c7c447254b288
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0112" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1997,9 +1997,9 @@ niiri:ca827c13c9bc5f06b55e3bd1cd175793
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "112"^^xsd:int .
 
-niiri:ca827c13c9bc5f06b55e3bd1cd175793 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:f994daab5ee703f5c75c7c447254b288 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8472115c12bd571d534dfe5bac960c80
+niiri:83cced094f39a6896a2e9e71f04942a7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0113" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2009,9 +2009,9 @@ niiri:8472115c12bd571d534dfe5bac960c80
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "113"^^xsd:int .
 
-niiri:8472115c12bd571d534dfe5bac960c80 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:83cced094f39a6896a2e9e71f04942a7 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:812c44e9a98ad090a6f8b72ffea8eb49
+niiri:8cebbc59dd1e18a1762d12ca4d90e931
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0114" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2021,9 +2021,9 @@ niiri:812c44e9a98ad090a6f8b72ffea8eb49
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "114"^^xsd:int .
 
-niiri:812c44e9a98ad090a6f8b72ffea8eb49 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8cebbc59dd1e18a1762d12ca4d90e931 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:eb1e036b54bfd5155015ad5c924a62ce
+niiri:8c6f92e0a397a1c5c883eb79ede81691
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0115" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2033,9 +2033,9 @@ niiri:eb1e036b54bfd5155015ad5c924a62ce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "115"^^xsd:int .
 
-niiri:eb1e036b54bfd5155015ad5c924a62ce prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8c6f92e0a397a1c5c883eb79ede81691 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8bac0f00c0d1f0f9f5c118004ab17321
+niiri:6e55a4195849427172678126ca78b28a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0116" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2045,9 +2045,9 @@ niiri:8bac0f00c0d1f0f9f5c118004ab17321
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "116"^^xsd:int .
 
-niiri:8bac0f00c0d1f0f9f5c118004ab17321 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:6e55a4195849427172678126ca78b28a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:4f4b190235fbb136b1bb7467b78730d6
+niiri:3d5e4a6eb5d78cc1ef178561e41ba9ee
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0117" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2057,9 +2057,9 @@ niiri:4f4b190235fbb136b1bb7467b78730d6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "117"^^xsd:int .
 
-niiri:4f4b190235fbb136b1bb7467b78730d6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:3d5e4a6eb5d78cc1ef178561e41ba9ee prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:d04d2676281bca09e8a782500650e993
+niiri:263da8c4eb7cf40aac1b2acc6184c451
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0118" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2069,9 +2069,9 @@ niiri:d04d2676281bca09e8a782500650e993
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "118"^^xsd:int .
 
-niiri:d04d2676281bca09e8a782500650e993 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:263da8c4eb7cf40aac1b2acc6184c451 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:59c6e585fc56ebce5a5d95b959cc120d
+niiri:d4fbe5cc673433a4ae33bce2f4d62046
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0119" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2081,9 +2081,9 @@ niiri:59c6e585fc56ebce5a5d95b959cc120d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "119"^^xsd:int .
 
-niiri:59c6e585fc56ebce5a5d95b959cc120d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:d4fbe5cc673433a4ae33bce2f4d62046 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:a4d82c21752d17f68b6fbf41caa89a4b
+niiri:92b2dd79b91691fa3fee9530c07ced7e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0120" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2093,9 +2093,9 @@ niiri:a4d82c21752d17f68b6fbf41caa89a4b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "120"^^xsd:int .
 
-niiri:a4d82c21752d17f68b6fbf41caa89a4b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:92b2dd79b91691fa3fee9530c07ced7e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9c09ac30035d9617daad1f111fa1b47f
+niiri:0791bb16705c92dfa0eb9a2399ad7c01
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0121" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2105,9 +2105,9 @@ niiri:9c09ac30035d9617daad1f111fa1b47f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "121"^^xsd:int .
 
-niiri:9c09ac30035d9617daad1f111fa1b47f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:0791bb16705c92dfa0eb9a2399ad7c01 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:b5d02c34e634c7f52d94137fbd9f8813
+niiri:51393db8b7b8a6fffbbd81b5df93450e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0122" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2117,9 +2117,9 @@ niiri:b5d02c34e634c7f52d94137fbd9f8813
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "122"^^xsd:int .
 
-niiri:b5d02c34e634c7f52d94137fbd9f8813 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:51393db8b7b8a6fffbbd81b5df93450e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:fc91a408c252d8e2b7beb4005554eaf8
+niiri:868dad72b2c68d3fbc6510a6d5cb9231
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0123" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2129,9 +2129,9 @@ niiri:fc91a408c252d8e2b7beb4005554eaf8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "123"^^xsd:int .
 
-niiri:fc91a408c252d8e2b7beb4005554eaf8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:868dad72b2c68d3fbc6510a6d5cb9231 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9b0591f2b854d2643aaf1afaa93cb549
+niiri:f010113cde48b81f7b8ed0070c723116
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0124" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2141,9 +2141,9 @@ niiri:9b0591f2b854d2643aaf1afaa93cb549
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "124"^^xsd:int .
 
-niiri:9b0591f2b854d2643aaf1afaa93cb549 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:f010113cde48b81f7b8ed0070c723116 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:d54744a8017e84d7adb355fc9412fba3
+niiri:0265995653f234724934abae5c95f7d7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0125" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2153,9 +2153,9 @@ niiri:d54744a8017e84d7adb355fc9412fba3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "125"^^xsd:int .
 
-niiri:d54744a8017e84d7adb355fc9412fba3 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:0265995653f234724934abae5c95f7d7 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:e49a03f4d60a11688f798fc5bc43c1b2
+niiri:f99e0a55aff25b99b4c4ccb40319fa7b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0126" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2165,9 +2165,9 @@ niiri:e49a03f4d60a11688f798fc5bc43c1b2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "126"^^xsd:int .
 
-niiri:e49a03f4d60a11688f798fc5bc43c1b2 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:f99e0a55aff25b99b4c4ccb40319fa7b prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:b04a187086857b7422c8096db14ee613
+niiri:48a348ba7dc61a80c12ae68ab1b56cad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0127" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2177,9 +2177,9 @@ niiri:b04a187086857b7422c8096db14ee613
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "127"^^xsd:int .
 
-niiri:b04a187086857b7422c8096db14ee613 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:48a348ba7dc61a80c12ae68ab1b56cad prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:39ce93dd6abab662ab6da84a046a56bd
+niiri:adc463abce824f98736aecdc0ef0fc44
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0128" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2189,9 +2189,9 @@ niiri:39ce93dd6abab662ab6da84a046a56bd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "128"^^xsd:int .
 
-niiri:39ce93dd6abab662ab6da84a046a56bd prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:adc463abce824f98736aecdc0ef0fc44 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e
+niiri:2a0123807eeff74fec9051900072009a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0129" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2201,9 +2201,9 @@ niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "129"^^xsd:int .
 
-niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:2a0123807eeff74fec9051900072009a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:ca20dee3ba6bf36049f99642c710470d
+niiri:3c9c41ca803aea8e1aa376a37e7fd405
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0130" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2213,9 +2213,9 @@ niiri:ca20dee3ba6bf36049f99642c710470d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "130"^^xsd:int .
 
-niiri:ca20dee3ba6bf36049f99642c710470d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:3c9c41ca803aea8e1aa376a37e7fd405 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:26fa7a82c298f218eb7fd282cfbf7a81
+niiri:4ac51018dc7ac193d610d2175b143f4f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0131" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2225,9 +2225,9 @@ niiri:26fa7a82c298f218eb7fd282cfbf7a81
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "131"^^xsd:int .
 
-niiri:26fa7a82c298f218eb7fd282cfbf7a81 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:4ac51018dc7ac193d610d2175b143f4f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:e518dd980ffdb694adcf472695d5a40a
+niiri:9411d8ecf0144381e141c863accd8f82
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0132" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2237,9 +2237,9 @@ niiri:e518dd980ffdb694adcf472695d5a40a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "132"^^xsd:int .
 
-niiri:e518dd980ffdb694adcf472695d5a40a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:9411d8ecf0144381e141c863accd8f82 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:5f278b6b11fae0c4b4f9690852a71d0c
+niiri:58ff840b981e30971a46c0cdee9acc43
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0133" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2249,9 +2249,9 @@ niiri:5f278b6b11fae0c4b4f9690852a71d0c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "133"^^xsd:int .
 
-niiri:5f278b6b11fae0c4b4f9690852a71d0c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:58ff840b981e30971a46c0cdee9acc43 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:87f8233f1c48acf6ecdd7339055182ae
+niiri:81d9ad132a8f471d00cb8b3aef33836f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0134" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2261,9 +2261,9 @@ niiri:87f8233f1c48acf6ecdd7339055182ae
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "134"^^xsd:int .
 
-niiri:87f8233f1c48acf6ecdd7339055182ae prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:81d9ad132a8f471d00cb8b3aef33836f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:0189728b5aaa10d4eb4ff53d1fbc5843
+niiri:b85e89811d403dd797f7d9315b0c1779
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0135" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2273,9 +2273,9 @@ niiri:0189728b5aaa10d4eb4ff53d1fbc5843
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "135"^^xsd:int .
 
-niiri:0189728b5aaa10d4eb4ff53d1fbc5843 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:b85e89811d403dd797f7d9315b0c1779 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:453f1919d7df3d7e610709f6fdecbf62
+niiri:559e52e372bf37a3bd9f89fe7d257b7f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0136" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2285,9 +2285,9 @@ niiri:453f1919d7df3d7e610709f6fdecbf62
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "136"^^xsd:int .
 
-niiri:453f1919d7df3d7e610709f6fdecbf62 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:559e52e372bf37a3bd9f89fe7d257b7f prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:5b21dda7a2823d1c7efeff7947020767
+niiri:8675dcbc163828022ee916bae686b21e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0137" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2297,9 +2297,9 @@ niiri:5b21dda7a2823d1c7efeff7947020767
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "137"^^xsd:int .
 
-niiri:5b21dda7a2823d1c7efeff7947020767 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:8675dcbc163828022ee916bae686b21e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:a6dc495a077e17aa8f96566659037e0b
+niiri:2ebb70aec77a1bb19cfa4bb0e86df28c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0138" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2309,9 +2309,9 @@ niiri:a6dc495a077e17aa8f96566659037e0b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "138"^^xsd:int .
 
-niiri:a6dc495a077e17aa8f96566659037e0b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:2ebb70aec77a1bb19cfa4bb0e86df28c prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:e5e5eeee288ec088072a80af972a3638
+niiri:c3f909ea8341d2a928e08b183a5eb9b8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0139" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2321,9 +2321,9 @@ niiri:e5e5eeee288ec088072a80af972a3638
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "139"^^xsd:int .
 
-niiri:e5e5eeee288ec088072a80af972a3638 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:c3f909ea8341d2a928e08b183a5eb9b8 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1
+niiri:7da0c40e610d05ef5fcd5df75e03757e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0140" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2333,9 +2333,9 @@ niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "140"^^xsd:int .
 
-niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:7da0c40e610d05ef5fcd5df75e03757e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:66cf0dbeb1aa03edbab1a35c2d527a55
+niiri:88cc306d767adb94ebbccf9ff7621ad9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0141" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2345,9 +2345,9 @@ niiri:66cf0dbeb1aa03edbab1a35c2d527a55
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "141"^^xsd:int .
 
-niiri:66cf0dbeb1aa03edbab1a35c2d527a55 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:88cc306d767adb94ebbccf9ff7621ad9 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:09d8898196c5c40aec6f995a2b0c383d
+niiri:74ee3d5df4f8c42807338247cfe92970
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0142" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2357,9 +2357,9 @@ niiri:09d8898196c5c40aec6f995a2b0c383d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "142"^^xsd:int .
 
-niiri:09d8898196c5c40aec6f995a2b0c383d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:74ee3d5df4f8c42807338247cfe92970 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:bfe644ea717165d3b6b50431d8e57c87
+niiri:cdf3f858b94767540e52edcfccc91cae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0143" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2369,9 +2369,9 @@ niiri:bfe644ea717165d3b6b50431d8e57c87
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "143"^^xsd:int .
 
-niiri:bfe644ea717165d3b6b50431d8e57c87 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:cdf3f858b94767540e52edcfccc91cae prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:0d278ee0d105de3a7319a5acaa11c631
+niiri:d47a915a52d84b041200dd225d0d123a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0144" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2381,9 +2381,9 @@ niiri:0d278ee0d105de3a7319a5acaa11c631
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "144"^^xsd:int .
 
-niiri:0d278ee0d105de3a7319a5acaa11c631 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:d47a915a52d84b041200dd225d0d123a prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:9a54b30308f71d0c474dab56acec5885
+niiri:a0b6cde2f07cadad11fae188db97aa3e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0145" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2393,9 +2393,9 @@ niiri:9a54b30308f71d0c474dab56acec5885
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "145"^^xsd:int .
 
-niiri:9a54b30308f71d0c474dab56acec5885 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:a0b6cde2f07cadad11fae188db97aa3e prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:f219989ec875846cc4815fffc10bd118
+niiri:28cf85781211b96d1afff400e743d8e0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0146" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2405,9 +2405,9 @@ niiri:f219989ec875846cc4815fffc10bd118
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "146"^^xsd:int .
 
-niiri:f219989ec875846cc4815fffc10bd118 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:28cf85781211b96d1afff400e743d8e0 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:4b37375a8d01d1d9009b430352062714
+niiri:3d1ef8f1229ad13d14520be973ee405c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0147" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2417,9 +2417,9 @@ niiri:4b37375a8d01d1d9009b430352062714
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "147"^^xsd:int .
 
-niiri:4b37375a8d01d1d9009b430352062714 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:3d1ef8f1229ad13d14520be973ee405c prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:0f0a4015dd42d89522302ce792b20d6d
+niiri:2960c762474a0ecebef6e8e066482105
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0148" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2429,9 +2429,9 @@ niiri:0f0a4015dd42d89522302ce792b20d6d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "148"^^xsd:int .
 
-niiri:0f0a4015dd42d89522302ce792b20d6d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:2960c762474a0ecebef6e8e066482105 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a
+niiri:a86c5c480c3033b63bc45962d5c32c41
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0149" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2441,9 +2441,9 @@ niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "149"^^xsd:int .
 
-niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:a86c5c480c3033b63bc45962d5c32c41 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:f6e36041fd68625d6c7813fe63387c51
+niiri:9d76bd2f2d73c5dfd99aa453786bb3d2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0150" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2453,3048 +2453,3048 @@ niiri:f6e36041fd68625d6c7813fe63387c51
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "150"^^xsd:int .
 
-niiri:f6e36041fd68625d6c7813fe63387c51 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
+niiri:9d76bd2f2d73c5dfd99aa453786bb3d2 prov:wasDerivedFrom niiri:3fd40489e0c7ad32d9dfa018bf86de4d .
 
-niiri:442ae032432253444ea32f99f4dc387c
+niiri:9b7a6f8fe35f2a47bcfd75c409f14815
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:a4693444c0135c8dfe9d5e4683a03a3a ;
+    prov:atLocation niiri:c008cc59281fa7515bca5cbcc36458ba ;
     prov:value "2.18819689750671"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5114661254844"^^xsd:float ;
     nidm_pValueUncorrected: "0.000222821126723893"^^xsd:float ;
     nidm_pValueFWER: "0.999999868311968"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a4693444c0135c8dfe9d5e4683a03a3a
+niiri:c008cc59281fa7515bca5cbcc36458ba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-28,24,4]"^^xsd:string .
 
-niiri:442ae032432253444ea32f99f4dc387c prov:wasDerivedFrom niiri:4362f5eac9972bf179ea49be33151c8e .
+niiri:9b7a6f8fe35f2a47bcfd75c409f14815 prov:wasDerivedFrom niiri:eaccd3ae3e22bfdca0eb19a7d8d32655 .
 
-niiri:2cc0e4b46ef04062f76f3cd9f58335d7
+niiri:e47bb82f7e55707630bbc40a4ee3aaf1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:21b2ec6e254ee0565b8270bfcfc0e2c7 ;
+    prov:atLocation niiri:19ecc7fec1ab9e465679a4c1330d1f70 ;
     prov:value "2.07190132141113"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35835159739265"^^xsd:float ;
     nidm_pValueUncorrected: "0.000392044053194152"^^xsd:float ;
     nidm_pValueFWER: "0.999999999969126"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:21b2ec6e254ee0565b8270bfcfc0e2c7
+niiri:19ecc7fec1ab9e465679a4c1330d1f70
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-28,26,12]"^^xsd:string .
 
-niiri:2cc0e4b46ef04062f76f3cd9f58335d7 prov:wasDerivedFrom niiri:4362f5eac9972bf179ea49be33151c8e .
+niiri:e47bb82f7e55707630bbc40a4ee3aaf1 prov:wasDerivedFrom niiri:eaccd3ae3e22bfdca0eb19a7d8d32655 .
 
-niiri:bf2f05f6426d9b3de806efb87eb24421
+niiri:020818951231889a14c8a658a2fb9afa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:63e78c482af8490d5dfa90d0a0e92669 ;
+    prov:atLocation niiri:0177753ae893aa15acf02da2338a4b6e ;
     prov:value "1.94285821914673"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18853089402481"^^xsd:float ;
     nidm_pValueUncorrected: "0.000714988643396364"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:63e78c482af8490d5dfa90d0a0e92669
+niiri:0177753ae893aa15acf02da2338a4b6e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-42,20,36]"^^xsd:string .
 
-niiri:bf2f05f6426d9b3de806efb87eb24421 prov:wasDerivedFrom niiri:4362f5eac9972bf179ea49be33151c8e .
+niiri:020818951231889a14c8a658a2fb9afa prov:wasDerivedFrom niiri:eaccd3ae3e22bfdca0eb19a7d8d32655 .
 
-niiri:6d4129ab6385c802707ca56c724df92f
+niiri:3d036da0329b3609a9a6261f8555fd39
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:de746baa0f488d3bbadc409c300d1274 ;
+    prov:atLocation niiri:8d8393df7a5e35e7ad7f2394c4aa5d54 ;
     prov:value "2.1167094707489"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41734061195353"^^xsd:float ;
     nidm_pValueUncorrected: "0.000316180548517564"^^xsd:float ;
     nidm_pValueFWER: "0.999999998897938"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:de746baa0f488d3bbadc409c300d1274
+niiri:8d8393df7a5e35e7ad7f2394c4aa5d54
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[36,-84,2]"^^xsd:string .
 
-niiri:6d4129ab6385c802707ca56c724df92f prov:wasDerivedFrom niiri:00f296730dd06a43e5f7334c226305c6 .
+niiri:3d036da0329b3609a9a6261f8555fd39 prov:wasDerivedFrom niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e .
 
-niiri:3398d8202d4e93e898d65527617056fc
+niiri:0098f2aeef861167067e9f9491ea1182
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:787673d51909fd4b7955adca6289845e ;
+    prov:atLocation niiri:60ffd2d3a7a1286cd7710dc29c6f6d07 ;
     prov:value "2.00524592399597"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27061943294259"^^xsd:float ;
     nidm_pValueUncorrected: "0.000536561087325027"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999994"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:787673d51909fd4b7955adca6289845e
+niiri:60ffd2d3a7a1286cd7710dc29c6f6d07
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[34,-84,14]"^^xsd:string .
 
-niiri:3398d8202d4e93e898d65527617056fc prov:wasDerivedFrom niiri:00f296730dd06a43e5f7334c226305c6 .
+niiri:0098f2aeef861167067e9f9491ea1182 prov:wasDerivedFrom niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e .
 
-niiri:d0c21323683c00398f1fe5b8cd2b1821
+niiri:e6739e9ae8332b314223bc21cd011d03
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:c2e490ac6fc0201797ed715401260ead ;
+    prov:atLocation niiri:f04469bdfb14f7143a2944a5f25c8ae9 ;
     prov:value "1.9834691286087"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24196265203981"^^xsd:float ;
     nidm_pValueUncorrected: "0.000593547891254209"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999994"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c2e490ac6fc0201797ed715401260ead
+niiri:f04469bdfb14f7143a2944a5f25c8ae9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[34,-78,36]"^^xsd:string .
 
-niiri:d0c21323683c00398f1fe5b8cd2b1821 prov:wasDerivedFrom niiri:00f296730dd06a43e5f7334c226305c6 .
+niiri:e6739e9ae8332b314223bc21cd011d03 prov:wasDerivedFrom niiri:10f6e8abcdcc6a5dfaefd19d37e0f90e .
 
-niiri:1f3d65d5c16aacc0308451722678f7de
+niiri:325a9af4c986d5e88d093c8f57319bfc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:7291a001aa765929838e01ce77a9da57 ;
+    prov:atLocation niiri:85f2862ec8d073265d5d0d93ef5e63be ;
     prov:value "2.07622194290161"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36403923290147"^^xsd:float ;
     nidm_pValueUncorrected: "0.000384053116980865"^^xsd:float ;
     nidm_pValueFWER: "0.999999999955495"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7291a001aa765929838e01ce77a9da57
+niiri:85f2862ec8d073265d5d0d93ef5e63be
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[52,48,12]"^^xsd:string .
 
-niiri:1f3d65d5c16aacc0308451722678f7de prov:wasDerivedFrom niiri:39a3babf6ed520d78e67263717ca5dbb .
+niiri:325a9af4c986d5e88d093c8f57319bfc prov:wasDerivedFrom niiri:01caf6dcc4c07046ab44e8a119bab255 .
 
-niiri:6c8bcca3f301b2525f53e90e5d2e044e
+niiri:808bcd026ac240ae9425800b48644b6d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:dcdc8cced1a70ed65194762748dd42f2 ;
+    prov:atLocation niiri:22cdaa124958cc1f12bf80546757ef10 ;
     prov:value "2.0327205657959"^^xsd:float ;
     nidm_equivalentZStatistic: "3.306778623673"^^xsd:float ;
     nidm_pValueUncorrected: "0.000471877215462824"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999097"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:dcdc8cced1a70ed65194762748dd42f2
+niiri:22cdaa124958cc1f12bf80546757ef10
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[30,68,12]"^^xsd:string .
 
-niiri:6c8bcca3f301b2525f53e90e5d2e044e prov:wasDerivedFrom niiri:39a3babf6ed520d78e67263717ca5dbb .
+niiri:808bcd026ac240ae9425800b48644b6d prov:wasDerivedFrom niiri:01caf6dcc4c07046ab44e8a119bab255 .
 
-niiri:dc9c09a94ef328a1469d800c80f6fc2f
+niiri:4db5e18b36a3e85181e92f727586a86f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:508dc677de99afa67c363c475a5c743e ;
+    prov:atLocation niiri:cfd70f8eea67c129f7fa2224871f1827 ;
     prov:value "1.63326919078827"^^xsd:float ;
     nidm_equivalentZStatistic: "2.78184273056811"^^xsd:float ;
     nidm_pValueUncorrected: "0.00270256128658664"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:508dc677de99afa67c363c475a5c743e
+niiri:cfd70f8eea67c129f7fa2224871f1827
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[14,74,6]"^^xsd:string .
 
-niiri:dc9c09a94ef328a1469d800c80f6fc2f prov:wasDerivedFrom niiri:39a3babf6ed520d78e67263717ca5dbb .
+niiri:4db5e18b36a3e85181e92f727586a86f prov:wasDerivedFrom niiri:01caf6dcc4c07046ab44e8a119bab255 .
 
-niiri:0445099b3ad94f2a7bffd17b72c32178
+niiri:b160b4ecbdbbfda45b1aee101e93e903
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:d2747be6a82e62e1332bff6a58f4d7f5 ;
+    prov:atLocation niiri:8db786a8fb51025a0f98e6b8fea3043c ;
     prov:value "2.04988360404968"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32936904595179"^^xsd:float ;
     nidm_pValueUncorrected: "0.000435214929046523"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995547"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d2747be6a82e62e1332bff6a58f4d7f5
+niiri:8db786a8fb51025a0f98e6b8fea3043c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[34,-54,52]"^^xsd:string .
 
-niiri:0445099b3ad94f2a7bffd17b72c32178 prov:wasDerivedFrom niiri:26ed93f97118482ea99f750276db5700 .
+niiri:b160b4ecbdbbfda45b1aee101e93e903 prov:wasDerivedFrom niiri:9a28574137dba928b957fda9013d355a .
 
-niiri:6cf57566c63330551854cd41c76c7945
+niiri:1000565e793f000cf9b2c8d2a289cbec
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:2e98c4783a911189aca09f35a6897677 ;
+    prov:atLocation niiri:7c521b4beb7f5ead8a32b666e19f1d1b ;
     prov:value "1.17590498924255"^^xsd:float ;
     nidm_equivalentZStatistic: "2.18553018514689"^^xsd:float ;
     nidm_pValueUncorrected: "0.0144249976129074"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2e98c4783a911189aca09f35a6897677
+niiri:7c521b4beb7f5ead8a32b666e19f1d1b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[26,-48,50]"^^xsd:string .
 
-niiri:6cf57566c63330551854cd41c76c7945 prov:wasDerivedFrom niiri:26ed93f97118482ea99f750276db5700 .
+niiri:1000565e793f000cf9b2c8d2a289cbec prov:wasDerivedFrom niiri:9a28574137dba928b957fda9013d355a .
 
-niiri:43ebe5004c0f1a88f50fa9cffeb58814
+niiri:dd0385d1a2c1edf101d66d2482f78a08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:f2579430fdf3f2f8395d1d9fb3007977 ;
+    prov:atLocation niiri:7efe58cd9db4f5795487ee3bfda08304 ;
     prov:value "1.17325437068939"^^xsd:float ;
     nidm_equivalentZStatistic: "2.18210185402812"^^xsd:float ;
     nidm_pValueUncorrected: "0.0145510082060974"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f2579430fdf3f2f8395d1d9fb3007977
+niiri:7efe58cd9db4f5795487ee3bfda08304
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[32,-54,62]"^^xsd:string .
 
-niiri:43ebe5004c0f1a88f50fa9cffeb58814 prov:wasDerivedFrom niiri:26ed93f97118482ea99f750276db5700 .
+niiri:dd0385d1a2c1edf101d66d2482f78a08 prov:wasDerivedFrom niiri:9a28574137dba928b957fda9013d355a .
 
-niiri:d5d5aad603484d20a1db3818d3e3212c
+niiri:5c19ae6baeefcc74d9ced9a9372ca5eb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:0fa634cf4f8cd761e5a8e1556dae51af ;
+    prov:atLocation niiri:f264d8cda2f387101ec768f5305a082f ;
     prov:value "1.69681537151337"^^xsd:float ;
     nidm_equivalentZStatistic: "2.86519802999163"^^xsd:float ;
     nidm_pValueUncorrected: "0.00208374267085354"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0fa634cf4f8cd761e5a8e1556dae51af
+niiri:f264d8cda2f387101ec768f5305a082f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-28,50,36]"^^xsd:string .
 
-niiri:d5d5aad603484d20a1db3818d3e3212c prov:wasDerivedFrom niiri:c0faffa954cb5edf1bd166b3c13b64b6 .
+niiri:5c19ae6baeefcc74d9ced9a9372ca5eb prov:wasDerivedFrom niiri:be0a079f2f0b4ba9e502f600a4b77251 .
 
-niiri:98d4353d19758293894ef727f5c50955
+niiri:8a3985f227e111c7e8758ec46c529db0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:f1befc6625b08ba88efdc7f2bfff4a08 ;
+    prov:atLocation niiri:ef19a5fc9f128819eeacaa79f71a5237 ;
     prov:value "0.933988809585571"^^xsd:float ;
     nidm_equivalentZStatistic: "1.8747737054388"^^xsd:float ;
     nidm_pValueUncorrected: "0.0304119310280364"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f1befc6625b08ba88efdc7f2bfff4a08
+niiri:ef19a5fc9f128819eeacaa79f71a5237
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-46,38,30]"^^xsd:string .
 
-niiri:98d4353d19758293894ef727f5c50955 prov:wasDerivedFrom niiri:c0faffa954cb5edf1bd166b3c13b64b6 .
+niiri:8a3985f227e111c7e8758ec46c529db0 prov:wasDerivedFrom niiri:be0a079f2f0b4ba9e502f600a4b77251 .
 
-niiri:36a41856d01473f63c7c845ca39839d6
+niiri:e151d850eabe3ed6554330c51b7c4261
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:605d54e8c542405ec983a5d0a512106f ;
+    prov:atLocation niiri:3b8ac2784ea06bbdd5f1e9c1d0514aa5 ;
     prov:value "1.66940176486969"^^xsd:float ;
     nidm_equivalentZStatistic: "2.82922911554701"^^xsd:float ;
     nidm_pValueUncorrected: "0.00233301407977504"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:605d54e8c542405ec983a5d0a512106f
+niiri:3b8ac2784ea06bbdd5f1e9c1d0514aa5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[16,-94,-30]"^^xsd:string .
 
-niiri:36a41856d01473f63c7c845ca39839d6 prov:wasDerivedFrom niiri:1baee1eea0758a922f6c4f1f12441da6 .
+niiri:e151d850eabe3ed6554330c51b7c4261 prov:wasDerivedFrom niiri:5c92eec2bb2da6800e461deccb3a6c17 .
 
-niiri:d8f65681bb1bfa31766963ffbe28cead
+niiri:32398273df940601469f78597544a3b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:8e641bae5b55cb975397775ca4f1465e ;
+    prov:atLocation niiri:57a11fb2f64ed51c5a756583086612db ;
     prov:value "1.5886458158493"^^xsd:float ;
     nidm_equivalentZStatistic: "2.72335979311329"^^xsd:float ;
     nidm_pValueUncorrected: "0.00323108192435606"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8e641bae5b55cb975397775ca4f1465e
+niiri:57a11fb2f64ed51c5a756583086612db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[24,-92,-30]"^^xsd:string .
 
-niiri:d8f65681bb1bfa31766963ffbe28cead prov:wasDerivedFrom niiri:1baee1eea0758a922f6c4f1f12441da6 .
+niiri:32398273df940601469f78597544a3b0 prov:wasDerivedFrom niiri:5c92eec2bb2da6800e461deccb3a6c17 .
 
-niiri:b277f286259eb04c946603cb6ba51822
+niiri:5f0ffc888d7244cc8858761bbc7ad727
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:225f9a677dc138e3dd97c18cbf2884ef ;
+    prov:atLocation niiri:9364bab6dc2738419beaf4eea7d5a29d ;
     prov:value "1.51174938678741"^^xsd:float ;
     nidm_equivalentZStatistic: "2.62269482082508"^^xsd:float ;
     nidm_pValueUncorrected: "0.00436186877852962"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:225f9a677dc138e3dd97c18cbf2884ef
+niiri:9364bab6dc2738419beaf4eea7d5a29d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[34,-84,-48]"^^xsd:string .
 
-niiri:b277f286259eb04c946603cb6ba51822 prov:wasDerivedFrom niiri:1baee1eea0758a922f6c4f1f12441da6 .
+niiri:5f0ffc888d7244cc8858761bbc7ad727 prov:wasDerivedFrom niiri:5c92eec2bb2da6800e461deccb3a6c17 .
 
-niiri:cee39f86215489cfd805b4d5f5dab3a2
+niiri:a65b728c7710923f24e0fc6ebd563120
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:9d6418747114ca65b24a6f9e53156964 ;
+    prov:atLocation niiri:a3811e5b29ae233e6e1b7dc3557dd2c8 ;
     prov:value "1.6600536108017"^^xsd:float ;
     nidm_equivalentZStatistic: "2.81696686061887"^^xsd:float ;
     nidm_pValueUncorrected: "0.00242397637898328"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9d6418747114ca65b24a6f9e53156964
+niiri:a3811e5b29ae233e6e1b7dc3557dd2c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-44,-56,-32]"^^xsd:string .
 
-niiri:cee39f86215489cfd805b4d5f5dab3a2 prov:wasDerivedFrom niiri:1aa58b6ce0025b1ec01cb8a983388e1d .
+niiri:a65b728c7710923f24e0fc6ebd563120 prov:wasDerivedFrom niiri:a87a039e7919a12304129d212230f18a .
 
-niiri:10d3d3d8948f818e3d2670f3b08476f8
+niiri:c972ef8c9922a6c6469238f35fa13b9f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:5c9455cedfce2a1f699bcd725ce4b27e ;
+    prov:atLocation niiri:6fed42f8e866c5c1d7799ee58e8d8b35 ;
     prov:value "1.5787501335144"^^xsd:float ;
     nidm_equivalentZStatistic: "2.71039687336073"^^xsd:float ;
     nidm_pValueUncorrected: "0.00336013715292427"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5c9455cedfce2a1f699bcd725ce4b27e
+niiri:6fed42f8e866c5c1d7799ee58e8d8b35
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-10,72,0]"^^xsd:string .
 
-niiri:10d3d3d8948f818e3d2670f3b08476f8 prov:wasDerivedFrom niiri:3198b98e15c5c56654d8a4ffe4b44ce8 .
+niiri:c972ef8c9922a6c6469238f35fa13b9f prov:wasDerivedFrom niiri:e274a3eaada08953bd1833b7c48506f2 .
 
-niiri:fb4201c849e6cb24fb95b4ccf6b6e5b3
+niiri:a425b12ef6a4f4de2fd7b5d75435f474
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:76b9f21dd86f54f4686cb3f8ad313ccc ;
+    prov:atLocation niiri:de75b28ec25e88fbf3970e0deac065dd ;
     prov:value "1.37760043144226"^^xsd:float ;
     nidm_equivalentZStatistic: "2.44750858968075"^^xsd:float ;
     nidm_pValueUncorrected: "0.0071923848185762"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:76b9f21dd86f54f4686cb3f8ad313ccc
+niiri:de75b28ec25e88fbf3970e0deac065dd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-24,68,10]"^^xsd:string .
 
-niiri:fb4201c849e6cb24fb95b4ccf6b6e5b3 prov:wasDerivedFrom niiri:3198b98e15c5c56654d8a4ffe4b44ce8 .
+niiri:a425b12ef6a4f4de2fd7b5d75435f474 prov:wasDerivedFrom niiri:e274a3eaada08953bd1833b7c48506f2 .
 
-niiri:50e767c1e55c55fd6f705e63b8194c22
+niiri:de53fffe0663909b6e3f958356870d95
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:200e07f7941deec2e3926a00d9c097f1 ;
+    prov:atLocation niiri:b5140c630fbb2dd4d49c35006d2f3132 ;
     prov:value "1.35886359214783"^^xsd:float ;
     nidm_equivalentZStatistic: "2.42309168524595"^^xsd:float ;
     nidm_pValueUncorrected: "0.00769452108984159"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:200e07f7941deec2e3926a00d9c097f1
+niiri:b5140c630fbb2dd4d49c35006d2f3132
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-14,64,28]"^^xsd:string .
 
-niiri:50e767c1e55c55fd6f705e63b8194c22 prov:wasDerivedFrom niiri:3198b98e15c5c56654d8a4ffe4b44ce8 .
+niiri:de53fffe0663909b6e3f958356870d95 prov:wasDerivedFrom niiri:e274a3eaada08953bd1833b7c48506f2 .
 
-niiri:651e85007a5f5536ec2697c8749ec5f0
+niiri:78c8a26930efa326681e90dff555fc77
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:a825a8bc763b96a41ba63085944a53f5 ;
+    prov:atLocation niiri:66be040da5c4acc0a89ea6b3e5f93b73 ;
     prov:value "1.53290164470673"^^xsd:float ;
     nidm_equivalentZStatistic: "2.65036951622375"^^xsd:float ;
     nidm_pValueUncorrected: "0.00402018893002576"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a825a8bc763b96a41ba63085944a53f5
+niiri:66be040da5c4acc0a89ea6b3e5f93b73
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-32,-80,10]"^^xsd:string .
 
-niiri:651e85007a5f5536ec2697c8749ec5f0 prov:wasDerivedFrom niiri:7d6744d8bee9e326b4381ceb83e93c8d .
+niiri:78c8a26930efa326681e90dff555fc77 prov:wasDerivedFrom niiri:245273ed130aa663dd8395923de7d766 .
 
-niiri:97da40b69bc71f2a3cbe9bddb8d74db7
+niiri:e27450db030879526e2cd37f19b6068a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:92aaec6881a3d0f16d11925a7c0e8a35 ;
+    prov:atLocation niiri:9a134c4eb3f236a583bfeb4e2510100b ;
     prov:value "1.34681856632233"^^xsd:float ;
     nidm_equivalentZStatistic: "2.4074027844201"^^xsd:float ;
     nidm_pValueUncorrected: "0.00803321955273906"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:92aaec6881a3d0f16d11925a7c0e8a35
+niiri:9a134c4eb3f236a583bfeb4e2510100b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-32,-88,8]"^^xsd:string .
 
-niiri:97da40b69bc71f2a3cbe9bddb8d74db7 prov:wasDerivedFrom niiri:7d6744d8bee9e326b4381ceb83e93c8d .
+niiri:e27450db030879526e2cd37f19b6068a prov:wasDerivedFrom niiri:245273ed130aa663dd8395923de7d766 .
 
-niiri:4a7114ba39dbababe80905fe47a8cbc5
+niiri:61a1f119a58200fd0ce3b1e2fd682e00
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:a5814c8553718d88d2b132f5baa18703 ;
+    prov:atLocation niiri:f356a7d47e82f8102335f0556cb01595 ;
     prov:value "1.31222748756409"^^xsd:float ;
     nidm_equivalentZStatistic: "2.36238178325093"^^xsd:float ;
     nidm_pValueUncorrected: "0.00907896581463363"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a5814c8553718d88d2b132f5baa18703
+niiri:f356a7d47e82f8102335f0556cb01595
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-30,-78,26]"^^xsd:string .
 
-niiri:4a7114ba39dbababe80905fe47a8cbc5 prov:wasDerivedFrom niiri:7d6744d8bee9e326b4381ceb83e93c8d .
+niiri:61a1f119a58200fd0ce3b1e2fd682e00 prov:wasDerivedFrom niiri:245273ed130aa663dd8395923de7d766 .
 
-niiri:891a014c9e49c38970fb24d2eaae740d
+niiri:229356d269942dce89a3a7c973961faa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:7d0bd7b1f39fd643840af9787a78ba95 ;
+    prov:atLocation niiri:744ef1cac9a60dbcaad14b0240043509 ;
     prov:value "1.47698056697845"^^xsd:float ;
     nidm_equivalentZStatistic: "2.57723307746183"^^xsd:float ;
     nidm_pValueUncorrected: "0.00497973845037369"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7d0bd7b1f39fd643840af9787a78ba95
+niiri:744ef1cac9a60dbcaad14b0240043509
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[24,-64,62]"^^xsd:string .
 
-niiri:891a014c9e49c38970fb24d2eaae740d prov:wasDerivedFrom niiri:1593dbfe6a27c4bfd6c7c865a55e6758 .
+niiri:229356d269942dce89a3a7c973961faa prov:wasDerivedFrom niiri:d173e9e0c068ad3a55c343fddbeff960 .
 
-niiri:f4b89e59bc3ef696d8778bd6b6dea759
+niiri:579ab60fab49539d2dcc0aec8d3e6f1b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:1d699923abf53a3abefc6961b7996e12 ;
+    prov:atLocation niiri:bd285c68570a449ae738f6d1546377c9 ;
     prov:value "1.47098410129547"^^xsd:float ;
     nidm_equivalentZStatistic: "2.56939616988394"^^xsd:float ;
     nidm_pValueUncorrected: "0.00509379579800051"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1d699923abf53a3abefc6961b7996e12
+niiri:bd285c68570a449ae738f6d1546377c9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[42,2,42]"^^xsd:string .
 
-niiri:f4b89e59bc3ef696d8778bd6b6dea759 prov:wasDerivedFrom niiri:537cd4e035d031e1d96dcc9b62c35112 .
+niiri:579ab60fab49539d2dcc0aec8d3e6f1b prov:wasDerivedFrom niiri:26532b37abc532050b4bc4be92087a96 .
 
-niiri:6d3354cad50b2f85dd7cb7909270bbd9
+niiri:5d2f66f6ea92771fa62de13e4aaed7f3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:a0853cb3b872dd490c0e659c3b8de3c5 ;
+    prov:atLocation niiri:9ccf61688dd58507429dc35697a26efd ;
     prov:value "1.28529334068298"^^xsd:float ;
     nidm_equivalentZStatistic: "2.32736401858338"^^xsd:float ;
     nidm_pValueUncorrected: "0.00997294956075112"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a0853cb3b872dd490c0e659c3b8de3c5
+niiri:9ccf61688dd58507429dc35697a26efd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[52,6,36]"^^xsd:string .
 
-niiri:6d3354cad50b2f85dd7cb7909270bbd9 prov:wasDerivedFrom niiri:537cd4e035d031e1d96dcc9b62c35112 .
+niiri:5d2f66f6ea92771fa62de13e4aaed7f3 prov:wasDerivedFrom niiri:26532b37abc532050b4bc4be92087a96 .
 
-niiri:c9fd614181dc2572b186e5053efcd59d
+niiri:75ccce0f3228ed0ea90d8f61e6a628f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:f39a7e048d6696e150550855cdb219a4 ;
+    prov:atLocation niiri:3d0c194e760a2dd9d0d578b8ebea83d7 ;
     prov:value "1.46635723114014"^^xsd:float ;
     nidm_equivalentZStatistic: "2.56334999311601"^^xsd:float ;
     nidm_pValueUncorrected: "0.00518337435668992"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f39a7e048d6696e150550855cdb219a4
+niiri:3d0c194e760a2dd9d0d578b8ebea83d7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[-28,-60,54]"^^xsd:string .
 
-niiri:c9fd614181dc2572b186e5053efcd59d prov:wasDerivedFrom niiri:3330f53a36ff5c9ef2f20b1290e9d286 .
+niiri:75ccce0f3228ed0ea90d8f61e6a628f9 prov:wasDerivedFrom niiri:aa0ecf58900f58c3045f470d5e5cd69a .
 
-niiri:a16bea998c35dc62efc05b93e35b430f
+niiri:0a8f07ba5e6a270fb827db109ad495b3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:b2d449babe5545c90ba00fa714a59c65 ;
+    prov:atLocation niiri:a48160de56360c867ce27ffd993c3bbe ;
     prov:value "1.35919630527496"^^xsd:float ;
     nidm_equivalentZStatistic: "2.42352513638295"^^xsd:float ;
     nidm_pValueUncorrected: "0.00768534474692273"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b2d449babe5545c90ba00fa714a59c65
+niiri:a48160de56360c867ce27ffd993c3bbe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-30,-56,62]"^^xsd:string .
 
-niiri:a16bea998c35dc62efc05b93e35b430f prov:wasDerivedFrom niiri:3330f53a36ff5c9ef2f20b1290e9d286 .
+niiri:0a8f07ba5e6a270fb827db109ad495b3 prov:wasDerivedFrom niiri:aa0ecf58900f58c3045f470d5e5cd69a .
 
-niiri:0103dbc26eaf007da3744695bb9e0aa0
+niiri:2a16b9a23c54607f89ce1afaa023ee14
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:cba23a81a0efa6d0d2133678dd3ac39f ;
+    prov:atLocation niiri:e8e1a406248262013c0b6a701696cc35 ;
     prov:value "1.3043509721756"^^xsd:float ;
     nidm_equivalentZStatistic: "2.35213781333103"^^xsd:float ;
     nidm_pValueUncorrected: "0.00933292892535331"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:cba23a81a0efa6d0d2133678dd3ac39f
+niiri:e8e1a406248262013c0b6a701696cc35
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-18,-62,52]"^^xsd:string .
 
-niiri:0103dbc26eaf007da3744695bb9e0aa0 prov:wasDerivedFrom niiri:3330f53a36ff5c9ef2f20b1290e9d286 .
+niiri:2a16b9a23c54607f89ce1afaa023ee14 prov:wasDerivedFrom niiri:aa0ecf58900f58c3045f470d5e5cd69a .
 
-niiri:f75194d50d0d5b9cd1dcdbd886ebd682
+niiri:12302feaed198aa713f9e1c1f7af9c7e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:1adec05c4ab0624228a2752245a4ad8b ;
+    prov:atLocation niiri:48dd2000662814bc84558738c5e24c54 ;
     prov:value "1.45064067840576"^^xsd:float ;
     nidm_equivalentZStatistic: "2.54281750257153"^^xsd:float ;
     nidm_pValueUncorrected: "0.00549813229675677"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1adec05c4ab0624228a2752245a4ad8b
+niiri:48dd2000662814bc84558738c5e24c54
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-30,-84,-48]"^^xsd:string .
 
-niiri:f75194d50d0d5b9cd1dcdbd886ebd682 prov:wasDerivedFrom niiri:9c973b3443bcab76e6ce5b021d6b1a13 .
+niiri:12302feaed198aa713f9e1c1f7af9c7e prov:wasDerivedFrom niiri:901b9fd9da6bf5e77628b338170d2e8d .
 
-niiri:acc4812fde8a87c23d34ba26b370d53f
+niiri:17a02fc314bca00a903267e8fe361e7c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:886a9d589ec63742ed0ea381ebb81a8f ;
+    prov:atLocation niiri:83bac3dfa0ac2b0a2eeeecf18d99728a ;
     prov:value "1.37874686717987"^^xsd:float ;
     nidm_equivalentZStatistic: "2.44900302114624"^^xsd:float ;
     nidm_pValueUncorrected: "0.00716261232865922"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:886a9d589ec63742ed0ea381ebb81a8f
+niiri:83bac3dfa0ac2b0a2eeeecf18d99728a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-22,-84,-50]"^^xsd:string .
 
-niiri:acc4812fde8a87c23d34ba26b370d53f prov:wasDerivedFrom niiri:9c973b3443bcab76e6ce5b021d6b1a13 .
+niiri:17a02fc314bca00a903267e8fe361e7c prov:wasDerivedFrom niiri:901b9fd9da6bf5e77628b338170d2e8d .
 
-niiri:15ccd6b0b7514b3584e9c6b60bb007cb
+niiri:664902a2909e45a871762350e07ff964
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:156b51e696a83a537ee4ec10986ac2ce ;
+    prov:atLocation niiri:1d8b5ada3c9045bff9869305f2821f2f ;
     prov:value "1.1024569272995"^^xsd:float ;
     nidm_equivalentZStatistic: "2.09070134301333"^^xsd:float ;
     nidm_pValueUncorrected: "0.0182774222681363"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:156b51e696a83a537ee4ec10986ac2ce
+niiri:1d8b5ada3c9045bff9869305f2821f2f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-24,-90,-42]"^^xsd:string .
 
-niiri:15ccd6b0b7514b3584e9c6b60bb007cb prov:wasDerivedFrom niiri:9c973b3443bcab76e6ce5b021d6b1a13 .
+niiri:664902a2909e45a871762350e07ff964 prov:wasDerivedFrom niiri:901b9fd9da6bf5e77628b338170d2e8d .
 
-niiri:4777cf2071b7b41500a1f57022890df8
+niiri:24eaee863fcdfc204b0ce8fc5d61cd1d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:1af93548bf2bbf22f69bc6640b686613 ;
+    prov:atLocation niiri:61f3fe7972829fec8bde60e9d9f9e245 ;
     prov:value "1.43723428249359"^^xsd:float ;
     nidm_equivalentZStatistic: "2.52530953068747"^^xsd:float ;
     nidm_pValueUncorrected: "0.00577982121839438"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1af93548bf2bbf22f69bc6640b686613
+niiri:61f3fe7972829fec8bde60e9d9f9e245
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-24,40,46]"^^xsd:string .
 
-niiri:4777cf2071b7b41500a1f57022890df8 prov:wasDerivedFrom niiri:27a3407fb41dee69924952963bf01095 .
+niiri:24eaee863fcdfc204b0ce8fc5d61cd1d prov:wasDerivedFrom niiri:54e9eacbd4a27d2bb3a673e3ecd6842c .
 
-niiri:eacfb263b90cde13ef784658cf25eb48
+niiri:26343fd11572bb24257abcb3944a6ebe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:7ac57d87a6011aa306f5300c51620b1f ;
+    prov:atLocation niiri:cbf2928cfc607ea4fcba74676638f7e3 ;
     prov:value "1.11286687850952"^^xsd:float ;
     nidm_equivalentZStatistic: "2.10411930550185"^^xsd:float ;
     nidm_pValueUncorrected: "0.0176840206088169"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7ac57d87a6011aa306f5300c51620b1f
+niiri:cbf2928cfc607ea4fcba74676638f7e3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-16,50,46]"^^xsd:string .
 
-niiri:eacfb263b90cde13ef784658cf25eb48 prov:wasDerivedFrom niiri:27a3407fb41dee69924952963bf01095 .
+niiri:26343fd11572bb24257abcb3944a6ebe prov:wasDerivedFrom niiri:54e9eacbd4a27d2bb3a673e3ecd6842c .
 
-niiri:f954f6180923bbe6c50483cd884c34cb
+niiri:81d3cdeaca658f010af81a67520b4b89
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:7beb4ee855117da9771f3319e86d6926 ;
+    prov:atLocation niiri:d3e259c6333491ced7f35c96d536bb8d ;
     prov:value "1.42738270759583"^^xsd:float ;
     nidm_equivalentZStatistic: "2.51244786328393"^^xsd:float ;
     nidm_pValueUncorrected: "0.00599484099495173"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7beb4ee855117da9771f3319e86d6926
+niiri:d3e259c6333491ced7f35c96d536bb8d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[40,32,42]"^^xsd:string .
 
-niiri:f954f6180923bbe6c50483cd884c34cb prov:wasDerivedFrom niiri:9c3f0991818d487326255d5ca7862e30 .
+niiri:81d3cdeaca658f010af81a67520b4b89 prov:wasDerivedFrom niiri:102bcff4159cf1d08e8b6d4fdfbaade6 .
 
-niiri:f04690c008db60f141bbb5f8963ea62f
+niiri:5b296736e349e0c0d6c37d50f3ce649a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:dc9d047e50802cd5dfea68f14c77fdb3 ;
+    prov:atLocation niiri:8ae8485dbc29c7d3d5cfb7b28efa1138 ;
     prov:value "1.05634605884552"^^xsd:float ;
     nidm_equivalentZStatistic: "2.03136304442869"^^xsd:float ;
     nidm_pValueUncorrected: "0.0211090901815698"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:dc9d047e50802cd5dfea68f14c77fdb3
+niiri:8ae8485dbc29c7d3d5cfb7b28efa1138
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[38,40,36]"^^xsd:string .
 
-niiri:f04690c008db60f141bbb5f8963ea62f prov:wasDerivedFrom niiri:9c3f0991818d487326255d5ca7862e30 .
+niiri:5b296736e349e0c0d6c37d50f3ce649a prov:wasDerivedFrom niiri:102bcff4159cf1d08e8b6d4fdfbaade6 .
 
-niiri:f2927e668b305ce4095e4a1fae3d5ba5
+niiri:8cf4705ae6d69a2d312549186137f822
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:ee21681844ab92db1f554ed686e6cb97 ;
+    prov:atLocation niiri:70f5848935192c2f9c73c5bc880dce82 ;
     prov:value "1.40870463848114"^^xsd:float ;
     nidm_equivalentZStatistic: "2.4880722231724"^^xsd:float ;
     nidm_pValueUncorrected: "0.00642188235953201"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ee21681844ab92db1f554ed686e6cb97
+niiri:70f5848935192c2f9c73c5bc880dce82
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-42,-84,-6]"^^xsd:string .
 
-niiri:f2927e668b305ce4095e4a1fae3d5ba5 prov:wasDerivedFrom niiri:73094daa238696f8de11ef4e56a95c30 .
+niiri:8cf4705ae6d69a2d312549186137f822 prov:wasDerivedFrom niiri:71589bd4c92a13b9d77db1a0f4dfe621 .
 
-niiri:402e0d4048e6d12f11de0e3c9bdf055c
+niiri:0dd3698237b6362f90b33d2433b0478e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:9e67d185caabdc161e0d312461d9cdd0 ;
+    prov:atLocation niiri:060e12f85e9cf56d29828d41b5de6eba ;
     prov:value "1.13220155239105"^^xsd:float ;
     nidm_equivalentZStatistic: "2.12906102075628"^^xsd:float ;
     nidm_pValueUncorrected: "0.0166246060871375"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9e67d185caabdc161e0d312461d9cdd0
+niiri:060e12f85e9cf56d29828d41b5de6eba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-50,-78,0]"^^xsd:string .
 
-niiri:402e0d4048e6d12f11de0e3c9bdf055c prov:wasDerivedFrom niiri:73094daa238696f8de11ef4e56a95c30 .
+niiri:0dd3698237b6362f90b33d2433b0478e prov:wasDerivedFrom niiri:71589bd4c92a13b9d77db1a0f4dfe621 .
 
-niiri:ce6f3e2f152234ea375751cc54fa9c85
+niiri:1e54eee3467b7fb8f7b3d6f4f6a52ee0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:93fdcdaf5f69c6e135d078d6217da497 ;
+    prov:atLocation niiri:2cfbace584ca70fa07c72dace3b804e0 ;
     prov:value "1.34917068481445"^^xsd:float ;
     nidm_equivalentZStatistic: "2.41046599292312"^^xsd:float ;
     nidm_pValueUncorrected: "0.00796607827138629"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:93fdcdaf5f69c6e135d078d6217da497
+niiri:2cfbace584ca70fa07c72dace3b804e0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[12,-20,80]"^^xsd:string .
 
-niiri:ce6f3e2f152234ea375751cc54fa9c85 prov:wasDerivedFrom niiri:35af8997746066bb4be8d3a9cebf0640 .
+niiri:1e54eee3467b7fb8f7b3d6f4f6a52ee0 prov:wasDerivedFrom niiri:59224724a1e5e6aa2048738e448b7eb6 .
 
-niiri:b988b89ef13b4938653637ed36c2bc4d
+niiri:5d2341704a7e536bbc30a147b3fdb40e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:8bc4c3b0a3463c5ccd6748b60c01b1b7 ;
+    prov:atLocation niiri:7b320bcd0aea26dd35055afdae5821d2 ;
     prov:value "1.34354746341705"^^xsd:float ;
     nidm_equivalentZStatistic: "2.40314315325023"^^xsd:float ;
     nidm_pValueUncorrected: "0.0081274114265858"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8bc4c3b0a3463c5ccd6748b60c01b1b7
+niiri:7b320bcd0aea26dd35055afdae5821d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[18,48,44]"^^xsd:string .
 
-niiri:b988b89ef13b4938653637ed36c2bc4d prov:wasDerivedFrom niiri:9d0b757e22fc3f0156790583744c1334 .
+niiri:5d2341704a7e536bbc30a147b3fdb40e prov:wasDerivedFrom niiri:6b72e4095c1f07ea4ea737f0c44371c4 .
 
-niiri:1d5df79c27d668272e122666fca002b8
+niiri:43ed1491cc19f7e7aff955c8842cbc4f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:6429c604174465ae78baf35ecfc017c4 ;
+    prov:atLocation niiri:fa685a13be0595595616be60e9c54c60 ;
     prov:value "1.14962959289551"^^xsd:float ;
     nidm_equivalentZStatistic: "2.15156492154198"^^xsd:float ;
     nidm_pValueUncorrected: "0.015715818709074"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6429c604174465ae78baf35ecfc017c4
+niiri:fa685a13be0595595616be60e9c54c60
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[8,52,46]"^^xsd:string .
 
-niiri:1d5df79c27d668272e122666fca002b8 prov:wasDerivedFrom niiri:9d0b757e22fc3f0156790583744c1334 .
+niiri:43ed1491cc19f7e7aff955c8842cbc4f prov:wasDerivedFrom niiri:6b72e4095c1f07ea4ea737f0c44371c4 .
 
-niiri:3141b4c6e901f4ec1f5e0352c6d0360d
+niiri:459ed47a48d1df07a89f83b8f1ac0c69
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:65ae40d69c72f6ee264d19c45986f3b4 ;
+    prov:atLocation niiri:0fc5888e3b443b2a1df816962b2fc3dd ;
     prov:value "1.33556091785431"^^xsd:float ;
     nidm_equivalentZStatistic: "2.39274498818401"^^xsd:float ;
     nidm_pValueUncorrected: "0.00836142979663967"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:65ae40d69c72f6ee264d19c45986f3b4
+niiri:0fc5888e3b443b2a1df816962b2fc3dd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[64,-52,2]"^^xsd:string .
 
-niiri:3141b4c6e901f4ec1f5e0352c6d0360d prov:wasDerivedFrom niiri:8d3362f5850c9379377b0d1f0b1c2735 .
+niiri:459ed47a48d1df07a89f83b8f1ac0c69 prov:wasDerivedFrom niiri:adcf7702789aacaca259aab58c015a1b .
 
-niiri:469e72c7f14e92f86f0ec5262a435c39
+niiri:14d7a1850581b6956488a368f171e3cf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:a51b4e8c46bf9aa3e74eadca19ad0968 ;
+    prov:atLocation niiri:836f43e4e1f3e9f4635c5ddfe843e3e3 ;
     prov:value "1.30518817901611"^^xsd:float ;
     nidm_equivalentZStatistic: "2.35322652463791"^^xsd:float ;
     nidm_pValueUncorrected: "0.00930564616578244"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a51b4e8c46bf9aa3e74eadca19ad0968
+niiri:836f43e4e1f3e9f4635c5ddfe843e3e3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[26,-74,-30]"^^xsd:string .
 
-niiri:469e72c7f14e92f86f0ec5262a435c39 prov:wasDerivedFrom niiri:227019e17364687787db60a4a8267663 .
+niiri:14d7a1850581b6956488a368f171e3cf prov:wasDerivedFrom niiri:9583432017e2a81f5dfd9ee21e31202e .
 
-niiri:99a673bf7bd432cda404ddae34a3c146
+niiri:1302b9300cedb561929231efc9492a17
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:85071e33199bbf64537a2df42a3a1673 ;
+    prov:atLocation niiri:80bda3ee5f37298b4b39cb791e126ae9 ;
     prov:value "1.30020189285278"^^xsd:float ;
     nidm_equivalentZStatistic: "2.34674279460019"^^xsd:float ;
     nidm_pValueUncorrected: "0.00946916148556731"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:85071e33199bbf64537a2df42a3a1673
+niiri:80bda3ee5f37298b4b39cb791e126ae9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-44,-82,-34]"^^xsd:string .
 
-niiri:99a673bf7bd432cda404ddae34a3c146 prov:wasDerivedFrom niiri:8669f380bd303fec5b169e636d626ce3 .
+niiri:1302b9300cedb561929231efc9492a17 prov:wasDerivedFrom niiri:4d1c403da9e27b79352d1129d7d66218 .
 
-niiri:09715737634975b7e4a53926319b1bee
+niiri:928c7de4a7c271559d39f39ca6ad73a3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:b8520f4b473a7db7a8a22098c02388df ;
+    prov:atLocation niiri:3826704f625e88111646a8c9959f204c ;
     prov:value "1.2840074300766"^^xsd:float ;
     nidm_equivalentZStatistic: "2.32569303609441"^^xsd:float ;
     nidm_pValueUncorrected: "0.0100174661332294"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b8520f4b473a7db7a8a22098c02388df
+niiri:3826704f625e88111646a8c9959f204c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[-6,62,36]"^^xsd:string .
 
-niiri:09715737634975b7e4a53926319b1bee prov:wasDerivedFrom niiri:f38934924fa68b3b9a71fb9c8171e8b6 .
+niiri:928c7de4a7c271559d39f39ca6ad73a3 prov:wasDerivedFrom niiri:7ac836ca3990ce9f1e31e9eb1801404a .
 
-niiri:a950180a6b2d1ba6bd0c8453f6aa57c6
+niiri:2ad53ef72da7feef4241d530910c3059
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:1f3bac07c06f6c4da947941a3e0d40d2 ;
+    prov:atLocation niiri:95fe8a40c4c4abb8182e888bc8731540 ;
     prov:value "1.26505351066589"^^xsd:float ;
     nidm_equivalentZStatistic: "2.30107272004429"^^xsd:float ;
     nidm_pValueUncorrected: "0.0106937605017341"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1f3bac07c06f6c4da947941a3e0d40d2
+niiri:95fe8a40c4c4abb8182e888bc8731540
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-50,-2,50]"^^xsd:string .
 
-niiri:a950180a6b2d1ba6bd0c8453f6aa57c6 prov:wasDerivedFrom niiri:1793504b32e2869dcb2fbd3af062f8bc .
+niiri:2ad53ef72da7feef4241d530910c3059 prov:wasDerivedFrom niiri:fe6bad7c2c3cd88c5e91fc8c7f05871c .
 
-niiri:a59a5d4bd11645916f5cb26b0edecf9d
+niiri:3931e7effd25e2bca692d42cb4be7fdf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:686f5e6308163bd9a97c3148f494b7b8 ;
+    prov:atLocation niiri:4320b94b260e1ab5e9bf6ae2ce37ec21 ;
     prov:value "1.24030959606171"^^xsd:float ;
     nidm_equivalentZStatistic: "2.26895897281379"^^xsd:float ;
     nidm_pValueUncorrected: "0.0116354104606456"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:686f5e6308163bd9a97c3148f494b7b8
+niiri:4320b94b260e1ab5e9bf6ae2ce37ec21
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-18,6,32]"^^xsd:string .
 
-niiri:a59a5d4bd11645916f5cb26b0edecf9d prov:wasDerivedFrom niiri:55aacac3d3863ecd2c5789acfd6b261d .
+niiri:3931e7effd25e2bca692d42cb4be7fdf prov:wasDerivedFrom niiri:af4a779ba8799ad0c9fe505505295a71 .
 
-niiri:fb31a7b6c3f653a71eb02bc199c1c87d
+niiri:d3d4be6c2db0dbdcc7b2d8f9dba10557
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:86d95b0aaa548888f11ac1f3260b8a14 ;
+    prov:atLocation niiri:b6308ae0f236e4a1c0a36b987dae355b ;
     prov:value "1.23086047172546"^^xsd:float ;
     nidm_equivalentZStatistic: "2.25670403369037"^^xsd:float ;
     nidm_pValueUncorrected: "0.0120132873197203"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:86d95b0aaa548888f11ac1f3260b8a14
+niiri:b6308ae0f236e4a1c0a36b987dae355b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[32,-44,-30]"^^xsd:string .
 
-niiri:fb31a7b6c3f653a71eb02bc199c1c87d prov:wasDerivedFrom niiri:03238c6a619b9f265421cbb7a0cda76e .
+niiri:d3d4be6c2db0dbdcc7b2d8f9dba10557 prov:wasDerivedFrom niiri:034859fff2bec220b9605fe31c29e464 .
 
-niiri:573a177d63d9c9f2fb4fa151422f89eb
+niiri:5946f3ffe932cd7089f09585f0ea10ab
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:d21d8383c2ef494476f34cb7efde4323 ;
+    prov:atLocation niiri:f6a9e6f3d876bef6da1f25ca40fcea8f ;
     prov:value "1.22944271564484"^^xsd:float ;
     nidm_equivalentZStatistic: "2.25486570897048"^^xsd:float ;
     nidm_pValueUncorrected: "0.012070879644426"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d21d8383c2ef494476f34cb7efde4323
+niiri:f6a9e6f3d876bef6da1f25ca40fcea8f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-46,-10,58]"^^xsd:string .
 
-niiri:573a177d63d9c9f2fb4fa151422f89eb prov:wasDerivedFrom niiri:bc83f4e59851c0ed8424e3172a378ee4 .
+niiri:5946f3ffe932cd7089f09585f0ea10ab prov:wasDerivedFrom niiri:e4a8ed309e5dfdfbdd940912aa7b9917 .
 
-niiri:9fac645dbbfbce2fe558862574fd138e
+niiri:11570b8227fe008a9ad3e7f235166414
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:df5af951356032bbf21dae5e4eafe818 ;
+    prov:atLocation niiri:dab3f47042b08489e32b41af5dc6d145 ;
     prov:value "1.22471487522125"^^xsd:float ;
     nidm_equivalentZStatistic: "2.24873618228261"^^xsd:float ;
     nidm_pValueUncorrected: "0.0122646428654261"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:df5af951356032bbf21dae5e4eafe818
+niiri:dab3f47042b08489e32b41af5dc6d145
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-22,-94,26]"^^xsd:string .
 
-niiri:9fac645dbbfbce2fe558862574fd138e prov:wasDerivedFrom niiri:c340f3ccccc1a020f9aef989954e51fc .
+niiri:11570b8227fe008a9ad3e7f235166414 prov:wasDerivedFrom niiri:54cdf7b7e5fb6a712a9931f377c09dad .
 
-niiri:85c21df54812854d9dcc91de1c9501e3
+niiri:f77468942763f8e191e11dddee19d43a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:b1d19ddb93361faaef7a254dcfaf85f5 ;
+    prov:atLocation niiri:213a51e4d0cd0916770b07505d60d6cb ;
     prov:value "1.21706402301788"^^xsd:float ;
     nidm_equivalentZStatistic: "2.23881967357295"^^xsd:float ;
     nidm_pValueUncorrected: "0.0125838258304741"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b1d19ddb93361faaef7a254dcfaf85f5
+niiri:213a51e4d0cd0916770b07505d60d6cb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[36,32,8]"^^xsd:string .
 
-niiri:85c21df54812854d9dcc91de1c9501e3 prov:wasDerivedFrom niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5 .
+niiri:f77468942763f8e191e11dddee19d43a prov:wasDerivedFrom niiri:f86480eb515c35553583815451053247 .
 
-niiri:419edd7ae0533f67f4b514cad51a7e40
+niiri:2bb7a0ae8224d3d87a2d1e162463a80f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:9e821e6d86a5b665b7128c83d0b55b57 ;
+    prov:atLocation niiri:246a5f68eb203f6e3f9476c5929534b1 ;
     prov:value "1.1321427822113"^^xsd:float ;
     nidm_equivalentZStatistic: "2.12898516834439"^^xsd:float ;
     nidm_pValueUncorrected: "0.0166277437596988"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9e821e6d86a5b665b7128c83d0b55b57
+niiri:246a5f68eb203f6e3f9476c5929534b1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[32,28,2]"^^xsd:string .
 
-niiri:419edd7ae0533f67f4b514cad51a7e40 prov:wasDerivedFrom niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5 .
+niiri:2bb7a0ae8224d3d87a2d1e162463a80f prov:wasDerivedFrom niiri:f86480eb515c35553583815451053247 .
 
-niiri:cbe78a0c214f75fee02b8f4215a8d050
+niiri:b69bbb0f81f95850657d5352879fb5ab
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:61ea3aa03f07e52544d1f2c561b325f5 ;
+    prov:atLocation niiri:9f0de39e9fe7f38ddad952a0d7bccc8f ;
     prov:value "1.21668255329132"^^xsd:float ;
     nidm_equivalentZStatistic: "2.23832532460858"^^xsd:float ;
     nidm_pValueUncorrected: "0.0125999239065135"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:61ea3aa03f07e52544d1f2c561b325f5
+niiri:9f0de39e9fe7f38ddad952a0d7bccc8f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-36,-42,38]"^^xsd:string .
 
-niiri:cbe78a0c214f75fee02b8f4215a8d050 prov:wasDerivedFrom niiri:cb85dd1324b2d86671b2fe868f4dafc0 .
+niiri:b69bbb0f81f95850657d5352879fb5ab prov:wasDerivedFrom niiri:797c0d6ce89eec38f010854e7e38594b .
 
-niiri:0a98388a34991d9fe59b4a9cf396642c
+niiri:1c99fba420ab95e54f5e82f1c2a767db
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:ef543ad68b3140441251e0efe0af7cd1 ;
+    prov:atLocation niiri:4dfa41027eded7653e2d6ff0fbd63da3 ;
     prov:value "1.19720852375031"^^xsd:float ;
     nidm_equivalentZStatistic: "2.21309986746215"^^xsd:float ;
     nidm_pValueUncorrected: "0.0134453806257753"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ef543ad68b3140441251e0efe0af7cd1
+niiri:4dfa41027eded7653e2d6ff0fbd63da3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[2,68,26]"^^xsd:string .
 
-niiri:0a98388a34991d9fe59b4a9cf396642c prov:wasDerivedFrom niiri:0dc11dbfea7cb1fef76a1c48d7f8750f .
+niiri:1c99fba420ab95e54f5e82f1c2a767db prov:wasDerivedFrom niiri:223b74991051acba66efeafdae50f4c4 .
 
-niiri:acf1658fdc834ef5f68e881f5de034af
+niiri:6a6243c36daeead679e5dc9b4b70fc84
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:ba2d9a0c93e36c103ea6c6300ded5fa8 ;
+    prov:atLocation niiri:6dad428dc18a6069931ebbf2fcba9dcf ;
     prov:value "1.1896378993988"^^xsd:float ;
     nidm_equivalentZStatistic: "2.20329932117063"^^xsd:float ;
     nidm_pValueUncorrected: "0.013786829398946"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ba2d9a0c93e36c103ea6c6300ded5fa8
+niiri:6dad428dc18a6069931ebbf2fcba9dcf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[46,14,2]"^^xsd:string .
 
-niiri:acf1658fdc834ef5f68e881f5de034af prov:wasDerivedFrom niiri:6db75fb201d2decf706c9d2dd225cb5a .
+niiri:6a6243c36daeead679e5dc9b4b70fc84 prov:wasDerivedFrom niiri:294fdb1b5bfd7e0473b8498bbe447111 .
 
-niiri:82118381b7674f736b0f0cd125544fe3
+niiri:df04715790f66448d96cbbc580c69445
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:d8f27c43af5b906ba5f0b6da34c9df35 ;
+    prov:atLocation niiri:84731f87155885fd75a8ffe0e64d7f6a ;
     prov:value "0.84699684381485"^^xsd:float ;
     nidm_equivalentZStatistic: "1.76435736331002"^^xsd:float ;
     nidm_pValueUncorrected: "0.0388359158916027"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d8f27c43af5b906ba5f0b6da34c9df35
+niiri:84731f87155885fd75a8ffe0e64d7f6a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[40,10,10]"^^xsd:string .
 
-niiri:82118381b7674f736b0f0cd125544fe3 prov:wasDerivedFrom niiri:6db75fb201d2decf706c9d2dd225cb5a .
+niiri:df04715790f66448d96cbbc580c69445 prov:wasDerivedFrom niiri:294fdb1b5bfd7e0473b8498bbe447111 .
 
-niiri:71125be49af0dc99c2e40193fb5e66b2
+niiri:ae975e66ecc6bc89e61cc1c6ba62c79d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:fdf68d1a3ec000d7fa998a7c58e56d5d ;
+    prov:atLocation niiri:8bedce252c2de48da69a3b37443ed2a4 ;
     prov:value "1.18655109405518"^^xsd:float ;
     nidm_equivalentZStatistic: "2.19930428061828"^^xsd:float ;
     nidm_pValueUncorrected: "0.0139281467706139"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:fdf68d1a3ec000d7fa998a7c58e56d5d
+niiri:8bedce252c2de48da69a3b37443ed2a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-32,-28,-2]"^^xsd:string .
 
-niiri:71125be49af0dc99c2e40193fb5e66b2 prov:wasDerivedFrom niiri:8fae62d51a220dbd34d1d3074ad97c80 .
+niiri:ae975e66ecc6bc89e61cc1c6ba62c79d prov:wasDerivedFrom niiri:317b26ee6683fc2d7e4152e9f21569d5 .
 
-niiri:4e602b57e82d39a3379ea0238f2f065a
+niiri:65cce8abcbb33fd2c8c6a019e9bb7038
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:2f57e4ad9e363502818b5b7af383279e ;
+    prov:atLocation niiri:00c23da14f9cf7988bcbc63d84fe0d88 ;
     prov:value "1.17589449882507"^^xsd:float ;
     nidm_equivalentZStatistic: "2.18551661590201"^^xsd:float ;
     nidm_pValueUncorrected: "0.0144254945017301"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2f57e4ad9e363502818b5b7af383279e
+niiri:00c23da14f9cf7988bcbc63d84fe0d88
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-18,30,50]"^^xsd:string .
 
-niiri:4e602b57e82d39a3379ea0238f2f065a prov:wasDerivedFrom niiri:1b3f6a9bf76e54ad12539e190c7c838c .
+niiri:65cce8abcbb33fd2c8c6a019e9bb7038 prov:wasDerivedFrom niiri:7a8231297a4abeb5308420c5bd8b95b0 .
 
-niiri:127254d5f8144e53a6000f178ba9832f
+niiri:3b9f724439a601a2217386ee517c26d1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:f78dbb802d360f040867d01f91280a3e ;
+    prov:atLocation niiri:61b8ab33a1b0f17d66c8c98888b7aa6d ;
     prov:value "1.17159426212311"^^xsd:float ;
     nidm_equivalentZStatistic: "2.17995487813573"^^xsd:float ;
     nidm_pValueUncorrected: "0.0146304032058477"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f78dbb802d360f040867d01f91280a3e
+niiri:61b8ab33a1b0f17d66c8c98888b7aa6d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-14,-26,66]"^^xsd:string .
 
-niiri:127254d5f8144e53a6000f178ba9832f prov:wasDerivedFrom niiri:dc2d50ba6c535742eed46213fc557f6a .
+niiri:3b9f724439a601a2217386ee517c26d1 prov:wasDerivedFrom niiri:6b7b56e17486f776bce05e82a97e5bb7 .
 
-niiri:323e53e57a73eedef512b5baa864925b
+niiri:92731d2fdb3968c2064b6892b4a6c735
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:e99f8650eabbc3b1cd1432e8b2374a82 ;
+    prov:atLocation niiri:c9b930c22d2863c88d596a347430fb43 ;
     prov:value "1.1714745759964"^^xsd:float ;
     nidm_equivalentZStatistic: "2.17980009775463"^^xsd:float ;
     nidm_pValueUncorrected: "0.0146361413495164"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e99f8650eabbc3b1cd1432e8b2374a82
+niiri:c9b930c22d2863c88d596a347430fb43
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[18,60,34]"^^xsd:string .
 
-niiri:323e53e57a73eedef512b5baa864925b prov:wasDerivedFrom niiri:416dfaa44bb6a7fe97539c984a9173c3 .
+niiri:92731d2fdb3968c2064b6892b4a6c735 prov:wasDerivedFrom niiri:dbaf33f41cd427af7e5a021f10031a6a .
 
-niiri:617a5f940f4b8fb780b2b0fba6f13c31
+niiri:5764da2697fce92e5bdd83dfee44f500
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:45d2e869fd9ca2ba349709e3128b5308 ;
+    prov:atLocation niiri:3497a1d298e28ded5637bf48b84d5733 ;
     prov:value "1.17128801345825"^^xsd:float ;
     nidm_equivalentZStatistic: "2.17955883330163"^^xsd:float ;
     nidm_pValueUncorrected: "0.0146450895624214"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:45d2e869fd9ca2ba349709e3128b5308
+niiri:3497a1d298e28ded5637bf48b84d5733
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-30,-72,-50]"^^xsd:string .
 
-niiri:617a5f940f4b8fb780b2b0fba6f13c31 prov:wasDerivedFrom niiri:31033e543fb9492bc06e61625ca6b410 .
+niiri:5764da2697fce92e5bdd83dfee44f500 prov:wasDerivedFrom niiri:2cb148daa680c4c53ffa5337fb86c905 .
 
-niiri:14ae1fa9257e4c53338274fcc108384b
+niiri:3dc749ec7b2f059a8b5376f0602ce80c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:f5920a1ad34f8b842af3e79ef81c8e61 ;
+    prov:atLocation niiri:53765155d8a469d9d77032055bf2673b ;
     prov:value "1.15287852287292"^^xsd:float ;
     nidm_equivalentZStatistic: "2.15576230673889"^^xsd:float ;
     nidm_pValueUncorrected: "0.0155511150762138"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f5920a1ad34f8b842af3e79ef81c8e61
+niiri:53765155d8a469d9d77032055bf2673b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[10,6,74]"^^xsd:string .
 
-niiri:14ae1fa9257e4c53338274fcc108384b prov:wasDerivedFrom niiri:7a8b21e9acaff0531c73c9fe0bfaeb53 .
+niiri:3dc749ec7b2f059a8b5376f0602ce80c prov:wasDerivedFrom niiri:1d84285e01d49d904f7b5e9f0333287b .
 
-niiri:7eb75ab35a0ed1f5c8a184d8d88a9b5c
+niiri:494fcc7b0e2ed566e5f8a2478f2485a1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:7e6b90a96f7d814724fd0f217cbe1716 ;
+    prov:atLocation niiri:c5a39b376cec940e5b6f5e749210ca95 ;
     prov:value "1.14964759349823"^^xsd:float ;
     nidm_equivalentZStatistic: "2.15158817513994"^^xsd:float ;
     nidm_pValueUncorrected: "0.0157149021414998"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7e6b90a96f7d814724fd0f217cbe1716
+niiri:c5a39b376cec940e5b6f5e749210ca95
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[-40,48,22]"^^xsd:string .
 
-niiri:7eb75ab35a0ed1f5c8a184d8d88a9b5c prov:wasDerivedFrom niiri:5102964768a1c4313f8c0e48d48f8b40 .
+niiri:494fcc7b0e2ed566e5f8a2478f2485a1 prov:wasDerivedFrom niiri:8cb6b321e3922f27346febc1c617df72 .
 
-niiri:23a04d6d64ae1555176652a69477cb6e
+niiri:761a60caff966c3e9100c61d125e846c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:ceee7ccdc7c470b175dedd001c1ea7f6 ;
+    prov:atLocation niiri:d9c29a8c9776b18525935ece2a275428 ;
     prov:value "1.14813911914825"^^xsd:float ;
     nidm_equivalentZStatistic: "2.14963956628403"^^xsd:float ;
     nidm_pValueUncorrected: "0.0157918680840622"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ceee7ccdc7c470b175dedd001c1ea7f6
+niiri:d9c29a8c9776b18525935ece2a275428
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[10,-78,-40]"^^xsd:string .
 
-niiri:23a04d6d64ae1555176652a69477cb6e prov:wasDerivedFrom niiri:256070c77a58b8b64913a5b6bfb81f60 .
+niiri:761a60caff966c3e9100c61d125e846c prov:wasDerivedFrom niiri:bd60388f21dba151ffa9b94fc56a76fc .
 
-niiri:cf610736c17264f136dfe0eb89ee2a05
+niiri:bed8d5d8fa75f809069ec2833a81f4ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:279a6a11962ed1f111fb8d7a02bb5d8a ;
+    prov:atLocation niiri:7236907b7bfecfe0ada496a13aa8158d ;
     prov:value "1.14065408706665"^^xsd:float ;
     nidm_equivalentZStatistic: "2.13997280538058"^^xsd:float ;
     nidm_pValueUncorrected: "0.0161784822721924"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:279a6a11962ed1f111fb8d7a02bb5d8a
+niiri:7236907b7bfecfe0ada496a13aa8158d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-12,2,70]"^^xsd:string .
 
-niiri:cf610736c17264f136dfe0eb89ee2a05 prov:wasDerivedFrom niiri:96604941a960daa1e224727cb5ba2d60 .
+niiri:bed8d5d8fa75f809069ec2833a81f4ea prov:wasDerivedFrom niiri:2634cefb56e62fe1daef544f6c3dc96a .
 
-niiri:515a57e55082e7aaafd8054cc4375e77
+niiri:c65e794da990db696a73c27b821aa5bb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:fe98447baa6baac51db022671fc048f4 ;
+    prov:atLocation niiri:c8be43b69b65fd7bd6fcfe9003806301 ;
     prov:value "1.1338312625885"^^xsd:float ;
     nidm_equivalentZStatistic: "2.13116451819532"^^xsd:float ;
     nidm_pValueUncorrected: "0.0165377954988448"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:fe98447baa6baac51db022671fc048f4
+niiri:c8be43b69b65fd7bd6fcfe9003806301
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[22,-18,48]"^^xsd:string .
 
-niiri:515a57e55082e7aaafd8054cc4375e77 prov:wasDerivedFrom niiri:529af4aecda9065e5cce8adf4cdfd5c6 .
+niiri:c65e794da990db696a73c27b821aa5bb prov:wasDerivedFrom niiri:eaf17770fa04ac0e839b538c792a3073 .
 
-niiri:7d5fd522914b718d895ca04f556b7437
+niiri:c5fe85ea37711b9210d10755ac8c11e1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:966a95b3241bbaf0d187fd1e341c79bf ;
+    prov:atLocation niiri:e2973e9fea14c5a99804e786bf6fc076 ;
     prov:value "1.11546647548676"^^xsd:float ;
     nidm_equivalentZStatistic: "2.10747127106409"^^xsd:float ;
     nidm_pValueUncorrected: "0.0175383747043093"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:966a95b3241bbaf0d187fd1e341c79bf
+niiri:e2973e9fea14c5a99804e786bf6fc076
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[30,-18,16]"^^xsd:string .
 
-niiri:7d5fd522914b718d895ca04f556b7437 prov:wasDerivedFrom niiri:bdef3fee2464d33f021c131ff78646c7 .
+niiri:c5fe85ea37711b9210d10755ac8c11e1 prov:wasDerivedFrom niiri:79667c98e94d775596ecebd364219144 .
 
-niiri:3eefe07ca12961dd4d03965206e8cb06
+niiri:8ac8469c9dcf83f4841a272192fc0c34
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:a233e11baaca31ed80be42d76e85c346 ;
+    prov:atLocation niiri:2b70ceb182df8bebc9f8c76761a4cc1a ;
     prov:value "1.11363661289215"^^xsd:float ;
     nidm_equivalentZStatistic: "2.10511176477938"^^xsd:float ;
     nidm_pValueUncorrected: "0.0176407901931581"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a233e11baaca31ed80be42d76e85c346
+niiri:2b70ceb182df8bebc9f8c76761a4cc1a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[16,2,56]"^^xsd:string .
 
-niiri:3eefe07ca12961dd4d03965206e8cb06 prov:wasDerivedFrom niiri:e8088392c69eb956afef92cedfa6aeb4 .
+niiri:8ac8469c9dcf83f4841a272192fc0c34 prov:wasDerivedFrom niiri:a9ca1d216068df228b4f56edb8974b0f .
 
-niiri:ec714042c4c04e8a27fea498c29a9f63
+niiri:998f850a75eb862538438d7c67c9746f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:9467ed32fd2aaef55d31182b82d68662 ;
+    prov:atLocation niiri:66e6a864e1379db647d5020c3ede2fa8 ;
     prov:value "1.10444390773773"^^xsd:float ;
     nidm_equivalentZStatistic: "2.09326187305734"^^xsd:float ;
     nidm_pValueUncorrected: "0.0181628920812176"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9467ed32fd2aaef55d31182b82d68662
+niiri:66e6a864e1379db647d5020c3ede2fa8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[-32,-52,14]"^^xsd:string .
 
-niiri:ec714042c4c04e8a27fea498c29a9f63 prov:wasDerivedFrom niiri:8b4322c153a15066be2583d11b23925c .
+niiri:998f850a75eb862538438d7c67c9746f prov:wasDerivedFrom niiri:8bd946eb61909b953aeda01719f94d66 .
 
-niiri:b5ad2afffcf7769dff075c2ad1bcfb1d
+niiri:b14ce44894b188593156f60c6d6febea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:1e589a760119fa51b33a0aee5879a1c9 ;
+    prov:atLocation niiri:429f05522c8c9ea8849a7f284cabadfc ;
     prov:value "1.01987111568451"^^xsd:float ;
     nidm_equivalentZStatistic: "1.98454402904349"^^xsd:float ;
     nidm_pValueUncorrected: "0.0235976124289208"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1e589a760119fa51b33a0aee5879a1c9
+niiri:429f05522c8c9ea8849a7f284cabadfc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-32,-60,18]"^^xsd:string .
 
-niiri:b5ad2afffcf7769dff075c2ad1bcfb1d prov:wasDerivedFrom niiri:8b4322c153a15066be2583d11b23925c .
+niiri:b14ce44894b188593156f60c6d6febea prov:wasDerivedFrom niiri:8bd946eb61909b953aeda01719f94d66 .
 
-niiri:82ce4d65f10bc5c571a676520fb3526a
+niiri:360dab51259c713e829b994ba8824f4f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:7edb55b74d2a34760e50cf1502d58c54 ;
+    prov:atLocation niiri:da24a94414680a235f8c03368fc7a6fa ;
     prov:value "0.951668322086334"^^xsd:float ;
     nidm_equivalentZStatistic: "1.89731313030669"^^xsd:float ;
     nidm_pValueUncorrected: "0.0288933115272303"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7edb55b74d2a34760e50cf1502d58c54
+niiri:da24a94414680a235f8c03368fc7a6fa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-24,-50,20]"^^xsd:string .
 
-niiri:82ce4d65f10bc5c571a676520fb3526a prov:wasDerivedFrom niiri:8b4322c153a15066be2583d11b23925c .
+niiri:360dab51259c713e829b994ba8824f4f prov:wasDerivedFrom niiri:8bd946eb61909b953aeda01719f94d66 .
 
-niiri:51c84dd2b7a652dbbe29eec2ec10da45
+niiri:e5475d3cadc57811178268faabdde254
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:42bd98c846ed3e6b2f8267e9e359b51c ;
+    prov:atLocation niiri:b09818ac6236576063ffd0e16d44009e ;
     prov:value "1.10060369968414"^^xsd:float ;
     nidm_equivalentZStatistic: "2.08831343102831"^^xsd:float ;
     nidm_pValueUncorrected: "0.0183847853440164"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:42bd98c846ed3e6b2f8267e9e359b51c
+niiri:b09818ac6236576063ffd0e16d44009e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[10,50,18]"^^xsd:string .
 
-niiri:51c84dd2b7a652dbbe29eec2ec10da45 prov:wasDerivedFrom niiri:0c0e48a110ec2c20b75585b9e5372d67 .
+niiri:e5475d3cadc57811178268faabdde254 prov:wasDerivedFrom niiri:e49222f43a2c5f3b6f74b9eb9a47bd2f .
 
-niiri:4c431af959a928867e01e3773e1b88b0
+niiri:e8319110e20edbd00beee44e2faa7150
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:84ebd2f1bc394a77f0212ac8234096da ;
+    prov:atLocation niiri:416e73485c421b4f8e221cd6755977d2 ;
     prov:value "1.09576165676117"^^xsd:float ;
     nidm_equivalentZStatistic: "2.08207556282094"^^xsd:float ;
     nidm_pValueUncorrected: "0.0186677841332979"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:84ebd2f1bc394a77f0212ac8234096da
+niiri:416e73485c421b4f8e221cd6755977d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-46,6,34]"^^xsd:string .
 
-niiri:4c431af959a928867e01e3773e1b88b0 prov:wasDerivedFrom niiri:1bf866f2d8a1a832a120aa9c02c60efd .
+niiri:e8319110e20edbd00beee44e2faa7150 prov:wasDerivedFrom niiri:cccc8624875aafd03105dd4bd6af0ac3 .
 
-niiri:35a5c8c115f0abfbfa3d921633f364a7
+niiri:a7f5bb980c1234c0b6a4202a36c25405
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:3018cf0b63274458035abe5fb99ee859 ;
+    prov:atLocation niiri:3e607638a1673e2c3095f2dc73f95698 ;
     prov:value "1.09575474262238"^^xsd:float ;
     nidm_equivalentZStatistic: "2.08206665675352"^^xsd:float ;
     nidm_pValueUncorrected: "0.0186681908185171"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:3018cf0b63274458035abe5fb99ee859
+niiri:3e607638a1673e2c3095f2dc73f95698
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[28,-8,70]"^^xsd:string .
 
-niiri:35a5c8c115f0abfbfa3d921633f364a7 prov:wasDerivedFrom niiri:a44aefad34ca2359e69bf6f9306bc2c6 .
+niiri:a7f5bb980c1234c0b6a4202a36c25405 prov:wasDerivedFrom niiri:c163699e2c590670b56fd1928fe502a8 .
 
-niiri:d9f041fefa100fdb8132c7a4b6108de0
+niiri:df76b0971b4b5de66f8c278de97ee3c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:b4abdf84c2b011481d11ad3d94001873 ;
+    prov:atLocation niiri:2f8b006298b7ec9f1ed1f7b8311e90ca ;
     prov:value "1.07974576950073"^^xsd:float ;
     nidm_equivalentZStatistic: "2.06145507795256"^^xsd:float ;
     nidm_pValueUncorrected: "0.019629822462089"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b4abdf84c2b011481d11ad3d94001873
+niiri:2f8b006298b7ec9f1ed1f7b8311e90ca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[-58,18,30]"^^xsd:string .
 
-niiri:d9f041fefa100fdb8132c7a4b6108de0 prov:wasDerivedFrom niiri:ab78ea55fc7f212636dd2f73bdc99032 .
+niiri:df76b0971b4b5de66f8c278de97ee3c7 prov:wasDerivedFrom niiri:4824d04f1a3ab526790824f893297a94 .
 
-niiri:b1760aaa8500b6832a7af07d81d63e5d
+niiri:f79befe504bc7cf2d60a0bc41882c1f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:285bc9cc2ba32db7f5e98cd91fb2cfdc ;
+    prov:atLocation niiri:2293ee429f376629915b7d742c9deaa6 ;
     prov:value "1.07930290699005"^^xsd:float ;
     nidm_equivalentZStatistic: "2.06088516484109"^^xsd:float ;
     nidm_pValueUncorrected: "0.019656998463677"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:285bc9cc2ba32db7f5e98cd91fb2cfdc
+niiri:2293ee429f376629915b7d742c9deaa6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[-24,-66,24]"^^xsd:string .
 
-niiri:b1760aaa8500b6832a7af07d81d63e5d prov:wasDerivedFrom niiri:4128bacb45b84a2304aceeb9a3a06db7 .
+niiri:f79befe504bc7cf2d60a0bc41882c1f9 prov:wasDerivedFrom niiri:64a8a8faea43eec16f564fc4aaeca53d .
 
-niiri:7e3b976cef84740109d0eb1268357e83
+niiri:a3c279a10d848e11e97ebef3f2d73123
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:926d256b539273b87002cdf595c1f8fd ;
+    prov:atLocation niiri:d154a29c693d212b9dbbe2088571b958 ;
     prov:value "1.07559859752655"^^xsd:float ;
     nidm_equivalentZStatistic: "2.05611872869022"^^xsd:float ;
     nidm_pValueUncorrected: "0.0198855367075194"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:926d256b539273b87002cdf595c1f8fd
+niiri:d154a29c693d212b9dbbe2088571b958
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[34,34,-20]"^^xsd:string .
 
-niiri:7e3b976cef84740109d0eb1268357e83 prov:wasDerivedFrom niiri:282d81c6243a1094abf4c4787764df02 .
+niiri:a3c279a10d848e11e97ebef3f2d73123 prov:wasDerivedFrom niiri:0260356613cbea9c3fd0a42442707965 .
 
-niiri:73165ed86c4c250a74adde2ee20f14b8
+niiri:35e6e74115a2d1d1ffb378ec9262eeeb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:c0f34ced902e532fff9b867f315ddc89 ;
+    prov:atLocation niiri:6d90736d00550882400a7cbe20af36fa ;
     prov:value "1.07552266120911"^^xsd:float ;
     nidm_equivalentZStatistic: "2.05602103030259"^^xsd:float ;
     nidm_pValueUncorrected: "0.0198902445740951"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c0f34ced902e532fff9b867f315ddc89
+niiri:6d90736d00550882400a7cbe20af36fa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-32,-10,4]"^^xsd:string .
 
-niiri:73165ed86c4c250a74adde2ee20f14b8 prov:wasDerivedFrom niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb .
+niiri:35e6e74115a2d1d1ffb378ec9262eeeb prov:wasDerivedFrom niiri:6c858d3255cb0a3570ef36dfad0fb623 .
 
-niiri:9aafe36d107ae7055a61332c58a0078a
+niiri:d4c192c1569dc83d9ffdb7912bb5c3c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:8884d81ec71e104a0c484f8f5375a98f ;
+    prov:atLocation niiri:b9ba086df52dccdb9ac91cc8f89c41cf ;
     prov:value "1.06592130661011"^^xsd:float ;
     nidm_equivalentZStatistic: "2.04367166566034"^^xsd:float ;
     nidm_pValueUncorrected: "0.0204929970846689"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8884d81ec71e104a0c484f8f5375a98f
+niiri:b9ba086df52dccdb9ac91cc8f89c41cf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[8,-70,-18]"^^xsd:string .
 
-niiri:9aafe36d107ae7055a61332c58a0078a prov:wasDerivedFrom niiri:e58cf8e24a087d5746f02fb59416d367 .
+niiri:d4c192c1569dc83d9ffdb7912bb5c3c3 prov:wasDerivedFrom niiri:073492dcf968ea0eb583396771e18cab .
 
-niiri:05e6dc235f43178bc7d691271ff32879
+niiri:5fe5d0e93a3f396e39624e767f2a9a61
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:35353ef550e7b9afa6ef357536b0eef1 ;
+    prov:atLocation niiri:88daac370d1820736e40f7cdc0e04a89 ;
     prov:value "1.05881226062775"^^xsd:float ;
     nidm_equivalentZStatistic: "2.03453256202328"^^xsd:float ;
     nidm_pValueUncorrected: "0.0209489644915043"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:35353ef550e7b9afa6ef357536b0eef1
+niiri:88daac370d1820736e40f7cdc0e04a89
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[18,-56,74]"^^xsd:string .
 
-niiri:05e6dc235f43178bc7d691271ff32879 prov:wasDerivedFrom niiri:47a95f63466991d3e681c4886347a76b .
+niiri:5fe5d0e93a3f396e39624e767f2a9a61 prov:wasDerivedFrom niiri:780d9b79f072e4bd50e8f0325a0fab9c .
 
-niiri:9dcb3cd8472b6b25eb1fbcfcb93000f6
+niiri:42a52210a53d06ae32d6780e566dd401
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:f3eeefc4c0d3dd27751aef22dbdb7c8c ;
+    prov:atLocation niiri:28efcf6e1b05b157050c26f376336d49 ;
     prov:value "1.05682730674744"^^xsd:float ;
     nidm_equivalentZStatistic: "2.03198149751153"^^xsd:float ;
     nidm_pValueUncorrected: "0.0210777645475412"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f3eeefc4c0d3dd27751aef22dbdb7c8c
+niiri:28efcf6e1b05b157050c26f376336d49
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[28,-2,6]"^^xsd:string .
 
-niiri:9dcb3cd8472b6b25eb1fbcfcb93000f6 prov:wasDerivedFrom niiri:6a2d34c94894023a09a46d7ba699025b .
+niiri:42a52210a53d06ae32d6780e566dd401 prov:wasDerivedFrom niiri:81f84bc9b5b654bad34cdaaac10ba1b6 .
 
-niiri:e9806207a16169f3be4d10f35b194c85
+niiri:ad76f527b91ba78b206d32c7f100894a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:766104bfba8f24878b83241025cb8ce1 ;
+    prov:atLocation niiri:335dcb194bd2015598fc3583680cdbc3 ;
     prov:value "1.05488443374634"^^xsd:float ;
     nidm_equivalentZStatistic: "2.02948481888272"^^xsd:float ;
     nidm_pValueUncorrected: "0.0212044668522343"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:766104bfba8f24878b83241025cb8ce1
+niiri:335dcb194bd2015598fc3583680cdbc3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[12,-58,-26]"^^xsd:string .
 
-niiri:e9806207a16169f3be4d10f35b194c85 prov:wasDerivedFrom niiri:6ac7ce35dfb3dcf2c2696278c805c40a .
+niiri:ad76f527b91ba78b206d32c7f100894a prov:wasDerivedFrom niiri:90a20d94dc8e450298e631ead963f32b .
 
-niiri:6c0046aab9a8b299190ccc8aaedee47d
+niiri:c79e2a88c4292efb789de4859de56d08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:d186aa78992fc5d9cfe80768c6680e50 ;
+    prov:atLocation niiri:6a17b23b0a6d433f3dfc23c8c524da9a ;
     prov:value "1.05219066143036"^^xsd:float ;
     nidm_equivalentZStatistic: "2.02602370012315"^^xsd:float ;
     nidm_pValueUncorrected: "0.0213811780074668"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d186aa78992fc5d9cfe80768c6680e50
+niiri:6a17b23b0a6d433f3dfc23c8c524da9a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[46,-60,-36]"^^xsd:string .
 
-niiri:6c0046aab9a8b299190ccc8aaedee47d prov:wasDerivedFrom niiri:60e118fd5205eaa96f4b55808761eaf7 .
+niiri:c79e2a88c4292efb789de4859de56d08 prov:wasDerivedFrom niiri:f95655c375074857b8c6e69cc5aafd0f .
 
-niiri:08ed1b983e3a1203b8770d31cb409572
+niiri:ebd4a27d8bf566022e64d373894404d5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:c6cce78c32c1be7e581a855e903919a1 ;
+    prov:atLocation niiri:de95505d9e319af70e99cce4b0dbc76b ;
     prov:value "1.02921843528748"^^xsd:float ;
     nidm_equivalentZStatistic: "1.9965316371229"^^xsd:float ;
     nidm_pValueUncorrected: "0.0229380428256576"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c6cce78c32c1be7e581a855e903919a1
+niiri:de95505d9e319af70e99cce4b0dbc76b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[56,10,22]"^^xsd:string .
 
-niiri:08ed1b983e3a1203b8770d31cb409572 prov:wasDerivedFrom niiri:afff6750152337d325f510f877cd2b9c .
+niiri:ebd4a27d8bf566022e64d373894404d5 prov:wasDerivedFrom niiri:af7629a171a38e8e209c4bfe5f604c75 .
 
-niiri:c3a91a1145ae795e0275567c7afd4153
+niiri:f5915df818a315f89559dab93e544fc7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:3f578a0866ace4a3d5417fd1bda419bc ;
+    prov:atLocation niiri:dba053991ca17c094fb424c234b541eb ;
     prov:value "1.02376317977905"^^xsd:float ;
     nidm_equivalentZStatistic: "1.98953456023084"^^xsd:float ;
     nidm_pValueUncorrected: "0.0233211155368704"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:3f578a0866ace4a3d5417fd1bda419bc
+niiri:dba053991ca17c094fb424c234b541eb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[48,-40,48]"^^xsd:string .
 
-niiri:c3a91a1145ae795e0275567c7afd4153 prov:wasDerivedFrom niiri:c87d05b7d28080150c45409119a926f8 .
+niiri:f5915df818a315f89559dab93e544fc7 prov:wasDerivedFrom niiri:327ebdb7a1236038ee0a1c3dd96e5874 .
 
-niiri:b4d3685e07ada48df1c6167a6925950e
+niiri:7bb7989b699ac7fa7008bbe5bb854acc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:795be4dc59029fec477cb821024b0305 ;
+    prov:atLocation niiri:dcbbded9fea2dd6b1364026922e60cfb ;
     prov:value "1.01926970481873"^^xsd:float ;
     nidm_equivalentZStatistic: "1.98377299631032"^^xsd:float ;
     nidm_pValueUncorrected: "0.0236405758837211"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:795be4dc59029fec477cb821024b0305
+niiri:dcbbded9fea2dd6b1364026922e60cfb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-6,-74,6]"^^xsd:string .
 
-niiri:b4d3685e07ada48df1c6167a6925950e prov:wasDerivedFrom niiri:f1bb918000bbcdd8562fb7b7887a394d .
+niiri:7bb7989b699ac7fa7008bbe5bb854acc prov:wasDerivedFrom niiri:383ee7c40b6e148981f60c5244bc24eb .
 
-niiri:f80228783e894278ef084da2baf7ed31
+niiri:1ad10c296ccb6b3d01aa87dc5249331a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:2ca83eae786b7fda7e22a5a70371af3d ;
+    prov:atLocation niiri:32f775be0b42ac144b9528fceeae29e1 ;
     prov:value "1.01770269870758"^^xsd:float ;
     nidm_equivalentZStatistic: "1.9817641782018"^^xsd:float ;
     nidm_pValueUncorrected: "0.0237528202287247"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2ca83eae786b7fda7e22a5a70371af3d
+niiri:32f775be0b42ac144b9528fceeae29e1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[20,60,-18]"^^xsd:string .
 
-niiri:f80228783e894278ef084da2baf7ed31 prov:wasDerivedFrom niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c .
+niiri:1ad10c296ccb6b3d01aa87dc5249331a prov:wasDerivedFrom niiri:7f19917cc657f479955495d0706a5e07 .
 
-niiri:d9eeefbbebdab2ca09c4160ffbf3de45
+niiri:d1fe1137f09b0626f4c83b9eddcb166a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:53f418da90a8fac39b172895c357d44a ;
+    prov:atLocation niiri:0523fa71436283c95d0ceb61b239edac ;
     prov:value "0.994811475276947"^^xsd:float ;
     nidm_equivalentZStatistic: "1.95244337576045"^^xsd:float ;
     nidm_pValueUncorrected: "0.0254427937463042"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:53f418da90a8fac39b172895c357d44a
+niiri:0523fa71436283c95d0ceb61b239edac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[6,-2,60]"^^xsd:string .
 
-niiri:d9eeefbbebdab2ca09c4160ffbf3de45 prov:wasDerivedFrom niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f .
+niiri:d1fe1137f09b0626f4c83b9eddcb166a prov:wasDerivedFrom niiri:df2a03c212f39fc884fa4c74b8f9861f .
 
-niiri:48c043bcf9f7016d4422cd1eb0275f46
+niiri:d57a6c6df91f1e8ed6c3a2ec9c71f15d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:6077c53ec3ce7550b6798aee6404ca8b ;
+    prov:atLocation niiri:350ed7a0adbfad41ab7bf60ddf292e4f ;
     prov:value "0.99255907535553"^^xsd:float ;
     nidm_equivalentZStatistic: "1.94956085899435"^^xsd:float ;
     nidm_pValueUncorrected: "0.0256142412083677"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6077c53ec3ce7550b6798aee6404ca8b
+niiri:350ed7a0adbfad41ab7bf60ddf292e4f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[10,-42,48]"^^xsd:string .
 
-niiri:48c043bcf9f7016d4422cd1eb0275f46 prov:wasDerivedFrom niiri:9e7cd816ef42776bf358bfe67f08f014 .
+niiri:d57a6c6df91f1e8ed6c3a2ec9c71f15d prov:wasDerivedFrom niiri:d2f081110d405da4d574363c2c229683 .
 
-niiri:3cfe0ff468e6f850a19584472f45a4ca
+niiri:276f0c85068fe253b02d9c93aff123ac
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:64683e1e79d133f97706c9c14ce1de9a ;
+    prov:atLocation niiri:8c385aab9767fb464d437e8b648f313b ;
     prov:value "0.984159111976624"^^xsd:float ;
     nidm_equivalentZStatistic: "1.93881506095718"^^xsd:float ;
     nidm_pValueUncorrected: "0.0262619307677786"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:64683e1e79d133f97706c9c14ce1de9a
+niiri:8c385aab9767fb464d437e8b648f313b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[44,-2,-30]"^^xsd:string .
 
-niiri:3cfe0ff468e6f850a19584472f45a4ca prov:wasDerivedFrom niiri:712375a17d0ff43c9dca459517dff9b2 .
+niiri:276f0c85068fe253b02d9c93aff123ac prov:wasDerivedFrom niiri:a9fda50c3e4479f40fb3419e04ad60e2 .
 
-niiri:4cbbdabb6d9ca2894ccd7d8bf83c4b92
+niiri:3062094ae125936adc6f8e1677e03e37
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:057307222fb1d6a12be4aac362eeba79 ;
+    prov:atLocation niiri:b46169f62390c6f8268b141fcaa6158a ;
     prov:value "0.981177926063538"^^xsd:float ;
     nidm_equivalentZStatistic: "1.93500289088164"^^xsd:float ;
     nidm_pValueUncorrected: "0.0264949704670242"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:057307222fb1d6a12be4aac362eeba79
+niiri:b46169f62390c6f8268b141fcaa6158a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[-16,-98,-6]"^^xsd:string .
 
-niiri:4cbbdabb6d9ca2894ccd7d8bf83c4b92 prov:wasDerivedFrom niiri:feddd730f38d65d4f1fd0e8616bcc9a5 .
+niiri:3062094ae125936adc6f8e1677e03e37 prov:wasDerivedFrom niiri:2bc33575bac46d2c46e0ab7793110244 .
 
-niiri:a8d461e1b05a579974c9fa442ca95335
+niiri:2f981e6bb474e96b3ff279ee010df619
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:f56cb3f0f78382ca1667d4c9cb2a5fa9 ;
+    prov:atLocation niiri:f2652fba249b9e66acb7995fdac6415d ;
     prov:value "0.979127943515778"^^xsd:float ;
     nidm_equivalentZStatistic: "1.93238197004834"^^xsd:float ;
     nidm_pValueUncorrected: "0.026656188878889"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f56cb3f0f78382ca1667d4c9cb2a5fa9
+niiri:f2652fba249b9e66acb7995fdac6415d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[18,-54,-16]"^^xsd:string .
 
-niiri:a8d461e1b05a579974c9fa442ca95335 prov:wasDerivedFrom niiri:8041bc77682f50b65136018ca10c889c .
+niiri:2f981e6bb474e96b3ff279ee010df619 prov:wasDerivedFrom niiri:ddb629f82c3dbdee2cea3fa27c6ff935 .
 
-niiri:422e9504c658a0894198e2bc2af7dc45
+niiri:7731dd838fe87d9cc58300c17db9fc02
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:85068ba7ad3e2344be6218dbd67be2d4 ;
+    prov:atLocation niiri:8348066e2ea0d600e90b3c5790500bbd ;
     prov:value "0.971426725387573"^^xsd:float ;
     nidm_equivalentZStatistic: "1.92253941721557"^^xsd:float ;
     nidm_pValueUncorrected: "0.0272689593644924"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:85068ba7ad3e2344be6218dbd67be2d4
+niiri:8348066e2ea0d600e90b3c5790500bbd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[4,60,38]"^^xsd:string .
 
-niiri:422e9504c658a0894198e2bc2af7dc45 prov:wasDerivedFrom niiri:e852e949acffc71ed6cce677c7be19d6 .
+niiri:7731dd838fe87d9cc58300c17db9fc02 prov:wasDerivedFrom niiri:caa42f603185cae01bb9beafa64dc995 .
 
-niiri:5f72f791f7614242b4b6ad4e858c999a
+niiri:346bb89a5cb51ea237c8d4e3ae61e598
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:dbc6a1f63f9fa825746e17ef6fa5f72a ;
+    prov:atLocation niiri:b57aec85d53cee2b2f7e6a1394ca5271 ;
     prov:value "0.967807769775391"^^xsd:float ;
     nidm_equivalentZStatistic: "1.91791614515868"^^xsd:float ;
     nidm_pValueUncorrected: "0.0275608223501947"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:dbc6a1f63f9fa825746e17ef6fa5f72a
+niiri:b57aec85d53cee2b2f7e6a1394ca5271
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[20,18,-4]"^^xsd:string .
 
-niiri:5f72f791f7614242b4b6ad4e858c999a prov:wasDerivedFrom niiri:0d099ee69c96416336f843fd890da4a0 .
+niiri:346bb89a5cb51ea237c8d4e3ae61e598 prov:wasDerivedFrom niiri:c445a9fb8be8c80d5df620717862bf5f .
 
-niiri:de1fef4fc7d400efc2f44d0c30039c86
+niiri:0b3f328e53640174c17e513ebc52cc58
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:c12b5e9466736ae0a4035530d53f806a ;
+    prov:atLocation niiri:758f735a56d8fbaac97129a45913bc0d ;
     prov:value "0.959724724292755"^^xsd:float ;
     nidm_equivalentZStatistic: "1.90759446601654"^^xsd:float ;
     nidm_pValueUncorrected: "0.0282218254783678"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c12b5e9466736ae0a4035530d53f806a
+niiri:758f735a56d8fbaac97129a45913bc0d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[30,-32,10]"^^xsd:string .
 
-niiri:de1fef4fc7d400efc2f44d0c30039c86 prov:wasDerivedFrom niiri:6d0ee7f5877dfa2620f95f47e06e2a9a .
+niiri:0b3f328e53640174c17e513ebc52cc58 prov:wasDerivedFrom niiri:44518bfa6ffcd022c48e2ccb2c04ed0a .
 
-niiri:b8e4a8666a562187b667fd0000d52335
+niiri:cd3217ce17598e712e7491aeb85abdf0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:bfa0701f0eb2a5270ae3e9b16ebfc296 ;
+    prov:atLocation niiri:3855635f168a3bdaaaee9486acb9a661 ;
     prov:value "0.957907795906067"^^xsd:float ;
     nidm_equivalentZStatistic: "1.90527520238565"^^xsd:float ;
     nidm_pValueUncorrected: "0.0283721535699227"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:bfa0701f0eb2a5270ae3e9b16ebfc296
+niiri:3855635f168a3bdaaaee9486acb9a661
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[10,12,-10]"^^xsd:string .
 
-niiri:b8e4a8666a562187b667fd0000d52335 prov:wasDerivedFrom niiri:6ab419381418bd7fca0cb5bac6782b77 .
+niiri:cd3217ce17598e712e7491aeb85abdf0 prov:wasDerivedFrom niiri:82a21597b08e98aa671123ebbede6579 .
 
-niiri:d331e521291249d8ba1e2d26ee0d6359
+niiri:ef3f68546abf3df170c641c28001dd1a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:2b7cd0cd9952e2971cceba9068ca4224 ;
+    prov:atLocation niiri:50283c7f660364e245a75b11e6636fea ;
     prov:value "0.95493882894516"^^xsd:float ;
     nidm_equivalentZStatistic: "1.90148608420821"^^xsd:float ;
     nidm_pValueUncorrected: "0.0286191867597474"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2b7cd0cd9952e2971cceba9068ca4224
+niiri:50283c7f660364e245a75b11e6636fea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[-26,-94,-10]"^^xsd:string .
 
-niiri:d331e521291249d8ba1e2d26ee0d6359 prov:wasDerivedFrom niiri:b19325ccb6192dba58545cbeb7bc92e1 .
+niiri:ef3f68546abf3df170c641c28001dd1a prov:wasDerivedFrom niiri:15cc5ee45c7553094b172ffcbfc6a579 .
 
-niiri:8d11278149ef3ed6c1be32712cecb870
+niiri:43c393bbdc2304cbf9d4016430aa4598
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:444c6e0d2d8dae8e91a8b6fec5449cd8 ;
+    prov:atLocation niiri:bb6687543dca84c795dbc87e991f59e4 ;
     prov:value "0.950750410556793"^^xsd:float ;
     nidm_equivalentZStatistic: "1.89614212461773"^^xsd:float ;
     nidm_pValueUncorrected: "0.0289706268368529"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:444c6e0d2d8dae8e91a8b6fec5449cd8
+niiri:bb6687543dca84c795dbc87e991f59e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-50,-18,0]"^^xsd:string .
 
-niiri:8d11278149ef3ed6c1be32712cecb870 prov:wasDerivedFrom niiri:745fe95a68372701f2888393e817a23e .
+niiri:43c393bbdc2304cbf9d4016430aa4598 prov:wasDerivedFrom niiri:ff736f05be57ac9dd4cfdb8776f08af9 .
 
-niiri:2c0d2607032810a81675ff4225065850
+niiri:cf51c47582d2b2b05386f382a3d21c63
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:3e68989f6a6b2152794e95703c55559c ;
+    prov:atLocation niiri:599a85124187847d9c9c19579e6b2646 ;
     prov:value "0.949834227561951"^^xsd:float ;
     nidm_equivalentZStatistic: "1.89497340726092"^^xsd:float ;
     nidm_pValueUncorrected: "0.0290479624174936"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:3e68989f6a6b2152794e95703c55559c
+niiri:599a85124187847d9c9c19579e6b2646
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[42,36,18]"^^xsd:string .
 
-niiri:2c0d2607032810a81675ff4225065850 prov:wasDerivedFrom niiri:b1a5489610b480473aa63e95806df7d1 .
+niiri:cf51c47582d2b2b05386f382a3d21c63 prov:wasDerivedFrom niiri:08dde0ac9e0d585b26116508762ff9a0 .
 
-niiri:47b2ce9b5be41d91dfa11f100ed3ad82
+niiri:4dfd61566964ab64b7fa9261c635a341
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:eb5106a605d1357f4af29aa54137b817 ;
+    prov:atLocation niiri:036505a852d46704d9f5c80f04831b2a ;
     prov:value "0.949459254741669"^^xsd:float ;
     nidm_equivalentZStatistic: "1.89449510188639"^^xsd:float ;
     nidm_pValueUncorrected: "0.0290796619499293"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:eb5106a605d1357f4af29aa54137b817
+niiri:036505a852d46704d9f5c80f04831b2a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[46,-78,16]"^^xsd:string .
 
-niiri:47b2ce9b5be41d91dfa11f100ed3ad82 prov:wasDerivedFrom niiri:f6763487f8266f7e66acb49862c0bfa1 .
+niiri:4dfd61566964ab64b7fa9261c635a341 prov:wasDerivedFrom niiri:0571f33be5ada80ea4b8808edaa7d20b .
 
-niiri:bffc483b3f0c4050ac78cd4ff4a4338e
+niiri:c2126c0dd023e90eef0335f2fc52f7f4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:0cf2044fea597c136be141a7d8a4de31 ;
+    prov:atLocation niiri:775577aaed49524eee4f16b91353fbac ;
     prov:value "0.942987263202667"^^xsd:float ;
     nidm_equivalentZStatistic: "1.88624180999136"^^xsd:float ;
     nidm_pValueUncorrected: "0.0296311883673402"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0cf2044fea597c136be141a7d8a4de31
+niiri:775577aaed49524eee4f16b91353fbac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[-52,40,8]"^^xsd:string .
 
-niiri:bffc483b3f0c4050ac78cd4ff4a4338e prov:wasDerivedFrom niiri:f1b9cbe1f5cc757318e116f47537c68e .
+niiri:c2126c0dd023e90eef0335f2fc52f7f4 prov:wasDerivedFrom niiri:1ff90dcabb7242c8b1f78b63e5c5f98e .
 
-niiri:b2f0952d4932beebb348b8767e1b15d6
+niiri:ff903cea33e06ff766789de7140112dc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:7bb01c321a9f81f207675da840baca24 ;
+    prov:atLocation niiri:444609ca222121a7843273bd2c36928c ;
     prov:value "0.937418699264526"^^xsd:float ;
     nidm_equivalentZStatistic: "1.87914396799602"^^xsd:float ;
     nidm_pValueUncorrected: "0.0301124189915838"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7bb01c321a9f81f207675da840baca24
+niiri:444609ca222121a7843273bd2c36928c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[-12,42,48]"^^xsd:string .
 
-niiri:b2f0952d4932beebb348b8767e1b15d6 prov:wasDerivedFrom niiri:0299ab45ec018b51a01d2a8fe08bf4d0 .
+niiri:ff903cea33e06ff766789de7140112dc prov:wasDerivedFrom niiri:fddfbb23e75434759d3265d89c552324 .
 
-niiri:6bbcdf18aa971f01e2cb61e2a276a0c1
+niiri:7fb34d039923fe763e04aeb0c5892346
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0104" ;
-    prov:atLocation niiri:2cce387756fae768863a2b909443a366 ;
+    prov:atLocation niiri:b0cb3c750ba113e0dc29395267e8927d ;
     prov:value "0.933299362659454"^^xsd:float ;
     nidm_equivalentZStatistic: "1.87389537802186"^^xsd:float ;
     nidm_pValueUncorrected: "0.0304724233227471"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2cce387756fae768863a2b909443a366
+niiri:b0cb3c750ba113e0dc29395267e8927d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0104" ;
     nidm_coordinateVector: "[44,40,-20]"^^xsd:string .
 
-niiri:6bbcdf18aa971f01e2cb61e2a276a0c1 prov:wasDerivedFrom niiri:3bd0b694ec1e521a7072b15be74aa42c .
+niiri:7fb34d039923fe763e04aeb0c5892346 prov:wasDerivedFrom niiri:225e575718bd5f927d7a41b6e9cdd96b .
 
-niiri:e76b9afc8d6f8323f6709346e8342328
+niiri:95559a426e44487074969ba865235e01
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0105" ;
-    prov:atLocation niiri:6b6cd0eb3c448196f54b71c1dba6e4d6 ;
+    prov:atLocation niiri:c098ca2d9c3ffa6a78302faf76b61c96 ;
     prov:value "0.931596636772156"^^xsd:float ;
     nidm_equivalentZStatistic: "1.87172638333963"^^xsd:float ;
     nidm_pValueUncorrected: "0.0306222337565211"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6b6cd0eb3c448196f54b71c1dba6e4d6
+niiri:c098ca2d9c3ffa6a78302faf76b61c96
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0105" ;
     nidm_coordinateVector: "[-20,-74,-42]"^^xsd:string .
 
-niiri:e76b9afc8d6f8323f6709346e8342328 prov:wasDerivedFrom niiri:af9bee597f1e82856f732971c03e4ba5 .
+niiri:95559a426e44487074969ba865235e01 prov:wasDerivedFrom niiri:eed1f93c005d2b4525f8eff9003cba5f .
 
-niiri:731e7e0e8812977914ca201d6ec12be9
+niiri:2dd07750a017279a7abffa5eb950bebe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0106" ;
-    prov:atLocation niiri:b7cc5c0755b7af3c315c2d00ee88a4d2 ;
+    prov:atLocation niiri:ac52f2233df7136ec2dbaff1d0f4f0d7 ;
     prov:value "0.921256303787231"^^xsd:float ;
     nidm_equivalentZStatistic: "1.85856093332641"^^xsd:float ;
     nidm_pValueUncorrected: "0.031544699452275"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b7cc5c0755b7af3c315c2d00ee88a4d2
+niiri:ac52f2233df7136ec2dbaff1d0f4f0d7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0106" ;
     nidm_coordinateVector: "[-10,-26,78]"^^xsd:string .
 
-niiri:731e7e0e8812977914ca201d6ec12be9 prov:wasDerivedFrom niiri:7a01ea3f3b5332ecf281a7f277911529 .
+niiri:2dd07750a017279a7abffa5eb950bebe prov:wasDerivedFrom niiri:46a2cf3db4d3d8432ee134238328ee7d .
 
-niiri:d920f5295c82c34ffdb61a212ac97bda
+niiri:343eddd0b158ae01001ed5a519b906a5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0107" ;
-    prov:atLocation niiri:b9e3cdf7fa9c85cc1bd3ef2b223e5f10 ;
+    prov:atLocation niiri:4c794f29969754faf39304545d9ed9a8 ;
     prov:value "0.913095474243164"^^xsd:float ;
     nidm_equivalentZStatistic: "1.84817837718658"^^xsd:float ;
     nidm_pValueUncorrected: "0.0322882711892066"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b9e3cdf7fa9c85cc1bd3ef2b223e5f10
+niiri:4c794f29969754faf39304545d9ed9a8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0107" ;
     nidm_coordinateVector: "[-22,-34,-42]"^^xsd:string .
 
-niiri:d920f5295c82c34ffdb61a212ac97bda prov:wasDerivedFrom niiri:8d9244867124b8976a02c802025ebf7a .
+niiri:343eddd0b158ae01001ed5a519b906a5 prov:wasDerivedFrom niiri:cb8b7a24533bb98686a08aa454cf3945 .
 
-niiri:60cd8b72aba218010406e59a4d283f22
+niiri:2e550bb4b78ea76d79f4118f9ea5091e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0108" ;
-    prov:atLocation niiri:83348a06a08a490ee2ad27ad5f88b837 ;
+    prov:atLocation niiri:7c8e057832544f8166b50372b453b020 ;
     prov:value "0.910208523273468"^^xsd:float ;
     nidm_equivalentZStatistic: "1.84450717202411"^^xsd:float ;
     nidm_pValueUncorrected: "0.0325546307872665"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:83348a06a08a490ee2ad27ad5f88b837
+niiri:7c8e057832544f8166b50372b453b020
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0108" ;
     nidm_coordinateVector: "[-34,-52,40]"^^xsd:string .
 
-niiri:60cd8b72aba218010406e59a4d283f22 prov:wasDerivedFrom niiri:1acfcd5791fd893baf49e6750646bcbc .
+niiri:2e550bb4b78ea76d79f4118f9ea5091e prov:wasDerivedFrom niiri:ac46f34aa5d674ad08bca4f9e22cea59 .
 
-niiri:598d2ba06bdf7b67f6b54a339b88c029
+niiri:183f025599eb15195c17433da3bba50e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0109" ;
-    prov:atLocation niiri:df28a935119bc1a9fe922acf6abc9791 ;
+    prov:atLocation niiri:c41e0496eb80d24f4ca478bfc993d607 ;
     prov:value "0.909155905246735"^^xsd:float ;
     nidm_equivalentZStatistic: "1.84316882767473"^^xsd:float ;
     nidm_pValueUncorrected: "0.0326521823346975"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:df28a935119bc1a9fe922acf6abc9791
+niiri:c41e0496eb80d24f4ca478bfc993d607
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0109" ;
     nidm_coordinateVector: "[12,-70,-24]"^^xsd:string .
 
-niiri:598d2ba06bdf7b67f6b54a339b88c029 prov:wasDerivedFrom niiri:6bafc27afb06adc8274b4e85b0eb95cc .
+niiri:183f025599eb15195c17433da3bba50e prov:wasDerivedFrom niiri:dafb029bcb559a4294b48405b4710434 .
 
-niiri:a6db2f879c2f570c76c4c4fd60f93003
+niiri:1f1fcde3a8b79f3a49244050d94a15da
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0110" ;
-    prov:atLocation niiri:040670c2a1baf229dd4a840108736964 ;
+    prov:atLocation niiri:11089bcdb82ac977f5d5ae239b636ce9 ;
     prov:value "0.907121956348419"^^xsd:float ;
     nidm_equivalentZStatistic: "1.84058311467862"^^xsd:float ;
     nidm_pValueUncorrected: "0.0328413370266359"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:040670c2a1baf229dd4a840108736964
+niiri:11089bcdb82ac977f5d5ae239b636ce9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0110" ;
     nidm_coordinateVector: "[56,-36,52]"^^xsd:string .
 
-niiri:a6db2f879c2f570c76c4c4fd60f93003 prov:wasDerivedFrom niiri:ee5baff089dc6387c53821c05a9e9154 .
+niiri:1f1fcde3a8b79f3a49244050d94a15da prov:wasDerivedFrom niiri:99ae26cd919bcae015587fcb8e185e68 .
 
-niiri:069b63564a99aa9ff6d1ddb584fbf1db
+niiri:eb7839e6ba258340734103354dd2b8b4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0111" ;
-    prov:atLocation niiri:bfd62b4d2231ff667c215ff1fe989844 ;
+    prov:atLocation niiri:7b86b4f1c392283ae44a1f8806042f1f ;
     prov:value "0.904614567756653"^^xsd:float ;
     nidm_equivalentZStatistic: "1.83739614411337"^^xsd:float ;
     nidm_pValueUncorrected: "0.0330757178223472"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:bfd62b4d2231ff667c215ff1fe989844
+niiri:7b86b4f1c392283ae44a1f8806042f1f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0111" ;
     nidm_coordinateVector: "[36,-54,16]"^^xsd:string .
 
-niiri:069b63564a99aa9ff6d1ddb584fbf1db prov:wasDerivedFrom niiri:e4e0f746d182d60a55906480bc82791f .
+niiri:eb7839e6ba258340734103354dd2b8b4 prov:wasDerivedFrom niiri:9f9bf96c341750df802f301ac988f4b0 .
 
-niiri:ac8fabc6b095c00007fab8d02fe6ad74
+niiri:d260832806e1c25bc3d0d77ae5bf48c5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0112" ;
-    prov:atLocation niiri:fc4540b0a0db5dceda1b71fe564a0d94 ;
+    prov:atLocation niiri:50b00dbb1eefad016d2ac5427a043778 ;
     prov:value "0.902757167816162"^^xsd:float ;
     nidm_equivalentZStatistic: "1.83503576989372"^^xsd:float ;
     nidm_pValueUncorrected: "0.0332501948262349"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:fc4540b0a0db5dceda1b71fe564a0d94
+niiri:50b00dbb1eefad016d2ac5427a043778
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0112" ;
     nidm_coordinateVector: "[14,50,12]"^^xsd:string .
 
-niiri:ac8fabc6b095c00007fab8d02fe6ad74 prov:wasDerivedFrom niiri:07ef8bc1f56adef8bb96bf2e4e871509 .
+niiri:d260832806e1c25bc3d0d77ae5bf48c5 prov:wasDerivedFrom niiri:99e2b9de9821018fedc6a02eeea36eff .
 
-niiri:28e9ce4572be1966c1b7c8d5fcec989e
+niiri:1cc2bab8d89be3d79fcdb3439982f4f4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0113" ;
-    prov:atLocation niiri:4b30382d1e4ea48108691076704ac047 ;
+    prov:atLocation niiri:ff2691dba21009263cbebce34c551c69 ;
     prov:value "0.901206791400909"^^xsd:float ;
     nidm_equivalentZStatistic: "1.83306584752486"^^xsd:float ;
     nidm_pValueUncorrected: "0.0333963896408318"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4b30382d1e4ea48108691076704ac047
+niiri:ff2691dba21009263cbebce34c551c69
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0113" ;
     nidm_coordinateVector: "[-10,-70,-2]"^^xsd:string .
 
-niiri:28e9ce4572be1966c1b7c8d5fcec989e prov:wasDerivedFrom niiri:4909c1eb824545b47aa0943b33200588 .
+niiri:1cc2bab8d89be3d79fcdb3439982f4f4 prov:wasDerivedFrom niiri:19dd8817dc393deb5f3011d30203d171 .
 
-niiri:9b95918d4848aaeb3e55a87a62ab7a3e
+niiri:3f8ad4b7b6912679ab10b2fb4fd84763
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0114" ;
-    prov:atLocation niiri:fa0cc76b071f87753c14060810d31dfe ;
+    prov:atLocation niiri:0d210a5a8d997c4cc1342133bed723a2 ;
     prov:value "0.797126054763794"^^xsd:float ;
     nidm_equivalentZStatistic: "1.70146355236453"^^xsd:float ;
     nidm_pValueUncorrected: "0.0444279881500879"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:fa0cc76b071f87753c14060810d31dfe
+niiri:0d210a5a8d997c4cc1342133bed723a2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0114" ;
     nidm_coordinateVector: "[-16,-64,-2]"^^xsd:string .
 
-niiri:9b95918d4848aaeb3e55a87a62ab7a3e prov:wasDerivedFrom niiri:4909c1eb824545b47aa0943b33200588 .
+niiri:3f8ad4b7b6912679ab10b2fb4fd84763 prov:wasDerivedFrom niiri:19dd8817dc393deb5f3011d30203d171 .
 
-niiri:5629d46077dec98c74dfbc8e049ea517
+niiri:269952645645cd8baa0eb2f26a246253
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0115" ;
-    prov:atLocation niiri:55609d261623909025c92a20fcf0610b ;
+    prov:atLocation niiri:8b9e35fbd9f5fde24d4211d278f00c74 ;
     prov:value "0.899936437606812"^^xsd:float ;
     nidm_equivalentZStatistic: "1.83145192034408"^^xsd:float ;
     nidm_pValueUncorrected: "0.0335165588882574"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:55609d261623909025c92a20fcf0610b
+niiri:8b9e35fbd9f5fde24d4211d278f00c74
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0115" ;
     nidm_coordinateVector: "[10,-18,-14]"^^xsd:string .
 
-niiri:5629d46077dec98c74dfbc8e049ea517 prov:wasDerivedFrom niiri:9c28e7c0288f5d8601280d59308426e4 .
+niiri:269952645645cd8baa0eb2f26a246253 prov:wasDerivedFrom niiri:f578ebe5aa3293c5670125665cd21221 .
 
-niiri:0a467b6ecf94f5f6b8b6165d58bc65c5
+niiri:9eb3d60d7bc801da2ef325b6f1f84772
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0116" ;
-    prov:atLocation niiri:d4bc30138d04a5bbe3454b95ec405b94 ;
+    prov:atLocation niiri:697e76778687af351371482f7f313f99 ;
     prov:value "0.895962595939636"^^xsd:float ;
     nidm_equivalentZStatistic: "1.8264044782252"^^xsd:float ;
     nidm_pValueUncorrected: "0.0338946789087741"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d4bc30138d04a5bbe3454b95ec405b94
+niiri:697e76778687af351371482f7f313f99
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0116" ;
     nidm_coordinateVector: "[-42,-50,-42]"^^xsd:string .
 
-niiri:0a467b6ecf94f5f6b8b6165d58bc65c5 prov:wasDerivedFrom niiri:49c7e8d7404b8a93cc2dc6a52274f6ef .
+niiri:9eb3d60d7bc801da2ef325b6f1f84772 prov:wasDerivedFrom niiri:7166aa15d2e2b4eeab50316ce6eb7bff .
 
-niiri:9d771fa523b8607b56815b45270a4e93
+niiri:e6d56476400c2eda2bb12ea8573a604d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0117" ;
-    prov:atLocation niiri:82448dc2205297fdbefd6f106d891759 ;
+    prov:atLocation niiri:93b14541b6f6b7bebc32dbe2481caf9f ;
     prov:value "0.893008887767792"^^xsd:float ;
     nidm_equivalentZStatistic: "1.8226539056953"^^xsd:float ;
     nidm_pValueUncorrected: "0.0341779128567976"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:82448dc2205297fdbefd6f106d891759
+niiri:93b14541b6f6b7bebc32dbe2481caf9f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0117" ;
     nidm_coordinateVector: "[-60,-32,46]"^^xsd:string .
 
-niiri:9d771fa523b8607b56815b45270a4e93 prov:wasDerivedFrom niiri:5bc798e43cab1c880a412761cd0dabce .
+niiri:e6d56476400c2eda2bb12ea8573a604d prov:wasDerivedFrom niiri:7c7ff9e10d9ed65989abad6706fb240e .
 
-niiri:adb6b0a235ccc5b03f4e7c9f7dad9160
+niiri:9117835199b6871927a5258f349f17ef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0118" ;
-    prov:atLocation niiri:6f9fcf9029f665cf15d3412ed80b3a63 ;
+    prov:atLocation niiri:b00280726430f31e237be43c95b9cadf ;
     prov:value "0.888202428817749"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81655281460242"^^xsd:float ;
     nidm_pValueUncorrected: "0.0346428070130568"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6f9fcf9029f665cf15d3412ed80b3a63
+niiri:b00280726430f31e237be43c95b9cadf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0118" ;
     nidm_coordinateVector: "[56,-42,24]"^^xsd:string .
 
-niiri:adb6b0a235ccc5b03f4e7c9f7dad9160 prov:wasDerivedFrom niiri:d5f0da3a07b3d47197bf039d8d42b58f .
+niiri:9117835199b6871927a5258f349f17ef prov:wasDerivedFrom niiri:8134a1db611c7f7f2ed9c52d609bd453 .
 
-niiri:0024155386338cfcf3a295b23bf9be12
+niiri:4b50fca0c97d713c79d41fbc1e04e85d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0119" ;
-    prov:atLocation niiri:366db76495f9bc35da783cfa4d85aaad ;
+    prov:atLocation niiri:5ead31a014ab6206f353fa4aeb59222f ;
     prov:value "0.886661469936371"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81459734206643"^^xsd:float ;
     nidm_pValueUncorrected: "0.034792905633808"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:366db76495f9bc35da783cfa4d85aaad
+niiri:5ead31a014ab6206f353fa4aeb59222f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0119" ;
     nidm_coordinateVector: "[-34,-90,-30]"^^xsd:string .
 
-niiri:0024155386338cfcf3a295b23bf9be12 prov:wasDerivedFrom niiri:a57d901560addc33f414ddaed9a0c7fb .
+niiri:4b50fca0c97d713c79d41fbc1e04e85d prov:wasDerivedFrom niiri:8a671f919525c9984fd7a67105748a9d .
 
-niiri:8a1311806bb1778b621397b5a41dfd96
+niiri:534a3ccb005e5e1093fbb4026c43c313
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0120" ;
-    prov:atLocation niiri:b2b9b27d97fee31d70e759096f5c996a ;
+    prov:atLocation niiri:4866cdfd47e85855dccc46f53ad50b46 ;
     prov:value "0.88604724407196"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81381796560484"^^xsd:float ;
     nidm_pValueUncorrected: "0.0348528778271762"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b2b9b27d97fee31d70e759096f5c996a
+niiri:4866cdfd47e85855dccc46f53ad50b46
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0120" ;
     nidm_coordinateVector: "[-6,-72,-20]"^^xsd:string .
 
-niiri:8a1311806bb1778b621397b5a41dfd96 prov:wasDerivedFrom niiri:01d84a7c8c63b90d178c8c7623156c7d .
+niiri:534a3ccb005e5e1093fbb4026c43c313 prov:wasDerivedFrom niiri:df8ccdbc007e7b001a7788aa3910f000 .
 
-niiri:e2c16c6d913d0c2d6e9c5d0d27602288
+niiri:578560195be338aa8ecf191250fb731a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0121" ;
-    prov:atLocation niiri:70af9ae3e7f3d4faa43eb79a9091469f ;
+    prov:atLocation niiri:8ab727aa442e8af16f5a419e9cce99bf ;
     prov:value "0.884565353393555"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81193780520014"^^xsd:float ;
     nidm_pValueUncorrected: "0.0349979035410456"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:70af9ae3e7f3d4faa43eb79a9091469f
+niiri:8ab727aa442e8af16f5a419e9cce99bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0121" ;
     nidm_coordinateVector: "[62,-24,46]"^^xsd:string .
 
-niiri:e2c16c6d913d0c2d6e9c5d0d27602288 prov:wasDerivedFrom niiri:99056f1d754fd9f25d80632f06577e33 .
+niiri:578560195be338aa8ecf191250fb731a prov:wasDerivedFrom niiri:8f423109f6452d8619bfc5cbabbcae4c .
 
-niiri:85d9117015506ddb0393f7b060018584
+niiri:9662c3bacc953b09a8de8d20a89c562c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0122" ;
-    prov:atLocation niiri:a6e58394345941bac6a450ad0153b497 ;
+    prov:atLocation niiri:8bd961ce1f150069823abeeb7af6d3d4 ;
     prov:value "0.882052361965179"^^xsd:float ;
     nidm_equivalentZStatistic: "1.80874999534025"^^xsd:float ;
     nidm_pValueUncorrected: "0.0352449260120304"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a6e58394345941bac6a450ad0153b497
+niiri:8bd961ce1f150069823abeeb7af6d3d4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0122" ;
     nidm_coordinateVector: "[-16,34,12]"^^xsd:string .
 
-niiri:85d9117015506ddb0393f7b060018584 prov:wasDerivedFrom niiri:a0ee8183a98a000be01c4577a35a0d8c .
+niiri:9662c3bacc953b09a8de8d20a89c562c prov:wasDerivedFrom niiri:059825f02c7e3a034dd438fe5e192ff5 .
 
-niiri:cbd89dfc1ee38e3c17f96850cd7295e4
+niiri:3f60e68e7e4cf37d5f2137f9a45555f2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0123" ;
-    prov:atLocation niiri:5741a80cbff4ef218f24ec536bddbc1f ;
+    prov:atLocation niiri:98ebc36cf1b3185fdeb2c243b898105d ;
     prov:value "0.878161370754242"^^xsd:float ;
     nidm_equivalentZStatistic: "1.8038155651472"^^xsd:float ;
     nidm_pValueUncorrected: "0.0356301124625072"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5741a80cbff4ef218f24ec536bddbc1f
+niiri:98ebc36cf1b3185fdeb2c243b898105d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0123" ;
     nidm_coordinateVector: "[-20,-46,76]"^^xsd:string .
 
-niiri:cbd89dfc1ee38e3c17f96850cd7295e4 prov:wasDerivedFrom niiri:40c9456923bb7d18a8a4ec203aeea09d .
+niiri:3f60e68e7e4cf37d5f2137f9a45555f2 prov:wasDerivedFrom niiri:3da0464bd78bb8c10fbf370ecd7a9476 .
 
-niiri:37d38fb5427bb518c234bcdb93146792
+niiri:7664ae686a3d486e9acec8560806a3c6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0124" ;
-    prov:atLocation niiri:6ba75280f16989f0413cff07c5ae28d4 ;
+    prov:atLocation niiri:4bbf40a82cf0536de16d095ce55c07f0 ;
     prov:value "0.875840246677399"^^xsd:float ;
     nidm_equivalentZStatistic: "1.80087281439492"^^xsd:float ;
     nidm_pValueUncorrected: "0.0358614643888427"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6ba75280f16989f0413cff07c5ae28d4
+niiri:4bbf40a82cf0536de16d095ce55c07f0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0124" ;
     nidm_coordinateVector: "[-40,-6,34]"^^xsd:string .
 
-niiri:37d38fb5427bb518c234bcdb93146792 prov:wasDerivedFrom niiri:3cd64da8230af3c597bfb4e11e589670 .
+niiri:7664ae686a3d486e9acec8560806a3c6 prov:wasDerivedFrom niiri:8f8575f802002ae68576281bb473a96a .
 
-niiri:4b5895493ed07bacb9952f039a51b8f6
+niiri:d306012bf92eb74af9b7cecf10a666d1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0125" ;
-    prov:atLocation niiri:0edef54b9fb2741aebc7cda42a57bcf8 ;
+    prov:atLocation niiri:614801535ffe5f4c55d2531f004ac363 ;
     prov:value "0.875353574752808"^^xsd:float ;
     nidm_equivalentZStatistic: "1.80025588397551"^^xsd:float ;
     nidm_pValueUncorrected: "0.0359101216845089"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0edef54b9fb2741aebc7cda42a57bcf8
+niiri:614801535ffe5f4c55d2531f004ac363
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0125" ;
     nidm_coordinateVector: "[-20,-12,8]"^^xsd:string .
 
-niiri:4b5895493ed07bacb9952f039a51b8f6 prov:wasDerivedFrom niiri:32e5e0304b5a2c92b091fa83edcab359 .
+niiri:d306012bf92eb74af9b7cecf10a666d1 prov:wasDerivedFrom niiri:08bfdacca68fb28f9c006f7c77ce2d85 .
 
-niiri:5390aed5563081e77badfd3ed3e58844
+niiri:ae03667aceb7cbf14b4b9e2dc82bb138
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0126" ;
-    prov:atLocation niiri:9fb7d9fa270614bdf589782a12b43645 ;
+    prov:atLocation niiri:7cf301e9c3da7d19484a4a83b2d77938 ;
     prov:value "0.87107241153717"^^xsd:float ;
     nidm_equivalentZStatistic: "1.79483003828998"^^xsd:float ;
     nidm_pValueUncorrected: "0.0363403916799833"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9fb7d9fa270614bdf589782a12b43645
+niiri:7cf301e9c3da7d19484a4a83b2d77938
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0126" ;
     nidm_coordinateVector: "[12,-44,-14]"^^xsd:string .
 
-niiri:5390aed5563081e77badfd3ed3e58844 prov:wasDerivedFrom niiri:bf704e8aea1497f2136b7d0b3dde0bf6 .
+niiri:ae03667aceb7cbf14b4b9e2dc82bb138 prov:wasDerivedFrom niiri:6bb55a6a6929721f00e0951117b25f42 .
 
-niiri:6c566805e06c1caea5ba64a10caf0bd5
+niiri:2f189ccf478c1f7803a99294add6d13b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0127" ;
-    prov:atLocation niiri:7401db25a618931a21c1bd66336f51bb ;
+    prov:atLocation niiri:67f64698e8253ef928d17d99e92099ca ;
     prov:value "0.865115165710449"^^xsd:float ;
     nidm_equivalentZStatistic: "1.78728350813392"^^xsd:float ;
     nidm_pValueUncorrected: "0.0369458390734643"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7401db25a618931a21c1bd66336f51bb
+niiri:67f64698e8253ef928d17d99e92099ca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0127" ;
     nidm_coordinateVector: "[2,56,-22]"^^xsd:string .
 
-niiri:6c566805e06c1caea5ba64a10caf0bd5 prov:wasDerivedFrom niiri:316701aef465a5778181dd76a5331844 .
+niiri:2f189ccf478c1f7803a99294add6d13b prov:wasDerivedFrom niiri:37af7d521a2b88cd58b24d8684f7fef9 .
 
-niiri:6ab52d2779f2688ce41178fdd09b1849
+niiri:6b41f34b6d11482d641fbf6e724b14b9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0128" ;
-    prov:atLocation niiri:3886ebad71d47a06506e87cdb3d33fee ;
+    prov:atLocation niiri:dc37a81ea4668eecf38e1163432a2364 ;
     prov:value "0.864862859249115"^^xsd:float ;
     nidm_equivalentZStatistic: "1.78696398255915"^^xsd:float ;
     nidm_pValueUncorrected: "0.0369716550398422"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:3886ebad71d47a06506e87cdb3d33fee
+niiri:dc37a81ea4668eecf38e1163432a2364
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0128" ;
     nidm_coordinateVector: "[-4,12,50]"^^xsd:string .
 
-niiri:6ab52d2779f2688ce41178fdd09b1849 prov:wasDerivedFrom niiri:90bdcb5fb7ef48121124edfe5e0439e6 .
+niiri:6b41f34b6d11482d641fbf6e724b14b9 prov:wasDerivedFrom niiri:6fb39f850b88fc429c462810fc4c1cb0 .
 
-niiri:49c821b0d9d061981dc68b1e3e6abfea
+niiri:c5151588d7538e4fe417cc06b8b41a04
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0129" ;
-    prov:atLocation niiri:050099abcdfa23d375e581da2db19230 ;
+    prov:atLocation niiri:cde16f243d8a750921ee9b21a71d953e ;
     prov:value "0.864512741565704"^^xsd:float ;
     nidm_equivalentZStatistic: "1.78652059943143"^^xsd:float ;
     nidm_pValueUncorrected: "0.0370075024642879"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:050099abcdfa23d375e581da2db19230
+niiri:cde16f243d8a750921ee9b21a71d953e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0129" ;
     nidm_coordinateVector: "[-30,-78,-8]"^^xsd:string .
 
-niiri:49c821b0d9d061981dc68b1e3e6abfea prov:wasDerivedFrom niiri:d1db945756296f3d178c9d95312fcba1 .
+niiri:c5151588d7538e4fe417cc06b8b41a04 prov:wasDerivedFrom niiri:3b4cc47fe21026a8ff3cc6cae8366e5a .
 
-niiri:d51ddcc544b96cfa8316116f60aeb9d7
+niiri:492919352e3d47c6173bffe5d9b359e9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0130" ;
-    prov:atLocation niiri:577fa5fdf942816d72dee2d7adba9c04 ;
+    prov:atLocation niiri:9254ca8c360e7c8c32935f3c76dbbdad ;
     prov:value "0.860980033874512"^^xsd:float ;
     nidm_equivalentZStatistic: "1.7820476459466"^^xsd:float ;
     nidm_pValueUncorrected: "0.0373707311326116"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:577fa5fdf942816d72dee2d7adba9c04
+niiri:9254ca8c360e7c8c32935f3c76dbbdad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0130" ;
     nidm_coordinateVector: "[12,-92,28]"^^xsd:string .
 
-niiri:d51ddcc544b96cfa8316116f60aeb9d7 prov:wasDerivedFrom niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a .
+niiri:492919352e3d47c6173bffe5d9b359e9 prov:wasDerivedFrom niiri:cb21e315dda71865f3198bf3de5b7c55 .
 
-niiri:fa45d096c7906fe9ce12107ae864f03d
+niiri:3bfe16f27ba2a0b79f505be203d7e68f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0131" ;
-    prov:atLocation niiri:c322d812103d8b149095968fc937209e ;
+    prov:atLocation niiri:f245d5153fe44fb6c38cd4e34efe9d5b ;
     prov:value "0.854242324829102"^^xsd:float ;
     nidm_equivalentZStatistic: "1.77352076998315"^^xsd:float ;
     nidm_pValueUncorrected: "0.0380712266728884"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c322d812103d8b149095968fc937209e
+niiri:f245d5153fe44fb6c38cd4e34efe9d5b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0131" ;
     nidm_coordinateVector: "[44,-50,-4]"^^xsd:string .
 
-niiri:fa45d096c7906fe9ce12107ae864f03d prov:wasDerivedFrom niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c .
+niiri:3bfe16f27ba2a0b79f505be203d7e68f prov:wasDerivedFrom niiri:2e5418c351f653b423462944edc63136 .
 
-niiri:98d08117d5c59bca3961e8d0d91fb482
+niiri:6c76e471c03533bb1f5987a45db39955
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0132" ;
-    prov:atLocation niiri:17735795c02954ed333e3e53d28b146c ;
+    prov:atLocation niiri:fc53fd234d50c6fb7191d72517b75b67 ;
     prov:value "0.853475153446198"^^xsd:float ;
     nidm_equivalentZStatistic: "1.77255022378467"^^xsd:float ;
     nidm_pValueUncorrected: "0.0381516330201062"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:17735795c02954ed333e3e53d28b146c
+niiri:fc53fd234d50c6fb7191d72517b75b67
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0132" ;
     nidm_coordinateVector: "[20,48,8]"^^xsd:string .
 
-niiri:98d08117d5c59bca3961e8d0d91fb482 prov:wasDerivedFrom niiri:9304b0681f39be2e136e7d42baff625c .
+niiri:6c76e471c03533bb1f5987a45db39955 prov:wasDerivedFrom niiri:f9e4a916c73e380e7f2b04ae24edb3eb .
 
-niiri:99903325b32dacf464eb78e914073565
+niiri:514a728f700d8eae9a4d01bef97ce699
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0133" ;
-    prov:atLocation niiri:4ac846381c96ad6a617444612779bfc0 ;
+    prov:atLocation niiri:8e9d52e803698afa10541fc835c58053 ;
     prov:value "0.848101913928986"^^xsd:float ;
     nidm_equivalentZStatistic: "1.76575454216401"^^xsd:float ;
     nidm_pValueUncorrected: "0.0387185189613873"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4ac846381c96ad6a617444612779bfc0
+niiri:8e9d52e803698afa10541fc835c58053
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0133" ;
     nidm_coordinateVector: "[22,-10,68]"^^xsd:string .
 
-niiri:99903325b32dacf464eb78e914073565 prov:wasDerivedFrom niiri:c4a9ab38a5b5faf27a110372a76b690b .
+niiri:514a728f700d8eae9a4d01bef97ce699 prov:wasDerivedFrom niiri:7154c13ca1ce907cde82a8d61810577c .
 
-niiri:d04d5d2d100ceb80264f8137772a93bb
+niiri:b58b30fb101bfb1709c7cca394569751
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0134" ;
-    prov:atLocation niiri:5ebd6bd9f56805b7a73b57e890d2c9d3 ;
+    prov:atLocation niiri:d50eaca1969dea2ee978843abe1497b6 ;
     prov:value "0.845535814762115"^^xsd:float ;
     nidm_equivalentZStatistic: "1.76251036116829"^^xsd:float ;
     nidm_pValueUncorrected: "0.038991553676096"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5ebd6bd9f56805b7a73b57e890d2c9d3
+niiri:d50eaca1969dea2ee978843abe1497b6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0134" ;
     nidm_coordinateVector: "[10,16,62]"^^xsd:string .
 
-niiri:d04d5d2d100ceb80264f8137772a93bb prov:wasDerivedFrom niiri:b08c64db49c2acab9dde84fc5aaafee1 .
+niiri:b58b30fb101bfb1709c7cca394569751 prov:wasDerivedFrom niiri:79ad3466325804caf01c3623b06f85c5 .
 
-niiri:82bb09e80a51ba7c7cad776e0c839658
+niiri:23ed43ecc179ab2c90d8fdb998591666
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0135" ;
-    prov:atLocation niiri:8dfe0d34ef5e5740012a8bc214f3f619 ;
+    prov:atLocation niiri:ee67ae6fa60ae225aba88ea4a11eebbd ;
     prov:value "0.845024406909943"^^xsd:float ;
     nidm_equivalentZStatistic: "1.76186391162221"^^xsd:float ;
     nidm_pValueUncorrected: "0.0390461466343727"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8dfe0d34ef5e5740012a8bc214f3f619
+niiri:ee67ae6fa60ae225aba88ea4a11eebbd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0135" ;
     nidm_coordinateVector: "[-30,-60,-28]"^^xsd:string .
 
-niiri:82bb09e80a51ba7c7cad776e0c839658 prov:wasDerivedFrom niiri:a8f46a35300a709894debac1a5c7d877 .
+niiri:23ed43ecc179ab2c90d8fdb998591666 prov:wasDerivedFrom niiri:2e12076af378dbdca5de9e12404f5853 .
 
-niiri:ced019c79dabd92179f8a23ffb66322f
+niiri:6235312dbe0a50495db71d1cbcef370d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0136" ;
-    prov:atLocation niiri:b1f6f0554f2caf5a79e8f085d690f134 ;
+    prov:atLocation niiri:ac1addae966f13ce0b52a9768b4836fd ;
     prov:value "0.842050552368164"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75810541868522"^^xsd:float ;
     nidm_pValueUncorrected: "0.0393647869826912"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b1f6f0554f2caf5a79e8f085d690f134
+niiri:ac1addae966f13ce0b52a9768b4836fd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0136" ;
     nidm_coordinateVector: "[20,6,44]"^^xsd:string .
 
-niiri:ced019c79dabd92179f8a23ffb66322f prov:wasDerivedFrom niiri:147fb623ae052dca9733d6d1d2297af8 .
+niiri:6235312dbe0a50495db71d1cbcef370d prov:wasDerivedFrom niiri:88291e9044390a2d68e0e8f02afae64d .
 
-niiri:8c53fc407776cbf3f06af1e7d0d3050b
+niiri:d47b337e440883382de4fab28e6d94f8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0137" ;
-    prov:atLocation niiri:b14a5b57d07a5a949fbf0748f7fedeff ;
+    prov:atLocation niiri:ee184cacdde8de299e33532df8b43683 ;
     prov:value "0.837220907211304"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75200380991823"^^xsd:float ;
     nidm_pValueUncorrected: "0.0398865764002145"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b14a5b57d07a5a949fbf0748f7fedeff
+niiri:ee184cacdde8de299e33532df8b43683
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0137" ;
     nidm_coordinateVector: "[-4,-100,4]"^^xsd:string .
 
-niiri:8c53fc407776cbf3f06af1e7d0d3050b prov:wasDerivedFrom niiri:eb257014e1b6b6961786c8543836a579 .
+niiri:d47b337e440883382de4fab28e6d94f8 prov:wasDerivedFrom niiri:9219dd196f709ade4b7d68bb82531ae9 .
 
-niiri:daa38cc1c0f9bbbca8083b6dc150874a
+niiri:1a81f2b791ccebb1e9c0bde558a466c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0138" ;
-    prov:atLocation niiri:d8a9aa94958b15cdbfa143422db3e409 ;
+    prov:atLocation niiri:d3c9d34e7b4bd20b7efc87ab3f4a7ae1 ;
     prov:value "0.83669376373291"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75133800938073"^^xsd:float ;
     nidm_pValueUncorrected: "0.0399438520830083"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d8a9aa94958b15cdbfa143422db3e409
+niiri:d3c9d34e7b4bd20b7efc87ab3f4a7ae1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0138" ;
     nidm_coordinateVector: "[26,36,-8]"^^xsd:string .
 
-niiri:daa38cc1c0f9bbbca8083b6dc150874a prov:wasDerivedFrom niiri:3c0db86cde8ac7aa1cb1f7b208b617e8 .
+niiri:1a81f2b791ccebb1e9c0bde558a466c0 prov:wasDerivedFrom niiri:b5869855e2ed1bde6084a419ce135245 .
 
-niiri:e6ccc430058b7e6f4734a533b0653ecd
+niiri:729704c4f052081f1863d33a4e9f9f30
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0139" ;
-    prov:atLocation niiri:f7d532abb738d329ed77cfa4ca9d829d ;
+    prov:atLocation niiri:8e1d0f1031cd834986592fe31edb44e9 ;
     prov:value "0.835819184780121"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75023346183694"^^xsd:float ;
     nidm_pValueUncorrected: "0.0400390185167846"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f7d532abb738d329ed77cfa4ca9d829d
+niiri:8e1d0f1031cd834986592fe31edb44e9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0139" ;
     nidm_coordinateVector: "[30,-36,28]"^^xsd:string .
 
-niiri:e6ccc430058b7e6f4734a533b0653ecd prov:wasDerivedFrom niiri:e578dd3a170f088e47efd39f45837f4e .
+niiri:729704c4f052081f1863d33a4e9f9f30 prov:wasDerivedFrom niiri:3ed79923246b336ee14ba73c12fc89b8 .
 
-niiri:c0c01149ce0c0a7325cb0911837c39c0
+niiri:ff2e059e98e36207411765ac32b8f7d0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0140" ;
-    prov:atLocation niiri:f81887eda1e93b996e6c64febcb68a9f ;
+    prov:atLocation niiri:bec436ba508234eb75e5a5465c872720 ;
     prov:value "0.835755825042725"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75015344548878"^^xsd:float ;
     nidm_pValueUncorrected: "0.0400459197758659"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f81887eda1e93b996e6c64febcb68a9f
+niiri:bec436ba508234eb75e5a5465c872720
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0140" ;
     nidm_coordinateVector: "[16,48,10]"^^xsd:string .
 
-niiri:c0c01149ce0c0a7325cb0911837c39c0 prov:wasDerivedFrom niiri:ab7f882f69e9de3fd22bc39f3519003d .
+niiri:ff2e059e98e36207411765ac32b8f7d0 prov:wasDerivedFrom niiri:12413ac997763f6fabc508fd21bfae38 .
 
-niiri:46a1c5dc61e2d7b3c894f451385aef85
+niiri:6d0a5e28cb7df9eee3b154f98efd90ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0141" ;
-    prov:atLocation niiri:0fd17548f87f46ceba800b4df8d45ffc ;
+    prov:atLocation niiri:765adf84ddd52eb6e5d694ba6cec47a0 ;
     prov:value "0.827520847320557"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73975784824994"^^xsd:float ;
     nidm_pValueUncorrected: "0.0409507734302569"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0fd17548f87f46ceba800b4df8d45ffc
+niiri:765adf84ddd52eb6e5d694ba6cec47a0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0141" ;
     nidm_coordinateVector: "[24,34,2]"^^xsd:string .
 
-niiri:46a1c5dc61e2d7b3c894f451385aef85 prov:wasDerivedFrom niiri:ca827c13c9bc5f06b55e3bd1cd175793 .
+niiri:6d0a5e28cb7df9eee3b154f98efd90ea prov:wasDerivedFrom niiri:f994daab5ee703f5c75c7c447254b288 .
 
-niiri:82a28d110b435fed75bd1e9374b294b2
+niiri:e902209feaeb13aa59e67a7f3977bf1a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0142" ;
-    prov:atLocation niiri:9b4eccb2dece33b68e724e1fd45e6e19 ;
+    prov:atLocation niiri:22a252c18b9fc266e8b32326dc729ee3 ;
     prov:value "0.825629651546478"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73737166192306"^^xsd:float ;
     nidm_pValueUncorrected: "0.0411607949360844"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9b4eccb2dece33b68e724e1fd45e6e19
+niiri:22a252c18b9fc266e8b32326dc729ee3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0142" ;
     nidm_coordinateVector: "[62,-42,44]"^^xsd:string .
 
-niiri:82a28d110b435fed75bd1e9374b294b2 prov:wasDerivedFrom niiri:8472115c12bd571d534dfe5bac960c80 .
+niiri:e902209feaeb13aa59e67a7f3977bf1a prov:wasDerivedFrom niiri:83cced094f39a6896a2e9e71f04942a7 .
 
-niiri:2d3f5ec418b92bf3ca61148f66079396
+niiri:937ca91b092a9615108e156d006cd75f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0143" ;
-    prov:atLocation niiri:3dbcf5a5ae42f6e1526aa0d8720cdb8a ;
+    prov:atLocation niiri:0c7268ae1b298870e210c38e71475db6 ;
     prov:value "0.82505863904953"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73665128497546"^^xsd:float ;
     nidm_pValueUncorrected: "0.0412243706597636"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:3dbcf5a5ae42f6e1526aa0d8720cdb8a
+niiri:0c7268ae1b298870e210c38e71475db6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0143" ;
     nidm_coordinateVector: "[-46,-40,38]"^^xsd:string .
 
-niiri:2d3f5ec418b92bf3ca61148f66079396 prov:wasDerivedFrom niiri:812c44e9a98ad090a6f8b72ffea8eb49 .
+niiri:937ca91b092a9615108e156d006cd75f prov:wasDerivedFrom niiri:8cebbc59dd1e18a1762d12ca4d90e931 .
 
-niiri:3514e869d053964fca5f28a8c09f4e91
+niiri:e4e5e8bf127576928bc51c913aa4738e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0144" ;
-    prov:atLocation niiri:fb4af523bacf868c90bee16373434943 ;
+    prov:atLocation niiri:86dfaeee85a3c20d3fa1895f256886ae ;
     prov:value "0.824967801570892"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73653669020128"^^xsd:float ;
     nidm_pValueUncorrected: "0.0412344913749479"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:fb4af523bacf868c90bee16373434943
+niiri:86dfaeee85a3c20d3fa1895f256886ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0144" ;
     nidm_coordinateVector: "[-12,-58,-54]"^^xsd:string .
 
-niiri:3514e869d053964fca5f28a8c09f4e91 prov:wasDerivedFrom niiri:eb1e036b54bfd5155015ad5c924a62ce .
+niiri:e4e5e8bf127576928bc51c913aa4738e prov:wasDerivedFrom niiri:8c6f92e0a397a1c5c883eb79ede81691 .
 
-niiri:aee96554789220edfb0c2a5cb3e5dbcf
+niiri:348213d7436248cd56fb0d8e6f9b70d4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0145" ;
-    prov:atLocation niiri:e3ed6f4e37e26c035620e0009be1898c ;
+    prov:atLocation niiri:b7883e9d90d471712abd8c90c1a5dd3c ;
     prov:value "0.824692487716675"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73618937818564"^^xsd:float ;
     nidm_pValueUncorrected: "0.0412651773815628"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e3ed6f4e37e26c035620e0009be1898c
+niiri:b7883e9d90d471712abd8c90c1a5dd3c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0145" ;
     nidm_coordinateVector: "[26,-72,14]"^^xsd:string .
 
-niiri:aee96554789220edfb0c2a5cb3e5dbcf prov:wasDerivedFrom niiri:8bac0f00c0d1f0f9f5c118004ab17321 .
+niiri:348213d7436248cd56fb0d8e6f9b70d4 prov:wasDerivedFrom niiri:6e55a4195849427172678126ca78b28a .
 
-niiri:cc8b982d26d7b3eda03f32ed426ee111
+niiri:6ed89be12666768ddd7761719af22822
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0146" ;
-    prov:atLocation niiri:ed883e8d69ce8310e32c0e8becfe841e ;
+    prov:atLocation niiri:0ec8e7e416617b5bb2a8ca07a2c32fd3 ;
     prov:value "0.822546482086182"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73348249441809"^^xsd:float ;
     nidm_pValueUncorrected: "0.0415049731433188"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ed883e8d69ce8310e32c0e8becfe841e
+niiri:0ec8e7e416617b5bb2a8ca07a2c32fd3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0146" ;
     nidm_coordinateVector: "[-40,-10,40]"^^xsd:string .
 
-niiri:cc8b982d26d7b3eda03f32ed426ee111 prov:wasDerivedFrom niiri:4f4b190235fbb136b1bb7467b78730d6 .
+niiri:6ed89be12666768ddd7761719af22822 prov:wasDerivedFrom niiri:3d5e4a6eb5d78cc1ef178561e41ba9ee .
 
-niiri:5f5a39c0ec9f402ad6c7b83cd3403cc8
+niiri:8d954dfe5cc3c1744ec9b69c893a4ce7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0147" ;
-    prov:atLocation niiri:6f15a47567306fd72eb97be297c7405b ;
+    prov:atLocation niiri:c99de1733407f9b917d2fcf6f18107c7 ;
     prov:value "0.821757972240448"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73248804772578"^^xsd:float ;
     nidm_pValueUncorrected: "0.0415933516734939"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6f15a47567306fd72eb97be297c7405b
+niiri:c99de1733407f9b917d2fcf6f18107c7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0147" ;
     nidm_coordinateVector: "[54,-52,42]"^^xsd:string .
 
-niiri:5f5a39c0ec9f402ad6c7b83cd3403cc8 prov:wasDerivedFrom niiri:d04d2676281bca09e8a782500650e993 .
+niiri:8d954dfe5cc3c1744ec9b69c893a4ce7 prov:wasDerivedFrom niiri:263da8c4eb7cf40aac1b2acc6184c451 .
 
-niiri:21c2f0806b69f7a2007d792897684387
+niiri:f720acd422ca543f3b9d91c8bad1ff84
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0148" ;
-    prov:atLocation niiri:8c75ae64ad9880eeb66c7dfdeca370d8 ;
+    prov:atLocation niiri:86e21b78f8bbaad1b5d369b817045f62 ;
     prov:value "0.821538865566254"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73221173057204"^^xsd:float ;
     nidm_pValueUncorrected: "0.0416179355971084"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8c75ae64ad9880eeb66c7dfdeca370d8
+niiri:86e21b78f8bbaad1b5d369b817045f62
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0148" ;
     nidm_coordinateVector: "[-10,-66,8]"^^xsd:string .
 
-niiri:21c2f0806b69f7a2007d792897684387 prov:wasDerivedFrom niiri:59c6e585fc56ebce5a5d95b959cc120d .
+niiri:f720acd422ca543f3b9d91c8bad1ff84 prov:wasDerivedFrom niiri:d4fbe5cc673433a4ae33bce2f4d62046 .
 
-niiri:4f107ffd42ea6e3a3e3d2968400fa620
+niiri:6dc851372d8e3e27d41d97f6dab1a12b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0149" ;
-    prov:atLocation niiri:e296ec0027943c32f1d63187ca884faf ;
+    prov:atLocation niiri:6496c51bd773c1ae0b6d90ee2114dba0 ;
     prov:value "0.821337878704071"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73195826984928"^^xsd:float ;
     nidm_pValueUncorrected: "0.0416404963346692"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e296ec0027943c32f1d63187ca884faf
+niiri:6496c51bd773c1ae0b6d90ee2114dba0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0149" ;
     nidm_coordinateVector: "[20,-16,70]"^^xsd:string .
 
-niiri:4f107ffd42ea6e3a3e3d2968400fa620 prov:wasDerivedFrom niiri:a4d82c21752d17f68b6fbf41caa89a4b .
+niiri:6dc851372d8e3e27d41d97f6dab1a12b prov:wasDerivedFrom niiri:92b2dd79b91691fa3fee9530c07ced7e .
 
-niiri:52953fe00c54e610f78c8e2bd72debb1
+niiri:eacb189a4f6aad7ba7991ec7e8ee4a64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0150" ;
-    prov:atLocation niiri:d4f42ae011a1b1bcdfd446d63c416728 ;
+    prov:atLocation niiri:6b1547bb95fed435e85d0b37e1ae174c ;
     prov:value "0.821269989013672"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73187265661373"^^xsd:float ;
     nidm_pValueUncorrected: "0.0416481190738193"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d4f42ae011a1b1bcdfd446d63c416728
+niiri:6b1547bb95fed435e85d0b37e1ae174c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0150" ;
     nidm_coordinateVector: "[34,-56,18]"^^xsd:string .
 
-niiri:52953fe00c54e610f78c8e2bd72debb1 prov:wasDerivedFrom niiri:9c09ac30035d9617daad1f111fa1b47f .
+niiri:eacb189a4f6aad7ba7991ec7e8ee4a64 prov:wasDerivedFrom niiri:0791bb16705c92dfa0eb9a2399ad7c01 .
 
-niiri:b8bb24c25ece9a10c4a32995fda538dd
+niiri:0abc45dfbb89620780d8de5664cb5010
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0151" ;
-    prov:atLocation niiri:48f70704159960814be91b72a9bd2859 ;
+    prov:atLocation niiri:3dc38b67bdfcc504dc6cec93875d1d6b ;
     prov:value "0.82093757390976"^^xsd:float ;
     nidm_equivalentZStatistic: "1.7314534684428"^^xsd:float ;
     nidm_pValueUncorrected: "0.0416854586174026"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:48f70704159960814be91b72a9bd2859
+niiri:3dc38b67bdfcc504dc6cec93875d1d6b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0151" ;
     nidm_coordinateVector: "[58,32,22]"^^xsd:string .
 
-niiri:b8bb24c25ece9a10c4a32995fda538dd prov:wasDerivedFrom niiri:b5d02c34e634c7f52d94137fbd9f8813 .
+niiri:0abc45dfbb89620780d8de5664cb5010 prov:wasDerivedFrom niiri:51393db8b7b8a6fffbbd81b5df93450e .
 
-niiri:553be5643aa7f566f5428ca1f18a7e99
+niiri:af431788e35f94f8cb37bdfbd4f460da
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0152" ;
-    prov:atLocation niiri:793abb325ad9de1bede5b50108624f36 ;
+    prov:atLocation niiri:cd30e79318ec8a11a5787534f3a9030c ;
     prov:value "0.817427694797516"^^xsd:float ;
     nidm_equivalentZStatistic: "1.72702824070669"^^xsd:float ;
     nidm_pValueUncorrected: "0.0420812958690475"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:793abb325ad9de1bede5b50108624f36
+niiri:cd30e79318ec8a11a5787534f3a9030c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0152" ;
     nidm_coordinateVector: "[-28,-74,18]"^^xsd:string .
 
-niiri:553be5643aa7f566f5428ca1f18a7e99 prov:wasDerivedFrom niiri:fc91a408c252d8e2b7beb4005554eaf8 .
+niiri:af431788e35f94f8cb37bdfbd4f460da prov:wasDerivedFrom niiri:868dad72b2c68d3fbc6510a6d5cb9231 .
 
-niiri:50446d0a8adcadede38bdf0d08c3a7c9
+niiri:1a8f2ea7a45f2075e9f9f34168c9ff29
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0153" ;
-    prov:atLocation niiri:4691db3191597b7338e7c95c4a8f87e2 ;
+    prov:atLocation niiri:9df19e189040f4843e39f4748baf9672 ;
     prov:value "0.816389560699463"^^xsd:float ;
     nidm_equivalentZStatistic: "1.72571967296696"^^xsd:float ;
     nidm_pValueUncorrected: "0.0421989285126135"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4691db3191597b7338e7c95c4a8f87e2
+niiri:9df19e189040f4843e39f4748baf9672
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0153" ;
     nidm_coordinateVector: "[28,-30,34]"^^xsd:string .
 
-niiri:50446d0a8adcadede38bdf0d08c3a7c9 prov:wasDerivedFrom niiri:9b0591f2b854d2643aaf1afaa93cb549 .
+niiri:1a8f2ea7a45f2075e9f9f34168c9ff29 prov:wasDerivedFrom niiri:f010113cde48b81f7b8ed0070c723116 .
 
-niiri:65d8e0c0cee7cb9aedc8b05b70798526
+niiri:54183cc34e3e6967db364d7904a9e52d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0154" ;
-    prov:atLocation niiri:a8791185dbb796dbe126d712ae2b55e4 ;
+    prov:atLocation niiri:008e78402e17c38602734ce16c5f22d8 ;
     prov:value "0.810877442359924"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71877398514755"^^xsd:float ;
     nidm_pValueUncorrected: "0.0428277671196435"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a8791185dbb796dbe126d712ae2b55e4
+niiri:008e78402e17c38602734ce16c5f22d8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0154" ;
     nidm_coordinateVector: "[-4,-92,4]"^^xsd:string .
 
-niiri:65d8e0c0cee7cb9aedc8b05b70798526 prov:wasDerivedFrom niiri:d54744a8017e84d7adb355fc9412fba3 .
+niiri:54183cc34e3e6967db364d7904a9e52d prov:wasDerivedFrom niiri:0265995653f234724934abae5c95f7d7 .
 
-niiri:ac42ea1cc64c6d5a7de30ab94c30ef98
+niiri:46f6b44a41e9e8cb3de0ec11f8a393f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0155" ;
-    prov:atLocation niiri:e8237ec0f9d80f45182261107f27d393 ;
+    prov:atLocation niiri:149ba67b614148cadebeb33b2cb01bb7 ;
     prov:value "0.810260891914368"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71799733032142"^^xsd:float ;
     nidm_pValueUncorrected: "0.0428985511130971"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e8237ec0f9d80f45182261107f27d393
+niiri:149ba67b614148cadebeb33b2cb01bb7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0155" ;
     nidm_coordinateVector: "[-18,-22,44]"^^xsd:string .
 
-niiri:ac42ea1cc64c6d5a7de30ab94c30ef98 prov:wasDerivedFrom niiri:e49a03f4d60a11688f798fc5bc43c1b2 .
+niiri:46f6b44a41e9e8cb3de0ec11f8a393f6 prov:wasDerivedFrom niiri:f99e0a55aff25b99b4c4ccb40319fa7b .
 
-niiri:69ee373828c471312b7a98ecd9d058a9
+niiri:46adeac017faa4c69a20028b6f8e63c6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0156" ;
-    prov:atLocation niiri:c8b68f98c5cfe0ac5c2cdefaedfdf163 ;
+    prov:atLocation niiri:2773eefe6180cc14e7a7960b97901f27 ;
     prov:value "0.809625387191772"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71719685114941"^^xsd:float ;
     nidm_pValueUncorrected: "0.042971605350922"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c8b68f98c5cfe0ac5c2cdefaedfdf163
+niiri:2773eefe6180cc14e7a7960b97901f27
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0156" ;
     nidm_coordinateVector: "[-8,-88,-48]"^^xsd:string .
 
-niiri:69ee373828c471312b7a98ecd9d058a9 prov:wasDerivedFrom niiri:b04a187086857b7422c8096db14ee613 .
+niiri:46adeac017faa4c69a20028b6f8e63c6 prov:wasDerivedFrom niiri:48a348ba7dc61a80c12ae68ab1b56cad .
 
-niiri:b43fdbd7e0791111185f3e004a40b90f
+niiri:5100c19d55a2cc622e67db8f475de925
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0157" ;
-    prov:atLocation niiri:70a5abbded05158ae55374c9e47f8da2 ;
+    prov:atLocation niiri:5a8af079332b887b04f7005a6595a20c ;
     prov:value "0.807083547115326"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71399568809748"^^xsd:float ;
     nidm_pValueUncorrected: "0.0432647588890963"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:70a5abbded05158ae55374c9e47f8da2
+niiri:5a8af079332b887b04f7005a6595a20c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0157" ;
     nidm_coordinateVector: "[-28,-90,-14]"^^xsd:string .
 
-niiri:b43fdbd7e0791111185f3e004a40b90f prov:wasDerivedFrom niiri:39ce93dd6abab662ab6da84a046a56bd .
+niiri:5100c19d55a2cc622e67db8f475de925 prov:wasDerivedFrom niiri:adc463abce824f98736aecdc0ef0fc44 .
 
-niiri:74b1e30b0b85916615db0f4c7da8ca2a
+niiri:8c8a82f24104d341825f45a98d5506eb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0158" ;
-    prov:atLocation niiri:8b947c980b68849b563e6a600eb6f25e ;
+    prov:atLocation niiri:7359bf2ba1fa3b8608e099d2f80da1d0 ;
     prov:value "0.804524898529053"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71077421355999"^^xsd:float ;
     nidm_pValueUncorrected: "0.0435614007800803"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8b947c980b68849b563e6a600eb6f25e
+niiri:7359bf2ba1fa3b8608e099d2f80da1d0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0158" ;
     nidm_coordinateVector: "[54,18,14]"^^xsd:string .
 
-niiri:74b1e30b0b85916615db0f4c7da8ca2a prov:wasDerivedFrom niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e .
+niiri:8c8a82f24104d341825f45a98d5506eb prov:wasDerivedFrom niiri:2a0123807eeff74fec9051900072009a .
 
-niiri:6630427441c8fc15cc3a64424eb38ad1
+niiri:599fe24d4e0a62c0a4539e2b34d200da
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0159" ;
-    prov:atLocation niiri:2352aa9bc768856664d6689721c07c97 ;
+    prov:atLocation niiri:d905430746f831b8f4d4d82f144d3ea7 ;
     prov:value "0.801611304283142"^^xsd:float ;
     nidm_equivalentZStatistic: "1.70710689586196"^^xsd:float ;
     nidm_pValueUncorrected: "0.0439010928174099"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2352aa9bc768856664d6689721c07c97
+niiri:d905430746f831b8f4d4d82f144d3ea7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0159" ;
     nidm_coordinateVector: "[38,-48,18]"^^xsd:string .
 
-niiri:6630427441c8fc15cc3a64424eb38ad1 prov:wasDerivedFrom niiri:ca20dee3ba6bf36049f99642c710470d .
+niiri:599fe24d4e0a62c0a4539e2b34d200da prov:wasDerivedFrom niiri:3c9c41ca803aea8e1aa376a37e7fd405 .
 
-niiri:8292bd6d405860cc9e98ea0f6c90807b
+niiri:3c0e3d6e7514eaa237950debc30b47fd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0160" ;
-    prov:atLocation niiri:a2593a5375fecb7c266042738db0862e ;
+    prov:atLocation niiri:4cf1c35d95d7b5dd244c47e4c2790de2 ;
     prov:value "0.801064372062683"^^xsd:float ;
     nidm_equivalentZStatistic: "1.70641860205681"^^xsd:float ;
     nidm_pValueUncorrected: "0.0439650847967754"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a2593a5375fecb7c266042738db0862e
+niiri:4cf1c35d95d7b5dd244c47e4c2790de2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0160" ;
     nidm_coordinateVector: "[-32,-70,28]"^^xsd:string .
 
-niiri:8292bd6d405860cc9e98ea0f6c90807b prov:wasDerivedFrom niiri:26fa7a82c298f218eb7fd282cfbf7a81 .
+niiri:3c0e3d6e7514eaa237950debc30b47fd prov:wasDerivedFrom niiri:4ac51018dc7ac193d610d2175b143f4f .
 
-niiri:40736270f2699f261bc17555c7292552
+niiri:9bef5b0ca963e53070a3a99033f87f38
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0161" ;
-    prov:atLocation niiri:f1dfb9a6e43d0bb924ebeb2df5b8754b ;
+    prov:atLocation niiri:2d34e4b441f7b135e77d543d9f66dadb ;
     prov:value "0.796977043151855"^^xsd:float ;
     nidm_equivalentZStatistic: "1.70127611195347"^^xsd:float ;
     nidm_pValueUncorrected: "0.0444455757271468"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f1dfb9a6e43d0bb924ebeb2df5b8754b
+niiri:2d34e4b441f7b135e77d543d9f66dadb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0161" ;
     nidm_coordinateVector: "[40,-8,-32]"^^xsd:string .
 
-niiri:40736270f2699f261bc17555c7292552 prov:wasDerivedFrom niiri:e518dd980ffdb694adcf472695d5a40a .
+niiri:9bef5b0ca963e53070a3a99033f87f38 prov:wasDerivedFrom niiri:9411d8ecf0144381e141c863accd8f82 .
 
-niiri:0f9175ee5293a19900d9c265070230b1
+niiri:f6d4c9131d22036aec030e09ab39c6dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0162" ;
-    prov:atLocation niiri:a2480bf60f7e38c86231bf76032bf596 ;
+    prov:atLocation niiri:6aa2fbb29246a07a9badf57a76c05ab5 ;
     prov:value "0.795195400714874"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69903522990177"^^xsd:float ;
     nidm_pValueUncorrected: "0.044656272931023"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a2480bf60f7e38c86231bf76032bf596
+niiri:6aa2fbb29246a07a9badf57a76c05ab5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0162" ;
     nidm_coordinateVector: "[10,-10,4]"^^xsd:string .
 
-niiri:0f9175ee5293a19900d9c265070230b1 prov:wasDerivedFrom niiri:5f278b6b11fae0c4b4f9690852a71d0c .
+niiri:f6d4c9131d22036aec030e09ab39c6dd prov:wasDerivedFrom niiri:58ff840b981e30971a46c0cdee9acc43 .
 
-niiri:9288e365e8e166d1d7201abdec31d34d
+niiri:0a6dd43a51f3ce9c34de2142af6b02e6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0163" ;
-    prov:atLocation niiri:360956c141f1348efb9ba6e9bda173e8 ;
+    prov:atLocation niiri:da7303ac72bc02c9cd855044756c5de5 ;
     prov:value "0.793771862983704"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69724506469093"^^xsd:float ;
     nidm_pValueUncorrected: "0.0448251692331177"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:360956c141f1348efb9ba6e9bda173e8
+niiri:da7303ac72bc02c9cd855044756c5de5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0163" ;
     nidm_coordinateVector: "[36,-38,16]"^^xsd:string .
 
-niiri:9288e365e8e166d1d7201abdec31d34d prov:wasDerivedFrom niiri:87f8233f1c48acf6ecdd7339055182ae .
+niiri:0a6dd43a51f3ce9c34de2142af6b02e6 prov:wasDerivedFrom niiri:81d9ad132a8f471d00cb8b3aef33836f .
 
-niiri:5eefd7306b4387e0f534121efebdd08c
+niiri:9a78a0f7476ba56a9df1ed696f78fe77
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0164" ;
-    prov:atLocation niiri:c6bbb6da467f04755510516c59db89cc ;
+    prov:atLocation niiri:3b43899302ca56905cfe7f84b26615cf ;
     prov:value "0.791125535964966"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69391791067376"^^xsd:float ;
     nidm_pValueUncorrected: "0.0451404415013222"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c6bbb6da467f04755510516c59db89cc
+niiri:3b43899302ca56905cfe7f84b26615cf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0164" ;
     nidm_coordinateVector: "[36,-58,-34]"^^xsd:string .
 
-niiri:5eefd7306b4387e0f534121efebdd08c prov:wasDerivedFrom niiri:0189728b5aaa10d4eb4ff53d1fbc5843 .
+niiri:9a78a0f7476ba56a9df1ed696f78fe77 prov:wasDerivedFrom niiri:b85e89811d403dd797f7d9315b0c1779 .
 
-niiri:0d043095f5b8ce7d202f6fc55b3238bc
+niiri:2cb31cb7b093dad502997f78c9a4e430
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0165" ;
-    prov:atLocation niiri:00bfef980e3b46b82577ed05a18e2998 ;
+    prov:atLocation niiri:0c6294ba2898494ddcc11332935ee7b8 ;
     prov:value "0.790164232254028"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69270952448475"^^xsd:float ;
     nidm_pValueUncorrected: "0.0452553857167721"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:00bfef980e3b46b82577ed05a18e2998
+niiri:0c6294ba2898494ddcc11332935ee7b8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0165" ;
     nidm_coordinateVector: "[-24,-68,40]"^^xsd:string .
 
-niiri:0d043095f5b8ce7d202f6fc55b3238bc prov:wasDerivedFrom niiri:453f1919d7df3d7e610709f6fdecbf62 .
+niiri:2cb31cb7b093dad502997f78c9a4e430 prov:wasDerivedFrom niiri:559e52e372bf37a3bd9f89fe7d257b7f .
 
-niiri:d3837181ec2883710db3c1e102047902
+niiri:51c2f67a4825f1b51311539b25ee7829
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0166" ;
-    prov:atLocation niiri:6839436079db4de6e679f679c75a4c7e ;
+    prov:atLocation niiri:3ea5e74a42e56df9c591de50df3e57a3 ;
     prov:value "0.789975047111511"^^xsd:float ;
     nidm_equivalentZStatistic: "1.6924717281141"^^xsd:float ;
     nidm_pValueUncorrected: "0.045278033108256"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6839436079db4de6e679f679c75a4c7e
+niiri:3ea5e74a42e56df9c591de50df3e57a3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0166" ;
     nidm_coordinateVector: "[-32,-66,-54]"^^xsd:string .
 
-niiri:d3837181ec2883710db3c1e102047902 prov:wasDerivedFrom niiri:5b21dda7a2823d1c7efeff7947020767 .
+niiri:51c2f67a4825f1b51311539b25ee7829 prov:wasDerivedFrom niiri:8675dcbc163828022ee916bae686b21e .
 
-niiri:7ada6738ac4a3476b738b4b0994fd916
+niiri:d572a9f3f060da98ea22bc80c122a357
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0167" ;
-    prov:atLocation niiri:0e72b69c8d3905c21cb76f5d803a0e4d ;
+    prov:atLocation niiri:de264a5f790a2be83bd78daa8fa8bde4 ;
     prov:value "0.785030126571655"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68625793462611"^^xsd:float ;
     nidm_pValueUncorrected: "0.0458730647233518"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0e72b69c8d3905c21cb76f5d803a0e4d
+niiri:de264a5f790a2be83bd78daa8fa8bde4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0167" ;
     nidm_coordinateVector: "[-38,-4,36]"^^xsd:string .
 
-niiri:7ada6738ac4a3476b738b4b0994fd916 prov:wasDerivedFrom niiri:a6dc495a077e17aa8f96566659037e0b .
+niiri:d572a9f3f060da98ea22bc80c122a357 prov:wasDerivedFrom niiri:2ebb70aec77a1bb19cfa4bb0e86df28c .
 
-niiri:9c5822f4331f39fcb128f71e39c9a258
+niiri:57888f359906dd4ad43ceadb5ca1aaf2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0168" ;
-    prov:atLocation niiri:ff06c430dadf64ca774b3086a78659e3 ;
+    prov:atLocation niiri:50211b7729f84e2eee954df78ae7c694 ;
     prov:value "0.783349096775055"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68414631143602"^^xsd:float ;
     nidm_pValueUncorrected: "0.0460766980434556"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ff06c430dadf64ca774b3086a78659e3
+niiri:50211b7729f84e2eee954df78ae7c694
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0168" ;
     nidm_coordinateVector: "[-50,10,-6]"^^xsd:string .
 
-niiri:9c5822f4331f39fcb128f71e39c9a258 prov:wasDerivedFrom niiri:e5e5eeee288ec088072a80af972a3638 .
+niiri:57888f359906dd4ad43ceadb5ca1aaf2 prov:wasDerivedFrom niiri:c3f909ea8341d2a928e08b183a5eb9b8 .
 
-niiri:ccb323d69fd85ace7df2130c0f358f1e
+niiri:b2bf188e739b8f5d5cead545d7bd3a14
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0169" ;
-    prov:atLocation niiri:217b8e666093093f4b98080437a0d243 ;
+    prov:atLocation niiri:78cd9a9cdaed3e069d100845a7bfd965 ;
     prov:value "0.780271351337433"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68028121266012"^^xsd:float ;
     nidm_pValueUncorrected: "0.046451307319556"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:217b8e666093093f4b98080437a0d243
+niiri:78cd9a9cdaed3e069d100845a7bfd965
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0169" ;
     nidm_coordinateVector: "[-18,-22,34]"^^xsd:string .
 
-niiri:ccb323d69fd85ace7df2130c0f358f1e prov:wasDerivedFrom niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1 .
+niiri:b2bf188e739b8f5d5cead545d7bd3a14 prov:wasDerivedFrom niiri:7da0c40e610d05ef5fcd5df75e03757e .
 
-niiri:cf35bc5d34495239fdb3d14ae313539a
+niiri:0233592a88bd1be7e7a031f75ae13813
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0170" ;
-    prov:atLocation niiri:6a7144a67e64589dcd898f89b4f5a115 ;
+    prov:atLocation niiri:ba73c9d83c778237f47a9adf18f1fb7d ;
     prov:value "0.778013467788696"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67744654581037"^^xsd:float ;
     nidm_pValueUncorrected: "0.046727596979824"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6a7144a67e64589dcd898f89b4f5a115
+niiri:ba73c9d83c778237f47a9adf18f1fb7d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0170" ;
     nidm_coordinateVector: "[-20,-22,38]"^^xsd:string .
 
-niiri:cf35bc5d34495239fdb3d14ae313539a prov:wasDerivedFrom niiri:66cf0dbeb1aa03edbab1a35c2d527a55 .
+niiri:0233592a88bd1be7e7a031f75ae13813 prov:wasDerivedFrom niiri:88cc306d767adb94ebbccf9ff7621ad9 .
 
-niiri:8a057d875ec99d9bc03c3b517547b1ea
+niiri:d69c50de58f7fd7a1f64ba4b4fd99d9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0171" ;
-    prov:atLocation niiri:074b47096ccc51be98dbe94fdd69bdea ;
+    prov:atLocation niiri:37454513b78e9abdf3a0cc61d7e5c7be ;
     prov:value "0.775993704795837"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67491142741087"^^xsd:float ;
     nidm_pValueUncorrected: "0.0469758055929785"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:074b47096ccc51be98dbe94fdd69bdea
+niiri:37454513b78e9abdf3a0cc61d7e5c7be
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0171" ;
     nidm_coordinateVector: "[12,-92,2]"^^xsd:string .
 
-niiri:8a057d875ec99d9bc03c3b517547b1ea prov:wasDerivedFrom niiri:09d8898196c5c40aec6f995a2b0c383d .
+niiri:d69c50de58f7fd7a1f64ba4b4fd99d9d prov:wasDerivedFrom niiri:74ee3d5df4f8c42807338247cfe92970 .
 
-niiri:136d5427f1933a243c7f06af362e36ee
+niiri:7c59dea47bc9bb0c6e1644fc44dbec4a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0172" ;
-    prov:atLocation niiri:78b0fee3f9559ef3905e7bf963b53e38 ;
+    prov:atLocation niiri:1c18bf474c8f011148fe77f34b1c8d4b ;
     prov:value "0.774858772754669"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67348715940063"^^xsd:float ;
     nidm_pValueUncorrected: "0.0471157161396256"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:78b0fee3f9559ef3905e7bf963b53e38
+niiri:1c18bf474c8f011148fe77f34b1c8d4b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0172" ;
     nidm_coordinateVector: "[52,-44,58]"^^xsd:string .
 
-niiri:136d5427f1933a243c7f06af362e36ee prov:wasDerivedFrom niiri:bfe644ea717165d3b6b50431d8e57c87 .
+niiri:7c59dea47bc9bb0c6e1644fc44dbec4a prov:wasDerivedFrom niiri:cdf3f858b94767540e52edcfccc91cae .
 
-niiri:f4fabce2608abd82f4cb41cc5b313112
+niiri:570b7b59ff44fc705fdaa803ba38b444
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0173" ;
-    prov:atLocation niiri:907619d79ece58eff1df517e0cbd5f78 ;
+    prov:atLocation niiri:5235c98b2b9af63a0b7f146548cf6c9d ;
     prov:value "0.766564428806305"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66308376386524"^^xsd:float ;
     nidm_pValueUncorrected: "0.0481478347201374"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:907619d79ece58eff1df517e0cbd5f78
+niiri:5235c98b2b9af63a0b7f146548cf6c9d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0173" ;
     nidm_coordinateVector: "[46,30,-8]"^^xsd:string .
 
-niiri:f4fabce2608abd82f4cb41cc5b313112 prov:wasDerivedFrom niiri:0d278ee0d105de3a7319a5acaa11c631 .
+niiri:570b7b59ff44fc705fdaa803ba38b444 prov:wasDerivedFrom niiri:d47a915a52d84b041200dd225d0d123a .
 
-niiri:f47917da4ed2d8c7e7324d2c0d02a46d
+niiri:80def1f8a0731234b7509b9b4f521a78
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0174" ;
-    prov:atLocation niiri:4c0ec437ff4662e7d0eac4dcd51885cb ;
+    prov:atLocation niiri:4df3c96aa2621e41fa961300b05f4c73 ;
     prov:value "0.766485750675201"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66298512623431"^^xsd:float ;
     nidm_pValueUncorrected: "0.0481577064245639"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4c0ec437ff4662e7d0eac4dcd51885cb
+niiri:4df3c96aa2621e41fa961300b05f4c73
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0174" ;
     nidm_coordinateVector: "[20,-72,-22]"^^xsd:string .
 
-niiri:f47917da4ed2d8c7e7324d2c0d02a46d prov:wasDerivedFrom niiri:9a54b30308f71d0c474dab56acec5885 .
+niiri:80def1f8a0731234b7509b9b4f521a78 prov:wasDerivedFrom niiri:a0b6cde2f07cadad11fae188db97aa3e .
 
-niiri:8e9351607907220ceb9c4d03fd181a94
+niiri:f2b4c8fde8e4f84a6a4912601523b7df
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0175" ;
-    prov:atLocation niiri:35e7e4f379992bd20464a3fd82e6925c ;
+    prov:atLocation niiri:84d153ca4a1304647807d3be47f7888a ;
     prov:value "0.764753878116608"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66081412523685"^^xsd:float ;
     nidm_pValueUncorrected: "0.0483753916847881"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:35e7e4f379992bd20464a3fd82e6925c
+niiri:84d153ca4a1304647807d3be47f7888a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0175" ;
     nidm_coordinateVector: "[30,-32,14]"^^xsd:string .
 
-niiri:8e9351607907220ceb9c4d03fd181a94 prov:wasDerivedFrom niiri:f219989ec875846cc4815fffc10bd118 .
+niiri:f2b4c8fde8e4f84a6a4912601523b7df prov:wasDerivedFrom niiri:28cf85781211b96d1afff400e743d8e0 .
 
-niiri:33b88df2af789585f536f999c5e3786b
+niiri:757185c9fd95e6316258dfd8ad5f1ff6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0176" ;
-    prov:atLocation niiri:753a6ac393f5e043a90380ea38ab0569 ;
+    prov:atLocation niiri:6acd7d3913ce7522e14fde1e44943e73 ;
     prov:value "0.764399468898773"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66036990560998"^^xsd:float ;
     nidm_pValueUncorrected: "0.0484200302267611"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:753a6ac393f5e043a90380ea38ab0569
+niiri:6acd7d3913ce7522e14fde1e44943e73
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0176" ;
     nidm_coordinateVector: "[-8,-2,66]"^^xsd:string .
 
-niiri:33b88df2af789585f536f999c5e3786b prov:wasDerivedFrom niiri:4b37375a8d01d1d9009b430352062714 .
+niiri:757185c9fd95e6316258dfd8ad5f1ff6 prov:wasDerivedFrom niiri:3d1ef8f1229ad13d14520be973ee405c .
 
-niiri:bb74269075716d4be58818314e11eb5f
+niiri:e0f17b2441dc69b87cdd45e8ca4ee7c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0177" ;
-    prov:atLocation niiri:750f7b5e0fd142e4019c35e2387fbbba ;
+    prov:atLocation niiri:3617ff6ee179b8c6a14ac8eba47e10fe ;
     prov:value "0.763978481292725"^^xsd:float ;
     nidm_equivalentZStatistic: "1.65984225927592"^^xsd:float ;
     nidm_pValueUncorrected: "0.0484730949107541"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:750f7b5e0fd142e4019c35e2387fbbba
+niiri:3617ff6ee179b8c6a14ac8eba47e10fe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0177" ;
     nidm_coordinateVector: "[-20,10,-22]"^^xsd:string .
 
-niiri:bb74269075716d4be58818314e11eb5f prov:wasDerivedFrom niiri:0f0a4015dd42d89522302ce792b20d6d .
+niiri:e0f17b2441dc69b87cdd45e8ca4ee7c7 prov:wasDerivedFrom niiri:2960c762474a0ecebef6e8e066482105 .
 
-niiri:3ad00aa4ff8a097302d4f9fa2f588f84
+niiri:4df33de97684a17b10e203e3c302d01c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0178" ;
-    prov:atLocation niiri:35bb5e6863e088834438d69e3f1e49f6 ;
+    prov:atLocation niiri:1879b473543bd6074c1745df6f3c6cdc ;
     prov:value "0.763044834136963"^^xsd:float ;
     nidm_equivalentZStatistic: "1.65867215934383"^^xsd:float ;
     nidm_pValueUncorrected: "0.0485909362055301"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:35bb5e6863e088834438d69e3f1e49f6
+niiri:1879b473543bd6074c1745df6f3c6cdc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0178" ;
     nidm_coordinateVector: "[-62,2,14]"^^xsd:string .
 
-niiri:3ad00aa4ff8a097302d4f9fa2f588f84 prov:wasDerivedFrom niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a .
+niiri:4df33de97684a17b10e203e3c302d01c prov:wasDerivedFrom niiri:a86c5c480c3033b63bc45962d5c32c41 .
 
-niiri:fad858bb75eed0c28b072161552a6ba5
+niiri:954abdec09c8dd4a4898bbfe748cfcd9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0179" ;
-    prov:atLocation niiri:5bb50d8540759ebdbe65ef922e6b9009 ;
+    prov:atLocation niiri:19eeb0792f31b2212bb6d81c0bab4b01 ;
     prov:value "0.762995421886444"^^xsd:float ;
     nidm_equivalentZStatistic: "1.65861023655314"^^xsd:float ;
     nidm_pValueUncorrected: "0.0485971788535396"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5bb50d8540759ebdbe65ef922e6b9009
+niiri:19eeb0792f31b2212bb6d81c0bab4b01
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0179" ;
     nidm_coordinateVector: "[-12,-28,80]"^^xsd:string .
 
-niiri:fad858bb75eed0c28b072161552a6ba5 prov:wasDerivedFrom niiri:f6e36041fd68625d6c7813fe63387c51 .
+niiri:954abdec09c8dd4a4898bbfe748cfcd9 prov:wasDerivedFrom niiri:9d76bd2f2d73c5dfd99aa453786bb3d2 .
 

--- a/spmexport/ex_spm_partial_conjunction/nidm.ttl
+++ b/spmexport/ex_spm_partial_conjunction/nidm.ttl
@@ -1,0 +1,5500 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:040b09b9b063245a4737fca3df5cdd7d
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:81951937f6ae09441f641771cfea9128
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:cc2545342f68b7d4d79cd122b1fcabbb
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:cc2545342f68b7d4d79cd122b1fcabbb prov:wasAssociatedWith niiri:81951937f6ae09441f641771cfea9128 .
+
+_:blank5 a prov:Generation .
+
+niiri:040b09b9b063245a4737fca3df5cdd7d prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:11:58"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix spm_partialConjunctionDegree: <http://purl.org/nidash/spm#SPM_0000015> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070> .
+@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
+@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .
+@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .
+@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082> .
+@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .
+@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092> .
+@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
+@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
+
+niiri:ca46a12c6a6d80a84b02ee07a74d055c
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:4ddf2148145597f7f7c9369cb269b13f
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:1c3284ad8fc17300f53a85a850aa14b6
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:1a568ef0c2c5aa1a886880bbdf2d08f8
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:87e000d813ecf48e9045ac10927bd76c
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:29dae04876f55e477f52f60d27b0ce4d ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:1a568ef0c2c5aa1a886880bbdf2d08f8 ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:29dae04876f55e477f52f60d27b0ce4d
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:07c328d2e12fa56c0f2874230dfc8be8
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:a36c7399032b89af037fcdfdcf2d9f29
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:a36c7399032b89af037fcdfdcf2d9f29 prov:wasAssociatedWith niiri:ca46a12c6a6d80a84b02ee07a74d055c .
+
+niiri:a36c7399032b89af037fcdfdcf2d9f29 prov:used niiri:87e000d813ecf48e9045ac10927bd76c .
+
+niiri:a36c7399032b89af037fcdfdcf2d9f29 prov:used niiri:1c3284ad8fc17300f53a85a850aa14b6 .
+
+niiri:a36c7399032b89af037fcdfdcf2d9f29 prov:used niiri:07c328d2e12fa56c0f2874230dfc8be8 .
+
+niiri:297de961f206e0187be8fdda200091ee
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
+
+niiri:ec2656e975a6d0642c33357bfa356e4b
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
+
+niiri:297de961f206e0187be8fdda200091ee prov:wasDerivedFrom niiri:ec2656e975a6d0642c33357bfa356e4b .
+
+niiri:297de961f206e0187be8fdda200091ee prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:a354106ee78314547a9438f2bb2dee6c
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "108.038318634033"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
+
+niiri:a354106ee78314547a9438f2bb2dee6c prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:38c86177a556ef8eb57c8feb5a72bbe6
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+
+niiri:379fb8881957a95b855265fdeb2eae08
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f"^^xsd:string .
+
+niiri:38c86177a556ef8eb57c8feb5a72bbe6 prov:wasDerivedFrom niiri:379fb8881957a95b855265fdeb2eae08 .
+
+niiri:38c86177a556ef8eb57c8feb5a72bbe6 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:0640a7b36210753d2e9b544c3f195a55
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+
+niiri:6b197125a990fba281a71f02c3a45aac
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
+
+niiri:0640a7b36210753d2e9b544c3f195a55 prov:wasDerivedFrom niiri:6b197125a990fba281a71f02c3a45aac .
+
+niiri:0640a7b36210753d2e9b544c3f195a55 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:2d0fff51543ffad218594440febbbc00
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+
+niiri:2bcd6acc3147da711188ef3d9591491e
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb"^^xsd:string .
+
+niiri:2d0fff51543ffad218594440febbbc00 prov:wasDerivedFrom niiri:2bcd6acc3147da711188ef3d9591491e .
+
+niiri:2d0fff51543ffad218594440febbbc00 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:1e3dffce54f22bc8a196481235889e5a
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 4" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+
+niiri:59d5f854810e0cf53187fca482714676
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0004.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6"^^xsd:string .
+
+niiri:1e3dffce54f22bc8a196481235889e5a prov:wasDerivedFrom niiri:59d5f854810e0cf53187fca482714676 .
+
+niiri:1e3dffce54f22bc8a196481235889e5a prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:883679c50b07b857a6c67ccde5dc3273
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 5" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+
+niiri:0db23e51e95f52cb9f0539d9da712088
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0005.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff"^^xsd:string .
+
+niiri:883679c50b07b857a6c67ccde5dc3273 prov:wasDerivedFrom niiri:0db23e51e95f52cb9f0539d9da712088 .
+
+niiri:883679c50b07b857a6c67ccde5dc3273 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:67e0052a2914e6b58321e390f9d4a9ea
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 6" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+
+niiri:7654bad538105caaf15e55efcb04c343
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0006.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
+
+niiri:67e0052a2914e6b58321e390f9d4a9ea prov:wasDerivedFrom niiri:7654bad538105caaf15e55efcb04c343 .
+
+niiri:67e0052a2914e6b58321e390f9d4a9ea prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:a79b8d0835c3bf79e9faf32502e506b4
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8"^^xsd:string .
+
+niiri:28c03f1f4b9973dbb638d943ac9944e6
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81"^^xsd:string .
+
+niiri:a79b8d0835c3bf79e9faf32502e506b4 prov:wasDerivedFrom niiri:28c03f1f4b9973dbb638d943ac9944e6 .
+
+niiri:a79b8d0835c3bf79e9faf32502e506b4 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:089005ddd166a56358c0d0ec21720e18
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8"^^xsd:string .
+
+niiri:949f5e9e8329eea5ff262f3113b92d3c
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29"^^xsd:string .
+
+niiri:089005ddd166a56358c0d0ec21720e18 prov:wasDerivedFrom niiri:949f5e9e8329eea5ff262f3113b92d3c .
+
+niiri:089005ddd166a56358c0d0ec21720e18 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+
+niiri:6310b38d15cf70fcc0b18a630086f710
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    rdfs:label "Contrast: mr vs plain" ;
+    prov:value "[1, 1, -1, -1, 0, 0]"^^xsd:string .
+
+niiri:470a6da8f55eec239393f9743368624c
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation 1" .
+
+niiri:470a6da8f55eec239393f9743368624c prov:wasAssociatedWith niiri:ca46a12c6a6d80a84b02ee07a74d055c .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:297de961f206e0187be8fdda200091ee .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:a79b8d0835c3bf79e9faf32502e506b4 .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:87e000d813ecf48e9045ac10927bd76c .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:6310b38d15cf70fcc0b18a630086f710 .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:38c86177a556ef8eb57c8feb5a72bbe6 .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:0640a7b36210753d2e9b544c3f195a55 .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:2d0fff51543ffad218594440febbbc00 .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:1e3dffce54f22bc8a196481235889e5a .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:883679c50b07b857a6c67ccde5dc3273 .
+
+niiri:470a6da8f55eec239393f9743368624c prov:used niiri:67e0052a2914e6b58321e390f9d4a9ea .
+
+niiri:7512552d6509729de4464db02c1b2b85
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic_0001.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic_0001.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: mr vs plain" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "3d222abce9f360902d01cb45ffaaa3d711c699c6771f36ee61630ccc2fec2275897a15dd31b846a074e20b59337bae8b171223c15f22d8f2168a1967e85b397a"^^xsd:string .
+
+niiri:fb4dee4e1331d80c18561bf743daf272
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782"^^xsd:string .
+
+niiri:7512552d6509729de4464db02c1b2b85 prov:wasDerivedFrom niiri:fb4dee4e1331d80c18561bf743daf272 .
+
+niiri:7512552d6509729de4464db02c1b2b85 prov:wasGeneratedBy niiri:470a6da8f55eec239393f9743368624c .
+
+niiri:b4a484110c0e0f1679fe0a5f8bdff03e
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast_0001.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast_0001.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: mr vs plain" ;
+    nidm_contrastName: "mr vs plain"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5"^^xsd:string .
+
+niiri:1dd135affe7808067a99b5363be9574c
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28"^^xsd:string .
+
+niiri:b4a484110c0e0f1679fe0a5f8bdff03e prov:wasDerivedFrom niiri:1dd135affe7808067a99b5363be9574c .
+
+niiri:b4a484110c0e0f1679fe0a5f8bdff03e prov:wasGeneratedBy niiri:470a6da8f55eec239393f9743368624c .
+
+niiri:759cc611eb1badedf971eb0bbd3381ef
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError_0001.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError_0001.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b"^^xsd:string .
+
+niiri:759cc611eb1badedf971eb0bbd3381ef prov:wasGeneratedBy niiri:470a6da8f55eec239393f9743368624c .
+
+niiri:830506c8d8c91472fbeb134a312b9816
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
+    rdfs:label "Contrast: switch vs nonswitch (orth. w.r.t {1})" ;
+    prov:value "[0.953151930124911, -1.04684806987509, 1.04684806987509, -0.953151930124911, 0, 0]"^^xsd:string .
+
+niiri:d74adb2677a9d89623e02872d79aefab
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation 2" .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:wasAssociatedWith niiri:ca46a12c6a6d80a84b02ee07a74d055c .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:297de961f206e0187be8fdda200091ee .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:a79b8d0835c3bf79e9faf32502e506b4 .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:87e000d813ecf48e9045ac10927bd76c .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:830506c8d8c91472fbeb134a312b9816 .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:38c86177a556ef8eb57c8feb5a72bbe6 .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:0640a7b36210753d2e9b544c3f195a55 .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:2d0fff51543ffad218594440febbbc00 .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:1e3dffce54f22bc8a196481235889e5a .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:883679c50b07b857a6c67ccde5dc3273 .
+
+niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:67e0052a2914e6b58321e390f9d4a9ea .
+
+niiri:3847144ad5571b76c8855c604579438d
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic_0002.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic_0002.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: switch vs nonswitch (orth. w.r.t {1})" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "ec2f61dbf28ab2256a374dc5e3a93ba3a54e520c6bccd089dfbd07421e445b4881154433ea31e32587c1fae170daa5dc0a21f6efc328b90727d8d25bbd524e2f"^^xsd:string .
+
+niiri:d321a1053a1ad60011b5d0c936fced97
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0005.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "4a7d076c01440a170e048ebe9644f90193b2aaf1291f454bdc6be2cf17e11a66b1d177025f5ed77434afe780ff8dcba710ec41120246e38894f823eb0fd88621"^^xsd:string .
+
+niiri:3847144ad5571b76c8855c604579438d prov:wasDerivedFrom niiri:d321a1053a1ad60011b5d0c936fced97 .
+
+niiri:3847144ad5571b76c8855c604579438d prov:wasGeneratedBy niiri:d74adb2677a9d89623e02872d79aefab .
+
+niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast_0002.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast_0002.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: switch vs nonswitch (orth. w.r.t {1})" ;
+    nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "31a00f409f493fc214fe1f84fe2a799bb96d1e03d67f2ce5b8c5b5fdb934bb0005f1be68addb81934052af4643c3099542ea4944013e9346042a44c2ed8f3788"^^xsd:string .
+
+niiri:a98253404e56b8be6f3aecf1424cb0f4
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0005.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "6d92adc90c0045445b66064818fdae617474690e92e9cb332e73fa8bf27f6d1d18367c0648ffbc74196a5c2ce9f4af4186394628eed475a0e2866efe3d4eee9b"^^xsd:string .
+
+niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc prov:wasDerivedFrom niiri:a98253404e56b8be6f3aecf1424cb0f4 .
+
+niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc prov:wasGeneratedBy niiri:d74adb2677a9d89623e02872d79aefab .
+
+niiri:ec1657f37e3b226c40848c8427be67c3
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError_0002.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError_0002.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "ac87f548f0d92f929c05476d2aacbc7e5319da6d62a5585a72d714be836b1b86962a36c6d473ae84c17cd613d683976e9fc562d6d7692cb8e942966f71e34a08"^^xsd:string .
+
+niiri:ec1657f37e3b226c40848c8427be67c3 prov:wasGeneratedBy niiri:d74adb2677a9d89623e02872d79aefab .
+
+niiri:bcc964db0d0638d6cba59069ee9e794b
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.048771 (unc.)" ;
+    prov:value "0.0487705355732563"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:d7de198640509df2418dca3bf55b09d0 ;
+    nidm_equivalentThreshold: niiri:33a31ffbbf2d136c84bd8c001890f221 .
+
+niiri:d7de198640509df2418dca3bf55b09d0
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.761625168301108"^^xsd:float .
+
+niiri:33a31ffbbf2d136c84bd8c001890f221
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:f41b4c97497eeb8255330583a8825b93
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:22c0ec80ae0df81cd54796dadc1cfffb ;
+    nidm_equivalentThreshold: niiri:0b3f07f9fa7448b8eeed2625fdc5d588 .
+
+niiri:22c0ec80ae0df81cd54796dadc1cfffb
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:0b3f07f9fa7448b8eeed2625fdc5d588
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:a71a2dfa1ab66a64c9d2c36c5c2f03b1
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:074ce8c7927ae74cf34930d375480b95
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde
+    a prov:Activity, spm_PartialConjunctionInference ; 
+    rdfs:label " Partial Conjunction Inference" ;
+    spm_partialConjunctionDegree: "2"^^xsd:int .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:wasAssociatedWith niiri:ca46a12c6a6d80a84b02ee07a74d055c .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:bcc964db0d0638d6cba59069ee9e794b .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:f41b4c97497eeb8255330583a8825b93 .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:7512552d6509729de4464db02c1b2b85 .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:3847144ad5571b76c8855c604579438d .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:089005ddd166a56358c0d0ec21720e18 .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:297de961f206e0187be8fdda200091ee .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:a71a2dfa1ab66a64c9d2c36c5c2f03b1 .
+
+niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:074ce8c7927ae74cf34930d375480b95 .
+
+niiri:992e1b6a07509a3db325ed8f8bfff412
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
+    nidm_reselSizeInVoxels: "68.4409986586553"^^xsd:float ;
+    nidm_searchVolumeInResels: "2811.45809925534"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[5, 96.6116867805852, 900.100332657535, 2811.45809925534]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.16320607513012, 4.05765428344905, 4.05147708968699]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.32641215026024, 8.1153085668981, 8.10295417937398]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "42.8953324296065"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "329.33969238683"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "3.3473195251917"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "NaN"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "NaN"^^xsd:int ;
+    crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
+
+niiri:992e1b6a07509a3db325ed8f8bfff412 prov:wasGeneratedBy niiri:f5c1c82a9559f27878c8865f0d227dde .
+
+niiri:9315492073c635bc63a9934fefeda6b6
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "150"^^xsd:int ;
+    nidm_pValue: "1"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:e9451253b0a75869524801c98a6d921e ;
+    nidm_hasMaximumIntensityProjection: niiri:29a5a2562dde36cf7698f1dad4b98ea5 ;
+    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    crypto:sha512 "662dfeb3cba04a6a6beda3e1e23ff90c951f3ffae3d379b8fbfef06307db3055236586cace653593957e67f60c9dbbaadb5f3cc87c0ecc9dcfb81727d86f177f"^^xsd:string .
+
+niiri:e9451253b0a75869524801c98a6d921e
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:29a5a2562dde36cf7698f1dad4b98ea5
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:9315492073c635bc63a9934fefeda6b6 prov:wasGeneratedBy niiri:f5c1c82a9559f27878c8865f0d227dde .
+
+niiri:43fc9ecb30d51558da2aa2580905eaab
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0001" ;
+    nidm_clusterSizeInVoxels: "2637"^^xsd:int ;
+    nidm_clusterSizeInResels: "38.5295371441299"^^xsd:float ;
+    nidm_pValueUncorrected: "6.6293581341946e-09"^^xsd:float ;
+    nidm_pValueFWER: "2.1833083851952e-06"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "1"^^xsd:int .
+
+niiri:43fc9ecb30d51558da2aa2580905eaab prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:417cabd3eeb412117d20f4882d064567
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0002" ;
+    nidm_clusterSizeInVoxels: "1415"^^xsd:int ;
+    nidm_clusterSizeInResels: "20.6747421535623"^^xsd:float ;
+    nidm_pValueUncorrected: "3.97587518110427e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.0013085566013008"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "2"^^xsd:int .
+
+niiri:417cabd3eeb412117d20f4882d064567 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:6cc5ea3c57b906137def3d6777b0000f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0003" ;
+    nidm_clusterSizeInVoxels: "376"^^xsd:int ;
+    nidm_clusterSizeInResels: "5.49378307402079"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00585910744472404"^^xsd:float ;
+    nidm_pValueFWER: "0.854799051393012"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "3"^^xsd:int .
+
+niiri:6cc5ea3c57b906137def3d6777b0000f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c29516aed6cf24b95d9653e2365e0ced
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0004" ;
+    nidm_clusterSizeInVoxels: "128"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.87022402519857"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0816050965065906"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999997872"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "4"^^xsd:int .
+
+niiri:c29516aed6cf24b95d9653e2365e0ced prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:1c26e68b379e5bd715e75014cca849ab
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0005" ;
+    nidm_clusterSizeInVoxels: "31"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.452944881102778"^^xsd:float ;
+    nidm_pValueUncorrected: "0.377711191466036"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "5"^^xsd:int .
+
+niiri:1c26e68b379e5bd715e75014cca849ab prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:8b5d6e1bd5480bd6366d0094c92d4851
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0006" ;
+    nidm_clusterSizeInVoxels: "482"^^xsd:int ;
+    nidm_clusterSizeInResels: "7.04256234488835"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00232217436293709"^^xsd:float ;
+    nidm_pValueFWER: "0.5345656346398"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "6"^^xsd:int .
+
+niiri:8b5d6e1bd5480bd6366d0094c92d4851 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:7e631bc430702f08996bcc12a090f463
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0007" ;
+    nidm_clusterSizeInVoxels: "31"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.452944881102778"^^xsd:float ;
+    nidm_pValueUncorrected: "0.377711191466036"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "7"^^xsd:int .
+
+niiri:7e631bc430702f08996bcc12a090f463 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c21e2ede0b4f245e2d9f679a7862569e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0008" ;
+    nidm_clusterSizeInVoxels: "292"^^xsd:int ;
+    nidm_clusterSizeInResels: "4.26644855748423"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0130040406385965"^^xsd:float ;
+    nidm_pValueFWER: "0.986195307987511"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "8"^^xsd:int .
+
+niiri:c21e2ede0b4f245e2d9f679a7862569e prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c8c6cee0456ea9b67ae74c71ec73d58a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0009" ;
+    nidm_clusterSizeInVoxels: "454"^^xsd:int ;
+    nidm_clusterSizeInResels: "6.63345083937617"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00294388790129395"^^xsd:float ;
+    nidm_pValueFWER: "0.620742215844192"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "9"^^xsd:int .
+
+niiri:c8c6cee0456ea9b67ae74c71ec73d58a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0010" ;
+    nidm_clusterSizeInVoxels: "30"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.385747209296087"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "10"^^xsd:int .
+
+niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c8915bbac48c4a94d3bf54f07d28091a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0011" ;
+    nidm_clusterSizeInVoxels: "121"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.76794614882052"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0894880360135627"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999841"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "11"^^xsd:int .
+
+niiri:c8915bbac48c4a94d3bf54f07d28091a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:81f39aacce9db78e536cab5c96400969
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0012" ;
+    nidm_clusterSizeInVoxels: "152"^^xsd:int ;
+    nidm_clusterSizeInResels: "2.2208910299233"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0602023253747671"^^xsd:float ;
+    nidm_pValueFWER: "0.999999997549602"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "12"^^xsd:int .
+
+niiri:81f39aacce9db78e536cab5c96400969 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:95cfa48491de3b2db8a60dc29bdeb6af
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0013" ;
+    nidm_clusterSizeInVoxels: "118"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.72411277322993"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0931458632313952"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999952"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "13"^^xsd:int .
+
+niiri:95cfa48491de3b2db8a60dc29bdeb6af prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:e7fc37cb04d1a3f58136cfb12f992f34
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0014" ;
+    nidm_clusterSizeInVoxels: "41"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.599056133071416"^^xsd:float ;
+    nidm_pValueUncorrected: "0.309402133457245"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "14"^^xsd:int .
+
+niiri:e7fc37cb04d1a3f58136cfb12f992f34 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:de5b4d0f5d84034ba5fd7975873cc2e6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0015" ;
+    nidm_clusterSizeInVoxels: "53"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.774389635433782"^^xsd:float ;
+    nidm_pValueUncorrected: "0.248554717392983"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "15"^^xsd:int .
+
+niiri:de5b4d0f5d84034ba5fd7975873cc2e6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:1d6209037825fb7ee168299aa10d5ad7
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0016" ;
+    nidm_clusterSizeInVoxels: "38"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.555222757480825"^^xsd:float ;
+    nidm_pValueUncorrected: "0.32786058081731"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "16"^^xsd:int .
+
+niiri:1d6209037825fb7ee168299aa10d5ad7 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:b1918e5ede22fa7e1d3a1399a34a2d45
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0017" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160722377165502"^^xsd:float ;
+    nidm_pValueUncorrected: "0.613857878847171"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "17"^^xsd:int .
+
+niiri:b1918e5ede22fa7e1d3a1399a34a2d45 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:5d9799711b35085d7a8bcba1641700b1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0018" ;
+    nidm_clusterSizeInVoxels: "51"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.745167385040054"^^xsd:float ;
+    nidm_pValueUncorrected: "0.257471294871549"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "18"^^xsd:int .
+
+niiri:5d9799711b35085d7a8bcba1641700b1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:437180e47264cc4e09dc17b204fd0a89
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0019" ;
+    nidm_clusterSizeInVoxels: "24"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.350667004724731"^^xsd:float ;
+    nidm_pValueUncorrected: "0.440034324197539"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "19"^^xsd:int .
+
+niiri:437180e47264cc4e09dc17b204fd0a89 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:1cd87c105e9a1996f42e3171bad089a8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0020" ;
+    nidm_clusterSizeInVoxels: "19"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.277611378740412"^^xsd:float ;
+    nidm_pValueUncorrected: "0.495339905158013"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "20"^^xsd:int .
+
+niiri:1cd87c105e9a1996f42e3171bad089a8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:cc02b2de189bcf80b0afcbe487b0d1e8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0021" ;
+    nidm_clusterSizeInVoxels: "23"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.336055879527868"^^xsd:float ;
+    nidm_pValueUncorrected: "0.450256284065057"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "21"^^xsd:int .
+
+niiri:cc02b2de189bcf80b0afcbe487b0d1e8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:3ae2e3cf05ec7ac4b46544f268071134
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0022" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.073055625984319"^^xsd:float ;
+    nidm_pValueUncorrected: "0.749394292194427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "22"^^xsd:int .
+
+niiri:3ae2e3cf05ec7ac4b46544f268071134 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:3c84c74526e078ad8336fd968ec9d7f0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0023" ;
+    nidm_clusterSizeInVoxels: "20"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.483381408929991"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "23"^^xsd:int .
+
+niiri:3c84c74526e078ad8336fd968ec9d7f0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:8a1438a34faf87d03af2d9853b038bb2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0024" ;
+    nidm_clusterSizeInVoxels: "13"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.189944627559229"^^xsd:float ;
+    nidm_pValueUncorrected: "0.579562911476358"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "24"^^xsd:int .
+
+niiri:8a1438a34faf87d03af2d9853b038bb2 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:5aecd2a653cabfaff01cc936a5319173
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0025" ;
+    nidm_clusterSizeInVoxels: "42"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.61366725826828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.303579503022166"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "25"^^xsd:int .
+
+niiri:5aecd2a653cabfaff01cc936a5319173 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:04baa9610947313ff840ab800dc602ff
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0026" ;
+    nidm_clusterSizeInVoxels: "34"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.496778256693369"^^xsd:float ;
+    nidm_pValueUncorrected: "0.355060142353217"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "26"^^xsd:int .
+
+niiri:04baa9610947313ff840ab800dc602ff prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:bbf4ae108fc8903d38a040cb96a5f8c7
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0027" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.520844357026983"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "27"^^xsd:int .
+
+niiri:bbf4ae108fc8903d38a040cb96a5f8c7 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:4df2335aa8db3e5be136eacbcea883d6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0028" ;
+    nidm_clusterSizeInVoxels: "38"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.555222757480825"^^xsd:float ;
+    nidm_pValueUncorrected: "0.32786058081731"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "28"^^xsd:int .
+
+niiri:4df2335aa8db3e5be136eacbcea883d6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:9d79a6339d6f2901fb1cf662d6f17331
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0029" ;
+    nidm_clusterSizeInVoxels: "19"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.277611378740412"^^xsd:float ;
+    nidm_pValueUncorrected: "0.495339905158013"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "29"^^xsd:int .
+
+niiri:9d79a6339d6f2901fb1cf662d6f17331 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:b8abe2a725005d9ab6e1e988f192f41c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0030" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.520844357026983"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "30"^^xsd:int .
+
+niiri:b8abe2a725005d9ab6e1e988f192f41c prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:483de03930aa5641b0fe297f66f6c4ed
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0031" ;
+    nidm_clusterSizeInVoxels: "29"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.42372263070905"^^xsd:float ;
+    nidm_pValueUncorrected: "0.394046894825167"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "31"^^xsd:int .
+
+niiri:483de03930aa5641b0fe297f66f6c4ed prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:4f303edac6b82f93c47e1a6448e1cb52
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0032" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.073055625984319"^^xsd:float ;
+    nidm_pValueUncorrected: "0.749394292194427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "32"^^xsd:int .
+
+niiri:4f303edac6b82f93c47e1a6448e1cb52 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:d987cfa4a10011187d0a3eef178d5a46
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0033" ;
+    nidm_clusterSizeInVoxels: "37"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.540611632283961"^^xsd:float ;
+    nidm_pValueUncorrected: "0.334367142215632"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "33"^^xsd:int .
+
+niiri:d987cfa4a10011187d0a3eef178d5a46 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:98d187b5c539ea98df7343b0d0821b17
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0034" ;
+    nidm_clusterSizeInVoxels: "38"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.555222757480825"^^xsd:float ;
+    nidm_pValueUncorrected: "0.32786058081731"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "34"^^xsd:int .
+
+niiri:98d187b5c539ea98df7343b0d0821b17 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:5c38b60ed820b070d98e016bc1431008
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0035" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.520844357026983"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "35"^^xsd:int .
+
+niiri:5c38b60ed820b070d98e016bc1431008 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:a86e2297836b759380804c1713e267cd
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0036" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.11688900157491"^^xsd:float ;
+    nidm_pValueUncorrected: "0.673916689895827"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "36"^^xsd:int .
+
+niiri:a86e2297836b759380804c1713e267cd prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:f4ed594992095609e2ba62eca01c9faf
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0037" ;
+    nidm_clusterSizeInVoxels: "22"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.321444754331004"^^xsd:float ;
+    nidm_pValueUncorrected: "0.460870231738788"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "37"^^xsd:int .
+
+niiri:f4ed594992095609e2ba62eca01c9faf prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c8ce85b44b984de4fe78c06b64713bb8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0038" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.175333502362366"^^xsd:float ;
+    nidm_pValueUncorrected: "0.596225577050815"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "38"^^xsd:int .
+
+niiri:c8ce85b44b984de4fe78c06b64713bb8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:55d04469f144e7c5053124929003df79
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0039" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160722377165502"^^xsd:float ;
+    nidm_pValueUncorrected: "0.613857878847171"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "39"^^xsd:int .
+
+niiri:55d04469f144e7c5053124929003df79 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:895da0556b5b38697a9d4eacde3a587e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0040" ;
+    nidm_clusterSizeInVoxels: "23"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.336055879527868"^^xsd:float ;
+    nidm_pValueUncorrected: "0.450256284065057"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "40"^^xsd:int .
+
+niiri:895da0556b5b38697a9d4eacde3a587e prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:30470d6217b4a75fdd554906028c6670
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0041" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.175333502362366"^^xsd:float ;
+    nidm_pValueUncorrected: "0.596225577050815"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "41"^^xsd:int .
+
+niiri:30470d6217b4a75fdd554906028c6670 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:62c58cbe35737a64415ff840b7810e7d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0042" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102277876378047"^^xsd:float ;
+    nidm_pValueUncorrected: "0.69695451079807"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "42"^^xsd:int .
+
+niiri:62c58cbe35737a64415ff840b7810e7d prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:ec26c7d95e0c041f81b882cd245b0915
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0043" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "43"^^xsd:int .
+
+niiri:ec26c7d95e0c041f81b882cd245b0915 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:6750b72bbafd12ba75c6c383539599c6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0044" ;
+    nidm_clusterSizeInVoxels: "21"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.30683362913414"^^xsd:float ;
+    nidm_pValueUncorrected: "0.471902282658156"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "44"^^xsd:int .
+
+niiri:6750b72bbafd12ba75c6c383539599c6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:ccbc770b946f9dfd1beecfa8843cb3fd
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0045" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.721967329508528"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "45"^^xsd:int .
+
+niiri:ccbc770b946f9dfd1beecfa8843cb3fd prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:daf3e2ea8bf3273801d2e921f611a23f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0046" ;
+    nidm_clusterSizeInVoxels: "24"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.350667004724731"^^xsd:float ;
+    nidm_pValueUncorrected: "0.440034324197539"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "46"^^xsd:int .
+
+niiri:daf3e2ea8bf3273801d2e921f611a23f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:3df484ba108f4b88e1a4f123023bad18
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0047" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102277876378047"^^xsd:float ;
+    nidm_pValueUncorrected: "0.69695451079807"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "47"^^xsd:int .
+
+niiri:3df484ba108f4b88e1a4f123023bad18 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:0b63cbadf7d3234250fdc4f399321ae5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0048" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "48"^^xsd:int .
+
+niiri:0b63cbadf7d3234250fdc4f399321ae5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:16c6b9ef292ea8d86c2980e2bfee9806
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0049" ;
+    nidm_clusterSizeInVoxels: "19"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.277611378740412"^^xsd:float ;
+    nidm_pValueUncorrected: "0.495339905158013"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "49"^^xsd:int .
+
+niiri:16c6b9ef292ea8d86c2980e2bfee9806 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0050" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.160722377165502"^^xsd:float ;
+    nidm_pValueUncorrected: "0.613857878847171"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "50"^^xsd:int .
+
+niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:fb45985c130da20eafb7b2bc740e6b34
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0051" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.632579519337259"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "51"^^xsd:int .
+
+niiri:fb45985c130da20eafb7b2bc740e6b34 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:65722b667917e9f42cf82ee2175b666b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0052" ;
+    nidm_clusterSizeInVoxels: "17"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.248389128346685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.520844357026983"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "52"^^xsd:int .
+
+niiri:65722b667917e9f42cf82ee2175b666b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:59675618f95ad14de633584e8aa5881a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0053" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.77988160960367"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "53"^^xsd:int .
+
+niiri:59675618f95ad14de633584e8aa5881a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:2efe263e1c4f04d8ddb54023002360d9
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0054" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102277876378047"^^xsd:float ;
+    nidm_pValueUncorrected: "0.69695451079807"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "54"^^xsd:int .
+
+niiri:2efe263e1c4f04d8ddb54023002360d9 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:fa0929f452cd3f13857c087a02f6da1f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0055" ;
+    nidm_clusterSizeInVoxels: "16"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.233778003149821"^^xsd:float ;
+    nidm_pValueUncorrected: "0.534477368719457"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "55"^^xsd:int .
+
+niiri:fa0929f452cd3f13857c087a02f6da1f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:4c6401bfd1d939fec8234ff093a37d0d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0056" ;
+    nidm_clusterSizeInVoxels: "13"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.189944627559229"^^xsd:float ;
+    nidm_pValueUncorrected: "0.579562911476358"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "56"^^xsd:int .
+
+niiri:4c6401bfd1d939fec8234ff093a37d0d prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:b40302277817265d7af623887ab2e22c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0057" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.073055625984319"^^xsd:float ;
+    nidm_pValueUncorrected: "0.749394292194427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "57"^^xsd:int .
+
+niiri:b40302277817265d7af623887ab2e22c prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:e3091fadc7ff93e5e16f94b04590b938
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0058" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.721967329508528"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "58"^^xsd:int .
+
+niiri:e3091fadc7ff93e5e16f94b04590b938 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:e36b80790f32a55a90c503e6f29918bb
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0059" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.632579519337259"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "59"^^xsd:int .
+
+niiri:e36b80790f32a55a90c503e6f29918bb prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:6e8c86e4ccb82a0a6076eb58e14b07a6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0060" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "60"^^xsd:int .
+
+niiri:6e8c86e4ccb82a0a6076eb58e14b07a6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:42f7f7a26e0c7f6124775e7e757b315c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0061" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.77988160960367"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "61"^^xsd:int .
+
+niiri:42f7f7a26e0c7f6124775e7e757b315c prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:14ff66df771d191b9d2e8a3b0f78eda6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0062" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "62"^^xsd:int .
+
+niiri:14ff66df771d191b9d2e8a3b0f78eda6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:912e881f26994ef7af5c7f0b222db9ea
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0063" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.175333502362366"^^xsd:float ;
+    nidm_pValueUncorrected: "0.596225577050815"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "63"^^xsd:int .
+
+niiri:912e881f26994ef7af5c7f0b222db9ea prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:9a1887d93b55705b2ff04804a00c27c3
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0064" ;
+    nidm_clusterSizeInVoxels: "7"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.102277876378047"^^xsd:float ;
+    nidm_pValueUncorrected: "0.69695451079807"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "64"^^xsd:int .
+
+niiri:9a1887d93b55705b2ff04804a00c27c3 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:e6e6da4cb58bd6ee501d8b5597467832
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0065" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.77988160960367"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "65"^^xsd:int .
+
+niiri:e6e6da4cb58bd6ee501d8b5597467832 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0066" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "66"^^xsd:int .
+
+niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:949a7d86dacbe35af10b6aad92fe2224
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0067" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.721967329508528"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "67"^^xsd:int .
+
+niiri:949a7d86dacbe35af10b6aad92fe2224 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:6cc27bdc40320dac88fe94690c9a2006
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0068" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "68"^^xsd:int .
+
+niiri:6cc27bdc40320dac88fe94690c9a2006 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c04d4059d5535de349435e25559a51cf
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0069" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.11688900157491"^^xsd:float ;
+    nidm_pValueUncorrected: "0.673916689895827"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "69"^^xsd:int .
+
+niiri:c04d4059d5535de349435e25559a51cf prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:4b22fd081d5be6319a728e5343897301
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0070" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.073055625984319"^^xsd:float ;
+    nidm_pValueUncorrected: "0.749394292194427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "70"^^xsd:int .
+
+niiri:4b22fd081d5be6319a728e5343897301 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:f0f729dae8a39ee9247f706bc80f8df0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0071" ;
+    nidm_clusterSizeInVoxels: "9"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.131500126771774"^^xsd:float ;
+    nidm_pValueUncorrected: "0.652537593858019"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "71"^^xsd:int .
+
+niiri:f0f729dae8a39ee9247f706bc80f8df0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:cd47d3687de0d428289d5ee8d941860d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0072" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.77988160960367"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "72"^^xsd:int .
+
+niiri:cd47d3687de0d428289d5ee8d941860d prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:20959c12c3afc9ceb8477f395c0f1d11
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0073" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "73"^^xsd:int .
+
+niiri:20959c12c3afc9ceb8477f395c0f1d11 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:4eb3e8fe236fda4e725ee89c277cccc8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0074" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "74"^^xsd:int .
+
+niiri:4eb3e8fe236fda4e725ee89c277cccc8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0075" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "75"^^xsd:int .
+
+niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:4fad08e49bad24baddc3d418f97db0ce
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0076" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "76"^^xsd:int .
+
+niiri:4fad08e49bad24baddc3d418f97db0ce prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:d9eee0810d67b936a31fa3c66d2e8721
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0077" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "77"^^xsd:int .
+
+niiri:d9eee0810d67b936a31fa3c66d2e8721 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c8715267e94716796c464182b4ba6959
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0078" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "78"^^xsd:int .
+
+niiri:c8715267e94716796c464182b4ba6959 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:8f90bd7cc0deb45b7b7bd4b560274456
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0079" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "79"^^xsd:int .
+
+niiri:8f90bd7cc0deb45b7b7bd4b560274456 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:38f5a60345c88d7c9e0484d8735d5ffe
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0080" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "80"^^xsd:int .
+
+niiri:38f5a60345c88d7c9e0484d8735d5ffe prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:e6b43073ea58d734c57cff5767e3921f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0081" ;
+    nidm_clusterSizeInVoxels: "13"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.189944627559229"^^xsd:float ;
+    nidm_pValueUncorrected: "0.579562911476358"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "81"^^xsd:int .
+
+niiri:e6b43073ea58d734c57cff5767e3921f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:1cdb6dbe1bc79e13d52d0d3c171bab06
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0082" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "82"^^xsd:int .
+
+niiri:1cdb6dbe1bc79e13d52d0d3c171bab06 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:ee19df6f4d0113ba7e7f064a4048e753
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0083" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "83"^^xsd:int .
+
+niiri:ee19df6f4d0113ba7e7f064a4048e753 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:71af61a5c3e3beaf82f85e9971911d0f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0084" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "84"^^xsd:int .
+
+niiri:71af61a5c3e3beaf82f85e9971911d0f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:46c8b3f4803e6bb0b2862d8598ece061
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0085" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.175333502362366"^^xsd:float ;
+    nidm_pValueUncorrected: "0.596225577050815"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "85"^^xsd:int .
+
+niiri:46c8b3f4803e6bb0b2862d8598ece061 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:5e385b701ab7f21285e4ab5006f3b0cc
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0086" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "86"^^xsd:int .
+
+niiri:5e385b701ab7f21285e4ab5006f3b0cc prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:9b4e4e9b57eb3e981b1ba74aae8a7114
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0087" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.721967329508528"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "87"^^xsd:int .
+
+niiri:9b4e4e9b57eb3e981b1ba74aae8a7114 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:6d27ace5181c44103420a9d6058ab0d2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0088" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.073055625984319"^^xsd:float ;
+    nidm_pValueUncorrected: "0.749394292194427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "88"^^xsd:int .
+
+niiri:6d27ace5181c44103420a9d6058ab0d2 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:315d7b893c25221ef60daf1e43984066
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0089" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "89"^^xsd:int .
+
+niiri:315d7b893c25221ef60daf1e43984066 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:34f88b9c2c80714dbe516b3f7ef092bb
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0090" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.073055625984319"^^xsd:float ;
+    nidm_pValueUncorrected: "0.749394292194427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "90"^^xsd:int .
+
+niiri:34f88b9c2c80714dbe516b3f7ef092bb prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c07d0db5466c33ca960e3dd77f21333c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0091" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "91"^^xsd:int .
+
+niiri:c07d0db5466c33ca960e3dd77f21333c prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:90645273f08ccfc7b9bf300a122cc2af
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0092" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "92"^^xsd:int .
+
+niiri:90645273f08ccfc7b9bf300a122cc2af prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c12f0aee596eddb11ad8e3268c4eb077
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0093" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "93"^^xsd:int .
+
+niiri:c12f0aee596eddb11ad8e3268c4eb077 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:b74b40058d530ee5632e1df25f911065
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0094" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "94"^^xsd:int .
+
+niiri:b74b40058d530ee5632e1df25f911065 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:169fad64b64219293f6c913c296583bc
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0095" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "95"^^xsd:int .
+
+niiri:169fad64b64219293f6c913c296583bc prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c9ba05614242ea84b1cd6a9c5ec414e4
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0096" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "96"^^xsd:int .
+
+niiri:c9ba05614242ea84b1cd6a9c5ec414e4 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:be38e2f5b8c4edd116eb0a55684fdab2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0097" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "97"^^xsd:int .
+
+niiri:be38e2f5b8c4edd116eb0a55684fdab2 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:9506dd108b62896cd6d8225dfc0e2e59
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0098" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "98"^^xsd:int .
+
+niiri:9506dd108b62896cd6d8225dfc0e2e59 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:f404d574847ee68f9dc6bd08393bd9a1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0099" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0876667511811828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.721967329508528"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "99"^^xsd:int .
+
+niiri:f404d574847ee68f9dc6bd08393bd9a1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:99948f53ace7073cd3002a5850ecd361
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0100" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "100"^^xsd:int .
+
+niiri:99948f53ace7073cd3002a5850ecd361 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:c8c7dba5be58cecd8f14593ccfb69e4b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0101" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "101"^^xsd:int .
+
+niiri:c8c7dba5be58cecd8f14593ccfb69e4b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:a56ce0c60fde3ec8bf474d645a951d38
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0102" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "102"^^xsd:int .
+
+niiri:a56ce0c60fde3ec8bf474d645a951d38 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:82e02fb05b18c0c2a70d55d5e415aee5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0103" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "103"^^xsd:int .
+
+niiri:82e02fb05b18c0c2a70d55d5e415aee5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:8d8ac9fae20babb989f7c367a4c4a609
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0104" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.073055625984319"^^xsd:float ;
+    nidm_pValueUncorrected: "0.749394292194427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "104"^^xsd:int .
+
+niiri:8d8ac9fae20babb989f7c367a4c4a609 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:1a41584c1187bb4a87d3cc1af9993773
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0105" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "105"^^xsd:int .
+
+niiri:1a41584c1187bb4a87d3cc1af9993773 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:43ed38ee11c52db758569877faabd695
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0106" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "106"^^xsd:int .
+
+niiri:43ed38ee11c52db758569877faabd695 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:ee629aca5d18e60c2724bfd2e1b3fc6b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0107" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "107"^^xsd:int .
+
+niiri:ee629aca5d18e60c2724bfd2e1b3fc6b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:8b0a58d02f59556fa0151651c6d40cc0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0108" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "108"^^xsd:int .
+
+niiri:8b0a58d02f59556fa0151651c6d40cc0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:eeb7c0ae3047601cda9c179c68e75d65
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0109" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "109"^^xsd:int .
+
+niiri:eeb7c0ae3047601cda9c179c68e75d65 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:543214dac714341af8aeaa4b70f41266
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0110" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "110"^^xsd:int .
+
+niiri:543214dac714341af8aeaa4b70f41266 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:86191fa377232381128e79c2a57a4af6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0111" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "111"^^xsd:int .
+
+niiri:86191fa377232381128e79c2a57a4af6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:6f236184b94e16d3fb82cdd60cd19a6d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0112" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "112"^^xsd:int .
+
+niiri:6f236184b94e16d3fb82cdd60cd19a6d prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:9ae54c5470ad002b7ae47f7b67b248ad
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0113" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "113"^^xsd:int .
+
+niiri:9ae54c5470ad002b7ae47f7b67b248ad prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:0104fa6d88bd50793a3b65b47635e2c6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0114" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "114"^^xsd:int .
+
+niiri:0104fa6d88bd50793a3b65b47635e2c6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:1ff5ea3ca56fb13894e4e43c39a861c9
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0115" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.77988160960367"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "115"^^xsd:int .
+
+niiri:1ff5ea3ca56fb13894e4e43c39a861c9 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:9e02c41cd62cc06c92b5e2b56a706886
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0116" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "116"^^xsd:int .
+
+niiri:9e02c41cd62cc06c92b5e2b56a706886 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:a5e308239dff195e8c67ca5b964d553a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0117" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "117"^^xsd:int .
+
+niiri:a5e308239dff195e8c67ca5b964d553a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:aeffc3536799596ea12e2467fc52bd65
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0118" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "118"^^xsd:int .
+
+niiri:aeffc3536799596ea12e2467fc52bd65 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:3e987521ad9deca092879412707ea491
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0119" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "119"^^xsd:int .
+
+niiri:3e987521ad9deca092879412707ea491 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:f54f30ee52ac26f6dae0749e096ea6c1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0120" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "120"^^xsd:int .
+
+niiri:f54f30ee52ac26f6dae0749e096ea6c1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:692bc9543cbfc2b98e06dde4c8e7603f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0121" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "121"^^xsd:int .
+
+niiri:692bc9543cbfc2b98e06dde4c8e7603f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:be235801557e66b2190c98cd649588c0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0122" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "122"^^xsd:int .
+
+niiri:be235801557e66b2190c98cd649588c0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:baf9fc0b69478678bb8ed7430b24c094
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0123" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "123"^^xsd:int .
+
+niiri:baf9fc0b69478678bb8ed7430b24c094 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:27343a380f46da81b03903d4cf6193dc
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0124" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "124"^^xsd:int .
+
+niiri:27343a380f46da81b03903d4cf6193dc prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:158f1d535951e2b7d78ea10b066c15f3
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0125" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "125"^^xsd:int .
+
+niiri:158f1d535951e2b7d78ea10b066c15f3 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:842d2062c93ff252780aae9939a20111
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0126" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "126"^^xsd:int .
+
+niiri:842d2062c93ff252780aae9939a20111 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:d27fbf9c8044e6b188c300c4990f6f54
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0127" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "127"^^xsd:int .
+
+niiri:d27fbf9c8044e6b188c300c4990f6f54 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:2a4965b8fc709556c2aa1abb6adf5441
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0128" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "128"^^xsd:int .
+
+niiri:2a4965b8fc709556c2aa1abb6adf5441 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:9cc63018305b210a50122f137d979802
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0129" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0584445007874552"^^xsd:float ;
+    nidm_pValueUncorrected: "0.77988160960367"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "129"^^xsd:int .
+
+niiri:9cc63018305b210a50122f137d979802 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:965ac0d53ae837b608d6841eb6671ec5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0130" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "130"^^xsd:int .
+
+niiri:965ac0d53ae837b608d6841eb6671ec5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:d20a800c34ef4ebbc2c9d064007ca5a5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0131" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "131"^^xsd:int .
+
+niiri:d20a800c34ef4ebbc2c9d064007ca5a5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:0a26619869c6304390cf220d86997062
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0132" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "132"^^xsd:int .
+
+niiri:0a26619869c6304390cf220d86997062 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:6a5b8fb86c67c0eb5b9c606e6b810510
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0133" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "133"^^xsd:int .
+
+niiri:6a5b8fb86c67c0eb5b9c606e6b810510 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:99f3a2d8e7661135dd74892e7227bd72
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0134" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "134"^^xsd:int .
+
+niiri:99f3a2d8e7661135dd74892e7227bd72 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:64a5de9f75df294ee267e34b2597bc84
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0135" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "135"^^xsd:int .
+
+niiri:64a5de9f75df294ee267e34b2597bc84 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:2c98abbba202c2ed1fa8e08549a97cb1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0136" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0438333755905914"^^xsd:float ;
+    nidm_pValueUncorrected: "0.814463523065273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "136"^^xsd:int .
+
+niiri:2c98abbba202c2ed1fa8e08549a97cb1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:35bfc5987aa4a1eba01be33e4c1ee7f2
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0137" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "137"^^xsd:int .
+
+niiri:35bfc5987aa4a1eba01be33e4c1ee7f2 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:33395b862a603ee1373735759fed1bcb
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0138" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "138"^^xsd:int .
+
+niiri:33395b862a603ee1373735759fed1bcb prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:635a4fc24d89b14d261b42d568e53ac8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0139" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "139"^^xsd:int .
+
+niiri:635a4fc24d89b14d261b42d568e53ac8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:55b4eeddb69bb03436464cf696dd593b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0140" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0292222503937276"^^xsd:float ;
+    nidm_pValueUncorrected: "0.855031924102486"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "140"^^xsd:int .
+
+niiri:55b4eeddb69bb03436464cf696dd593b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:493898a476d4ce4bf533682e007422c5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0141" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "141"^^xsd:int .
+
+niiri:493898a476d4ce4bf533682e007422c5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:b841eb2677ab2ad59ce73103265cdee0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0142" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "142"^^xsd:int .
+
+niiri:b841eb2677ab2ad59ce73103265cdee0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:4c7ec0be40515b0eae812fe9befe02f1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0143" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "143"^^xsd:int .
+
+niiri:4c7ec0be40515b0eae812fe9befe02f1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0144" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "144"^^xsd:int .
+
+niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:9d494c09341573a6df3c044f6f353a5a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0145" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "145"^^xsd:int .
+
+niiri:9d494c09341573a6df3c044f6f353a5a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:630ac6074dee24b42295002659ee6cd4
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0146" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "146"^^xsd:int .
+
+niiri:630ac6074dee24b42295002659ee6cd4 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:97f9982dca21f34e7ea0fcb977fcf50b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0147" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "147"^^xsd:int .
+
+niiri:97f9982dca21f34e7ea0fcb977fcf50b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:b7588b8a823a7341bbdb4d3e8686e040
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0148" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "148"^^xsd:int .
+
+niiri:b7588b8a823a7341bbdb4d3e8686e040 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:31b704c584e2aae3b394c52754216fae
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0149" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "149"^^xsd:int .
+
+niiri:31b704c584e2aae3b394c52754216fae prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:2eff95031f5301f6a29990e69708dce1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0150" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0146111251968638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.906048723849963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "150"^^xsd:int .
+
+niiri:2eff95031f5301f6a29990e69708dce1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+
+niiri:47e960742a534223746b8914f30df973
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0001" ;
+    prov:atLocation niiri:7ffeabdba971025768378cc6c32ca5fe ;
+    prov:value "2.18819689750671"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.5114661254844"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000222821126723893"^^xsd:float ;
+    nidm_pValueFWER: "0.999999868311968"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:7ffeabdba971025768378cc6c32ca5fe
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0001" ;
+    nidm_coordinateVector: "[-28,24,4]"^^xsd:string .
+
+niiri:47e960742a534223746b8914f30df973 prov:wasDerivedFrom niiri:43fc9ecb30d51558da2aa2580905eaab .
+
+niiri:78e2d8c40d6e4600a75cdea76efced8c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0002" ;
+    prov:atLocation niiri:35dde01361b1ceeb6c6b77cfaa742ec4 ;
+    prov:value "2.07190132141113"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.35835159739265"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000392044053194152"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999969126"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:35dde01361b1ceeb6c6b77cfaa742ec4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0002" ;
+    nidm_coordinateVector: "[-28,26,12]"^^xsd:string .
+
+niiri:78e2d8c40d6e4600a75cdea76efced8c prov:wasDerivedFrom niiri:43fc9ecb30d51558da2aa2580905eaab .
+
+niiri:dc356018e062c59172dcd1e78418a358
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0003" ;
+    prov:atLocation niiri:eb6d8af6a185c83b9c38e3a1630a4622 ;
+    prov:value "1.94285821914673"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.18853089402481"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000714988643396364"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:eb6d8af6a185c83b9c38e3a1630a4622
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0003" ;
+    nidm_coordinateVector: "[-42,20,36]"^^xsd:string .
+
+niiri:dc356018e062c59172dcd1e78418a358 prov:wasDerivedFrom niiri:43fc9ecb30d51558da2aa2580905eaab .
+
+niiri:59f453279ae60b2e7633608a74b392af
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0004" ;
+    prov:atLocation niiri:8613dd8cea932331a073b148edfe5144 ;
+    prov:value "2.1167094707489"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.41734061195353"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000316180548517564"^^xsd:float ;
+    nidm_pValueFWER: "0.999999998897938"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:8613dd8cea932331a073b148edfe5144
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0004" ;
+    nidm_coordinateVector: "[36,-84,2]"^^xsd:string .
+
+niiri:59f453279ae60b2e7633608a74b392af prov:wasDerivedFrom niiri:417cabd3eeb412117d20f4882d064567 .
+
+niiri:30c43a8440f4ec3cda96fcd40be4d4d5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0005" ;
+    prov:atLocation niiri:c5988d123290f51d40d4592a7961f1d1 ;
+    prov:value "2.00524592399597"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.27061943294259"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000536561087325027"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999999994"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:c5988d123290f51d40d4592a7961f1d1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0005" ;
+    nidm_coordinateVector: "[34,-84,14]"^^xsd:string .
+
+niiri:30c43a8440f4ec3cda96fcd40be4d4d5 prov:wasDerivedFrom niiri:417cabd3eeb412117d20f4882d064567 .
+
+niiri:7188131da5a3b3086de0052afecc1b23
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0006" ;
+    prov:atLocation niiri:8014c5c8b33dfb4ba42f7cc5ed169849 ;
+    prov:value "1.9834691286087"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.24196265203981"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000593547891254209"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999994"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:8014c5c8b33dfb4ba42f7cc5ed169849
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0006" ;
+    nidm_coordinateVector: "[34,-78,36]"^^xsd:string .
+
+niiri:7188131da5a3b3086de0052afecc1b23 prov:wasDerivedFrom niiri:417cabd3eeb412117d20f4882d064567 .
+
+niiri:12ddd7ac78265e0515a406f79cd7b60b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0007" ;
+    prov:atLocation niiri:4f09bb3884a3beab368df1e4cbdd6c5a ;
+    prov:value "2.07622194290161"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.36403923290147"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000384053116980865"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999955495"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:4f09bb3884a3beab368df1e4cbdd6c5a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0007" ;
+    nidm_coordinateVector: "[52,48,12]"^^xsd:string .
+
+niiri:12ddd7ac78265e0515a406f79cd7b60b prov:wasDerivedFrom niiri:6cc5ea3c57b906137def3d6777b0000f .
+
+niiri:a8daaa449eaabd54146c2443c52b2405
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0008" ;
+    prov:atLocation niiri:ced65fab2ecc31645054de6698a6e193 ;
+    prov:value "2.0327205657959"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.306778623673"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000471877215462824"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999097"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ced65fab2ecc31645054de6698a6e193
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0008" ;
+    nidm_coordinateVector: "[30,68,12]"^^xsd:string .
+
+niiri:a8daaa449eaabd54146c2443c52b2405 prov:wasDerivedFrom niiri:6cc5ea3c57b906137def3d6777b0000f .
+
+niiri:073f17f5ff09cc49a92a3da9639c7ec8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0009" ;
+    prov:atLocation niiri:9e58a2008800aed167f2193e6475edaa ;
+    prov:value "1.63326919078827"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.78184273056811"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00270256128658664"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:9e58a2008800aed167f2193e6475edaa
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0009" ;
+    nidm_coordinateVector: "[14,74,6]"^^xsd:string .
+
+niiri:073f17f5ff09cc49a92a3da9639c7ec8 prov:wasDerivedFrom niiri:6cc5ea3c57b906137def3d6777b0000f .
+
+niiri:d0393b0ebc9411a5d45ca86b90a5f75a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0010" ;
+    prov:atLocation niiri:32c57c9426babf3fe0244d15351d0daf ;
+    prov:value "2.04988360404968"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.32936904595179"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000435214929046523"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999995547"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:32c57c9426babf3fe0244d15351d0daf
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0010" ;
+    nidm_coordinateVector: "[34,-54,52]"^^xsd:string .
+
+niiri:d0393b0ebc9411a5d45ca86b90a5f75a prov:wasDerivedFrom niiri:c29516aed6cf24b95d9653e2365e0ced .
+
+niiri:603843b40d6d98501a421775119d3ad1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0011" ;
+    prov:atLocation niiri:fcdba63eb7662475636125721f54320e ;
+    prov:value "1.17590498924255"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.18553018514689"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0144249976129074"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:fcdba63eb7662475636125721f54320e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0011" ;
+    nidm_coordinateVector: "[26,-48,50]"^^xsd:string .
+
+niiri:603843b40d6d98501a421775119d3ad1 prov:wasDerivedFrom niiri:c29516aed6cf24b95d9653e2365e0ced .
+
+niiri:16b2952800d349d84a763795197c8b0b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0012" ;
+    prov:atLocation niiri:ac144f9a90591900cfb49f146349a1b8 ;
+    prov:value "1.17325437068939"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.18210185402812"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0145510082060974"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ac144f9a90591900cfb49f146349a1b8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0012" ;
+    nidm_coordinateVector: "[32,-54,62]"^^xsd:string .
+
+niiri:16b2952800d349d84a763795197c8b0b prov:wasDerivedFrom niiri:c29516aed6cf24b95d9653e2365e0ced .
+
+niiri:d7a85cf00dbcad11964be5f20d4b99ff
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0013" ;
+    prov:atLocation niiri:0de0e683dce5cc8a49c6c73eedac8c40 ;
+    prov:value "1.69681537151337"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.86519802999163"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00208374267085354"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:0de0e683dce5cc8a49c6c73eedac8c40
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0013" ;
+    nidm_coordinateVector: "[-28,50,36]"^^xsd:string .
+
+niiri:d7a85cf00dbcad11964be5f20d4b99ff prov:wasDerivedFrom niiri:1c26e68b379e5bd715e75014cca849ab .
+
+niiri:90e0ff48a341c849ccd5b511385d366a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0014" ;
+    prov:atLocation niiri:c1f676e8a11713f1a14d11da4d4c21cd ;
+    prov:value "0.933988809585571"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.8747737054388"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0304119310280364"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:c1f676e8a11713f1a14d11da4d4c21cd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0014" ;
+    nidm_coordinateVector: "[-46,38,30]"^^xsd:string .
+
+niiri:90e0ff48a341c849ccd5b511385d366a prov:wasDerivedFrom niiri:1c26e68b379e5bd715e75014cca849ab .
+
+niiri:d405f97c1debf6dfef53e4c341960b1c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0015" ;
+    prov:atLocation niiri:bac6269bd3bba27583f4d36c34dcbaf1 ;
+    prov:value "1.66940176486969"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.82922911554701"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00233301407977504"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:bac6269bd3bba27583f4d36c34dcbaf1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0015" ;
+    nidm_coordinateVector: "[16,-94,-30]"^^xsd:string .
+
+niiri:d405f97c1debf6dfef53e4c341960b1c prov:wasDerivedFrom niiri:8b5d6e1bd5480bd6366d0094c92d4851 .
+
+niiri:4e793a27eff6bd141a437820cd72dd10
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0016" ;
+    prov:atLocation niiri:02f3a870411865e426e29828e46ed3f9 ;
+    prov:value "1.5886458158493"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.72335979311329"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00323108192435606"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:02f3a870411865e426e29828e46ed3f9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0016" ;
+    nidm_coordinateVector: "[24,-92,-30]"^^xsd:string .
+
+niiri:4e793a27eff6bd141a437820cd72dd10 prov:wasDerivedFrom niiri:8b5d6e1bd5480bd6366d0094c92d4851 .
+
+niiri:7eccc401f6068789908f149147981921
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0017" ;
+    prov:atLocation niiri:371d66a66b29fdb967d17dd294dfe6e3 ;
+    prov:value "1.51174938678741"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.62269482082508"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00436186877852962"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:371d66a66b29fdb967d17dd294dfe6e3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0017" ;
+    nidm_coordinateVector: "[34,-84,-48]"^^xsd:string .
+
+niiri:7eccc401f6068789908f149147981921 prov:wasDerivedFrom niiri:8b5d6e1bd5480bd6366d0094c92d4851 .
+
+niiri:bc7a7d099b4aa5c027485a3f6e273f75
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0018" ;
+    prov:atLocation niiri:05b822162b985baea86f5f76eaf274eb ;
+    prov:value "1.6600536108017"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.81696686061887"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00242397637898328"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:05b822162b985baea86f5f76eaf274eb
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0018" ;
+    nidm_coordinateVector: "[-44,-56,-32]"^^xsd:string .
+
+niiri:bc7a7d099b4aa5c027485a3f6e273f75 prov:wasDerivedFrom niiri:7e631bc430702f08996bcc12a090f463 .
+
+niiri:5d6079cd009bcfed9d07102c8bf1cd64
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0019" ;
+    prov:atLocation niiri:b5301e158adbbc221d5e73c472172d3e ;
+    prov:value "1.5787501335144"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.71039687336073"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00336013715292427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:b5301e158adbbc221d5e73c472172d3e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0019" ;
+    nidm_coordinateVector: "[-10,72,0]"^^xsd:string .
+
+niiri:5d6079cd009bcfed9d07102c8bf1cd64 prov:wasDerivedFrom niiri:c21e2ede0b4f245e2d9f679a7862569e .
+
+niiri:67a82cc3c6fe87003f709a11853632a1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0020" ;
+    prov:atLocation niiri:be6a1b05017c497d1872f0ed60f8f931 ;
+    prov:value "1.37760043144226"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.44750858968075"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0071923848185762"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:be6a1b05017c497d1872f0ed60f8f931
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0020" ;
+    nidm_coordinateVector: "[-24,68,10]"^^xsd:string .
+
+niiri:67a82cc3c6fe87003f709a11853632a1 prov:wasDerivedFrom niiri:c21e2ede0b4f245e2d9f679a7862569e .
+
+niiri:8fbbec051d375de1ec30261a1f32f9a5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0021" ;
+    prov:atLocation niiri:9d8f2d489780f5c4762d7ff3891155a2 ;
+    prov:value "1.35886359214783"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.42309168524595"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00769452108984159"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:9d8f2d489780f5c4762d7ff3891155a2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0021" ;
+    nidm_coordinateVector: "[-14,64,28]"^^xsd:string .
+
+niiri:8fbbec051d375de1ec30261a1f32f9a5 prov:wasDerivedFrom niiri:c21e2ede0b4f245e2d9f679a7862569e .
+
+niiri:722e903ee5178a4981cc55266210bd89
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0022" ;
+    prov:atLocation niiri:9f719f92694484cd7261b1c6255b52c0 ;
+    prov:value "1.53290164470673"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.65036951622375"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00402018893002576"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:9f719f92694484cd7261b1c6255b52c0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0022" ;
+    nidm_coordinateVector: "[-32,-80,10]"^^xsd:string .
+
+niiri:722e903ee5178a4981cc55266210bd89 prov:wasDerivedFrom niiri:c8c6cee0456ea9b67ae74c71ec73d58a .
+
+niiri:43c73ccd4ff874b4159d8e343817709e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0023" ;
+    prov:atLocation niiri:d6269808ee48c8a2f54e9d917e97a97d ;
+    prov:value "1.34681856632233"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.4074027844201"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00803321955273906"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:d6269808ee48c8a2f54e9d917e97a97d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0023" ;
+    nidm_coordinateVector: "[-32,-88,8]"^^xsd:string .
+
+niiri:43c73ccd4ff874b4159d8e343817709e prov:wasDerivedFrom niiri:c8c6cee0456ea9b67ae74c71ec73d58a .
+
+niiri:5b402b3505886d69eee1da65259dfff5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0024" ;
+    prov:atLocation niiri:e3be3bddf8e8cf2bc774db0b5fd4ccf9 ;
+    prov:value "1.31222748756409"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.36238178325093"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00907896581463363"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:e3be3bddf8e8cf2bc774db0b5fd4ccf9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0024" ;
+    nidm_coordinateVector: "[-30,-78,26]"^^xsd:string .
+
+niiri:5b402b3505886d69eee1da65259dfff5 prov:wasDerivedFrom niiri:c8c6cee0456ea9b67ae74c71ec73d58a .
+
+niiri:5516b5835629ab543345d78e4c6e7f84
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0025" ;
+    prov:atLocation niiri:5fa024f29ffd7dd65df2521965746c10 ;
+    prov:value "1.47698056697845"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.57723307746183"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00497973845037369"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:5fa024f29ffd7dd65df2521965746c10
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0025" ;
+    nidm_coordinateVector: "[24,-64,62]"^^xsd:string .
+
+niiri:5516b5835629ab543345d78e4c6e7f84 prov:wasDerivedFrom niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5 .
+
+niiri:b0048f0b19299e2890e2feec137562bd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0026" ;
+    prov:atLocation niiri:dfffa57a27812cbdb97937c604ce644d ;
+    prov:value "1.47098410129547"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.56939616988394"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00509379579800051"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:dfffa57a27812cbdb97937c604ce644d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0026" ;
+    nidm_coordinateVector: "[42,2,42]"^^xsd:string .
+
+niiri:b0048f0b19299e2890e2feec137562bd prov:wasDerivedFrom niiri:c8915bbac48c4a94d3bf54f07d28091a .
+
+niiri:44cc0c30dff2ae8e59814059b0d808d8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0027" ;
+    prov:atLocation niiri:9cfb25b1548c7ea2a37d91c1cdc97937 ;
+    prov:value "1.28529334068298"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.32736401858338"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00997294956075112"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:9cfb25b1548c7ea2a37d91c1cdc97937
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0027" ;
+    nidm_coordinateVector: "[52,6,36]"^^xsd:string .
+
+niiri:44cc0c30dff2ae8e59814059b0d808d8 prov:wasDerivedFrom niiri:c8915bbac48c4a94d3bf54f07d28091a .
+
+niiri:8f81caeadc613b2befe266e538a005b4
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0028" ;
+    prov:atLocation niiri:192ea9c42130b9f2836346385ffa8ac6 ;
+    prov:value "1.46635723114014"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.56334999311601"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00518337435668992"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:192ea9c42130b9f2836346385ffa8ac6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0028" ;
+    nidm_coordinateVector: "[-28,-60,54]"^^xsd:string .
+
+niiri:8f81caeadc613b2befe266e538a005b4 prov:wasDerivedFrom niiri:81f39aacce9db78e536cab5c96400969 .
+
+niiri:49b88a38ee8eb23aa88417b585a3c019
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0029" ;
+    prov:atLocation niiri:2e4756a1fc7f488d50c7e456c8606411 ;
+    prov:value "1.35919630527496"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.42352513638295"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00768534474692273"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:2e4756a1fc7f488d50c7e456c8606411
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0029" ;
+    nidm_coordinateVector: "[-30,-56,62]"^^xsd:string .
+
+niiri:49b88a38ee8eb23aa88417b585a3c019 prov:wasDerivedFrom niiri:81f39aacce9db78e536cab5c96400969 .
+
+niiri:d526e3755e8ee1eb281731fad0d751f7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0030" ;
+    prov:atLocation niiri:7f8d1d4f81b26e2e937ef2c6c7065a2f ;
+    prov:value "1.3043509721756"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.35213781333103"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00933292892535331"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:7f8d1d4f81b26e2e937ef2c6c7065a2f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0030" ;
+    nidm_coordinateVector: "[-18,-62,52]"^^xsd:string .
+
+niiri:d526e3755e8ee1eb281731fad0d751f7 prov:wasDerivedFrom niiri:81f39aacce9db78e536cab5c96400969 .
+
+niiri:803b5b1f8348b033ada171621cc5c167
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0031" ;
+    prov:atLocation niiri:a13a3d48a1429418bba0b99d4e9725bb ;
+    prov:value "1.45064067840576"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.54281750257153"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00549813229675677"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:a13a3d48a1429418bba0b99d4e9725bb
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0031" ;
+    nidm_coordinateVector: "[-30,-84,-48]"^^xsd:string .
+
+niiri:803b5b1f8348b033ada171621cc5c167 prov:wasDerivedFrom niiri:95cfa48491de3b2db8a60dc29bdeb6af .
+
+niiri:10252df0ea1e4565a8207dad73957039
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0032" ;
+    prov:atLocation niiri:6e55e818af807eb11d9ab4e1a7d892a8 ;
+    prov:value "1.37874686717987"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.44900302114624"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00716261232865922"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:6e55e818af807eb11d9ab4e1a7d892a8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0032" ;
+    nidm_coordinateVector: "[-22,-84,-50]"^^xsd:string .
+
+niiri:10252df0ea1e4565a8207dad73957039 prov:wasDerivedFrom niiri:95cfa48491de3b2db8a60dc29bdeb6af .
+
+niiri:1b619cb22a788dbfcac8e6547b8cf9c3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0033" ;
+    prov:atLocation niiri:a196ba726a6cf6e1af92ce4f926bddd6 ;
+    prov:value "1.1024569272995"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.09070134301333"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0182774222681363"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:a196ba726a6cf6e1af92ce4f926bddd6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0033" ;
+    nidm_coordinateVector: "[-24,-90,-42]"^^xsd:string .
+
+niiri:1b619cb22a788dbfcac8e6547b8cf9c3 prov:wasDerivedFrom niiri:95cfa48491de3b2db8a60dc29bdeb6af .
+
+niiri:e7bccdc00c0d8eba721b2ada820c74eb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0034" ;
+    prov:atLocation niiri:07a292d3fca36fc7398026cd440e98ff ;
+    prov:value "1.43723428249359"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.52530953068747"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00577982121839438"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:07a292d3fca36fc7398026cd440e98ff
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0034" ;
+    nidm_coordinateVector: "[-24,40,46]"^^xsd:string .
+
+niiri:e7bccdc00c0d8eba721b2ada820c74eb prov:wasDerivedFrom niiri:e7fc37cb04d1a3f58136cfb12f992f34 .
+
+niiri:b04044222ee790cf55bdaa521739b13d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0035" ;
+    prov:atLocation niiri:ee1d4ec9c2f0fec55c6dd0053012c88a ;
+    prov:value "1.11286687850952"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.10411930550185"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0176840206088169"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ee1d4ec9c2f0fec55c6dd0053012c88a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0035" ;
+    nidm_coordinateVector: "[-16,50,46]"^^xsd:string .
+
+niiri:b04044222ee790cf55bdaa521739b13d prov:wasDerivedFrom niiri:e7fc37cb04d1a3f58136cfb12f992f34 .
+
+niiri:2d1b96b3d3613decbd596f70088a278e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0036" ;
+    prov:atLocation niiri:e1970f3d88404b41f93f350066b20ee5 ;
+    prov:value "1.42738270759583"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.51244786328393"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00599484099495173"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:e1970f3d88404b41f93f350066b20ee5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0036" ;
+    nidm_coordinateVector: "[40,32,42]"^^xsd:string .
+
+niiri:2d1b96b3d3613decbd596f70088a278e prov:wasDerivedFrom niiri:de5b4d0f5d84034ba5fd7975873cc2e6 .
+
+niiri:7cd243c2f0efa2926ee101eb0ddaa71f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0037" ;
+    prov:atLocation niiri:2d93df4bc1c8bdc309f561183cf1d559 ;
+    prov:value "1.05634605884552"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.03136304442869"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0211090901815698"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:2d93df4bc1c8bdc309f561183cf1d559
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0037" ;
+    nidm_coordinateVector: "[38,40,36]"^^xsd:string .
+
+niiri:7cd243c2f0efa2926ee101eb0ddaa71f prov:wasDerivedFrom niiri:de5b4d0f5d84034ba5fd7975873cc2e6 .
+
+niiri:af520ea7a2b622b616f138da20521f11
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0038" ;
+    prov:atLocation niiri:25eebb30f786b56bc44db03461f48217 ;
+    prov:value "1.40870463848114"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.4880722231724"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00642188235953201"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:25eebb30f786b56bc44db03461f48217
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0038" ;
+    nidm_coordinateVector: "[-42,-84,-6]"^^xsd:string .
+
+niiri:af520ea7a2b622b616f138da20521f11 prov:wasDerivedFrom niiri:1d6209037825fb7ee168299aa10d5ad7 .
+
+niiri:1296043c9bfe3127d5cc76c217e1e26d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0039" ;
+    prov:atLocation niiri:21698b9502c51709153adfed9abb8986 ;
+    prov:value "1.13220155239105"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.12906102075628"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0166246060871375"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:21698b9502c51709153adfed9abb8986
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0039" ;
+    nidm_coordinateVector: "[-50,-78,0]"^^xsd:string .
+
+niiri:1296043c9bfe3127d5cc76c217e1e26d prov:wasDerivedFrom niiri:1d6209037825fb7ee168299aa10d5ad7 .
+
+niiri:23d6198c7c453ccfbd7fb701c34b6e26
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0040" ;
+    prov:atLocation niiri:28a96db39c58e234af2cc132fa98f4bc ;
+    prov:value "1.34917068481445"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.41046599292312"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00796607827138629"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:28a96db39c58e234af2cc132fa98f4bc
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0040" ;
+    nidm_coordinateVector: "[12,-20,80]"^^xsd:string .
+
+niiri:23d6198c7c453ccfbd7fb701c34b6e26 prov:wasDerivedFrom niiri:b1918e5ede22fa7e1d3a1399a34a2d45 .
+
+niiri:2b724527e8d3c9b6e97424cd9b8d15aa
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0041" ;
+    prov:atLocation niiri:42b34ad9cce6394b101fbaa08a07f29f ;
+    prov:value "1.34354746341705"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.40314315325023"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0081274114265858"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:42b34ad9cce6394b101fbaa08a07f29f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0041" ;
+    nidm_coordinateVector: "[18,48,44]"^^xsd:string .
+
+niiri:2b724527e8d3c9b6e97424cd9b8d15aa prov:wasDerivedFrom niiri:5d9799711b35085d7a8bcba1641700b1 .
+
+niiri:4de941e56885958a7463bfabb4b85cf9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0042" ;
+    prov:atLocation niiri:91689c74edc5692bdf656cdf4e590451 ;
+    prov:value "1.14962959289551"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.15156492154198"^^xsd:float ;
+    nidm_pValueUncorrected: "0.015715818709074"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:91689c74edc5692bdf656cdf4e590451
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0042" ;
+    nidm_coordinateVector: "[8,52,46]"^^xsd:string .
+
+niiri:4de941e56885958a7463bfabb4b85cf9 prov:wasDerivedFrom niiri:5d9799711b35085d7a8bcba1641700b1 .
+
+niiri:2a1e41375178ee6048cfe473ad850d9d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0043" ;
+    prov:atLocation niiri:d103ae494461197404d4d98c94ab55d0 ;
+    prov:value "1.33556091785431"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.39274498818401"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00836142979663967"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:d103ae494461197404d4d98c94ab55d0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0043" ;
+    nidm_coordinateVector: "[64,-52,2]"^^xsd:string .
+
+niiri:2a1e41375178ee6048cfe473ad850d9d prov:wasDerivedFrom niiri:437180e47264cc4e09dc17b204fd0a89 .
+
+niiri:b2e28fc4cb7873bae7dfcec9c622a9c0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0044" ;
+    prov:atLocation niiri:d4322ad7c793d679b708c35788e9eb73 ;
+    prov:value "1.30518817901611"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.35322652463791"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00930564616578244"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:d4322ad7c793d679b708c35788e9eb73
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0044" ;
+    nidm_coordinateVector: "[26,-74,-30]"^^xsd:string .
+
+niiri:b2e28fc4cb7873bae7dfcec9c622a9c0 prov:wasDerivedFrom niiri:1cd87c105e9a1996f42e3171bad089a8 .
+
+niiri:4957f8f40371d5539e9b85697134e63f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0045" ;
+    prov:atLocation niiri:5e9202a8879f71e2067d4c3d52dedb20 ;
+    prov:value "1.30020189285278"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.34674279460019"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00946916148556731"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:5e9202a8879f71e2067d4c3d52dedb20
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0045" ;
+    nidm_coordinateVector: "[-44,-82,-34]"^^xsd:string .
+
+niiri:4957f8f40371d5539e9b85697134e63f prov:wasDerivedFrom niiri:cc02b2de189bcf80b0afcbe487b0d1e8 .
+
+niiri:6c2bd69486f6f2fc98bdad9a9249cde9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0046" ;
+    prov:atLocation niiri:372619818a34b671fccfef60836977b8 ;
+    prov:value "1.2840074300766"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.32569303609441"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0100174661332294"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:372619818a34b671fccfef60836977b8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0046" ;
+    nidm_coordinateVector: "[-6,62,36]"^^xsd:string .
+
+niiri:6c2bd69486f6f2fc98bdad9a9249cde9 prov:wasDerivedFrom niiri:3ae2e3cf05ec7ac4b46544f268071134 .
+
+niiri:8bc88f0d5c04e29ab34863cd24e68863
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0047" ;
+    prov:atLocation niiri:ce40992a0b5e259f1b43758c5d68ea28 ;
+    prov:value "1.26505351066589"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.30107272004429"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0106937605017341"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ce40992a0b5e259f1b43758c5d68ea28
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0047" ;
+    nidm_coordinateVector: "[-50,-2,50]"^^xsd:string .
+
+niiri:8bc88f0d5c04e29ab34863cd24e68863 prov:wasDerivedFrom niiri:3c84c74526e078ad8336fd968ec9d7f0 .
+
+niiri:8a59a15e6d4b148aaa0593801d721b02
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0048" ;
+    prov:atLocation niiri:4f32af48b33fc420912cf278bf0e8c3c ;
+    prov:value "1.24030959606171"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.26895897281379"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0116354104606456"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:4f32af48b33fc420912cf278bf0e8c3c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0048" ;
+    nidm_coordinateVector: "[-18,6,32]"^^xsd:string .
+
+niiri:8a59a15e6d4b148aaa0593801d721b02 prov:wasDerivedFrom niiri:8a1438a34faf87d03af2d9853b038bb2 .
+
+niiri:22b4df385352baee01307cab01764e69
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0049" ;
+    prov:atLocation niiri:6b72057b1a69bb07b793d0aaa063f078 ;
+    prov:value "1.23086047172546"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.25670403369037"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0120132873197203"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:6b72057b1a69bb07b793d0aaa063f078
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0049" ;
+    nidm_coordinateVector: "[32,-44,-30]"^^xsd:string .
+
+niiri:22b4df385352baee01307cab01764e69 prov:wasDerivedFrom niiri:5aecd2a653cabfaff01cc936a5319173 .
+
+niiri:6bd95507897b5f8465d65ded242e547c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0050" ;
+    prov:atLocation niiri:cb9c025473a7e46fa185ff9de6d2eecf ;
+    prov:value "1.22944271564484"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.25486570897048"^^xsd:float ;
+    nidm_pValueUncorrected: "0.012070879644426"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:cb9c025473a7e46fa185ff9de6d2eecf
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0050" ;
+    nidm_coordinateVector: "[-46,-10,58]"^^xsd:string .
+
+niiri:6bd95507897b5f8465d65ded242e547c prov:wasDerivedFrom niiri:04baa9610947313ff840ab800dc602ff .
+
+niiri:4143adeb44c98572c57b47081885265e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0051" ;
+    prov:atLocation niiri:4071d9d4ce99f6a6d655e297984278e8 ;
+    prov:value "1.22471487522125"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.24873618228261"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0122646428654261"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:4071d9d4ce99f6a6d655e297984278e8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0051" ;
+    nidm_coordinateVector: "[-22,-94,26]"^^xsd:string .
+
+niiri:4143adeb44c98572c57b47081885265e prov:wasDerivedFrom niiri:bbf4ae108fc8903d38a040cb96a5f8c7 .
+
+niiri:677b1c427e116e323ccaeb43a4fcc8ea
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0052" ;
+    prov:atLocation niiri:59ab9ec5ff9c6474e96185492d155b6a ;
+    prov:value "1.21706402301788"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.23881967357295"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0125838258304741"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:59ab9ec5ff9c6474e96185492d155b6a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0052" ;
+    nidm_coordinateVector: "[36,32,8]"^^xsd:string .
+
+niiri:677b1c427e116e323ccaeb43a4fcc8ea prov:wasDerivedFrom niiri:4df2335aa8db3e5be136eacbcea883d6 .
+
+niiri:5f1c8d3e35aa5357a031ef92edb5ec90
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0053" ;
+    prov:atLocation niiri:a57e5490085c1d02f350a38c8affd373 ;
+    prov:value "1.1321427822113"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.12898516834439"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0166277437596988"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:a57e5490085c1d02f350a38c8affd373
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0053" ;
+    nidm_coordinateVector: "[32,28,2]"^^xsd:string .
+
+niiri:5f1c8d3e35aa5357a031ef92edb5ec90 prov:wasDerivedFrom niiri:4df2335aa8db3e5be136eacbcea883d6 .
+
+niiri:71e9024f0319e7ffdb91e7e9ef0f632b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0054" ;
+    prov:atLocation niiri:05aeae1bb56c868f7f9ca3927fd6f960 ;
+    prov:value "1.21668255329132"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.23832532460858"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0125999239065135"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:05aeae1bb56c868f7f9ca3927fd6f960
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0054" ;
+    nidm_coordinateVector: "[-36,-42,38]"^^xsd:string .
+
+niiri:71e9024f0319e7ffdb91e7e9ef0f632b prov:wasDerivedFrom niiri:9d79a6339d6f2901fb1cf662d6f17331 .
+
+niiri:089018a569a6a201160974bff8392bfd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0055" ;
+    prov:atLocation niiri:e27e392fffbf5a9a3177a7ac19ff9008 ;
+    prov:value "1.19720852375031"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.21309986746215"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0134453806257753"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:e27e392fffbf5a9a3177a7ac19ff9008
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0055" ;
+    nidm_coordinateVector: "[2,68,26]"^^xsd:string .
+
+niiri:089018a569a6a201160974bff8392bfd prov:wasDerivedFrom niiri:b8abe2a725005d9ab6e1e988f192f41c .
+
+niiri:c4700a2462ced300c4a44bf88e97f271
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0056" ;
+    prov:atLocation niiri:1ded169ba4a3f3e742789782ebf9e21d ;
+    prov:value "1.1896378993988"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.20329932117063"^^xsd:float ;
+    nidm_pValueUncorrected: "0.013786829398946"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:1ded169ba4a3f3e742789782ebf9e21d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0056" ;
+    nidm_coordinateVector: "[46,14,2]"^^xsd:string .
+
+niiri:c4700a2462ced300c4a44bf88e97f271 prov:wasDerivedFrom niiri:483de03930aa5641b0fe297f66f6c4ed .
+
+niiri:be0117fcc9b16f8118a34f6688a334a6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0057" ;
+    prov:atLocation niiri:a404d8c08401c4552c6273afdc67726c ;
+    prov:value "0.84699684381485"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.76435736331002"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0388359158916027"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:a404d8c08401c4552c6273afdc67726c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0057" ;
+    nidm_coordinateVector: "[40,10,10]"^^xsd:string .
+
+niiri:be0117fcc9b16f8118a34f6688a334a6 prov:wasDerivedFrom niiri:483de03930aa5641b0fe297f66f6c4ed .
+
+niiri:303d5f4df2d0d08184a8559af50bd6c1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0058" ;
+    prov:atLocation niiri:070a4d4397d04007720d2af356c40f7a ;
+    prov:value "1.18655109405518"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.19930428061828"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0139281467706139"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:070a4d4397d04007720d2af356c40f7a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0058" ;
+    nidm_coordinateVector: "[-32,-28,-2]"^^xsd:string .
+
+niiri:303d5f4df2d0d08184a8559af50bd6c1 prov:wasDerivedFrom niiri:4f303edac6b82f93c47e1a6448e1cb52 .
+
+niiri:60e4d404f23dc518a79132762c323919
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0059" ;
+    prov:atLocation niiri:8c5cc76b2edcfc58bde42f3e4a12935f ;
+    prov:value "1.17589449882507"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.18551661590201"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0144254945017301"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:8c5cc76b2edcfc58bde42f3e4a12935f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0059" ;
+    nidm_coordinateVector: "[-18,30,50]"^^xsd:string .
+
+niiri:60e4d404f23dc518a79132762c323919 prov:wasDerivedFrom niiri:d987cfa4a10011187d0a3eef178d5a46 .
+
+niiri:b38281d4642204a1940b6ebe7b4e1531
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0060" ;
+    prov:atLocation niiri:3e550c577ebfcc9bdf25a911ee937fbe ;
+    prov:value "1.17159426212311"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.17995487813573"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0146304032058477"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:3e550c577ebfcc9bdf25a911ee937fbe
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0060" ;
+    nidm_coordinateVector: "[-14,-26,66]"^^xsd:string .
+
+niiri:b38281d4642204a1940b6ebe7b4e1531 prov:wasDerivedFrom niiri:98d187b5c539ea98df7343b0d0821b17 .
+
+niiri:e54beb18ffa5912f369d1f235557359f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0061" ;
+    prov:atLocation niiri:7e83d5be32f3ac082fae74d72a17293b ;
+    prov:value "1.1714745759964"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.17980009775463"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0146361413495164"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:7e83d5be32f3ac082fae74d72a17293b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0061" ;
+    nidm_coordinateVector: "[18,60,34]"^^xsd:string .
+
+niiri:e54beb18ffa5912f369d1f235557359f prov:wasDerivedFrom niiri:5c38b60ed820b070d98e016bc1431008 .
+
+niiri:5cdcba284a1740e0a95bf39bfc59090f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0062" ;
+    prov:atLocation niiri:4d1d923218a5a86f14b80c5d9024c436 ;
+    prov:value "1.17128801345825"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.17955883330163"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0146450895624214"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:4d1d923218a5a86f14b80c5d9024c436
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0062" ;
+    nidm_coordinateVector: "[-30,-72,-50]"^^xsd:string .
+
+niiri:5cdcba284a1740e0a95bf39bfc59090f prov:wasDerivedFrom niiri:a86e2297836b759380804c1713e267cd .
+
+niiri:9608a0b9921f169205a67f91b0c8646d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0063" ;
+    prov:atLocation niiri:5ea0a149f7e30f52d50d149bf7dc7f86 ;
+    prov:value "1.15287852287292"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.15576230673889"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0155511150762138"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:5ea0a149f7e30f52d50d149bf7dc7f86
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0063" ;
+    nidm_coordinateVector: "[10,6,74]"^^xsd:string .
+
+niiri:9608a0b9921f169205a67f91b0c8646d prov:wasDerivedFrom niiri:f4ed594992095609e2ba62eca01c9faf .
+
+niiri:f8ec021e67601d83fa30a8d652cef986
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0064" ;
+    prov:atLocation niiri:8800f25bc9569134e36fe056c55dccea ;
+    prov:value "1.14964759349823"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.15158817513994"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0157149021414998"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:8800f25bc9569134e36fe056c55dccea
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0064" ;
+    nidm_coordinateVector: "[-40,48,22]"^^xsd:string .
+
+niiri:f8ec021e67601d83fa30a8d652cef986 prov:wasDerivedFrom niiri:c8ce85b44b984de4fe78c06b64713bb8 .
+
+niiri:f317a0bc0be15c3af8b8f12eddef0171
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0065" ;
+    prov:atLocation niiri:f23773c36e8aa842670cc820c8e3cf8e ;
+    prov:value "1.14813911914825"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.14963956628403"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0157918680840622"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:f23773c36e8aa842670cc820c8e3cf8e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0065" ;
+    nidm_coordinateVector: "[10,-78,-40]"^^xsd:string .
+
+niiri:f317a0bc0be15c3af8b8f12eddef0171 prov:wasDerivedFrom niiri:55d04469f144e7c5053124929003df79 .
+
+niiri:131fdfd62367b034e5115d813dae4043
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0066" ;
+    prov:atLocation niiri:9d2a2a255f2ef73de9a55449d983e205 ;
+    prov:value "1.14065408706665"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.13997280538058"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0161784822721924"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:9d2a2a255f2ef73de9a55449d983e205
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0066" ;
+    nidm_coordinateVector: "[-12,2,70]"^^xsd:string .
+
+niiri:131fdfd62367b034e5115d813dae4043 prov:wasDerivedFrom niiri:895da0556b5b38697a9d4eacde3a587e .
+
+niiri:411f4505c8a2beb209d54060d7e4a887
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0067" ;
+    prov:atLocation niiri:d9f9f53784b39c50a0d16feea151376a ;
+    prov:value "1.1338312625885"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.13116451819532"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0165377954988448"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:d9f9f53784b39c50a0d16feea151376a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0067" ;
+    nidm_coordinateVector: "[22,-18,48]"^^xsd:string .
+
+niiri:411f4505c8a2beb209d54060d7e4a887 prov:wasDerivedFrom niiri:30470d6217b4a75fdd554906028c6670 .
+
+niiri:8fb2c69443ae1c39858b37ffc89e3b1a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0068" ;
+    prov:atLocation niiri:70474983d603f7935620a9ebd96f0f94 ;
+    prov:value "1.11546647548676"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.10747127106409"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0175383747043093"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:70474983d603f7935620a9ebd96f0f94
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0068" ;
+    nidm_coordinateVector: "[30,-18,16]"^^xsd:string .
+
+niiri:8fb2c69443ae1c39858b37ffc89e3b1a prov:wasDerivedFrom niiri:62c58cbe35737a64415ff840b7810e7d .
+
+niiri:22b280391bbb882a2a96e664a5ba3c29
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0069" ;
+    prov:atLocation niiri:1a565db1a9411cc339a617addf6cb2b3 ;
+    prov:value "1.11363661289215"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.10511176477938"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0176407901931581"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:1a565db1a9411cc339a617addf6cb2b3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0069" ;
+    nidm_coordinateVector: "[16,2,56]"^^xsd:string .
+
+niiri:22b280391bbb882a2a96e664a5ba3c29 prov:wasDerivedFrom niiri:ec26c7d95e0c041f81b882cd245b0915 .
+
+niiri:dfa59695fa3a75f5938b98bd6d614080
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0070" ;
+    prov:atLocation niiri:0fdedeb914d8a7a9aa38eebe69a60433 ;
+    prov:value "1.10444390773773"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.09326187305734"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0181628920812176"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:0fdedeb914d8a7a9aa38eebe69a60433
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0070" ;
+    nidm_coordinateVector: "[-32,-52,14]"^^xsd:string .
+
+niiri:dfa59695fa3a75f5938b98bd6d614080 prov:wasDerivedFrom niiri:6750b72bbafd12ba75c6c383539599c6 .
+
+niiri:95ed835f52649487e78cce778a0a0b58
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0071" ;
+    prov:atLocation niiri:0e6389f3c537bf47d48480692de843a2 ;
+    prov:value "1.01987111568451"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.98454402904349"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0235976124289208"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:0e6389f3c537bf47d48480692de843a2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0071" ;
+    nidm_coordinateVector: "[-32,-60,18]"^^xsd:string .
+
+niiri:95ed835f52649487e78cce778a0a0b58 prov:wasDerivedFrom niiri:6750b72bbafd12ba75c6c383539599c6 .
+
+niiri:142a7d0d29db608b63eb9837dffcce93
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0072" ;
+    prov:atLocation niiri:ce0896936b4f6f9d75172c347b6d85ae ;
+    prov:value "0.951668322086334"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.89731313030669"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0288933115272303"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ce0896936b4f6f9d75172c347b6d85ae
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0072" ;
+    nidm_coordinateVector: "[-24,-50,20]"^^xsd:string .
+
+niiri:142a7d0d29db608b63eb9837dffcce93 prov:wasDerivedFrom niiri:6750b72bbafd12ba75c6c383539599c6 .
+
+niiri:49f19b782f800a88c614d1eb19240c3f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0073" ;
+    prov:atLocation niiri:b0ec65390cf89796648ae2492af92382 ;
+    prov:value "1.10060369968414"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.08831343102831"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0183847853440164"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:b0ec65390cf89796648ae2492af92382
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0073" ;
+    nidm_coordinateVector: "[10,50,18]"^^xsd:string .
+
+niiri:49f19b782f800a88c614d1eb19240c3f prov:wasDerivedFrom niiri:ccbc770b946f9dfd1beecfa8843cb3fd .
+
+niiri:bd9ec3b420daeb84caf491e82d75c544
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0074" ;
+    prov:atLocation niiri:b599d290461736cc005eec1c5e81ed4c ;
+    prov:value "1.09576165676117"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.08207556282094"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0186677841332979"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:b599d290461736cc005eec1c5e81ed4c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0074" ;
+    nidm_coordinateVector: "[-46,6,34]"^^xsd:string .
+
+niiri:bd9ec3b420daeb84caf491e82d75c544 prov:wasDerivedFrom niiri:daf3e2ea8bf3273801d2e921f611a23f .
+
+niiri:d2067075554add565f286f8aa6960f34
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0075" ;
+    prov:atLocation niiri:5a8493408aba2205a6a5eccb4d185561 ;
+    prov:value "1.09575474262238"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.08206665675352"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0186681908185171"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:5a8493408aba2205a6a5eccb4d185561
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0075" ;
+    nidm_coordinateVector: "[28,-8,70]"^^xsd:string .
+
+niiri:d2067075554add565f286f8aa6960f34 prov:wasDerivedFrom niiri:3df484ba108f4b88e1a4f123023bad18 .
+
+niiri:35a385cc559c54821f03c31abe4e3a40
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0076" ;
+    prov:atLocation niiri:9c0fa7da9a830b1787be277dabdda98a ;
+    prov:value "1.07974576950073"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.06145507795256"^^xsd:float ;
+    nidm_pValueUncorrected: "0.019629822462089"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:9c0fa7da9a830b1787be277dabdda98a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0076" ;
+    nidm_coordinateVector: "[-58,18,30]"^^xsd:string .
+
+niiri:35a385cc559c54821f03c31abe4e3a40 prov:wasDerivedFrom niiri:0b63cbadf7d3234250fdc4f399321ae5 .
+
+niiri:cc689c4588c375b1d453ed77ddd6fb6d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0077" ;
+    prov:atLocation niiri:753bdbe5b8284958a521269d13a1e404 ;
+    prov:value "1.07930290699005"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.06088516484109"^^xsd:float ;
+    nidm_pValueUncorrected: "0.019656998463677"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:753bdbe5b8284958a521269d13a1e404
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0077" ;
+    nidm_coordinateVector: "[-24,-66,24]"^^xsd:string .
+
+niiri:cc689c4588c375b1d453ed77ddd6fb6d prov:wasDerivedFrom niiri:16c6b9ef292ea8d86c2980e2bfee9806 .
+
+niiri:d1dbb47690cc5b2c83785482d78f16a7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0078" ;
+    prov:atLocation niiri:bf94253209f4ce76ed67120ac09947a0 ;
+    prov:value "1.07559859752655"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.05611872869022"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0198855367075194"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:bf94253209f4ce76ed67120ac09947a0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0078" ;
+    nidm_coordinateVector: "[34,34,-20]"^^xsd:string .
+
+niiri:d1dbb47690cc5b2c83785482d78f16a7 prov:wasDerivedFrom niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239 .
+
+niiri:2122013d54fe0ea832506bdf2d8540de
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0079" ;
+    prov:atLocation niiri:c574ef3b9be61ebed55b8533b9f46810 ;
+    prov:value "1.07552266120911"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.05602103030259"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0198902445740951"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:c574ef3b9be61ebed55b8533b9f46810
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0079" ;
+    nidm_coordinateVector: "[-32,-10,4]"^^xsd:string .
+
+niiri:2122013d54fe0ea832506bdf2d8540de prov:wasDerivedFrom niiri:fb45985c130da20eafb7b2bc740e6b34 .
+
+niiri:0d7fd935b6f12b8a45e5998c9e7df404
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0080" ;
+    prov:atLocation niiri:cff65d718e4f4c00b6a73fca81e2a08a ;
+    prov:value "1.06592130661011"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.04367166566034"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0204929970846689"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:cff65d718e4f4c00b6a73fca81e2a08a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0080" ;
+    nidm_coordinateVector: "[8,-70,-18]"^^xsd:string .
+
+niiri:0d7fd935b6f12b8a45e5998c9e7df404 prov:wasDerivedFrom niiri:65722b667917e9f42cf82ee2175b666b .
+
+niiri:9f539949d98077facdaf736080419084
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0081" ;
+    prov:atLocation niiri:245a5e3a98a4a35d29a45725ace42bd7 ;
+    prov:value "1.05881226062775"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.03453256202328"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0209489644915043"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:245a5e3a98a4a35d29a45725ace42bd7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0081" ;
+    nidm_coordinateVector: "[18,-56,74]"^^xsd:string .
+
+niiri:9f539949d98077facdaf736080419084 prov:wasDerivedFrom niiri:59675618f95ad14de633584e8aa5881a .
+
+niiri:fb1dc826dd07c70437b4e3753dad9238
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0082" ;
+    prov:atLocation niiri:8d1ef8a5bb276ca7bcbedc1eb36d2523 ;
+    prov:value "1.05682730674744"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.03198149751153"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0210777645475412"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:8d1ef8a5bb276ca7bcbedc1eb36d2523
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0082" ;
+    nidm_coordinateVector: "[28,-2,6]"^^xsd:string .
+
+niiri:fb1dc826dd07c70437b4e3753dad9238 prov:wasDerivedFrom niiri:2efe263e1c4f04d8ddb54023002360d9 .
+
+niiri:b318391d5530313f8dbf1afdf06198b0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0083" ;
+    prov:atLocation niiri:f705d3b5969c62171b8d06eb1edb92c5 ;
+    prov:value "1.05488443374634"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.02948481888272"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0212044668522343"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:f705d3b5969c62171b8d06eb1edb92c5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0083" ;
+    nidm_coordinateVector: "[12,-58,-26]"^^xsd:string .
+
+niiri:b318391d5530313f8dbf1afdf06198b0 prov:wasDerivedFrom niiri:fa0929f452cd3f13857c087a02f6da1f .
+
+niiri:654841e54cd036eaea7a9254bc97bbae
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0084" ;
+    prov:atLocation niiri:025393763cebc3e6ed872ebae1ed7c39 ;
+    prov:value "1.05219066143036"^^xsd:float ;
+    nidm_equivalentZStatistic: "2.02602370012315"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0213811780074668"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:025393763cebc3e6ed872ebae1ed7c39
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0084" ;
+    nidm_coordinateVector: "[46,-60,-36]"^^xsd:string .
+
+niiri:654841e54cd036eaea7a9254bc97bbae prov:wasDerivedFrom niiri:4c6401bfd1d939fec8234ff093a37d0d .
+
+niiri:4a63aa7cb3283e351b1f1db27351b99b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0085" ;
+    prov:atLocation niiri:c9a40f2012163b6c974d796fd3afd59f ;
+    prov:value "1.02921843528748"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.9965316371229"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0229380428256576"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:c9a40f2012163b6c974d796fd3afd59f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0085" ;
+    nidm_coordinateVector: "[56,10,22]"^^xsd:string .
+
+niiri:4a63aa7cb3283e351b1f1db27351b99b prov:wasDerivedFrom niiri:b40302277817265d7af623887ab2e22c .
+
+niiri:17f16c1d68762a38e70a1c58b234a67a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0086" ;
+    prov:atLocation niiri:49e9405a1f52c29499902ca446cc4c53 ;
+    prov:value "1.02376317977905"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.98953456023084"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0233211155368704"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:49e9405a1f52c29499902ca446cc4c53
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0086" ;
+    nidm_coordinateVector: "[48,-40,48]"^^xsd:string .
+
+niiri:17f16c1d68762a38e70a1c58b234a67a prov:wasDerivedFrom niiri:e3091fadc7ff93e5e16f94b04590b938 .
+
+niiri:23433a28a600a0042f6709ad738f2eb9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0087" ;
+    prov:atLocation niiri:47c5f8b5b08ae3c044df320c0c5c11c8 ;
+    prov:value "1.01926970481873"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.98377299631032"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0236405758837211"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:47c5f8b5b08ae3c044df320c0c5c11c8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0087" ;
+    nidm_coordinateVector: "[-6,-74,6]"^^xsd:string .
+
+niiri:23433a28a600a0042f6709ad738f2eb9 prov:wasDerivedFrom niiri:e36b80790f32a55a90c503e6f29918bb .
+
+niiri:8799123eb9c654ee018726ee3931235b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0088" ;
+    prov:atLocation niiri:bd086e9bb08a9f7d410c5f66d4534fb1 ;
+    prov:value "1.01770269870758"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.9817641782018"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0237528202287247"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:bd086e9bb08a9f7d410c5f66d4534fb1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0088" ;
+    nidm_coordinateVector: "[20,60,-18]"^^xsd:string .
+
+niiri:8799123eb9c654ee018726ee3931235b prov:wasDerivedFrom niiri:6e8c86e4ccb82a0a6076eb58e14b07a6 .
+
+niiri:6ba4662560eeacf1805f42b92357c2d2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0089" ;
+    prov:atLocation niiri:ec4549b9790223d5e2588c6af87cbf82 ;
+    prov:value "0.994811475276947"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.95244337576045"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0254427937463042"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ec4549b9790223d5e2588c6af87cbf82
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0089" ;
+    nidm_coordinateVector: "[6,-2,60]"^^xsd:string .
+
+niiri:6ba4662560eeacf1805f42b92357c2d2 prov:wasDerivedFrom niiri:42f7f7a26e0c7f6124775e7e757b315c .
+
+niiri:3bda2d8d3c0edb9b3f719a8dae269a32
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0090" ;
+    prov:atLocation niiri:a7cb0f2475eb4b3ff5c54ba281637639 ;
+    prov:value "0.99255907535553"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.94956085899435"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0256142412083677"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:a7cb0f2475eb4b3ff5c54ba281637639
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0090" ;
+    nidm_coordinateVector: "[10,-42,48]"^^xsd:string .
+
+niiri:3bda2d8d3c0edb9b3f719a8dae269a32 prov:wasDerivedFrom niiri:14ff66df771d191b9d2e8a3b0f78eda6 .
+
+niiri:5cc4fd8f0181f9da651d725a89ad5e16
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0091" ;
+    prov:atLocation niiri:d21ede16c4ae0337bd51853a10b823a9 ;
+    prov:value "0.984159111976624"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.93881506095718"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0262619307677786"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:d21ede16c4ae0337bd51853a10b823a9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0091" ;
+    nidm_coordinateVector: "[44,-2,-30]"^^xsd:string .
+
+niiri:5cc4fd8f0181f9da651d725a89ad5e16 prov:wasDerivedFrom niiri:912e881f26994ef7af5c7f0b222db9ea .
+
+niiri:2aa6a02038d33bce0ab53247bbf23d60
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0092" ;
+    prov:atLocation niiri:722f766abf24b819064c7c6e42c70bea ;
+    prov:value "0.981177926063538"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.93500289088164"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0264949704670242"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:722f766abf24b819064c7c6e42c70bea
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0092" ;
+    nidm_coordinateVector: "[-16,-98,-6]"^^xsd:string .
+
+niiri:2aa6a02038d33bce0ab53247bbf23d60 prov:wasDerivedFrom niiri:9a1887d93b55705b2ff04804a00c27c3 .
+
+niiri:cec30b5da4341b39910fe9e39affefb2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0093" ;
+    prov:atLocation niiri:332a4bdfcb6f14b5c9d4279cb47be873 ;
+    prov:value "0.979127943515778"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.93238197004834"^^xsd:float ;
+    nidm_pValueUncorrected: "0.026656188878889"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:332a4bdfcb6f14b5c9d4279cb47be873
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0093" ;
+    nidm_coordinateVector: "[18,-54,-16]"^^xsd:string .
+
+niiri:cec30b5da4341b39910fe9e39affefb2 prov:wasDerivedFrom niiri:e6e6da4cb58bd6ee501d8b5597467832 .
+
+niiri:19d11b85cd1659ff5c89792f9cde9c94
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0094" ;
+    prov:atLocation niiri:4a95f88e28460ccd588491bc3403c7b9 ;
+    prov:value "0.971426725387573"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.92253941721557"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0272689593644924"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:4a95f88e28460ccd588491bc3403c7b9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0094" ;
+    nidm_coordinateVector: "[4,60,38]"^^xsd:string .
+
+niiri:19d11b85cd1659ff5c89792f9cde9c94 prov:wasDerivedFrom niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0 .
+
+niiri:d0eaf64ed42fd3f849b5e11ace433bd6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0095" ;
+    prov:atLocation niiri:4bc70f64f7da756569d0cd25adc88adf ;
+    prov:value "0.967807769775391"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.91791614515868"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0275608223501947"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:4bc70f64f7da756569d0cd25adc88adf
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0095" ;
+    nidm_coordinateVector: "[20,18,-4]"^^xsd:string .
+
+niiri:d0eaf64ed42fd3f849b5e11ace433bd6 prov:wasDerivedFrom niiri:949a7d86dacbe35af10b6aad92fe2224 .
+
+niiri:b15e367317090ff6141a89644f5183f5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0096" ;
+    prov:atLocation niiri:5f5788776577f486d7c0d234240362e9 ;
+    prov:value "0.959724724292755"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.90759446601654"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0282218254783678"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:5f5788776577f486d7c0d234240362e9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0096" ;
+    nidm_coordinateVector: "[30,-32,10]"^^xsd:string .
+
+niiri:b15e367317090ff6141a89644f5183f5 prov:wasDerivedFrom niiri:6cc27bdc40320dac88fe94690c9a2006 .
+
+niiri:816a2af39c014a3eff563b63568227ba
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0097" ;
+    prov:atLocation niiri:49d25efc3a1a6a15fd15ecbfc808987c ;
+    prov:value "0.957907795906067"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.90527520238565"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0283721535699227"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:49d25efc3a1a6a15fd15ecbfc808987c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0097" ;
+    nidm_coordinateVector: "[10,12,-10]"^^xsd:string .
+
+niiri:816a2af39c014a3eff563b63568227ba prov:wasDerivedFrom niiri:c04d4059d5535de349435e25559a51cf .
+
+niiri:35f059b4066985dec95a60afb4757fa5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0098" ;
+    prov:atLocation niiri:ae652a26b3559a00177ccb1d38ddf2ea ;
+    prov:value "0.95493882894516"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.90148608420821"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0286191867597474"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ae652a26b3559a00177ccb1d38ddf2ea
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0098" ;
+    nidm_coordinateVector: "[-26,-94,-10]"^^xsd:string .
+
+niiri:35f059b4066985dec95a60afb4757fa5 prov:wasDerivedFrom niiri:4b22fd081d5be6319a728e5343897301 .
+
+niiri:f01e638e0603ba7659f5763a2d8bc4dd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0099" ;
+    prov:atLocation niiri:7f5fa73a008f806d34e4133d4c182481 ;
+    prov:value "0.950750410556793"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.89614212461773"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0289706268368529"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:7f5fa73a008f806d34e4133d4c182481
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0099" ;
+    nidm_coordinateVector: "[-50,-18,0]"^^xsd:string .
+
+niiri:f01e638e0603ba7659f5763a2d8bc4dd prov:wasDerivedFrom niiri:f0f729dae8a39ee9247f706bc80f8df0 .
+
+niiri:f28c4268c860430233ff3485efbc9bb1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0100" ;
+    prov:atLocation niiri:497cb86fef9441e29d59581837fa7a72 ;
+    prov:value "0.949834227561951"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.89497340726092"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0290479624174936"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:497cb86fef9441e29d59581837fa7a72
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0100" ;
+    nidm_coordinateVector: "[42,36,18]"^^xsd:string .
+
+niiri:f28c4268c860430233ff3485efbc9bb1 prov:wasDerivedFrom niiri:cd47d3687de0d428289d5ee8d941860d .
+
+niiri:e78b40e65bb076e872f92f8886d6fb55
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0101" ;
+    prov:atLocation niiri:e7a5dbf5431a99354087860b2a10d16c ;
+    prov:value "0.949459254741669"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.89449510188639"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0290796619499293"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:e7a5dbf5431a99354087860b2a10d16c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0101" ;
+    nidm_coordinateVector: "[46,-78,16]"^^xsd:string .
+
+niiri:e78b40e65bb076e872f92f8886d6fb55 prov:wasDerivedFrom niiri:20959c12c3afc9ceb8477f395c0f1d11 .
+
+niiri:574b80e813133039f7edba5d74c437a7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0102" ;
+    prov:atLocation niiri:ec5e4ec4f22a9fe5061299186eb1a7df ;
+    prov:value "0.942987263202667"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.88624180999136"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0296311883673402"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ec5e4ec4f22a9fe5061299186eb1a7df
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0102" ;
+    nidm_coordinateVector: "[-52,40,8]"^^xsd:string .
+
+niiri:574b80e813133039f7edba5d74c437a7 prov:wasDerivedFrom niiri:4eb3e8fe236fda4e725ee89c277cccc8 .
+
+niiri:73e1b25dd37be5347183ed76eca13450
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0103" ;
+    prov:atLocation niiri:7d6edf93aed55973698b99ba16ef1865 ;
+    prov:value "0.937418699264526"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.87914396799602"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0301124189915838"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:7d6edf93aed55973698b99ba16ef1865
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0103" ;
+    nidm_coordinateVector: "[-12,42,48]"^^xsd:string .
+
+niiri:73e1b25dd37be5347183ed76eca13450 prov:wasDerivedFrom niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca .
+
+niiri:eb93d84a711109bd9b54c6b018d686d3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0104" ;
+    prov:atLocation niiri:65fa8002172898322aa4954394e16e2d ;
+    prov:value "0.933299362659454"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.87389537802186"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0304724233227471"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:65fa8002172898322aa4954394e16e2d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0104" ;
+    nidm_coordinateVector: "[44,40,-20]"^^xsd:string .
+
+niiri:eb93d84a711109bd9b54c6b018d686d3 prov:wasDerivedFrom niiri:4fad08e49bad24baddc3d418f97db0ce .
+
+niiri:14289e9dd02f6ca24827f1eb68744a10
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0105" ;
+    prov:atLocation niiri:b49fe1898121cadf26b62d7cef891fd4 ;
+    prov:value "0.931596636772156"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.87172638333963"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0306222337565211"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:b49fe1898121cadf26b62d7cef891fd4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0105" ;
+    nidm_coordinateVector: "[-20,-74,-42]"^^xsd:string .
+
+niiri:14289e9dd02f6ca24827f1eb68744a10 prov:wasDerivedFrom niiri:d9eee0810d67b936a31fa3c66d2e8721 .
+
+niiri:ff6121b7a9f9dbe98a1c2aa743d5f4e8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0106" ;
+    prov:atLocation niiri:45e6af0f0dc689c25f2e728abf47ad38 ;
+    prov:value "0.921256303787231"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.85856093332641"^^xsd:float ;
+    nidm_pValueUncorrected: "0.031544699452275"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:45e6af0f0dc689c25f2e728abf47ad38
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0106" ;
+    nidm_coordinateVector: "[-10,-26,78]"^^xsd:string .
+
+niiri:ff6121b7a9f9dbe98a1c2aa743d5f4e8 prov:wasDerivedFrom niiri:c8715267e94716796c464182b4ba6959 .
+
+niiri:e90e1fca92a0e22c713f9682392e7f12
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0107" ;
+    prov:atLocation niiri:fbbb756202b6d0be6eafa6dc866cd8c3 ;
+    prov:value "0.913095474243164"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.84817837718658"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0322882711892066"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:fbbb756202b6d0be6eafa6dc866cd8c3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0107" ;
+    nidm_coordinateVector: "[-22,-34,-42]"^^xsd:string .
+
+niiri:e90e1fca92a0e22c713f9682392e7f12 prov:wasDerivedFrom niiri:8f90bd7cc0deb45b7b7bd4b560274456 .
+
+niiri:b40b3acb742819cbaef72868cf6ef19a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0108" ;
+    prov:atLocation niiri:0c0e1df808ce80ff1bf83deb70997dda ;
+    prov:value "0.910208523273468"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.84450717202411"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0325546307872665"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:0c0e1df808ce80ff1bf83deb70997dda
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0108" ;
+    nidm_coordinateVector: "[-34,-52,40]"^^xsd:string .
+
+niiri:b40b3acb742819cbaef72868cf6ef19a prov:wasDerivedFrom niiri:38f5a60345c88d7c9e0484d8735d5ffe .
+
+niiri:25eb200bd03f426290a68a7c2b8e19fe
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0109" ;
+    prov:atLocation niiri:711f57ca8088fe4976d46723159bf11a ;
+    prov:value "0.909155905246735"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.84316882767473"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0326521823346975"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:711f57ca8088fe4976d46723159bf11a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0109" ;
+    nidm_coordinateVector: "[12,-70,-24]"^^xsd:string .
+
+niiri:25eb200bd03f426290a68a7c2b8e19fe prov:wasDerivedFrom niiri:e6b43073ea58d734c57cff5767e3921f .
+
+niiri:f22a9c0971a349a072973dd922cf0da5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0110" ;
+    prov:atLocation niiri:06bc6317f5dd0e19d7b2145cfc317c31 ;
+    prov:value "0.907121956348419"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.84058311467862"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0328413370266359"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:06bc6317f5dd0e19d7b2145cfc317c31
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0110" ;
+    nidm_coordinateVector: "[56,-36,52]"^^xsd:string .
+
+niiri:f22a9c0971a349a072973dd922cf0da5 prov:wasDerivedFrom niiri:1cdb6dbe1bc79e13d52d0d3c171bab06 .
+
+niiri:922af964cb0b1e93f68e8fa36f07f1ce
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0111" ;
+    prov:atLocation niiri:bf0370f8604a56c53402a8729aefae6b ;
+    prov:value "0.904614567756653"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.83739614411337"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0330757178223472"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:bf0370f8604a56c53402a8729aefae6b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0111" ;
+    nidm_coordinateVector: "[36,-54,16]"^^xsd:string .
+
+niiri:922af964cb0b1e93f68e8fa36f07f1ce prov:wasDerivedFrom niiri:ee19df6f4d0113ba7e7f064a4048e753 .
+
+niiri:3ba3e2d5a8b08d5f3408511de2fcea57
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0112" ;
+    prov:atLocation niiri:24965870248323c4385441c6aa85db8e ;
+    prov:value "0.902757167816162"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.83503576989372"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0332501948262349"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:24965870248323c4385441c6aa85db8e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0112" ;
+    nidm_coordinateVector: "[14,50,12]"^^xsd:string .
+
+niiri:3ba3e2d5a8b08d5f3408511de2fcea57 prov:wasDerivedFrom niiri:71af61a5c3e3beaf82f85e9971911d0f .
+
+niiri:c2e1702c643d5c90a4a81f48e223bd8e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0113" ;
+    prov:atLocation niiri:500217872b9641815f5c9ecf02da9de8 ;
+    prov:value "0.901206791400909"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.83306584752486"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0333963896408318"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:500217872b9641815f5c9ecf02da9de8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0113" ;
+    nidm_coordinateVector: "[-10,-70,-2]"^^xsd:string .
+
+niiri:c2e1702c643d5c90a4a81f48e223bd8e prov:wasDerivedFrom niiri:46c8b3f4803e6bb0b2862d8598ece061 .
+
+niiri:9554f50419ea4f396d53059910e8f01c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0114" ;
+    prov:atLocation niiri:ebfb05b2fc04e2d96ab9a666523e58b8 ;
+    prov:value "0.797126054763794"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.70146355236453"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0444279881500879"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:ebfb05b2fc04e2d96ab9a666523e58b8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0114" ;
+    nidm_coordinateVector: "[-16,-64,-2]"^^xsd:string .
+
+niiri:9554f50419ea4f396d53059910e8f01c prov:wasDerivedFrom niiri:46c8b3f4803e6bb0b2862d8598ece061 .
+
+niiri:7b3ef4930118f8730b06d784120ed132
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0115" ;
+    prov:atLocation niiri:1c34ff628baa6e5b4cebfc783d6f6235 ;
+    prov:value "0.899936437606812"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.83145192034408"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0335165588882574"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:1c34ff628baa6e5b4cebfc783d6f6235
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0115" ;
+    nidm_coordinateVector: "[10,-18,-14]"^^xsd:string .
+
+niiri:7b3ef4930118f8730b06d784120ed132 prov:wasDerivedFrom niiri:5e385b701ab7f21285e4ab5006f3b0cc .
+
+niiri:2b60d3a424b67aec66f9f99b0fccbb0d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0116" ;
+    prov:atLocation niiri:65f8612f3ec48ab25895d29bc35e3436 ;
+    prov:value "0.895962595939636"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.8264044782252"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0338946789087741"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:65f8612f3ec48ab25895d29bc35e3436
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0116" ;
+    nidm_coordinateVector: "[-42,-50,-42]"^^xsd:string .
+
+niiri:2b60d3a424b67aec66f9f99b0fccbb0d prov:wasDerivedFrom niiri:9b4e4e9b57eb3e981b1ba74aae8a7114 .
+
+niiri:1b85cec52ecc08fb6123be4911d70832
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0117" ;
+    prov:atLocation niiri:87e9ae97ab2460fd67bf107c00b14f4d ;
+    prov:value "0.893008887767792"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.8226539056953"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0341779128567976"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:87e9ae97ab2460fd67bf107c00b14f4d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0117" ;
+    nidm_coordinateVector: "[-60,-32,46]"^^xsd:string .
+
+niiri:1b85cec52ecc08fb6123be4911d70832 prov:wasDerivedFrom niiri:6d27ace5181c44103420a9d6058ab0d2 .
+
+niiri:1d5890d8c4a830c8c8f1f464ee06b062
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0118" ;
+    prov:atLocation niiri:23b41b3bc0b16ebee53dd102abdb11d4 ;
+    prov:value "0.888202428817749"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.81655281460242"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0346428070130568"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:23b41b3bc0b16ebee53dd102abdb11d4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0118" ;
+    nidm_coordinateVector: "[56,-42,24]"^^xsd:string .
+
+niiri:1d5890d8c4a830c8c8f1f464ee06b062 prov:wasDerivedFrom niiri:315d7b893c25221ef60daf1e43984066 .
+
+niiri:2565e317445870947786d1813b8bf01d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0119" ;
+    prov:atLocation niiri:f0a8bf2c4bce9536b2e34cad8fad2f2e ;
+    prov:value "0.886661469936371"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.81459734206643"^^xsd:float ;
+    nidm_pValueUncorrected: "0.034792905633808"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:f0a8bf2c4bce9536b2e34cad8fad2f2e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0119" ;
+    nidm_coordinateVector: "[-34,-90,-30]"^^xsd:string .
+
+niiri:2565e317445870947786d1813b8bf01d prov:wasDerivedFrom niiri:34f88b9c2c80714dbe516b3f7ef092bb .
+
+niiri:e73954e3237244d481bbcd6dc6911176
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0120" ;
+    prov:atLocation niiri:d5854cc9ae10a2a740a4698cfa6ad761 ;
+    prov:value "0.88604724407196"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.81381796560484"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0348528778271762"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:d5854cc9ae10a2a740a4698cfa6ad761
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0120" ;
+    nidm_coordinateVector: "[-6,-72,-20]"^^xsd:string .
+
+niiri:e73954e3237244d481bbcd6dc6911176 prov:wasDerivedFrom niiri:c07d0db5466c33ca960e3dd77f21333c .
+
+niiri:65e5e429d1c98e7a5de78ee327bfe175
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0121" ;
+    prov:atLocation niiri:9e7452e38b1a293e96d87620eeb74352 ;
+    prov:value "0.884565353393555"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.81193780520014"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0349979035410456"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:9e7452e38b1a293e96d87620eeb74352
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0121" ;
+    nidm_coordinateVector: "[62,-24,46]"^^xsd:string .
+
+niiri:65e5e429d1c98e7a5de78ee327bfe175 prov:wasDerivedFrom niiri:90645273f08ccfc7b9bf300a122cc2af .
+
+niiri:5eb9c920dba7f075a9df90020235c1a9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0122" ;
+    prov:atLocation niiri:c6ecfbf5d1e362ea14e87e5b5f48caf5 ;
+    prov:value "0.882052361965179"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.80874999534025"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0352449260120304"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:c6ecfbf5d1e362ea14e87e5b5f48caf5
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0122" ;
+    nidm_coordinateVector: "[-16,34,12]"^^xsd:string .
+
+niiri:5eb9c920dba7f075a9df90020235c1a9 prov:wasDerivedFrom niiri:c12f0aee596eddb11ad8e3268c4eb077 .
+
+niiri:506119698918e1fef046ce6c81d77ebe
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0123" ;
+    prov:atLocation niiri:09cff2c449ad605890a3ec72e7672784 ;
+    prov:value "0.878161370754242"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.8038155651472"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0356301124625072"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:09cff2c449ad605890a3ec72e7672784
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0123" ;
+    nidm_coordinateVector: "[-20,-46,76]"^^xsd:string .
+
+niiri:506119698918e1fef046ce6c81d77ebe prov:wasDerivedFrom niiri:b74b40058d530ee5632e1df25f911065 .
+
+niiri:d2d194c38029ea3cc730205928385128
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0124" ;
+    prov:atLocation niiri:205f90e44f29beb0016b33f7cd420e9d ;
+    prov:value "0.875840246677399"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.80087281439492"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0358614643888427"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:205f90e44f29beb0016b33f7cd420e9d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0124" ;
+    nidm_coordinateVector: "[-40,-6,34]"^^xsd:string .
+
+niiri:d2d194c38029ea3cc730205928385128 prov:wasDerivedFrom niiri:169fad64b64219293f6c913c296583bc .
+
+niiri:743c6582a5009b8dc4efb633233a4535
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0125" ;
+    prov:atLocation niiri:bcb2bb47914ac9215957ebf283630732 ;
+    prov:value "0.875353574752808"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.80025588397551"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0359101216845089"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:bcb2bb47914ac9215957ebf283630732
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0125" ;
+    nidm_coordinateVector: "[-20,-12,8]"^^xsd:string .
+
+niiri:743c6582a5009b8dc4efb633233a4535 prov:wasDerivedFrom niiri:c9ba05614242ea84b1cd6a9c5ec414e4 .
+
+niiri:c71bc3fe49c5d5a474cc15dc6dffb62d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0126" ;
+    prov:atLocation niiri:b96787f5a81fc13105fb48a6fd5ea1a0 ;
+    prov:value "0.87107241153717"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.79483003828998"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0363403916799833"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:b96787f5a81fc13105fb48a6fd5ea1a0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0126" ;
+    nidm_coordinateVector: "[12,-44,-14]"^^xsd:string .
+
+niiri:c71bc3fe49c5d5a474cc15dc6dffb62d prov:wasDerivedFrom niiri:be38e2f5b8c4edd116eb0a55684fdab2 .
+
+niiri:f05e911e91200fba2a69c0dbec52ed46
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0127" ;
+    prov:atLocation niiri:2d89278f9562ee144eb9d57189b71a2e ;
+    prov:value "0.865115165710449"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.78728350813392"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0369458390734643"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:2d89278f9562ee144eb9d57189b71a2e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0127" ;
+    nidm_coordinateVector: "[2,56,-22]"^^xsd:string .
+
+niiri:f05e911e91200fba2a69c0dbec52ed46 prov:wasDerivedFrom niiri:9506dd108b62896cd6d8225dfc0e2e59 .
+
+niiri:718114da93378acb4349a929b4418bb3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0128" ;
+    prov:atLocation niiri:76adcb2ddad656b23a665afa9087a907 ;
+    prov:value "0.864862859249115"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.78696398255915"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0369716550398422"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:76adcb2ddad656b23a665afa9087a907
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0128" ;
+    nidm_coordinateVector: "[-4,12,50]"^^xsd:string .
+
+niiri:718114da93378acb4349a929b4418bb3 prov:wasDerivedFrom niiri:f404d574847ee68f9dc6bd08393bd9a1 .
+
+niiri:03fc56b39e281ca8fbd18fd8b73b3a30
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0129" ;
+    prov:atLocation niiri:655c697c890d155ad920137ad8bbdd3a ;
+    prov:value "0.864512741565704"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.78652059943143"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0370075024642879"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:655c697c890d155ad920137ad8bbdd3a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0129" ;
+    nidm_coordinateVector: "[-30,-78,-8]"^^xsd:string .
+
+niiri:03fc56b39e281ca8fbd18fd8b73b3a30 prov:wasDerivedFrom niiri:99948f53ace7073cd3002a5850ecd361 .
+
+niiri:9fe346931ab5bee817eaea36f0a39a81
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0130" ;
+    prov:atLocation niiri:1a069cea9796d88418c354fa8b495668 ;
+    prov:value "0.860980033874512"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.7820476459466"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0373707311326116"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:1a069cea9796d88418c354fa8b495668
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0130" ;
+    nidm_coordinateVector: "[12,-92,28]"^^xsd:string .
+
+niiri:9fe346931ab5bee817eaea36f0a39a81 prov:wasDerivedFrom niiri:c8c7dba5be58cecd8f14593ccfb69e4b .
+
+niiri:1957ce020c99ce3df85faf2ec5078f77
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0131" ;
+    prov:atLocation niiri:98d11bc4b0ace2128270a5af1f3a8e18 ;
+    prov:value "0.854242324829102"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.77352076998315"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0380712266728884"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:98d11bc4b0ace2128270a5af1f3a8e18
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0131" ;
+    nidm_coordinateVector: "[44,-50,-4]"^^xsd:string .
+
+niiri:1957ce020c99ce3df85faf2ec5078f77 prov:wasDerivedFrom niiri:a56ce0c60fde3ec8bf474d645a951d38 .
+
+niiri:66c1e77cf01db1d64aa08bccb30f1ff7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0132" ;
+    prov:atLocation niiri:8f8663ded34d0a964fe049c0fc2e394e ;
+    prov:value "0.853475153446198"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.77255022378467"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0381516330201062"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:8f8663ded34d0a964fe049c0fc2e394e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0132" ;
+    nidm_coordinateVector: "[20,48,8]"^^xsd:string .
+
+niiri:66c1e77cf01db1d64aa08bccb30f1ff7 prov:wasDerivedFrom niiri:82e02fb05b18c0c2a70d55d5e415aee5 .
+
+niiri:b889d456c0879821e4ba3febfc7cbcc0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0133" ;
+    prov:atLocation niiri:7dea8bfc01118debf10f84544e468a5c ;
+    prov:value "0.848101913928986"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.76575454216401"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0387185189613873"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:7dea8bfc01118debf10f84544e468a5c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0133" ;
+    nidm_coordinateVector: "[22,-10,68]"^^xsd:string .
+
+niiri:b889d456c0879821e4ba3febfc7cbcc0 prov:wasDerivedFrom niiri:8d8ac9fae20babb989f7c367a4c4a609 .
+
+niiri:97a3bf83baba0ea813905300ee82fe23
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0134" ;
+    prov:atLocation niiri:1b9230ed2c839aa6d24e8d83c79d5dd6 ;
+    prov:value "0.845535814762115"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.76251036116829"^^xsd:float ;
+    nidm_pValueUncorrected: "0.038991553676096"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:1b9230ed2c839aa6d24e8d83c79d5dd6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0134" ;
+    nidm_coordinateVector: "[10,16,62]"^^xsd:string .
+
+niiri:97a3bf83baba0ea813905300ee82fe23 prov:wasDerivedFrom niiri:1a41584c1187bb4a87d3cc1af9993773 .
+
+niiri:6fbe9b8954c9f730c642daa8c4847b4a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0135" ;
+    prov:atLocation niiri:d1448e12a92a065f7e0cabf0e49e1ad3 ;
+    prov:value "0.845024406909943"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.76186391162221"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0390461466343727"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:d1448e12a92a065f7e0cabf0e49e1ad3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0135" ;
+    nidm_coordinateVector: "[-30,-60,-28]"^^xsd:string .
+
+niiri:6fbe9b8954c9f730c642daa8c4847b4a prov:wasDerivedFrom niiri:43ed38ee11c52db758569877faabd695 .
+
+niiri:2549eeee38c0e38dc94943a1ee2e5a72
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0136" ;
+    prov:atLocation niiri:c7735a5f5f10a0bd82c11474f8038741 ;
+    prov:value "0.842050552368164"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.75810541868522"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0393647869826912"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:c7735a5f5f10a0bd82c11474f8038741
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0136" ;
+    nidm_coordinateVector: "[20,6,44]"^^xsd:string .
+
+niiri:2549eeee38c0e38dc94943a1ee2e5a72 prov:wasDerivedFrom niiri:ee629aca5d18e60c2724bfd2e1b3fc6b .
+
+niiri:b8cf304e8ace22648efb5f4a9981bb03
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0137" ;
+    prov:atLocation niiri:04749d474e0bfc0ede32e54c5c11feca ;
+    prov:value "0.837220907211304"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.75200380991823"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0398865764002145"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:04749d474e0bfc0ede32e54c5c11feca
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0137" ;
+    nidm_coordinateVector: "[-4,-100,4]"^^xsd:string .
+
+niiri:b8cf304e8ace22648efb5f4a9981bb03 prov:wasDerivedFrom niiri:8b0a58d02f59556fa0151651c6d40cc0 .
+
+niiri:95679c7d59594699386070848d7545e6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0138" ;
+    prov:atLocation niiri:55bb0fca7b0a040e7258ea87a9d4c539 ;
+    prov:value "0.83669376373291"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.75133800938073"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0399438520830083"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:55bb0fca7b0a040e7258ea87a9d4c539
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0138" ;
+    nidm_coordinateVector: "[26,36,-8]"^^xsd:string .
+
+niiri:95679c7d59594699386070848d7545e6 prov:wasDerivedFrom niiri:eeb7c0ae3047601cda9c179c68e75d65 .
+
+niiri:972eb6a3d099f2c00c6eb4bbaa70ac1b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0139" ;
+    prov:atLocation niiri:eeb8c0cd15d6d5c6bc694fdae27267b2 ;
+    prov:value "0.835819184780121"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.75023346183694"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0400390185167846"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:eeb8c0cd15d6d5c6bc694fdae27267b2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0139" ;
+    nidm_coordinateVector: "[30,-36,28]"^^xsd:string .
+
+niiri:972eb6a3d099f2c00c6eb4bbaa70ac1b prov:wasDerivedFrom niiri:543214dac714341af8aeaa4b70f41266 .
+
+niiri:5be765fc7b710cbdb2e1d4bd46ecce60
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0140" ;
+    prov:atLocation niiri:60dea246d45afec73eaabe894de2e0d3 ;
+    prov:value "0.835755825042725"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.75015344548878"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0400459197758659"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:60dea246d45afec73eaabe894de2e0d3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0140" ;
+    nidm_coordinateVector: "[16,48,10]"^^xsd:string .
+
+niiri:5be765fc7b710cbdb2e1d4bd46ecce60 prov:wasDerivedFrom niiri:86191fa377232381128e79c2a57a4af6 .
+
+niiri:af472b64871726e5127b3c3b9738e96f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0141" ;
+    prov:atLocation niiri:1d48f9534397006412e809a8ce1f6646 ;
+    prov:value "0.827520847320557"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73975784824994"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0409507734302569"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:1d48f9534397006412e809a8ce1f6646
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0141" ;
+    nidm_coordinateVector: "[24,34,2]"^^xsd:string .
+
+niiri:af472b64871726e5127b3c3b9738e96f prov:wasDerivedFrom niiri:6f236184b94e16d3fb82cdd60cd19a6d .
+
+niiri:652faa5c53b766d8b0cf903c07dea641
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0142" ;
+    prov:atLocation niiri:74cfe0dca1f5419de1c3a172a2352d1c ;
+    prov:value "0.825629651546478"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73737166192306"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0411607949360844"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:74cfe0dca1f5419de1c3a172a2352d1c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0142" ;
+    nidm_coordinateVector: "[62,-42,44]"^^xsd:string .
+
+niiri:652faa5c53b766d8b0cf903c07dea641 prov:wasDerivedFrom niiri:9ae54c5470ad002b7ae47f7b67b248ad .
+
+niiri:d26b4b3fb5276da558b2ded4146aecb4
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0143" ;
+    prov:atLocation niiri:88d33018c3f9dbc230683ee47c7f469a ;
+    prov:value "0.82505863904953"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73665128497546"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0412243706597636"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:88d33018c3f9dbc230683ee47c7f469a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0143" ;
+    nidm_coordinateVector: "[-46,-40,38]"^^xsd:string .
+
+niiri:d26b4b3fb5276da558b2ded4146aecb4 prov:wasDerivedFrom niiri:0104fa6d88bd50793a3b65b47635e2c6 .
+
+niiri:5cc50ec6e00023b323ad96ff05dca350
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0144" ;
+    prov:atLocation niiri:b5c4ea65f2f942e5c79bd59f2797e844 ;
+    prov:value "0.824967801570892"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73653669020128"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0412344913749479"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:b5c4ea65f2f942e5c79bd59f2797e844
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0144" ;
+    nidm_coordinateVector: "[-12,-58,-54]"^^xsd:string .
+
+niiri:5cc50ec6e00023b323ad96ff05dca350 prov:wasDerivedFrom niiri:1ff5ea3ca56fb13894e4e43c39a861c9 .
+
+niiri:9e195ae526df87602b1a5980eb32f1a3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0145" ;
+    prov:atLocation niiri:09ab1d1db3cfbdd5ba683bbafc0a37e6 ;
+    prov:value "0.824692487716675"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73618937818564"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0412651773815628"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:09ab1d1db3cfbdd5ba683bbafc0a37e6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0145" ;
+    nidm_coordinateVector: "[26,-72,14]"^^xsd:string .
+
+niiri:9e195ae526df87602b1a5980eb32f1a3 prov:wasDerivedFrom niiri:9e02c41cd62cc06c92b5e2b56a706886 .
+
+niiri:9c93b5c306aacac5c321fe8b406ca25c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0146" ;
+    prov:atLocation niiri:87a6b40994dc4f90c9f3ccee7834c6b4 ;
+    prov:value "0.822546482086182"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73348249441809"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0415049731433188"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:87a6b40994dc4f90c9f3ccee7834c6b4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0146" ;
+    nidm_coordinateVector: "[-40,-10,40]"^^xsd:string .
+
+niiri:9c93b5c306aacac5c321fe8b406ca25c prov:wasDerivedFrom niiri:a5e308239dff195e8c67ca5b964d553a .
+
+niiri:87be53fc52f329c31a4bbf852d8d96af
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0147" ;
+    prov:atLocation niiri:8a23632000b73752391bf7b0889bdc03 ;
+    prov:value "0.821757972240448"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73248804772578"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0415933516734939"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:8a23632000b73752391bf7b0889bdc03
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0147" ;
+    nidm_coordinateVector: "[54,-52,42]"^^xsd:string .
+
+niiri:87be53fc52f329c31a4bbf852d8d96af prov:wasDerivedFrom niiri:aeffc3536799596ea12e2467fc52bd65 .
+
+niiri:522075dd68ebe791546a697684de5db9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0148" ;
+    prov:atLocation niiri:45539f048650428b2f89835fd4f28adf ;
+    prov:value "0.821538865566254"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73221173057204"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0416179355971084"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:45539f048650428b2f89835fd4f28adf
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0148" ;
+    nidm_coordinateVector: "[-10,-66,8]"^^xsd:string .
+
+niiri:522075dd68ebe791546a697684de5db9 prov:wasDerivedFrom niiri:3e987521ad9deca092879412707ea491 .
+
+niiri:322277ddac27387b3f1cf8caca630a5d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0149" ;
+    prov:atLocation niiri:dbba800ccf20410cbd8b17d4e7e3d71f ;
+    prov:value "0.821337878704071"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73195826984928"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0416404963346692"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:dbba800ccf20410cbd8b17d4e7e3d71f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0149" ;
+    nidm_coordinateVector: "[20,-16,70]"^^xsd:string .
+
+niiri:322277ddac27387b3f1cf8caca630a5d prov:wasDerivedFrom niiri:f54f30ee52ac26f6dae0749e096ea6c1 .
+
+niiri:c61ef0dd46c1c75dde8b0ff1cd46ff2a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0150" ;
+    prov:atLocation niiri:e6913f677376e8f8d0cbf5768e2b2957 ;
+    prov:value "0.821269989013672"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.73187265661373"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0416481190738193"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:e6913f677376e8f8d0cbf5768e2b2957
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0150" ;
+    nidm_coordinateVector: "[34,-56,18]"^^xsd:string .
+
+niiri:c61ef0dd46c1c75dde8b0ff1cd46ff2a prov:wasDerivedFrom niiri:692bc9543cbfc2b98e06dde4c8e7603f .
+
+niiri:a80bb377de34b37212750ae3db10e20a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0151" ;
+    prov:atLocation niiri:0458d3c1e0559783e4029b2a4be03a14 ;
+    prov:value "0.82093757390976"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.7314534684428"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0416854586174026"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:0458d3c1e0559783e4029b2a4be03a14
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0151" ;
+    nidm_coordinateVector: "[58,32,22]"^^xsd:string .
+
+niiri:a80bb377de34b37212750ae3db10e20a prov:wasDerivedFrom niiri:be235801557e66b2190c98cd649588c0 .
+
+niiri:9fc68b058dc6ee748e78bc0342d26c9f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0152" ;
+    prov:atLocation niiri:243d348e8bb24e528c34f0f61a042268 ;
+    prov:value "0.817427694797516"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.72702824070669"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0420812958690475"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:243d348e8bb24e528c34f0f61a042268
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0152" ;
+    nidm_coordinateVector: "[-28,-74,18]"^^xsd:string .
+
+niiri:9fc68b058dc6ee748e78bc0342d26c9f prov:wasDerivedFrom niiri:baf9fc0b69478678bb8ed7430b24c094 .
+
+niiri:b25ee7d26cd1e25affee2f1c6bc4278f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0153" ;
+    prov:atLocation niiri:f793261af421559e7bb8429a67afd216 ;
+    prov:value "0.816389560699463"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.72571967296696"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0421989285126135"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:f793261af421559e7bb8429a67afd216
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0153" ;
+    nidm_coordinateVector: "[28,-30,34]"^^xsd:string .
+
+niiri:b25ee7d26cd1e25affee2f1c6bc4278f prov:wasDerivedFrom niiri:27343a380f46da81b03903d4cf6193dc .
+
+niiri:b9cefb671f41cdcd2b2e4c69d6b7b359
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0154" ;
+    prov:atLocation niiri:e532ce509b03d476f34fbe3e3016c83c ;
+    prov:value "0.810877442359924"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.71877398514755"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0428277671196435"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:e532ce509b03d476f34fbe3e3016c83c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0154" ;
+    nidm_coordinateVector: "[-4,-92,4]"^^xsd:string .
+
+niiri:b9cefb671f41cdcd2b2e4c69d6b7b359 prov:wasDerivedFrom niiri:158f1d535951e2b7d78ea10b066c15f3 .
+
+niiri:2ad984f6f188e95e289d863a3dc28223
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0155" ;
+    prov:atLocation niiri:9a5b03d3a41f3e346f8f366b062b7b4b ;
+    prov:value "0.810260891914368"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.71799733032142"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0428985511130971"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:9a5b03d3a41f3e346f8f366b062b7b4b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0155" ;
+    nidm_coordinateVector: "[-18,-22,44]"^^xsd:string .
+
+niiri:2ad984f6f188e95e289d863a3dc28223 prov:wasDerivedFrom niiri:842d2062c93ff252780aae9939a20111 .
+
+niiri:3271f178664f3539edaa018f6f207fa8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0156" ;
+    prov:atLocation niiri:90a5129a6c43a75a468beb3757198213 ;
+    prov:value "0.809625387191772"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.71719685114941"^^xsd:float ;
+    nidm_pValueUncorrected: "0.042971605350922"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:90a5129a6c43a75a468beb3757198213
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0156" ;
+    nidm_coordinateVector: "[-8,-88,-48]"^^xsd:string .
+
+niiri:3271f178664f3539edaa018f6f207fa8 prov:wasDerivedFrom niiri:d27fbf9c8044e6b188c300c4990f6f54 .
+
+niiri:e89619f00261dd896c5e6b49b91ad9fa
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0157" ;
+    prov:atLocation niiri:cb30d0dcf44e480e9d546d120872d8b2 ;
+    prov:value "0.807083547115326"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.71399568809748"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0432647588890963"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:cb30d0dcf44e480e9d546d120872d8b2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0157" ;
+    nidm_coordinateVector: "[-28,-90,-14]"^^xsd:string .
+
+niiri:e89619f00261dd896c5e6b49b91ad9fa prov:wasDerivedFrom niiri:2a4965b8fc709556c2aa1abb6adf5441 .
+
+niiri:d514e4693dd32deec29d4b4747f44ab2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0158" ;
+    prov:atLocation niiri:b4bd0cc943eb4c6123bcaa4505ed1439 ;
+    prov:value "0.804524898529053"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.71077421355999"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0435614007800803"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:b4bd0cc943eb4c6123bcaa4505ed1439
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0158" ;
+    nidm_coordinateVector: "[54,18,14]"^^xsd:string .
+
+niiri:d514e4693dd32deec29d4b4747f44ab2 prov:wasDerivedFrom niiri:9cc63018305b210a50122f137d979802 .
+
+niiri:56f159e4b339f215b07ab529dcb6afe5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0159" ;
+    prov:atLocation niiri:0e2f64a7d2cf43118af0d523a1045abf ;
+    prov:value "0.801611304283142"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.70710689586196"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0439010928174099"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:0e2f64a7d2cf43118af0d523a1045abf
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0159" ;
+    nidm_coordinateVector: "[38,-48,18]"^^xsd:string .
+
+niiri:56f159e4b339f215b07ab529dcb6afe5 prov:wasDerivedFrom niiri:965ac0d53ae837b608d6841eb6671ec5 .
+
+niiri:3775e9935ca298404180c033594cef47
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0160" ;
+    prov:atLocation niiri:974a061454302498849b51020d3bcaf0 ;
+    prov:value "0.801064372062683"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.70641860205681"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0439650847967754"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:974a061454302498849b51020d3bcaf0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0160" ;
+    nidm_coordinateVector: "[-32,-70,28]"^^xsd:string .
+
+niiri:3775e9935ca298404180c033594cef47 prov:wasDerivedFrom niiri:d20a800c34ef4ebbc2c9d064007ca5a5 .
+
+niiri:67775b1fe689aac8a236bd5098ede3ac
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0161" ;
+    prov:atLocation niiri:2c52525c383497b335b50a9120c734ec ;
+    prov:value "0.796977043151855"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.70127611195347"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0444455757271468"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:2c52525c383497b335b50a9120c734ec
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0161" ;
+    nidm_coordinateVector: "[40,-8,-32]"^^xsd:string .
+
+niiri:67775b1fe689aac8a236bd5098ede3ac prov:wasDerivedFrom niiri:0a26619869c6304390cf220d86997062 .
+
+niiri:5338ab94ade7000ed4f4bdf7d9d76d2b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0162" ;
+    prov:atLocation niiri:f70d129d0d7c22e30869fb59d6e5cc46 ;
+    prov:value "0.795195400714874"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.69903522990177"^^xsd:float ;
+    nidm_pValueUncorrected: "0.044656272931023"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:f70d129d0d7c22e30869fb59d6e5cc46
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0162" ;
+    nidm_coordinateVector: "[10,-10,4]"^^xsd:string .
+
+niiri:5338ab94ade7000ed4f4bdf7d9d76d2b prov:wasDerivedFrom niiri:6a5b8fb86c67c0eb5b9c606e6b810510 .
+
+niiri:47f63f9dd57bbc2ec925efae82f98e54
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0163" ;
+    prov:atLocation niiri:f5fa7f06451efb337a56d65fce6310d4 ;
+    prov:value "0.793771862983704"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.69724506469093"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0448251692331177"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:f5fa7f06451efb337a56d65fce6310d4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0163" ;
+    nidm_coordinateVector: "[36,-38,16]"^^xsd:string .
+
+niiri:47f63f9dd57bbc2ec925efae82f98e54 prov:wasDerivedFrom niiri:99f3a2d8e7661135dd74892e7227bd72 .
+
+niiri:e057cf1a39f015eb9f597ecf60c28d8d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0164" ;
+    prov:atLocation niiri:408e388806b9aac265fd41d04872e446 ;
+    prov:value "0.791125535964966"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.69391791067376"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0451404415013222"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:408e388806b9aac265fd41d04872e446
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0164" ;
+    nidm_coordinateVector: "[36,-58,-34]"^^xsd:string .
+
+niiri:e057cf1a39f015eb9f597ecf60c28d8d prov:wasDerivedFrom niiri:64a5de9f75df294ee267e34b2597bc84 .
+
+niiri:f4707b696468bcd21beacb40c56d4112
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0165" ;
+    prov:atLocation niiri:8770aec72d29d54ccbc74852e6556723 ;
+    prov:value "0.790164232254028"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.69270952448475"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0452553857167721"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:8770aec72d29d54ccbc74852e6556723
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0165" ;
+    nidm_coordinateVector: "[-24,-68,40]"^^xsd:string .
+
+niiri:f4707b696468bcd21beacb40c56d4112 prov:wasDerivedFrom niiri:2c98abbba202c2ed1fa8e08549a97cb1 .
+
+niiri:0855ebe4c0e33757d2de5fe5b72c3aa4
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0166" ;
+    prov:atLocation niiri:1304b6c03fd823e5f08127fb56383466 ;
+    prov:value "0.789975047111511"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.6924717281141"^^xsd:float ;
+    nidm_pValueUncorrected: "0.045278033108256"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:1304b6c03fd823e5f08127fb56383466
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0166" ;
+    nidm_coordinateVector: "[-32,-66,-54]"^^xsd:string .
+
+niiri:0855ebe4c0e33757d2de5fe5b72c3aa4 prov:wasDerivedFrom niiri:35bfc5987aa4a1eba01be33e4c1ee7f2 .
+
+niiri:767f2a4a4176e20fbe7980bfd92d4d37
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0167" ;
+    prov:atLocation niiri:48c823ec7d05b841c28208a512ace325 ;
+    prov:value "0.785030126571655"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.68625793462611"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0458730647233518"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:48c823ec7d05b841c28208a512ace325
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0167" ;
+    nidm_coordinateVector: "[-38,-4,36]"^^xsd:string .
+
+niiri:767f2a4a4176e20fbe7980bfd92d4d37 prov:wasDerivedFrom niiri:33395b862a603ee1373735759fed1bcb .
+
+niiri:efc75d1d378ad8d8e290d9c8d692030e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0168" ;
+    prov:atLocation niiri:cf847ee221aa1a3ba5ad8ab6ceda969c ;
+    prov:value "0.783349096775055"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.68414631143602"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0460766980434556"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:cf847ee221aa1a3ba5ad8ab6ceda969c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0168" ;
+    nidm_coordinateVector: "[-50,10,-6]"^^xsd:string .
+
+niiri:efc75d1d378ad8d8e290d9c8d692030e prov:wasDerivedFrom niiri:635a4fc24d89b14d261b42d568e53ac8 .
+
+niiri:f23899f7631f3a7071c3337dd7fc2238
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0169" ;
+    prov:atLocation niiri:0bb4251c6e182321ff1b00b360bea5db ;
+    prov:value "0.780271351337433"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.68028121266012"^^xsd:float ;
+    nidm_pValueUncorrected: "0.046451307319556"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:0bb4251c6e182321ff1b00b360bea5db
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0169" ;
+    nidm_coordinateVector: "[-18,-22,34]"^^xsd:string .
+
+niiri:f23899f7631f3a7071c3337dd7fc2238 prov:wasDerivedFrom niiri:55b4eeddb69bb03436464cf696dd593b .
+
+niiri:e0c716598553c866132acb9e00a99269
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0170" ;
+    prov:atLocation niiri:bd016d0a131f74cd47766a37849f8af4 ;
+    prov:value "0.778013467788696"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.67744654581037"^^xsd:float ;
+    nidm_pValueUncorrected: "0.046727596979824"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:bd016d0a131f74cd47766a37849f8af4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0170" ;
+    nidm_coordinateVector: "[-20,-22,38]"^^xsd:string .
+
+niiri:e0c716598553c866132acb9e00a99269 prov:wasDerivedFrom niiri:493898a476d4ce4bf533682e007422c5 .
+
+niiri:23993fd78665c8c8cea4bbea816aa847
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0171" ;
+    prov:atLocation niiri:34c3f1555e908f480a1cd6c4105ace9b ;
+    prov:value "0.775993704795837"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.67491142741087"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0469758055929785"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:34c3f1555e908f480a1cd6c4105ace9b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0171" ;
+    nidm_coordinateVector: "[12,-92,2]"^^xsd:string .
+
+niiri:23993fd78665c8c8cea4bbea816aa847 prov:wasDerivedFrom niiri:b841eb2677ab2ad59ce73103265cdee0 .
+
+niiri:2f0c7a7defde925468925744ec810146
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0172" ;
+    prov:atLocation niiri:da9b38041402957b6d2f062656d107ff ;
+    prov:value "0.774858772754669"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.67348715940063"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0471157161396256"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:da9b38041402957b6d2f062656d107ff
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0172" ;
+    nidm_coordinateVector: "[52,-44,58]"^^xsd:string .
+
+niiri:2f0c7a7defde925468925744ec810146 prov:wasDerivedFrom niiri:4c7ec0be40515b0eae812fe9befe02f1 .
+
+niiri:f05db93a343d1865fd10001c92a30d32
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0173" ;
+    prov:atLocation niiri:5a77aafacf3c36dfd821f2078711b553 ;
+    prov:value "0.766564428806305"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.66308376386524"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0481478347201374"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:5a77aafacf3c36dfd821f2078711b553
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0173" ;
+    nidm_coordinateVector: "[46,30,-8]"^^xsd:string .
+
+niiri:f05db93a343d1865fd10001c92a30d32 prov:wasDerivedFrom niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22 .
+
+niiri:8185514955cc636d4b50aa7fd9985960
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0174" ;
+    prov:atLocation niiri:59906cc8f0c4f1ad9a16e5f64ecc97e9 ;
+    prov:value "0.766485750675201"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.66298512623431"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0481577064245639"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:59906cc8f0c4f1ad9a16e5f64ecc97e9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0174" ;
+    nidm_coordinateVector: "[20,-72,-22]"^^xsd:string .
+
+niiri:8185514955cc636d4b50aa7fd9985960 prov:wasDerivedFrom niiri:9d494c09341573a6df3c044f6f353a5a .
+
+niiri:f82c4e460ed68891672a882b6ca47ce7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0175" ;
+    prov:atLocation niiri:6b08822f4f84a3704fb33481c32938e7 ;
+    prov:value "0.764753878116608"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.66081412523685"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0483753916847881"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:6b08822f4f84a3704fb33481c32938e7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0175" ;
+    nidm_coordinateVector: "[30,-32,14]"^^xsd:string .
+
+niiri:f82c4e460ed68891672a882b6ca47ce7 prov:wasDerivedFrom niiri:630ac6074dee24b42295002659ee6cd4 .
+
+niiri:085070c6b1c81a70c7d9316dc333c5af
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0176" ;
+    prov:atLocation niiri:f2d70aea1159517722dc1f0e96049f7f ;
+    prov:value "0.764399468898773"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.66036990560998"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0484200302267611"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:f2d70aea1159517722dc1f0e96049f7f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0176" ;
+    nidm_coordinateVector: "[-8,-2,66]"^^xsd:string .
+
+niiri:085070c6b1c81a70c7d9316dc333c5af prov:wasDerivedFrom niiri:97f9982dca21f34e7ea0fcb977fcf50b .
+
+niiri:35df629079347c6c083f74c21c155794
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0177" ;
+    prov:atLocation niiri:6c5f4e78e250aba08a965b5ca9cce21d ;
+    prov:value "0.763978481292725"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.65984225927592"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0484730949107541"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:6c5f4e78e250aba08a965b5ca9cce21d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0177" ;
+    nidm_coordinateVector: "[-20,10,-22]"^^xsd:string .
+
+niiri:35df629079347c6c083f74c21c155794 prov:wasDerivedFrom niiri:b7588b8a823a7341bbdb4d3e8686e040 .
+
+niiri:81ebc55180aab5f90eb8e98ffc27a319
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0178" ;
+    prov:atLocation niiri:82ba696cda1e7d2d87bd5e1ac789e9b4 ;
+    prov:value "0.763044834136963"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.65867215934383"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0485909362055301"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:82ba696cda1e7d2d87bd5e1ac789e9b4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0178" ;
+    nidm_coordinateVector: "[-62,2,14]"^^xsd:string .
+
+niiri:81ebc55180aab5f90eb8e98ffc27a319 prov:wasDerivedFrom niiri:31b704c584e2aae3b394c52754216fae .
+
+niiri:21c18d8c769fb0c198241386ba803d0e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0179" ;
+    prov:atLocation niiri:38c7639cf73f14cd5fd84daa5a16b606 ;
+    prov:value "0.762995421886444"^^xsd:float ;
+    nidm_equivalentZStatistic: "1.65861023655314"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0485971788535396"^^xsd:float ;
+    nidm_pValueFWER: "1"^^xsd:float ;
+    nidm_qValueFDR: "0.928284605381944"^^xsd:float .
+
+niiri:38c7639cf73f14cd5fd84daa5a16b606
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0179" ;
+    nidm_coordinateVector: "[-12,-28,80]"^^xsd:string .
+
+niiri:21c18d8c769fb0c198241386ba803d0e prov:wasDerivedFrom niiri:2eff95031f5301f6a29990e69708dce1 .
+

--- a/spmexport/ex_spm_partial_conjunction/nidm.ttl
+++ b/spmexport/ex_spm_partial_conjunction/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:040b09b9b063245a4737fca3df5cdd7d
+niiri:243ddea5e5dff3c37c34dba282896eea
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:81951937f6ae09441f641771cfea9128
+niiri:25efcb2fdf89f72335565444747a8325
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:cc2545342f68b7d4d79cd122b1fcabbb
+niiri:bc9474858aa89d5580813e5a520e15a8
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:cc2545342f68b7d4d79cd122b1fcabbb prov:wasAssociatedWith niiri:81951937f6ae09441f641771cfea9128 .
+niiri:bc9474858aa89d5580813e5a520e15a8 prov:wasAssociatedWith niiri:25efcb2fdf89f72335565444747a8325 .
 
 _:blank5 a prov:Generation .
 
-niiri:040b09b9b063245a4737fca3df5cdd7d prov:qualifiedGeneration _:blank5 .
+niiri:243ddea5e5dff3c37c34dba282896eea prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:11:58"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:34:17"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -136,12 +136,12 @@ _:blank5 prov:atTime "2016-01-11T10:11:58"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:ca46a12c6a6d80a84b02ee07a74d055c
+niiri:1d7e73278ccee95e211689d9de8f4d4a
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:4ddf2148145597f7f7c9369cb269b13f
+niiri:a56db6367efd1f7176e69f24b028de94
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -151,35 +151,35 @@ niiri:4ddf2148145597f7f7c9369cb269b13f
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:1c3284ad8fc17300f53a85a850aa14b6
+niiri:03e7d0232ea5517ed14b6e2311b82699
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:1a568ef0c2c5aa1a886880bbdf2d08f8
+niiri:df0cfe4ba2647dd9f372f5d3b73c6885
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:87e000d813ecf48e9045ac10927bd76c
+niiri:1388e1cf368a92acbd46e47523c2061a
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:29dae04876f55e477f52f60d27b0ce4d ;
+    dc:description niiri:d17dbd59c5c8179a99d73392215c0c41 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) mr_sw*bf(1)\", \"Sn(1) mr_ns*bf(1)\", \"Sn(1) pl_sw*bf(1)\", \"Sn(1) pl_ns*bf(1)\", \"Sn(1) junk*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:1a568ef0c2c5aa1a886880bbdf2d08f8 ;
+    nidm_hasDriftModel: niiri:df0cfe4ba2647dd9f372f5d3b73c6885 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:29dae04876f55e477f52f60d27b0ce4d
+niiri:d17dbd59c5c8179a99d73392215c0c41
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:07c328d2e12fa56c0f2874230dfc8be8
+niiri:05be31167ef4404a70e4f0e58bd930aa
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -187,213 +187,213 @@ niiri:07c328d2e12fa56c0f2874230dfc8be8
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:a36c7399032b89af037fcdfdcf2d9f29
+niiri:8d051ec65c19e120a2e66d23f309c6e9
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:a36c7399032b89af037fcdfdcf2d9f29 prov:wasAssociatedWith niiri:ca46a12c6a6d80a84b02ee07a74d055c .
+niiri:8d051ec65c19e120a2e66d23f309c6e9 prov:wasAssociatedWith niiri:1d7e73278ccee95e211689d9de8f4d4a .
 
-niiri:a36c7399032b89af037fcdfdcf2d9f29 prov:used niiri:87e000d813ecf48e9045ac10927bd76c .
+niiri:8d051ec65c19e120a2e66d23f309c6e9 prov:used niiri:1388e1cf368a92acbd46e47523c2061a .
 
-niiri:a36c7399032b89af037fcdfdcf2d9f29 prov:used niiri:1c3284ad8fc17300f53a85a850aa14b6 .
+niiri:8d051ec65c19e120a2e66d23f309c6e9 prov:used niiri:03e7d0232ea5517ed14b6e2311b82699 .
 
-niiri:a36c7399032b89af037fcdfdcf2d9f29 prov:used niiri:07c328d2e12fa56c0f2874230dfc8be8 .
+niiri:8d051ec65c19e120a2e66d23f309c6e9 prov:used niiri:05be31167ef4404a70e4f0e58bd930aa .
 
-niiri:297de961f206e0187be8fdda200091ee
+niiri:d17318e0fda06cc6303389a919cffce0
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:ec2656e975a6d0642c33357bfa356e4b
+niiri:511e38d9f81db913e57cb2fda1bf7292
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bc0e22a3eb2c896557e1e680900858fc400231b687aee04d5e3c51cca04b17f4210b79c966e12ecb4b321c29dda58e5ffb15f851cdfd62c5a9cec6e56ccddd2b"^^xsd:string .
 
-niiri:297de961f206e0187be8fdda200091ee prov:wasDerivedFrom niiri:ec2656e975a6d0642c33357bfa356e4b .
+niiri:d17318e0fda06cc6303389a919cffce0 prov:wasDerivedFrom niiri:511e38d9f81db913e57cb2fda1bf7292 .
 
-niiri:297de961f206e0187be8fdda200091ee prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:d17318e0fda06cc6303389a919cffce0 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:a354106ee78314547a9438f2bb2dee6c
+niiri:b24768aaee9add9a163a13028ada6ac2
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "108.038318634033"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "73643a59abf52d8456d427b7c94a21fb5213b4b71c10ce39a94e1cd9995a58057fcf52794c7cb71ad9acf7a167eb0dbf0db3f9aeaeede1706cba904b73dca848"^^xsd:string .
 
-niiri:a354106ee78314547a9438f2bb2dee6c prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:b24768aaee9add9a163a13028ada6ac2 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:38c86177a556ef8eb57c8feb5a72bbe6
+niiri:fbf0025dc56929ec686d1a867cba4ed9
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
 
-niiri:379fb8881957a95b855265fdeb2eae08
+niiri:c6f77d4608bf5adce440967ee6f38924
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "be820a2f6c3699ac1a63bd9e0ba8518c1600a0313e193d4a3e19cc4362e545abd38469ddb3dcc3fb59efaeba50f12ab9ffcf502061631c642a884af56560be3f"^^xsd:string .
 
-niiri:38c86177a556ef8eb57c8feb5a72bbe6 prov:wasDerivedFrom niiri:379fb8881957a95b855265fdeb2eae08 .
+niiri:fbf0025dc56929ec686d1a867cba4ed9 prov:wasDerivedFrom niiri:c6f77d4608bf5adce440967ee6f38924 .
 
-niiri:38c86177a556ef8eb57c8feb5a72bbe6 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:fbf0025dc56929ec686d1a867cba4ed9 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:0640a7b36210753d2e9b544c3f195a55
+niiri:b0bd46832f113e655723b654eb1eb6ad
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
 
-niiri:6b197125a990fba281a71f02c3a45aac
+niiri:42e752fc06737a9878924396d3bfcce9
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1430335d25c76e19cb3bcfa012a51eda78c2534a3a3c15b9b31d7447d4d79f473b5875843e80740d16208d525aa141c861ab112507e2e7c5ed55959038c9f01b"^^xsd:string .
 
-niiri:0640a7b36210753d2e9b544c3f195a55 prov:wasDerivedFrom niiri:6b197125a990fba281a71f02c3a45aac .
+niiri:b0bd46832f113e655723b654eb1eb6ad prov:wasDerivedFrom niiri:42e752fc06737a9878924396d3bfcce9 .
 
-niiri:0640a7b36210753d2e9b544c3f195a55 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:b0bd46832f113e655723b654eb1eb6ad prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:2d0fff51543ffad218594440febbbc00
+niiri:09ee1b58f1cd2a34771305a61a8d1d32
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
 
-niiri:2bcd6acc3147da711188ef3d9591491e
+niiri:a2c15aa0c4d45f52407ac5827bbf73bb
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "a16b3cca7c22a4385dd5321a01cee79e2a1ccbd995ddf924fa7e6c8f286bbc99acb726584562c24bd4176f84130aea7218195aa090ddb84247ff94decfd850eb"^^xsd:string .
 
-niiri:2d0fff51543ffad218594440febbbc00 prov:wasDerivedFrom niiri:2bcd6acc3147da711188ef3d9591491e .
+niiri:09ee1b58f1cd2a34771305a61a8d1d32 prov:wasDerivedFrom niiri:a2c15aa0c4d45f52407ac5827bbf73bb .
 
-niiri:2d0fff51543ffad218594440febbbc00 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:09ee1b58f1cd2a34771305a61a8d1d32 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:1e3dffce54f22bc8a196481235889e5a
+niiri:16ce2036a3b6f15ece6fc491d108ae37
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
 
-niiri:59d5f854810e0cf53187fca482714676
+niiri:ee716d14a7ac59b3c4521ed8cbff1e3a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3ef040dd4156288f6e00f9dde6566008a74022758623483d269086ecfa4b3764f3bb05251a46ab326cd9971839c9c711006bd05f0d0e0d543612ab6fcdeb2fa6"^^xsd:string .
 
-niiri:1e3dffce54f22bc8a196481235889e5a prov:wasDerivedFrom niiri:59d5f854810e0cf53187fca482714676 .
+niiri:16ce2036a3b6f15ece6fc491d108ae37 prov:wasDerivedFrom niiri:ee716d14a7ac59b3c4521ed8cbff1e3a .
 
-niiri:1e3dffce54f22bc8a196481235889e5a prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:16ce2036a3b6f15ece6fc491d108ae37 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:883679c50b07b857a6c67ccde5dc3273
+niiri:c856b511969b2c541b07a88189532fa6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
 
-niiri:0db23e51e95f52cb9f0539d9da712088
+niiri:33afe3bb4683b8e28103d232fdf92af8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "fedee569e24e6a8b58ab59a2e10c6be3ba811752bb9f6da50709a5c7b1ace19d7ffda59fd2fe5ac07d9e9bc4da11338d71e7069b0e2ac852d39007789bbc52ff"^^xsd:string .
 
-niiri:883679c50b07b857a6c67ccde5dc3273 prov:wasDerivedFrom niiri:0db23e51e95f52cb9f0539d9da712088 .
+niiri:c856b511969b2c541b07a88189532fa6 prov:wasDerivedFrom niiri:33afe3bb4683b8e28103d232fdf92af8 .
 
-niiri:883679c50b07b857a6c67ccde5dc3273 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:c856b511969b2c541b07a88189532fa6 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:67e0052a2914e6b58321e390f9d4a9ea
+niiri:e8f6f2e9821e3f9556f500048b8ae9b5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 6" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f .
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 .
 
-niiri:7654bad538105caaf15e55efcb04c343
+niiri:8167c647e0923c3553c7c0ffc2d666d4
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5e4c12d0189a405df73642520fca3f6f23f37db75d202c03e217675ffcce441ebe42e99894b4561cf9739b46eb1371debf8a8b23efe9e86ec24166927794351c"^^xsd:string .
 
-niiri:67e0052a2914e6b58321e390f9d4a9ea prov:wasDerivedFrom niiri:7654bad538105caaf15e55efcb04c343 .
+niiri:e8f6f2e9821e3f9556f500048b8ae9b5 prov:wasDerivedFrom niiri:8167c647e0923c3553c7c0ffc2d666d4 .
 
-niiri:67e0052a2914e6b58321e390f9d4a9ea prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:e8f6f2e9821e3f9556f500048b8ae9b5 prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:a79b8d0835c3bf79e9faf32502e506b4
+niiri:ecf064f9baf28d8f742bd2855558502d
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "8721ece3d3084917bbd7cbf24e40027da6d6084caf0afa22783e9dc4279d1defe84362a827a06a4f7b81b75b771b2b819fc0720e957302d17f7afccce0fed2f8"^^xsd:string .
 
-niiri:28c03f1f4b9973dbb638d943ac9944e6
+niiri:2cbf5c3625b82cb3fee7b9e869188b55
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "90a4f0be6b668a65e01bcce5377a069670ec5ab135ff87f564cfbc0440318f6604470bd1e2baab9507d123f9a4be36c1a6847f4b1cd6c205f5dff1aafcd41b81"^^xsd:string .
 
-niiri:a79b8d0835c3bf79e9faf32502e506b4 prov:wasDerivedFrom niiri:28c03f1f4b9973dbb638d943ac9944e6 .
+niiri:ecf064f9baf28d8f742bd2855558502d prov:wasDerivedFrom niiri:2cbf5c3625b82cb3fee7b9e869188b55 .
 
-niiri:a79b8d0835c3bf79e9faf32502e506b4 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:ecf064f9baf28d8f742bd2855558502d prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:089005ddd166a56358c0d0ec21720e18
+niiri:0c0eb1d804cee8231e915a5fdfc5ab8b
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "bea02d144f49db7ea625da57e6929bcea39973d6ad9e47f5c09ca65b19f359837649da2dee7fdc4b668a677fc9d0cae380b082a753afba61ecf4bf705e9eead8"^^xsd:string .
 
-niiri:949f5e9e8329eea5ff262f3113b92d3c
+niiri:eeee4f9f7f0c1ed7696258b61716b549
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d65f7c471d6695e60691d74e52ac8d2d6f4c1e44764dad1fb672b49e3138d3e34f7a69367983607ad89b57bc0f464e5377bc76e3a6ea9624930372567273cb29"^^xsd:string .
 
-niiri:089005ddd166a56358c0d0ec21720e18 prov:wasDerivedFrom niiri:949f5e9e8329eea5ff262f3113b92d3c .
+niiri:0c0eb1d804cee8231e915a5fdfc5ab8b prov:wasDerivedFrom niiri:eeee4f9f7f0c1ed7696258b61716b549 .
 
-niiri:089005ddd166a56358c0d0ec21720e18 prov:wasGeneratedBy niiri:a36c7399032b89af037fcdfdcf2d9f29 .
+niiri:0c0eb1d804cee8231e915a5fdfc5ab8b prov:wasGeneratedBy niiri:8d051ec65c19e120a2e66d23f309c6e9 .
 
-niiri:6310b38d15cf70fcc0b18a630086f710
+niiri:0e92041f1c22bfbe8b6d3bba28b3ce18
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     rdfs:label "Contrast: mr vs plain" ;
     prov:value "[1, 1, -1, -1, 0, 0]"^^xsd:string .
 
-niiri:470a6da8f55eec239393f9743368624c
+niiri:4ee8aaeabfe9f5181a4281676d9a033d
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 1" .
 
-niiri:470a6da8f55eec239393f9743368624c prov:wasAssociatedWith niiri:ca46a12c6a6d80a84b02ee07a74d055c .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:wasAssociatedWith niiri:1d7e73278ccee95e211689d9de8f4d4a .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:297de961f206e0187be8fdda200091ee .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:d17318e0fda06cc6303389a919cffce0 .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:a79b8d0835c3bf79e9faf32502e506b4 .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:ecf064f9baf28d8f742bd2855558502d .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:87e000d813ecf48e9045ac10927bd76c .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:1388e1cf368a92acbd46e47523c2061a .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:6310b38d15cf70fcc0b18a630086f710 .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:0e92041f1c22bfbe8b6d3bba28b3ce18 .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:38c86177a556ef8eb57c8feb5a72bbe6 .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:fbf0025dc56929ec686d1a867cba4ed9 .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:0640a7b36210753d2e9b544c3f195a55 .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:b0bd46832f113e655723b654eb1eb6ad .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:2d0fff51543ffad218594440febbbc00 .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:09ee1b58f1cd2a34771305a61a8d1d32 .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:1e3dffce54f22bc8a196481235889e5a .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:16ce2036a3b6f15ece6fc491d108ae37 .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:883679c50b07b857a6c67ccde5dc3273 .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:c856b511969b2c541b07a88189532fa6 .
 
-niiri:470a6da8f55eec239393f9743368624c prov:used niiri:67e0052a2914e6b58321e390f9d4a9ea .
+niiri:4ee8aaeabfe9f5181a4281676d9a033d prov:used niiri:e8f6f2e9821e3f9556f500048b8ae9b5 .
 
-niiri:7512552d6509729de4464db02c1b2b85
+niiri:3ccd77b3de962099cf8ce0c08029054a
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0001.nii.gz"^^xsd:string ;
@@ -403,84 +403,84 @@ niiri:7512552d6509729de4464db02c1b2b85
     nidm_contrastName: "mr vs plain"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "3d222abce9f360902d01cb45ffaaa3d711c699c6771f36ee61630ccc2fec2275897a15dd31b846a074e20b59337bae8b171223c15f22d8f2168a1967e85b397a"^^xsd:string .
 
-niiri:fb4dee4e1331d80c18561bf743daf272
+niiri:f9a3461abe033c0b4194f4eb1324b723
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "aebdf5f3c741d8b2c2d2f4f924d9c82e393e8a534603fc77cad173fff1f70bba798fe74b2ff0a725c4181b1ad59b78d3f37db660ca10d3f22d71d0741f27c782"^^xsd:string .
 
-niiri:7512552d6509729de4464db02c1b2b85 prov:wasDerivedFrom niiri:fb4dee4e1331d80c18561bf743daf272 .
+niiri:3ccd77b3de962099cf8ce0c08029054a prov:wasDerivedFrom niiri:f9a3461abe033c0b4194f4eb1324b723 .
 
-niiri:7512552d6509729de4464db02c1b2b85 prov:wasGeneratedBy niiri:470a6da8f55eec239393f9743368624c .
+niiri:3ccd77b3de962099cf8ce0c08029054a prov:wasGeneratedBy niiri:4ee8aaeabfe9f5181a4281676d9a033d .
 
-niiri:b4a484110c0e0f1679fe0a5f8bdff03e
+niiri:8fec6cee88576b42702d9e1f7488e362
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: mr vs plain" ;
     nidm_contrastName: "mr vs plain"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "da03bc15b480c389aef3095d1a0ebd43f66d4f3ef7c4c30f4f1b4938f27392e060edc590d95edecda00ccf80bfc56d87f5b0c4c689ce32ba33506f9e0563a0d5"^^xsd:string .
 
-niiri:1dd135affe7808067a99b5363be9574c
+niiri:3dcfcea6814505f9436e9dba6e69af0a
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "56e20d705475fcdc2123532215e4dcbd7db25a6210c432017a8d965c794b9f09d860ab5fd6f3b84750f1db7610dd27ebfa97ea4abc640d110f672ca522f4dc28"^^xsd:string .
 
-niiri:b4a484110c0e0f1679fe0a5f8bdff03e prov:wasDerivedFrom niiri:1dd135affe7808067a99b5363be9574c .
+niiri:8fec6cee88576b42702d9e1f7488e362 prov:wasDerivedFrom niiri:3dcfcea6814505f9436e9dba6e69af0a .
 
-niiri:b4a484110c0e0f1679fe0a5f8bdff03e prov:wasGeneratedBy niiri:470a6da8f55eec239393f9743368624c .
+niiri:8fec6cee88576b42702d9e1f7488e362 prov:wasGeneratedBy niiri:4ee8aaeabfe9f5181a4281676d9a033d .
 
-niiri:759cc611eb1badedf971eb0bbd3381ef
+niiri:4ad1bd5ff050ee049008dafae70fffb2
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "5dc3fca765031371124b93ae045627c60482af20d5509f441903b60797b97ceac41218b785ea7705278a79198188ad288ca428c0de5f0e1b84032cb628f9720b"^^xsd:string .
 
-niiri:759cc611eb1badedf971eb0bbd3381ef prov:wasGeneratedBy niiri:470a6da8f55eec239393f9743368624c .
+niiri:4ad1bd5ff050ee049008dafae70fffb2 prov:wasGeneratedBy niiri:4ee8aaeabfe9f5181a4281676d9a033d .
 
-niiri:830506c8d8c91472fbeb134a312b9816
+niiri:13fb71f74ac2523fac8d4fe8ab7ecb1d
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
     rdfs:label "Contrast: switch vs nonswitch (orth. w.r.t {1})" ;
     prov:value "[0.953151930124911, -1.04684806987509, 1.04684806987509, -0.953151930124911, 0, 0]"^^xsd:string .
 
-niiri:d74adb2677a9d89623e02872d79aefab
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 2" .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:wasAssociatedWith niiri:ca46a12c6a6d80a84b02ee07a74d055c .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:wasAssociatedWith niiri:1d7e73278ccee95e211689d9de8f4d4a .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:297de961f206e0187be8fdda200091ee .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:d17318e0fda06cc6303389a919cffce0 .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:a79b8d0835c3bf79e9faf32502e506b4 .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:ecf064f9baf28d8f742bd2855558502d .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:87e000d813ecf48e9045ac10927bd76c .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:1388e1cf368a92acbd46e47523c2061a .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:830506c8d8c91472fbeb134a312b9816 .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:13fb71f74ac2523fac8d4fe8ab7ecb1d .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:38c86177a556ef8eb57c8feb5a72bbe6 .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:fbf0025dc56929ec686d1a867cba4ed9 .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:0640a7b36210753d2e9b544c3f195a55 .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:b0bd46832f113e655723b654eb1eb6ad .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:2d0fff51543ffad218594440febbbc00 .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:09ee1b58f1cd2a34771305a61a8d1d32 .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:1e3dffce54f22bc8a196481235889e5a .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:16ce2036a3b6f15ece6fc491d108ae37 .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:883679c50b07b857a6c67ccde5dc3273 .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:c856b511969b2c541b07a88189532fa6 .
 
-niiri:d74adb2677a9d89623e02872d79aefab prov:used niiri:67e0052a2914e6b58321e390f9d4a9ea .
+niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 prov:used niiri:e8f6f2e9821e3f9556f500048b8ae9b5 .
 
-niiri:3847144ad5571b76c8855c604579438d
+niiri:406c820ff107488cd976836b2d5c6516
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0002.nii.gz"^^xsd:string ;
@@ -490,126 +490,126 @@ niiri:3847144ad5571b76c8855c604579438d
     nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "192.99999999965"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "0.999999999999999"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "ec2f61dbf28ab2256a374dc5e3a93ba3a54e520c6bccd089dfbd07421e445b4881154433ea31e32587c1fae170daa5dc0a21f6efc328b90727d8d25bbd524e2f"^^xsd:string .
 
-niiri:d321a1053a1ad60011b5d0c936fced97
+niiri:e928c1c55744b1fd90a0de8fa5ab64b3
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4a7d076c01440a170e048ebe9644f90193b2aaf1291f454bdc6be2cf17e11a66b1d177025f5ed77434afe780ff8dcba710ec41120246e38894f823eb0fd88621"^^xsd:string .
 
-niiri:3847144ad5571b76c8855c604579438d prov:wasDerivedFrom niiri:d321a1053a1ad60011b5d0c936fced97 .
+niiri:406c820ff107488cd976836b2d5c6516 prov:wasDerivedFrom niiri:e928c1c55744b1fd90a0de8fa5ab64b3 .
 
-niiri:3847144ad5571b76c8855c604579438d prov:wasGeneratedBy niiri:d74adb2677a9d89623e02872d79aefab .
+niiri:406c820ff107488cd976836b2d5c6516 prov:wasGeneratedBy niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 .
 
-niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc
+niiri:769ec268b92ea35935ef54cff37b9b03
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: switch vs nonswitch (orth. w.r.t {1})" ;
     nidm_contrastName: "switch vs nonswitch (orth. w.r.t {1})"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "31a00f409f493fc214fe1f84fe2a799bb96d1e03d67f2ce5b8c5b5fdb934bb0005f1be68addb81934052af4643c3099542ea4944013e9346042a44c2ed8f3788"^^xsd:string .
 
-niiri:a98253404e56b8be6f3aecf1424cb0f4
+niiri:37d6e69cac2b0a5b938bfdfb712bf881
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "6d92adc90c0045445b66064818fdae617474690e92e9cb332e73fa8bf27f6d1d18367c0648ffbc74196a5c2ce9f4af4186394628eed475a0e2866efe3d4eee9b"^^xsd:string .
 
-niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc prov:wasDerivedFrom niiri:a98253404e56b8be6f3aecf1424cb0f4 .
+niiri:769ec268b92ea35935ef54cff37b9b03 prov:wasDerivedFrom niiri:37d6e69cac2b0a5b938bfdfb712bf881 .
 
-niiri:b8e01c5a1d3b8c69d403cc9c09e9abcc prov:wasGeneratedBy niiri:d74adb2677a9d89623e02872d79aefab .
+niiri:769ec268b92ea35935ef54cff37b9b03 prov:wasGeneratedBy niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 .
 
-niiri:ec1657f37e3b226c40848c8427be67c3
+niiri:791b2b0b99cd2c0794a3a2a508127afe
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "ac87f548f0d92f929c05476d2aacbc7e5319da6d62a5585a72d714be836b1b86962a36c6d473ae84c17cd613d683976e9fc562d6d7692cb8e942966f71e34a08"^^xsd:string .
 
-niiri:ec1657f37e3b226c40848c8427be67c3 prov:wasGeneratedBy niiri:d74adb2677a9d89623e02872d79aefab .
+niiri:791b2b0b99cd2c0794a3a2a508127afe prov:wasGeneratedBy niiri:f1caaf0c37a363ca6d9dba8a65ed8d08 .
 
-niiri:bcc964db0d0638d6cba59069ee9e794b
+niiri:926b152f947e98d6025b235c27f919b2
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.048771 (unc.)" ;
     prov:value "0.0487705355732563"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:d7de198640509df2418dca3bf55b09d0 ;
-    nidm_equivalentThreshold: niiri:33a31ffbbf2d136c84bd8c001890f221 .
+    nidm_equivalentThreshold: niiri:6c13a2215653fb5c58245ecb3124b723 ;
+    nidm_equivalentThreshold: niiri:e14ba17059f36074630699f7fc00a61e .
 
-niiri:d7de198640509df2418dca3bf55b09d0
+niiri:6c13a2215653fb5c58245ecb3124b723
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.761625168301108"^^xsd:float .
 
-niiri:33a31ffbbf2d136c84bd8c001890f221
+niiri:e14ba17059f36074630699f7fc00a61e
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:f41b4c97497eeb8255330583a8825b93
+niiri:57dbc4426669cb76ea05d5c255480994
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:22c0ec80ae0df81cd54796dadc1cfffb ;
-    nidm_equivalentThreshold: niiri:0b3f07f9fa7448b8eeed2625fdc5d588 .
+    nidm_equivalentThreshold: niiri:461720f2996e5344ac089e2cec429c07 ;
+    nidm_equivalentThreshold: niiri:abec52af88c1f072dc3422a358ae41ff .
 
-niiri:22c0ec80ae0df81cd54796dadc1cfffb
+niiri:461720f2996e5344ac089e2cec429c07
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:0b3f07f9fa7448b8eeed2625fdc5d588
+niiri:abec52af88c1f072dc3422a358ae41ff
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:a71a2dfa1ab66a64c9d2c36c5c2f03b1
+niiri:3d219576930e0e1002fa5ad61a717666
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:074ce8c7927ae74cf34930d375480b95
+niiri:a5a3ea39278acdf05599017327bbbab6
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9
     a prov:Activity, spm_PartialConjunctionInference ; 
     rdfs:label " Partial Conjunction Inference" ;
     spm_partialConjunctionDegree: "2"^^xsd:int .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:wasAssociatedWith niiri:ca46a12c6a6d80a84b02ee07a74d055c .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:wasAssociatedWith niiri:1d7e73278ccee95e211689d9de8f4d4a .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:bcc964db0d0638d6cba59069ee9e794b .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:926b152f947e98d6025b235c27f919b2 .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:f41b4c97497eeb8255330583a8825b93 .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:57dbc4426669cb76ea05d5c255480994 .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:7512552d6509729de4464db02c1b2b85 .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:3ccd77b3de962099cf8ce0c08029054a .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:3847144ad5571b76c8855c604579438d .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:406c820ff107488cd976836b2d5c6516 .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:089005ddd166a56358c0d0ec21720e18 .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:0c0eb1d804cee8231e915a5fdfc5ab8b .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:297de961f206e0187be8fdda200091ee .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:d17318e0fda06cc6303389a919cffce0 .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:a71a2dfa1ab66a64c9d2c36c5c2f03b1 .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:3d219576930e0e1002fa5ad61a717666 .
 
-niiri:f5c1c82a9559f27878c8865f0d227dde prov:used niiri:074ce8c7927ae74cf34930d375480b95 .
+niiri:8ca7abe146d9bd8a996b72f2d817f4e9 prov:used niiri:a5a3ea39278acdf05599017327bbbab6 .
 
-niiri:992e1b6a07509a3db325ed8f8bfff412
+niiri:d31b1142c5902eeff2fda19317e15bea
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     nidm_searchVolumeInVoxels: "207876"^^xsd:int ;
     nidm_searchVolumeInUnits: "1663008"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.4409986586553"^^xsd:float ;
@@ -626,9 +626,9 @@ niiri:992e1b6a07509a3db325ed8f8bfff412
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "NaN"^^xsd:int ;
     crypto:sha512 "d7ea5de8ac6126fad539cc6bebeecf2db149192b03153a2d1e470f551bf2ce7da6c2ffcc5b32693307c4f7801fbb0a4097087dfc90ef4c09cf727f7af14888c8"^^xsd:string .
 
-niiri:992e1b6a07509a3db325ed8f8bfff412 prov:wasGeneratedBy niiri:f5c1c82a9559f27878c8865f0d227dde .
+niiri:d31b1142c5902eeff2fda19317e15bea prov:wasGeneratedBy niiri:8ca7abe146d9bd8a996b72f2d817f4e9 .
 
-niiri:9315492073c635bc63a9934fefeda6b6
+niiri:d4dd8ab29b5f9534a65e9a4b237ca312
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -636,26 +636,26 @@ niiri:9315492073c635bc63a9934fefeda6b6
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "150"^^xsd:int ;
     nidm_pValue: "1"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:e9451253b0a75869524801c98a6d921e ;
-    nidm_hasMaximumIntensityProjection: niiri:29a5a2562dde36cf7698f1dad4b98ea5 ;
-    nidm_inCoordinateSpace: niiri:4ddf2148145597f7f7c9369cb269b13f ;
+    nidm_hasClusterLabelsMap: niiri:216bc8b13e5d82e899e5c52cbb83016c ;
+    nidm_hasMaximumIntensityProjection: niiri:84d7cbdeb48144857ed31bb58c5ddc5b ;
+    nidm_inCoordinateSpace: niiri:a56db6367efd1f7176e69f24b028de94 ;
     crypto:sha512 "662dfeb3cba04a6a6beda3e1e23ff90c951f3ffae3d379b8fbfef06307db3055236586cace653593957e67f60c9dbbaadb5f3cc87c0ecc9dcfb81727d86f177f"^^xsd:string .
 
-niiri:e9451253b0a75869524801c98a6d921e
+niiri:216bc8b13e5d82e899e5c52cbb83016c
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:29a5a2562dde36cf7698f1dad4b98ea5
+niiri:84d7cbdeb48144857ed31bb58c5ddc5b
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:9315492073c635bc63a9934fefeda6b6 prov:wasGeneratedBy niiri:f5c1c82a9559f27878c8865f0d227dde .
+niiri:d4dd8ab29b5f9534a65e9a4b237ca312 prov:wasGeneratedBy niiri:8ca7abe146d9bd8a996b72f2d817f4e9 .
 
-niiri:43fc9ecb30d51558da2aa2580905eaab
+niiri:4362f5eac9972bf179ea49be33151c8e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "2637"^^xsd:int ;
@@ -665,9 +665,9 @@ niiri:43fc9ecb30d51558da2aa2580905eaab
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:43fc9ecb30d51558da2aa2580905eaab prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:4362f5eac9972bf179ea49be33151c8e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:417cabd3eeb412117d20f4882d064567
+niiri:00f296730dd06a43e5f7334c226305c6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "1415"^^xsd:int ;
@@ -677,9 +677,9 @@ niiri:417cabd3eeb412117d20f4882d064567
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:417cabd3eeb412117d20f4882d064567 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:00f296730dd06a43e5f7334c226305c6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:6cc5ea3c57b906137def3d6777b0000f
+niiri:39a3babf6ed520d78e67263717ca5dbb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "376"^^xsd:int ;
@@ -689,9 +689,9 @@ niiri:6cc5ea3c57b906137def3d6777b0000f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:6cc5ea3c57b906137def3d6777b0000f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:39a3babf6ed520d78e67263717ca5dbb prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c29516aed6cf24b95d9653e2365e0ced
+niiri:26ed93f97118482ea99f750276db5700
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "128"^^xsd:int ;
@@ -701,9 +701,9 @@ niiri:c29516aed6cf24b95d9653e2365e0ced
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:c29516aed6cf24b95d9653e2365e0ced prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:26ed93f97118482ea99f750276db5700 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:1c26e68b379e5bd715e75014cca849ab
+niiri:c0faffa954cb5edf1bd166b3c13b64b6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -713,9 +713,9 @@ niiri:1c26e68b379e5bd715e75014cca849ab
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:1c26e68b379e5bd715e75014cca849ab prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:c0faffa954cb5edf1bd166b3c13b64b6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:8b5d6e1bd5480bd6366d0094c92d4851
+niiri:1baee1eea0758a922f6c4f1f12441da6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "482"^^xsd:int ;
@@ -725,9 +725,9 @@ niiri:8b5d6e1bd5480bd6366d0094c92d4851
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:8b5d6e1bd5480bd6366d0094c92d4851 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:1baee1eea0758a922f6c4f1f12441da6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:7e631bc430702f08996bcc12a090f463
+niiri:1aa58b6ce0025b1ec01cb8a983388e1d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -737,9 +737,9 @@ niiri:7e631bc430702f08996bcc12a090f463
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:7e631bc430702f08996bcc12a090f463 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:1aa58b6ce0025b1ec01cb8a983388e1d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c21e2ede0b4f245e2d9f679a7862569e
+niiri:3198b98e15c5c56654d8a4ffe4b44ce8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "292"^^xsd:int ;
@@ -749,9 +749,9 @@ niiri:c21e2ede0b4f245e2d9f679a7862569e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:c21e2ede0b4f245e2d9f679a7862569e prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:3198b98e15c5c56654d8a4ffe4b44ce8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c8c6cee0456ea9b67ae74c71ec73d58a
+niiri:7d6744d8bee9e326b4381ceb83e93c8d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "454"^^xsd:int ;
@@ -761,9 +761,9 @@ niiri:c8c6cee0456ea9b67ae74c71ec73d58a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:c8c6cee0456ea9b67ae74c71ec73d58a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:7d6744d8bee9e326b4381ceb83e93c8d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5
+niiri:1593dbfe6a27c4bfd6c7c865a55e6758
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -773,9 +773,9 @@ niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:1593dbfe6a27c4bfd6c7c865a55e6758 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c8915bbac48c4a94d3bf54f07d28091a
+niiri:537cd4e035d031e1d96dcc9b62c35112
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "121"^^xsd:int ;
@@ -785,9 +785,9 @@ niiri:c8915bbac48c4a94d3bf54f07d28091a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:c8915bbac48c4a94d3bf54f07d28091a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:537cd4e035d031e1d96dcc9b62c35112 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:81f39aacce9db78e536cab5c96400969
+niiri:3330f53a36ff5c9ef2f20b1290e9d286
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "152"^^xsd:int ;
@@ -797,9 +797,9 @@ niiri:81f39aacce9db78e536cab5c96400969
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:81f39aacce9db78e536cab5c96400969 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:3330f53a36ff5c9ef2f20b1290e9d286 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:95cfa48491de3b2db8a60dc29bdeb6af
+niiri:9c973b3443bcab76e6ce5b021d6b1a13
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "118"^^xsd:int ;
@@ -809,9 +809,9 @@ niiri:95cfa48491de3b2db8a60dc29bdeb6af
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:95cfa48491de3b2db8a60dc29bdeb6af prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9c973b3443bcab76e6ce5b021d6b1a13 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:e7fc37cb04d1a3f58136cfb12f992f34
+niiri:27a3407fb41dee69924952963bf01095
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -821,9 +821,9 @@ niiri:e7fc37cb04d1a3f58136cfb12f992f34
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:e7fc37cb04d1a3f58136cfb12f992f34 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:27a3407fb41dee69924952963bf01095 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:de5b4d0f5d84034ba5fd7975873cc2e6
+niiri:9c3f0991818d487326255d5ca7862e30
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "53"^^xsd:int ;
@@ -833,9 +833,9 @@ niiri:de5b4d0f5d84034ba5fd7975873cc2e6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:de5b4d0f5d84034ba5fd7975873cc2e6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9c3f0991818d487326255d5ca7862e30 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:1d6209037825fb7ee168299aa10d5ad7
+niiri:73094daa238696f8de11ef4e56a95c30
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -845,9 +845,9 @@ niiri:1d6209037825fb7ee168299aa10d5ad7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:1d6209037825fb7ee168299aa10d5ad7 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:73094daa238696f8de11ef4e56a95c30 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:b1918e5ede22fa7e1d3a1399a34a2d45
+niiri:35af8997746066bb4be8d3a9cebf0640
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -857,9 +857,9 @@ niiri:b1918e5ede22fa7e1d3a1399a34a2d45
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:b1918e5ede22fa7e1d3a1399a34a2d45 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:35af8997746066bb4be8d3a9cebf0640 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:5d9799711b35085d7a8bcba1641700b1
+niiri:9d0b757e22fc3f0156790583744c1334
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "51"^^xsd:int ;
@@ -869,9 +869,9 @@ niiri:5d9799711b35085d7a8bcba1641700b1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:5d9799711b35085d7a8bcba1641700b1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9d0b757e22fc3f0156790583744c1334 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:437180e47264cc4e09dc17b204fd0a89
+niiri:8d3362f5850c9379377b0d1f0b1c2735
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -881,9 +881,9 @@ niiri:437180e47264cc4e09dc17b204fd0a89
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:437180e47264cc4e09dc17b204fd0a89 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8d3362f5850c9379377b0d1f0b1c2735 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:1cd87c105e9a1996f42e3171bad089a8
+niiri:227019e17364687787db60a4a8267663
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -893,9 +893,9 @@ niiri:1cd87c105e9a1996f42e3171bad089a8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:1cd87c105e9a1996f42e3171bad089a8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:227019e17364687787db60a4a8267663 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:cc02b2de189bcf80b0afcbe487b0d1e8
+niiri:8669f380bd303fec5b169e636d626ce3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -905,9 +905,9 @@ niiri:cc02b2de189bcf80b0afcbe487b0d1e8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:cc02b2de189bcf80b0afcbe487b0d1e8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8669f380bd303fec5b169e636d626ce3 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:3ae2e3cf05ec7ac4b46544f268071134
+niiri:f38934924fa68b3b9a71fb9c8171e8b6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -917,9 +917,9 @@ niiri:3ae2e3cf05ec7ac4b46544f268071134
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:3ae2e3cf05ec7ac4b46544f268071134 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:f38934924fa68b3b9a71fb9c8171e8b6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:3c84c74526e078ad8336fd968ec9d7f0
+niiri:1793504b32e2869dcb2fbd3af062f8bc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -929,9 +929,9 @@ niiri:3c84c74526e078ad8336fd968ec9d7f0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:3c84c74526e078ad8336fd968ec9d7f0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:1793504b32e2869dcb2fbd3af062f8bc prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:8a1438a34faf87d03af2d9853b038bb2
+niiri:55aacac3d3863ecd2c5789acfd6b261d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -941,9 +941,9 @@ niiri:8a1438a34faf87d03af2d9853b038bb2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:8a1438a34faf87d03af2d9853b038bb2 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:55aacac3d3863ecd2c5789acfd6b261d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:5aecd2a653cabfaff01cc936a5319173
+niiri:03238c6a619b9f265421cbb7a0cda76e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "42"^^xsd:int ;
@@ -953,9 +953,9 @@ niiri:5aecd2a653cabfaff01cc936a5319173
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:5aecd2a653cabfaff01cc936a5319173 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:03238c6a619b9f265421cbb7a0cda76e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:04baa9610947313ff840ab800dc602ff
+niiri:bc83f4e59851c0ed8424e3172a378ee4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "34"^^xsd:int ;
@@ -965,9 +965,9 @@ niiri:04baa9610947313ff840ab800dc602ff
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:04baa9610947313ff840ab800dc602ff prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:bc83f4e59851c0ed8424e3172a378ee4 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:bbf4ae108fc8903d38a040cb96a5f8c7
+niiri:c340f3ccccc1a020f9aef989954e51fc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -977,9 +977,9 @@ niiri:bbf4ae108fc8903d38a040cb96a5f8c7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:bbf4ae108fc8903d38a040cb96a5f8c7 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:c340f3ccccc1a020f9aef989954e51fc prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:4df2335aa8db3e5be136eacbcea883d6
+niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -989,9 +989,9 @@ niiri:4df2335aa8db3e5be136eacbcea883d6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:4df2335aa8db3e5be136eacbcea883d6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:9d79a6339d6f2901fb1cf662d6f17331
+niiri:cb85dd1324b2d86671b2fe868f4dafc0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1001,9 +1001,9 @@ niiri:9d79a6339d6f2901fb1cf662d6f17331
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:9d79a6339d6f2901fb1cf662d6f17331 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:cb85dd1324b2d86671b2fe868f4dafc0 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:b8abe2a725005d9ab6e1e988f192f41c
+niiri:0dc11dbfea7cb1fef76a1c48d7f8750f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1013,9 +1013,9 @@ niiri:b8abe2a725005d9ab6e1e988f192f41c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:b8abe2a725005d9ab6e1e988f192f41c prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:0dc11dbfea7cb1fef76a1c48d7f8750f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:483de03930aa5641b0fe297f66f6c4ed
+niiri:6db75fb201d2decf706c9d2dd225cb5a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -1025,9 +1025,9 @@ niiri:483de03930aa5641b0fe297f66f6c4ed
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:483de03930aa5641b0fe297f66f6c4ed prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:6db75fb201d2decf706c9d2dd225cb5a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:4f303edac6b82f93c47e1a6448e1cb52
+niiri:8fae62d51a220dbd34d1d3074ad97c80
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1037,9 +1037,9 @@ niiri:4f303edac6b82f93c47e1a6448e1cb52
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:4f303edac6b82f93c47e1a6448e1cb52 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8fae62d51a220dbd34d1d3074ad97c80 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:d987cfa4a10011187d0a3eef178d5a46
+niiri:1b3f6a9bf76e54ad12539e190c7c838c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -1049,9 +1049,9 @@ niiri:d987cfa4a10011187d0a3eef178d5a46
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:d987cfa4a10011187d0a3eef178d5a46 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:1b3f6a9bf76e54ad12539e190c7c838c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:98d187b5c539ea98df7343b0d0821b17
+niiri:dc2d50ba6c535742eed46213fc557f6a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -1061,9 +1061,9 @@ niiri:98d187b5c539ea98df7343b0d0821b17
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:98d187b5c539ea98df7343b0d0821b17 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:dc2d50ba6c535742eed46213fc557f6a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:5c38b60ed820b070d98e016bc1431008
+niiri:416dfaa44bb6a7fe97539c984a9173c3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1073,9 +1073,9 @@ niiri:5c38b60ed820b070d98e016bc1431008
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:5c38b60ed820b070d98e016bc1431008 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:416dfaa44bb6a7fe97539c984a9173c3 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:a86e2297836b759380804c1713e267cd
+niiri:31033e543fb9492bc06e61625ca6b410
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1085,9 +1085,9 @@ niiri:a86e2297836b759380804c1713e267cd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:a86e2297836b759380804c1713e267cd prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:31033e543fb9492bc06e61625ca6b410 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:f4ed594992095609e2ba62eca01c9faf
+niiri:7a8b21e9acaff0531c73c9fe0bfaeb53
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1097,9 +1097,9 @@ niiri:f4ed594992095609e2ba62eca01c9faf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:f4ed594992095609e2ba62eca01c9faf prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:7a8b21e9acaff0531c73c9fe0bfaeb53 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c8ce85b44b984de4fe78c06b64713bb8
+niiri:5102964768a1c4313f8c0e48d48f8b40
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1109,9 +1109,9 @@ niiri:c8ce85b44b984de4fe78c06b64713bb8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:c8ce85b44b984de4fe78c06b64713bb8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:5102964768a1c4313f8c0e48d48f8b40 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:55d04469f144e7c5053124929003df79
+niiri:256070c77a58b8b64913a5b6bfb81f60
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1121,9 +1121,9 @@ niiri:55d04469f144e7c5053124929003df79
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:55d04469f144e7c5053124929003df79 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:256070c77a58b8b64913a5b6bfb81f60 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:895da0556b5b38697a9d4eacde3a587e
+niiri:96604941a960daa1e224727cb5ba2d60
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -1133,9 +1133,9 @@ niiri:895da0556b5b38697a9d4eacde3a587e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:895da0556b5b38697a9d4eacde3a587e prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:96604941a960daa1e224727cb5ba2d60 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:30470d6217b4a75fdd554906028c6670
+niiri:529af4aecda9065e5cce8adf4cdfd5c6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1145,9 +1145,9 @@ niiri:30470d6217b4a75fdd554906028c6670
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:30470d6217b4a75fdd554906028c6670 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:529af4aecda9065e5cce8adf4cdfd5c6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:62c58cbe35737a64415ff840b7810e7d
+niiri:bdef3fee2464d33f021c131ff78646c7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1157,9 +1157,9 @@ niiri:62c58cbe35737a64415ff840b7810e7d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:62c58cbe35737a64415ff840b7810e7d prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:bdef3fee2464d33f021c131ff78646c7 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:ec26c7d95e0c041f81b882cd245b0915
+niiri:e8088392c69eb956afef92cedfa6aeb4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1169,9 +1169,9 @@ niiri:ec26c7d95e0c041f81b882cd245b0915
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:ec26c7d95e0c041f81b882cd245b0915 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:e8088392c69eb956afef92cedfa6aeb4 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:6750b72bbafd12ba75c6c383539599c6
+niiri:8b4322c153a15066be2583d11b23925c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -1181,9 +1181,9 @@ niiri:6750b72bbafd12ba75c6c383539599c6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:6750b72bbafd12ba75c6c383539599c6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8b4322c153a15066be2583d11b23925c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:ccbc770b946f9dfd1beecfa8843cb3fd
+niiri:0c0e48a110ec2c20b75585b9e5372d67
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1193,9 +1193,9 @@ niiri:ccbc770b946f9dfd1beecfa8843cb3fd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:ccbc770b946f9dfd1beecfa8843cb3fd prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:0c0e48a110ec2c20b75585b9e5372d67 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:daf3e2ea8bf3273801d2e921f611a23f
+niiri:1bf866f2d8a1a832a120aa9c02c60efd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -1205,9 +1205,9 @@ niiri:daf3e2ea8bf3273801d2e921f611a23f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:daf3e2ea8bf3273801d2e921f611a23f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:1bf866f2d8a1a832a120aa9c02c60efd prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:3df484ba108f4b88e1a4f123023bad18
+niiri:a44aefad34ca2359e69bf6f9306bc2c6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1217,9 +1217,9 @@ niiri:3df484ba108f4b88e1a4f123023bad18
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:3df484ba108f4b88e1a4f123023bad18 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:a44aefad34ca2359e69bf6f9306bc2c6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:0b63cbadf7d3234250fdc4f399321ae5
+niiri:ab78ea55fc7f212636dd2f73bdc99032
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1229,9 +1229,9 @@ niiri:0b63cbadf7d3234250fdc4f399321ae5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:0b63cbadf7d3234250fdc4f399321ae5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:ab78ea55fc7f212636dd2f73bdc99032 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:16c6b9ef292ea8d86c2980e2bfee9806
+niiri:4128bacb45b84a2304aceeb9a3a06db7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1241,9 +1241,9 @@ niiri:16c6b9ef292ea8d86c2980e2bfee9806
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:16c6b9ef292ea8d86c2980e2bfee9806 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:4128bacb45b84a2304aceeb9a3a06db7 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239
+niiri:282d81c6243a1094abf4c4787764df02
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1253,9 +1253,9 @@ niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:282d81c6243a1094abf4c4787764df02 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:fb45985c130da20eafb7b2bc740e6b34
+niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1265,9 +1265,9 @@ niiri:fb45985c130da20eafb7b2bc740e6b34
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:fb45985c130da20eafb7b2bc740e6b34 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:65722b667917e9f42cf82ee2175b666b
+niiri:e58cf8e24a087d5746f02fb59416d367
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1277,9 +1277,9 @@ niiri:65722b667917e9f42cf82ee2175b666b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:65722b667917e9f42cf82ee2175b666b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:e58cf8e24a087d5746f02fb59416d367 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:59675618f95ad14de633584e8aa5881a
+niiri:47a95f63466991d3e681c4886347a76b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1289,9 +1289,9 @@ niiri:59675618f95ad14de633584e8aa5881a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:59675618f95ad14de633584e8aa5881a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:47a95f63466991d3e681c4886347a76b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:2efe263e1c4f04d8ddb54023002360d9
+niiri:6a2d34c94894023a09a46d7ba699025b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1301,9 +1301,9 @@ niiri:2efe263e1c4f04d8ddb54023002360d9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:2efe263e1c4f04d8ddb54023002360d9 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:6a2d34c94894023a09a46d7ba699025b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:fa0929f452cd3f13857c087a02f6da1f
+niiri:6ac7ce35dfb3dcf2c2696278c805c40a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1313,9 +1313,9 @@ niiri:fa0929f452cd3f13857c087a02f6da1f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:fa0929f452cd3f13857c087a02f6da1f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:6ac7ce35dfb3dcf2c2696278c805c40a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:4c6401bfd1d939fec8234ff093a37d0d
+niiri:60e118fd5205eaa96f4b55808761eaf7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1325,9 +1325,9 @@ niiri:4c6401bfd1d939fec8234ff093a37d0d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:4c6401bfd1d939fec8234ff093a37d0d prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:60e118fd5205eaa96f4b55808761eaf7 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:b40302277817265d7af623887ab2e22c
+niiri:afff6750152337d325f510f877cd2b9c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1337,9 +1337,9 @@ niiri:b40302277817265d7af623887ab2e22c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:b40302277817265d7af623887ab2e22c prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:afff6750152337d325f510f877cd2b9c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:e3091fadc7ff93e5e16f94b04590b938
+niiri:c87d05b7d28080150c45409119a926f8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1349,9 +1349,9 @@ niiri:e3091fadc7ff93e5e16f94b04590b938
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:e3091fadc7ff93e5e16f94b04590b938 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:c87d05b7d28080150c45409119a926f8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:e36b80790f32a55a90c503e6f29918bb
+niiri:f1bb918000bbcdd8562fb7b7887a394d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1361,9 +1361,9 @@ niiri:e36b80790f32a55a90c503e6f29918bb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:e36b80790f32a55a90c503e6f29918bb prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:f1bb918000bbcdd8562fb7b7887a394d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:6e8c86e4ccb82a0a6076eb58e14b07a6
+niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1373,9 +1373,9 @@ niiri:6e8c86e4ccb82a0a6076eb58e14b07a6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:6e8c86e4ccb82a0a6076eb58e14b07a6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:42f7f7a26e0c7f6124775e7e757b315c
+niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1385,9 +1385,9 @@ niiri:42f7f7a26e0c7f6124775e7e757b315c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:42f7f7a26e0c7f6124775e7e757b315c prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:14ff66df771d191b9d2e8a3b0f78eda6
+niiri:9e7cd816ef42776bf358bfe67f08f014
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1397,9 +1397,9 @@ niiri:14ff66df771d191b9d2e8a3b0f78eda6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:14ff66df771d191b9d2e8a3b0f78eda6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9e7cd816ef42776bf358bfe67f08f014 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:912e881f26994ef7af5c7f0b222db9ea
+niiri:712375a17d0ff43c9dca459517dff9b2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1409,9 +1409,9 @@ niiri:912e881f26994ef7af5c7f0b222db9ea
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:912e881f26994ef7af5c7f0b222db9ea prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:712375a17d0ff43c9dca459517dff9b2 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:9a1887d93b55705b2ff04804a00c27c3
+niiri:feddd730f38d65d4f1fd0e8616bcc9a5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1421,9 +1421,9 @@ niiri:9a1887d93b55705b2ff04804a00c27c3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:9a1887d93b55705b2ff04804a00c27c3 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:feddd730f38d65d4f1fd0e8616bcc9a5 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:e6e6da4cb58bd6ee501d8b5597467832
+niiri:8041bc77682f50b65136018ca10c889c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1433,9 +1433,9 @@ niiri:e6e6da4cb58bd6ee501d8b5597467832
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:e6e6da4cb58bd6ee501d8b5597467832 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8041bc77682f50b65136018ca10c889c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0
+niiri:e852e949acffc71ed6cce677c7be19d6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1445,9 +1445,9 @@ niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:e852e949acffc71ed6cce677c7be19d6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:949a7d86dacbe35af10b6aad92fe2224
+niiri:0d099ee69c96416336f843fd890da4a0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1457,9 +1457,9 @@ niiri:949a7d86dacbe35af10b6aad92fe2224
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:949a7d86dacbe35af10b6aad92fe2224 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:0d099ee69c96416336f843fd890da4a0 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:6cc27bdc40320dac88fe94690c9a2006
+niiri:6d0ee7f5877dfa2620f95f47e06e2a9a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1469,9 +1469,9 @@ niiri:6cc27bdc40320dac88fe94690c9a2006
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:6cc27bdc40320dac88fe94690c9a2006 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:6d0ee7f5877dfa2620f95f47e06e2a9a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c04d4059d5535de349435e25559a51cf
+niiri:6ab419381418bd7fca0cb5bac6782b77
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1481,9 +1481,9 @@ niiri:c04d4059d5535de349435e25559a51cf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:c04d4059d5535de349435e25559a51cf prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:6ab419381418bd7fca0cb5bac6782b77 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:4b22fd081d5be6319a728e5343897301
+niiri:b19325ccb6192dba58545cbeb7bc92e1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1493,9 +1493,9 @@ niiri:4b22fd081d5be6319a728e5343897301
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:4b22fd081d5be6319a728e5343897301 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:b19325ccb6192dba58545cbeb7bc92e1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:f0f729dae8a39ee9247f706bc80f8df0
+niiri:745fe95a68372701f2888393e817a23e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1505,9 +1505,9 @@ niiri:f0f729dae8a39ee9247f706bc80f8df0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:f0f729dae8a39ee9247f706bc80f8df0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:745fe95a68372701f2888393e817a23e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:cd47d3687de0d428289d5ee8d941860d
+niiri:b1a5489610b480473aa63e95806df7d1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1517,9 +1517,9 @@ niiri:cd47d3687de0d428289d5ee8d941860d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:cd47d3687de0d428289d5ee8d941860d prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:b1a5489610b480473aa63e95806df7d1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:20959c12c3afc9ceb8477f395c0f1d11
+niiri:f6763487f8266f7e66acb49862c0bfa1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1529,9 +1529,9 @@ niiri:20959c12c3afc9ceb8477f395c0f1d11
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:20959c12c3afc9ceb8477f395c0f1d11 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:f6763487f8266f7e66acb49862c0bfa1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:4eb3e8fe236fda4e725ee89c277cccc8
+niiri:f1b9cbe1f5cc757318e116f47537c68e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1541,9 +1541,9 @@ niiri:4eb3e8fe236fda4e725ee89c277cccc8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:4eb3e8fe236fda4e725ee89c277cccc8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:f1b9cbe1f5cc757318e116f47537c68e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca
+niiri:0299ab45ec018b51a01d2a8fe08bf4d0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1553,9 +1553,9 @@ niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:0299ab45ec018b51a01d2a8fe08bf4d0 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:4fad08e49bad24baddc3d418f97db0ce
+niiri:3bd0b694ec1e521a7072b15be74aa42c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1565,9 +1565,9 @@ niiri:4fad08e49bad24baddc3d418f97db0ce
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:4fad08e49bad24baddc3d418f97db0ce prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:3bd0b694ec1e521a7072b15be74aa42c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:d9eee0810d67b936a31fa3c66d2e8721
+niiri:af9bee597f1e82856f732971c03e4ba5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1577,9 +1577,9 @@ niiri:d9eee0810d67b936a31fa3c66d2e8721
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:d9eee0810d67b936a31fa3c66d2e8721 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:af9bee597f1e82856f732971c03e4ba5 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c8715267e94716796c464182b4ba6959
+niiri:7a01ea3f3b5332ecf281a7f277911529
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1589,9 +1589,9 @@ niiri:c8715267e94716796c464182b4ba6959
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:c8715267e94716796c464182b4ba6959 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:7a01ea3f3b5332ecf281a7f277911529 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:8f90bd7cc0deb45b7b7bd4b560274456
+niiri:8d9244867124b8976a02c802025ebf7a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1601,9 +1601,9 @@ niiri:8f90bd7cc0deb45b7b7bd4b560274456
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:8f90bd7cc0deb45b7b7bd4b560274456 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8d9244867124b8976a02c802025ebf7a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:38f5a60345c88d7c9e0484d8735d5ffe
+niiri:1acfcd5791fd893baf49e6750646bcbc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1613,9 +1613,9 @@ niiri:38f5a60345c88d7c9e0484d8735d5ffe
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:38f5a60345c88d7c9e0484d8735d5ffe prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:1acfcd5791fd893baf49e6750646bcbc prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:e6b43073ea58d734c57cff5767e3921f
+niiri:6bafc27afb06adc8274b4e85b0eb95cc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1625,9 +1625,9 @@ niiri:e6b43073ea58d734c57cff5767e3921f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:e6b43073ea58d734c57cff5767e3921f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:6bafc27afb06adc8274b4e85b0eb95cc prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:1cdb6dbe1bc79e13d52d0d3c171bab06
+niiri:ee5baff089dc6387c53821c05a9e9154
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1637,9 +1637,9 @@ niiri:1cdb6dbe1bc79e13d52d0d3c171bab06
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:1cdb6dbe1bc79e13d52d0d3c171bab06 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:ee5baff089dc6387c53821c05a9e9154 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:ee19df6f4d0113ba7e7f064a4048e753
+niiri:e4e0f746d182d60a55906480bc82791f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1649,9 +1649,9 @@ niiri:ee19df6f4d0113ba7e7f064a4048e753
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:ee19df6f4d0113ba7e7f064a4048e753 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:e4e0f746d182d60a55906480bc82791f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:71af61a5c3e3beaf82f85e9971911d0f
+niiri:07ef8bc1f56adef8bb96bf2e4e871509
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1661,9 +1661,9 @@ niiri:71af61a5c3e3beaf82f85e9971911d0f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:71af61a5c3e3beaf82f85e9971911d0f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:07ef8bc1f56adef8bb96bf2e4e871509 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:46c8b3f4803e6bb0b2862d8598ece061
+niiri:4909c1eb824545b47aa0943b33200588
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0085" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1673,9 +1673,9 @@ niiri:46c8b3f4803e6bb0b2862d8598ece061
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "85"^^xsd:int .
 
-niiri:46c8b3f4803e6bb0b2862d8598ece061 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:4909c1eb824545b47aa0943b33200588 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:5e385b701ab7f21285e4ab5006f3b0cc
+niiri:9c28e7c0288f5d8601280d59308426e4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0086" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1685,9 +1685,9 @@ niiri:5e385b701ab7f21285e4ab5006f3b0cc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "86"^^xsd:int .
 
-niiri:5e385b701ab7f21285e4ab5006f3b0cc prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9c28e7c0288f5d8601280d59308426e4 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:9b4e4e9b57eb3e981b1ba74aae8a7114
+niiri:49c7e8d7404b8a93cc2dc6a52274f6ef
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0087" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1697,9 +1697,9 @@ niiri:9b4e4e9b57eb3e981b1ba74aae8a7114
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "87"^^xsd:int .
 
-niiri:9b4e4e9b57eb3e981b1ba74aae8a7114 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:49c7e8d7404b8a93cc2dc6a52274f6ef prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:6d27ace5181c44103420a9d6058ab0d2
+niiri:5bc798e43cab1c880a412761cd0dabce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0088" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1709,9 +1709,9 @@ niiri:6d27ace5181c44103420a9d6058ab0d2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "88"^^xsd:int .
 
-niiri:6d27ace5181c44103420a9d6058ab0d2 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:5bc798e43cab1c880a412761cd0dabce prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:315d7b893c25221ef60daf1e43984066
+niiri:d5f0da3a07b3d47197bf039d8d42b58f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0089" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1721,9 +1721,9 @@ niiri:315d7b893c25221ef60daf1e43984066
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "89"^^xsd:int .
 
-niiri:315d7b893c25221ef60daf1e43984066 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:d5f0da3a07b3d47197bf039d8d42b58f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:34f88b9c2c80714dbe516b3f7ef092bb
+niiri:a57d901560addc33f414ddaed9a0c7fb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0090" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1733,9 +1733,9 @@ niiri:34f88b9c2c80714dbe516b3f7ef092bb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "90"^^xsd:int .
 
-niiri:34f88b9c2c80714dbe516b3f7ef092bb prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:a57d901560addc33f414ddaed9a0c7fb prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c07d0db5466c33ca960e3dd77f21333c
+niiri:01d84a7c8c63b90d178c8c7623156c7d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0091" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1745,9 +1745,9 @@ niiri:c07d0db5466c33ca960e3dd77f21333c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "91"^^xsd:int .
 
-niiri:c07d0db5466c33ca960e3dd77f21333c prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:01d84a7c8c63b90d178c8c7623156c7d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:90645273f08ccfc7b9bf300a122cc2af
+niiri:99056f1d754fd9f25d80632f06577e33
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0092" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1757,9 +1757,9 @@ niiri:90645273f08ccfc7b9bf300a122cc2af
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "92"^^xsd:int .
 
-niiri:90645273f08ccfc7b9bf300a122cc2af prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:99056f1d754fd9f25d80632f06577e33 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c12f0aee596eddb11ad8e3268c4eb077
+niiri:a0ee8183a98a000be01c4577a35a0d8c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0093" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1769,9 +1769,9 @@ niiri:c12f0aee596eddb11ad8e3268c4eb077
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "93"^^xsd:int .
 
-niiri:c12f0aee596eddb11ad8e3268c4eb077 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:a0ee8183a98a000be01c4577a35a0d8c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:b74b40058d530ee5632e1df25f911065
+niiri:40c9456923bb7d18a8a4ec203aeea09d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0094" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1781,9 +1781,9 @@ niiri:b74b40058d530ee5632e1df25f911065
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "94"^^xsd:int .
 
-niiri:b74b40058d530ee5632e1df25f911065 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:40c9456923bb7d18a8a4ec203aeea09d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:169fad64b64219293f6c913c296583bc
+niiri:3cd64da8230af3c597bfb4e11e589670
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0095" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1793,9 +1793,9 @@ niiri:169fad64b64219293f6c913c296583bc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "95"^^xsd:int .
 
-niiri:169fad64b64219293f6c913c296583bc prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:3cd64da8230af3c597bfb4e11e589670 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c9ba05614242ea84b1cd6a9c5ec414e4
+niiri:32e5e0304b5a2c92b091fa83edcab359
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0096" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1805,9 +1805,9 @@ niiri:c9ba05614242ea84b1cd6a9c5ec414e4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "96"^^xsd:int .
 
-niiri:c9ba05614242ea84b1cd6a9c5ec414e4 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:32e5e0304b5a2c92b091fa83edcab359 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:be38e2f5b8c4edd116eb0a55684fdab2
+niiri:bf704e8aea1497f2136b7d0b3dde0bf6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0097" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1817,9 +1817,9 @@ niiri:be38e2f5b8c4edd116eb0a55684fdab2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "97"^^xsd:int .
 
-niiri:be38e2f5b8c4edd116eb0a55684fdab2 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:bf704e8aea1497f2136b7d0b3dde0bf6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:9506dd108b62896cd6d8225dfc0e2e59
+niiri:316701aef465a5778181dd76a5331844
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0098" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1829,9 +1829,9 @@ niiri:9506dd108b62896cd6d8225dfc0e2e59
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "98"^^xsd:int .
 
-niiri:9506dd108b62896cd6d8225dfc0e2e59 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:316701aef465a5778181dd76a5331844 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:f404d574847ee68f9dc6bd08393bd9a1
+niiri:90bdcb5fb7ef48121124edfe5e0439e6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0099" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1841,9 +1841,9 @@ niiri:f404d574847ee68f9dc6bd08393bd9a1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "99"^^xsd:int .
 
-niiri:f404d574847ee68f9dc6bd08393bd9a1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:90bdcb5fb7ef48121124edfe5e0439e6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:99948f53ace7073cd3002a5850ecd361
+niiri:d1db945756296f3d178c9d95312fcba1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0100" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1853,9 +1853,9 @@ niiri:99948f53ace7073cd3002a5850ecd361
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "100"^^xsd:int .
 
-niiri:99948f53ace7073cd3002a5850ecd361 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:d1db945756296f3d178c9d95312fcba1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:c8c7dba5be58cecd8f14593ccfb69e4b
+niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0101" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1865,9 +1865,9 @@ niiri:c8c7dba5be58cecd8f14593ccfb69e4b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "101"^^xsd:int .
 
-niiri:c8c7dba5be58cecd8f14593ccfb69e4b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:a56ce0c60fde3ec8bf474d645a951d38
+niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0102" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1877,9 +1877,9 @@ niiri:a56ce0c60fde3ec8bf474d645a951d38
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "102"^^xsd:int .
 
-niiri:a56ce0c60fde3ec8bf474d645a951d38 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:82e02fb05b18c0c2a70d55d5e415aee5
+niiri:9304b0681f39be2e136e7d42baff625c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0103" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1889,9 +1889,9 @@ niiri:82e02fb05b18c0c2a70d55d5e415aee5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "103"^^xsd:int .
 
-niiri:82e02fb05b18c0c2a70d55d5e415aee5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9304b0681f39be2e136e7d42baff625c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:8d8ac9fae20babb989f7c367a4c4a609
+niiri:c4a9ab38a5b5faf27a110372a76b690b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0104" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1901,9 +1901,9 @@ niiri:8d8ac9fae20babb989f7c367a4c4a609
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "104"^^xsd:int .
 
-niiri:8d8ac9fae20babb989f7c367a4c4a609 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:c4a9ab38a5b5faf27a110372a76b690b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:1a41584c1187bb4a87d3cc1af9993773
+niiri:b08c64db49c2acab9dde84fc5aaafee1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0105" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1913,9 +1913,9 @@ niiri:1a41584c1187bb4a87d3cc1af9993773
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "105"^^xsd:int .
 
-niiri:1a41584c1187bb4a87d3cc1af9993773 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:b08c64db49c2acab9dde84fc5aaafee1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:43ed38ee11c52db758569877faabd695
+niiri:a8f46a35300a709894debac1a5c7d877
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0106" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1925,9 +1925,9 @@ niiri:43ed38ee11c52db758569877faabd695
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "106"^^xsd:int .
 
-niiri:43ed38ee11c52db758569877faabd695 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:a8f46a35300a709894debac1a5c7d877 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:ee629aca5d18e60c2724bfd2e1b3fc6b
+niiri:147fb623ae052dca9733d6d1d2297af8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0107" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1937,9 +1937,9 @@ niiri:ee629aca5d18e60c2724bfd2e1b3fc6b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "107"^^xsd:int .
 
-niiri:ee629aca5d18e60c2724bfd2e1b3fc6b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:147fb623ae052dca9733d6d1d2297af8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:8b0a58d02f59556fa0151651c6d40cc0
+niiri:eb257014e1b6b6961786c8543836a579
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0108" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1949,9 +1949,9 @@ niiri:8b0a58d02f59556fa0151651c6d40cc0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "108"^^xsd:int .
 
-niiri:8b0a58d02f59556fa0151651c6d40cc0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:eb257014e1b6b6961786c8543836a579 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:eeb7c0ae3047601cda9c179c68e75d65
+niiri:3c0db86cde8ac7aa1cb1f7b208b617e8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0109" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1961,9 +1961,9 @@ niiri:eeb7c0ae3047601cda9c179c68e75d65
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "109"^^xsd:int .
 
-niiri:eeb7c0ae3047601cda9c179c68e75d65 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:3c0db86cde8ac7aa1cb1f7b208b617e8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:543214dac714341af8aeaa4b70f41266
+niiri:e578dd3a170f088e47efd39f45837f4e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0110" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1973,9 +1973,9 @@ niiri:543214dac714341af8aeaa4b70f41266
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "110"^^xsd:int .
 
-niiri:543214dac714341af8aeaa4b70f41266 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:e578dd3a170f088e47efd39f45837f4e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:86191fa377232381128e79c2a57a4af6
+niiri:ab7f882f69e9de3fd22bc39f3519003d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0111" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1985,9 +1985,9 @@ niiri:86191fa377232381128e79c2a57a4af6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "111"^^xsd:int .
 
-niiri:86191fa377232381128e79c2a57a4af6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:ab7f882f69e9de3fd22bc39f3519003d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:6f236184b94e16d3fb82cdd60cd19a6d
+niiri:ca827c13c9bc5f06b55e3bd1cd175793
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0112" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1997,9 +1997,9 @@ niiri:6f236184b94e16d3fb82cdd60cd19a6d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "112"^^xsd:int .
 
-niiri:6f236184b94e16d3fb82cdd60cd19a6d prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:ca827c13c9bc5f06b55e3bd1cd175793 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:9ae54c5470ad002b7ae47f7b67b248ad
+niiri:8472115c12bd571d534dfe5bac960c80
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0113" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2009,9 +2009,9 @@ niiri:9ae54c5470ad002b7ae47f7b67b248ad
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "113"^^xsd:int .
 
-niiri:9ae54c5470ad002b7ae47f7b67b248ad prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8472115c12bd571d534dfe5bac960c80 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:0104fa6d88bd50793a3b65b47635e2c6
+niiri:812c44e9a98ad090a6f8b72ffea8eb49
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0114" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2021,9 +2021,9 @@ niiri:0104fa6d88bd50793a3b65b47635e2c6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "114"^^xsd:int .
 
-niiri:0104fa6d88bd50793a3b65b47635e2c6 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:812c44e9a98ad090a6f8b72ffea8eb49 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:1ff5ea3ca56fb13894e4e43c39a861c9
+niiri:eb1e036b54bfd5155015ad5c924a62ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0115" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2033,9 +2033,9 @@ niiri:1ff5ea3ca56fb13894e4e43c39a861c9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "115"^^xsd:int .
 
-niiri:1ff5ea3ca56fb13894e4e43c39a861c9 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:eb1e036b54bfd5155015ad5c924a62ce prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:9e02c41cd62cc06c92b5e2b56a706886
+niiri:8bac0f00c0d1f0f9f5c118004ab17321
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0116" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2045,9 +2045,9 @@ niiri:9e02c41cd62cc06c92b5e2b56a706886
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "116"^^xsd:int .
 
-niiri:9e02c41cd62cc06c92b5e2b56a706886 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8bac0f00c0d1f0f9f5c118004ab17321 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:a5e308239dff195e8c67ca5b964d553a
+niiri:4f4b190235fbb136b1bb7467b78730d6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0117" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2057,9 +2057,9 @@ niiri:a5e308239dff195e8c67ca5b964d553a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "117"^^xsd:int .
 
-niiri:a5e308239dff195e8c67ca5b964d553a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:4f4b190235fbb136b1bb7467b78730d6 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:aeffc3536799596ea12e2467fc52bd65
+niiri:d04d2676281bca09e8a782500650e993
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0118" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2069,9 +2069,9 @@ niiri:aeffc3536799596ea12e2467fc52bd65
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "118"^^xsd:int .
 
-niiri:aeffc3536799596ea12e2467fc52bd65 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:d04d2676281bca09e8a782500650e993 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:3e987521ad9deca092879412707ea491
+niiri:59c6e585fc56ebce5a5d95b959cc120d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0119" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2081,9 +2081,9 @@ niiri:3e987521ad9deca092879412707ea491
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "119"^^xsd:int .
 
-niiri:3e987521ad9deca092879412707ea491 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:59c6e585fc56ebce5a5d95b959cc120d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:f54f30ee52ac26f6dae0749e096ea6c1
+niiri:a4d82c21752d17f68b6fbf41caa89a4b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0120" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2093,9 +2093,9 @@ niiri:f54f30ee52ac26f6dae0749e096ea6c1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "120"^^xsd:int .
 
-niiri:f54f30ee52ac26f6dae0749e096ea6c1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:a4d82c21752d17f68b6fbf41caa89a4b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:692bc9543cbfc2b98e06dde4c8e7603f
+niiri:9c09ac30035d9617daad1f111fa1b47f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0121" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2105,9 +2105,9 @@ niiri:692bc9543cbfc2b98e06dde4c8e7603f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "121"^^xsd:int .
 
-niiri:692bc9543cbfc2b98e06dde4c8e7603f prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9c09ac30035d9617daad1f111fa1b47f prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:be235801557e66b2190c98cd649588c0
+niiri:b5d02c34e634c7f52d94137fbd9f8813
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0122" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2117,9 +2117,9 @@ niiri:be235801557e66b2190c98cd649588c0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "122"^^xsd:int .
 
-niiri:be235801557e66b2190c98cd649588c0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:b5d02c34e634c7f52d94137fbd9f8813 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:baf9fc0b69478678bb8ed7430b24c094
+niiri:fc91a408c252d8e2b7beb4005554eaf8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0123" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2129,9 +2129,9 @@ niiri:baf9fc0b69478678bb8ed7430b24c094
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "123"^^xsd:int .
 
-niiri:baf9fc0b69478678bb8ed7430b24c094 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:fc91a408c252d8e2b7beb4005554eaf8 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:27343a380f46da81b03903d4cf6193dc
+niiri:9b0591f2b854d2643aaf1afaa93cb549
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0124" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2141,9 +2141,9 @@ niiri:27343a380f46da81b03903d4cf6193dc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "124"^^xsd:int .
 
-niiri:27343a380f46da81b03903d4cf6193dc prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9b0591f2b854d2643aaf1afaa93cb549 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:158f1d535951e2b7d78ea10b066c15f3
+niiri:d54744a8017e84d7adb355fc9412fba3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0125" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2153,9 +2153,9 @@ niiri:158f1d535951e2b7d78ea10b066c15f3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "125"^^xsd:int .
 
-niiri:158f1d535951e2b7d78ea10b066c15f3 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:d54744a8017e84d7adb355fc9412fba3 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:842d2062c93ff252780aae9939a20111
+niiri:e49a03f4d60a11688f798fc5bc43c1b2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0126" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2165,9 +2165,9 @@ niiri:842d2062c93ff252780aae9939a20111
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "126"^^xsd:int .
 
-niiri:842d2062c93ff252780aae9939a20111 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:e49a03f4d60a11688f798fc5bc43c1b2 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:d27fbf9c8044e6b188c300c4990f6f54
+niiri:b04a187086857b7422c8096db14ee613
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0127" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2177,9 +2177,9 @@ niiri:d27fbf9c8044e6b188c300c4990f6f54
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "127"^^xsd:int .
 
-niiri:d27fbf9c8044e6b188c300c4990f6f54 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:b04a187086857b7422c8096db14ee613 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:2a4965b8fc709556c2aa1abb6adf5441
+niiri:39ce93dd6abab662ab6da84a046a56bd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0128" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2189,9 +2189,9 @@ niiri:2a4965b8fc709556c2aa1abb6adf5441
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "128"^^xsd:int .
 
-niiri:2a4965b8fc709556c2aa1abb6adf5441 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:39ce93dd6abab662ab6da84a046a56bd prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:9cc63018305b210a50122f137d979802
+niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0129" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2201,9 +2201,9 @@ niiri:9cc63018305b210a50122f137d979802
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "129"^^xsd:int .
 
-niiri:9cc63018305b210a50122f137d979802 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:965ac0d53ae837b608d6841eb6671ec5
+niiri:ca20dee3ba6bf36049f99642c710470d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0130" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2213,9 +2213,9 @@ niiri:965ac0d53ae837b608d6841eb6671ec5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "130"^^xsd:int .
 
-niiri:965ac0d53ae837b608d6841eb6671ec5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:ca20dee3ba6bf36049f99642c710470d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:d20a800c34ef4ebbc2c9d064007ca5a5
+niiri:26fa7a82c298f218eb7fd282cfbf7a81
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0131" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2225,9 +2225,9 @@ niiri:d20a800c34ef4ebbc2c9d064007ca5a5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "131"^^xsd:int .
 
-niiri:d20a800c34ef4ebbc2c9d064007ca5a5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:26fa7a82c298f218eb7fd282cfbf7a81 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:0a26619869c6304390cf220d86997062
+niiri:e518dd980ffdb694adcf472695d5a40a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0132" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2237,9 +2237,9 @@ niiri:0a26619869c6304390cf220d86997062
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "132"^^xsd:int .
 
-niiri:0a26619869c6304390cf220d86997062 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:e518dd980ffdb694adcf472695d5a40a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:6a5b8fb86c67c0eb5b9c606e6b810510
+niiri:5f278b6b11fae0c4b4f9690852a71d0c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0133" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2249,9 +2249,9 @@ niiri:6a5b8fb86c67c0eb5b9c606e6b810510
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "133"^^xsd:int .
 
-niiri:6a5b8fb86c67c0eb5b9c606e6b810510 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:5f278b6b11fae0c4b4f9690852a71d0c prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:99f3a2d8e7661135dd74892e7227bd72
+niiri:87f8233f1c48acf6ecdd7339055182ae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0134" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2261,9 +2261,9 @@ niiri:99f3a2d8e7661135dd74892e7227bd72
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "134"^^xsd:int .
 
-niiri:99f3a2d8e7661135dd74892e7227bd72 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:87f8233f1c48acf6ecdd7339055182ae prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:64a5de9f75df294ee267e34b2597bc84
+niiri:0189728b5aaa10d4eb4ff53d1fbc5843
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0135" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2273,9 +2273,9 @@ niiri:64a5de9f75df294ee267e34b2597bc84
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "135"^^xsd:int .
 
-niiri:64a5de9f75df294ee267e34b2597bc84 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:0189728b5aaa10d4eb4ff53d1fbc5843 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:2c98abbba202c2ed1fa8e08549a97cb1
+niiri:453f1919d7df3d7e610709f6fdecbf62
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0136" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2285,9 +2285,9 @@ niiri:2c98abbba202c2ed1fa8e08549a97cb1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "136"^^xsd:int .
 
-niiri:2c98abbba202c2ed1fa8e08549a97cb1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:453f1919d7df3d7e610709f6fdecbf62 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:35bfc5987aa4a1eba01be33e4c1ee7f2
+niiri:5b21dda7a2823d1c7efeff7947020767
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0137" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2297,9 +2297,9 @@ niiri:35bfc5987aa4a1eba01be33e4c1ee7f2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "137"^^xsd:int .
 
-niiri:35bfc5987aa4a1eba01be33e4c1ee7f2 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:5b21dda7a2823d1c7efeff7947020767 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:33395b862a603ee1373735759fed1bcb
+niiri:a6dc495a077e17aa8f96566659037e0b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0138" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2309,9 +2309,9 @@ niiri:33395b862a603ee1373735759fed1bcb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "138"^^xsd:int .
 
-niiri:33395b862a603ee1373735759fed1bcb prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:a6dc495a077e17aa8f96566659037e0b prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:635a4fc24d89b14d261b42d568e53ac8
+niiri:e5e5eeee288ec088072a80af972a3638
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0139" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2321,9 +2321,9 @@ niiri:635a4fc24d89b14d261b42d568e53ac8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "139"^^xsd:int .
 
-niiri:635a4fc24d89b14d261b42d568e53ac8 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:e5e5eeee288ec088072a80af972a3638 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:55b4eeddb69bb03436464cf696dd593b
+niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0140" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2333,9 +2333,9 @@ niiri:55b4eeddb69bb03436464cf696dd593b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "140"^^xsd:int .
 
-niiri:55b4eeddb69bb03436464cf696dd593b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:493898a476d4ce4bf533682e007422c5
+niiri:66cf0dbeb1aa03edbab1a35c2d527a55
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0141" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2345,9 +2345,9 @@ niiri:493898a476d4ce4bf533682e007422c5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "141"^^xsd:int .
 
-niiri:493898a476d4ce4bf533682e007422c5 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:66cf0dbeb1aa03edbab1a35c2d527a55 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:b841eb2677ab2ad59ce73103265cdee0
+niiri:09d8898196c5c40aec6f995a2b0c383d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0142" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2357,9 +2357,9 @@ niiri:b841eb2677ab2ad59ce73103265cdee0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "142"^^xsd:int .
 
-niiri:b841eb2677ab2ad59ce73103265cdee0 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:09d8898196c5c40aec6f995a2b0c383d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:4c7ec0be40515b0eae812fe9befe02f1
+niiri:bfe644ea717165d3b6b50431d8e57c87
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0143" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2369,9 +2369,9 @@ niiri:4c7ec0be40515b0eae812fe9befe02f1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "143"^^xsd:int .
 
-niiri:4c7ec0be40515b0eae812fe9befe02f1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:bfe644ea717165d3b6b50431d8e57c87 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22
+niiri:0d278ee0d105de3a7319a5acaa11c631
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0144" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2381,9 +2381,9 @@ niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "144"^^xsd:int .
 
-niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:0d278ee0d105de3a7319a5acaa11c631 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:9d494c09341573a6df3c044f6f353a5a
+niiri:9a54b30308f71d0c474dab56acec5885
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0145" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2393,9 +2393,9 @@ niiri:9d494c09341573a6df3c044f6f353a5a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "145"^^xsd:int .
 
-niiri:9d494c09341573a6df3c044f6f353a5a prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:9a54b30308f71d0c474dab56acec5885 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:630ac6074dee24b42295002659ee6cd4
+niiri:f219989ec875846cc4815fffc10bd118
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0146" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2405,9 +2405,9 @@ niiri:630ac6074dee24b42295002659ee6cd4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "146"^^xsd:int .
 
-niiri:630ac6074dee24b42295002659ee6cd4 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:f219989ec875846cc4815fffc10bd118 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:97f9982dca21f34e7ea0fcb977fcf50b
+niiri:4b37375a8d01d1d9009b430352062714
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0147" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2417,9 +2417,9 @@ niiri:97f9982dca21f34e7ea0fcb977fcf50b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "147"^^xsd:int .
 
-niiri:97f9982dca21f34e7ea0fcb977fcf50b prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:4b37375a8d01d1d9009b430352062714 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:b7588b8a823a7341bbdb4d3e8686e040
+niiri:0f0a4015dd42d89522302ce792b20d6d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0148" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2429,9 +2429,9 @@ niiri:b7588b8a823a7341bbdb4d3e8686e040
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "148"^^xsd:int .
 
-niiri:b7588b8a823a7341bbdb4d3e8686e040 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:0f0a4015dd42d89522302ce792b20d6d prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:31b704c584e2aae3b394c52754216fae
+niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0149" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2441,9 +2441,9 @@ niiri:31b704c584e2aae3b394c52754216fae
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "149"^^xsd:int .
 
-niiri:31b704c584e2aae3b394c52754216fae prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:2eff95031f5301f6a29990e69708dce1
+niiri:f6e36041fd68625d6c7813fe63387c51
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0150" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2453,3048 +2453,3048 @@ niiri:2eff95031f5301f6a29990e69708dce1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "150"^^xsd:int .
 
-niiri:2eff95031f5301f6a29990e69708dce1 prov:wasDerivedFrom niiri:9315492073c635bc63a9934fefeda6b6 .
+niiri:f6e36041fd68625d6c7813fe63387c51 prov:wasDerivedFrom niiri:d4dd8ab29b5f9534a65e9a4b237ca312 .
 
-niiri:47e960742a534223746b8914f30df973
+niiri:442ae032432253444ea32f99f4dc387c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:7ffeabdba971025768378cc6c32ca5fe ;
+    prov:atLocation niiri:a4693444c0135c8dfe9d5e4683a03a3a ;
     prov:value "2.18819689750671"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5114661254844"^^xsd:float ;
     nidm_pValueUncorrected: "0.000222821126723893"^^xsd:float ;
     nidm_pValueFWER: "0.999999868311968"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7ffeabdba971025768378cc6c32ca5fe
+niiri:a4693444c0135c8dfe9d5e4683a03a3a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-28,24,4]"^^xsd:string .
 
-niiri:47e960742a534223746b8914f30df973 prov:wasDerivedFrom niiri:43fc9ecb30d51558da2aa2580905eaab .
+niiri:442ae032432253444ea32f99f4dc387c prov:wasDerivedFrom niiri:4362f5eac9972bf179ea49be33151c8e .
 
-niiri:78e2d8c40d6e4600a75cdea76efced8c
+niiri:2cc0e4b46ef04062f76f3cd9f58335d7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:35dde01361b1ceeb6c6b77cfaa742ec4 ;
+    prov:atLocation niiri:21b2ec6e254ee0565b8270bfcfc0e2c7 ;
     prov:value "2.07190132141113"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35835159739265"^^xsd:float ;
     nidm_pValueUncorrected: "0.000392044053194152"^^xsd:float ;
     nidm_pValueFWER: "0.999999999969126"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:35dde01361b1ceeb6c6b77cfaa742ec4
+niiri:21b2ec6e254ee0565b8270bfcfc0e2c7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-28,26,12]"^^xsd:string .
 
-niiri:78e2d8c40d6e4600a75cdea76efced8c prov:wasDerivedFrom niiri:43fc9ecb30d51558da2aa2580905eaab .
+niiri:2cc0e4b46ef04062f76f3cd9f58335d7 prov:wasDerivedFrom niiri:4362f5eac9972bf179ea49be33151c8e .
 
-niiri:dc356018e062c59172dcd1e78418a358
+niiri:bf2f05f6426d9b3de806efb87eb24421
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:eb6d8af6a185c83b9c38e3a1630a4622 ;
+    prov:atLocation niiri:63e78c482af8490d5dfa90d0a0e92669 ;
     prov:value "1.94285821914673"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18853089402481"^^xsd:float ;
     nidm_pValueUncorrected: "0.000714988643396364"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:eb6d8af6a185c83b9c38e3a1630a4622
+niiri:63e78c482af8490d5dfa90d0a0e92669
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-42,20,36]"^^xsd:string .
 
-niiri:dc356018e062c59172dcd1e78418a358 prov:wasDerivedFrom niiri:43fc9ecb30d51558da2aa2580905eaab .
+niiri:bf2f05f6426d9b3de806efb87eb24421 prov:wasDerivedFrom niiri:4362f5eac9972bf179ea49be33151c8e .
 
-niiri:59f453279ae60b2e7633608a74b392af
+niiri:6d4129ab6385c802707ca56c724df92f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:8613dd8cea932331a073b148edfe5144 ;
+    prov:atLocation niiri:de746baa0f488d3bbadc409c300d1274 ;
     prov:value "2.1167094707489"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41734061195353"^^xsd:float ;
     nidm_pValueUncorrected: "0.000316180548517564"^^xsd:float ;
     nidm_pValueFWER: "0.999999998897938"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8613dd8cea932331a073b148edfe5144
+niiri:de746baa0f488d3bbadc409c300d1274
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[36,-84,2]"^^xsd:string .
 
-niiri:59f453279ae60b2e7633608a74b392af prov:wasDerivedFrom niiri:417cabd3eeb412117d20f4882d064567 .
+niiri:6d4129ab6385c802707ca56c724df92f prov:wasDerivedFrom niiri:00f296730dd06a43e5f7334c226305c6 .
 
-niiri:30c43a8440f4ec3cda96fcd40be4d4d5
+niiri:3398d8202d4e93e898d65527617056fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:c5988d123290f51d40d4592a7961f1d1 ;
+    prov:atLocation niiri:787673d51909fd4b7955adca6289845e ;
     prov:value "2.00524592399597"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27061943294259"^^xsd:float ;
     nidm_pValueUncorrected: "0.000536561087325027"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999994"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c5988d123290f51d40d4592a7961f1d1
+niiri:787673d51909fd4b7955adca6289845e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[34,-84,14]"^^xsd:string .
 
-niiri:30c43a8440f4ec3cda96fcd40be4d4d5 prov:wasDerivedFrom niiri:417cabd3eeb412117d20f4882d064567 .
+niiri:3398d8202d4e93e898d65527617056fc prov:wasDerivedFrom niiri:00f296730dd06a43e5f7334c226305c6 .
 
-niiri:7188131da5a3b3086de0052afecc1b23
+niiri:d0c21323683c00398f1fe5b8cd2b1821
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:8014c5c8b33dfb4ba42f7cc5ed169849 ;
+    prov:atLocation niiri:c2e490ac6fc0201797ed715401260ead ;
     prov:value "1.9834691286087"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24196265203981"^^xsd:float ;
     nidm_pValueUncorrected: "0.000593547891254209"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999994"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8014c5c8b33dfb4ba42f7cc5ed169849
+niiri:c2e490ac6fc0201797ed715401260ead
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[34,-78,36]"^^xsd:string .
 
-niiri:7188131da5a3b3086de0052afecc1b23 prov:wasDerivedFrom niiri:417cabd3eeb412117d20f4882d064567 .
+niiri:d0c21323683c00398f1fe5b8cd2b1821 prov:wasDerivedFrom niiri:00f296730dd06a43e5f7334c226305c6 .
 
-niiri:12ddd7ac78265e0515a406f79cd7b60b
+niiri:1f3d65d5c16aacc0308451722678f7de
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:4f09bb3884a3beab368df1e4cbdd6c5a ;
+    prov:atLocation niiri:7291a001aa765929838e01ce77a9da57 ;
     prov:value "2.07622194290161"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36403923290147"^^xsd:float ;
     nidm_pValueUncorrected: "0.000384053116980865"^^xsd:float ;
     nidm_pValueFWER: "0.999999999955495"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4f09bb3884a3beab368df1e4cbdd6c5a
+niiri:7291a001aa765929838e01ce77a9da57
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[52,48,12]"^^xsd:string .
 
-niiri:12ddd7ac78265e0515a406f79cd7b60b prov:wasDerivedFrom niiri:6cc5ea3c57b906137def3d6777b0000f .
+niiri:1f3d65d5c16aacc0308451722678f7de prov:wasDerivedFrom niiri:39a3babf6ed520d78e67263717ca5dbb .
 
-niiri:a8daaa449eaabd54146c2443c52b2405
+niiri:6c8bcca3f301b2525f53e90e5d2e044e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:ced65fab2ecc31645054de6698a6e193 ;
+    prov:atLocation niiri:dcdc8cced1a70ed65194762748dd42f2 ;
     prov:value "2.0327205657959"^^xsd:float ;
     nidm_equivalentZStatistic: "3.306778623673"^^xsd:float ;
     nidm_pValueUncorrected: "0.000471877215462824"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999097"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ced65fab2ecc31645054de6698a6e193
+niiri:dcdc8cced1a70ed65194762748dd42f2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[30,68,12]"^^xsd:string .
 
-niiri:a8daaa449eaabd54146c2443c52b2405 prov:wasDerivedFrom niiri:6cc5ea3c57b906137def3d6777b0000f .
+niiri:6c8bcca3f301b2525f53e90e5d2e044e prov:wasDerivedFrom niiri:39a3babf6ed520d78e67263717ca5dbb .
 
-niiri:073f17f5ff09cc49a92a3da9639c7ec8
+niiri:dc9c09a94ef328a1469d800c80f6fc2f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:9e58a2008800aed167f2193e6475edaa ;
+    prov:atLocation niiri:508dc677de99afa67c363c475a5c743e ;
     prov:value "1.63326919078827"^^xsd:float ;
     nidm_equivalentZStatistic: "2.78184273056811"^^xsd:float ;
     nidm_pValueUncorrected: "0.00270256128658664"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9e58a2008800aed167f2193e6475edaa
+niiri:508dc677de99afa67c363c475a5c743e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[14,74,6]"^^xsd:string .
 
-niiri:073f17f5ff09cc49a92a3da9639c7ec8 prov:wasDerivedFrom niiri:6cc5ea3c57b906137def3d6777b0000f .
+niiri:dc9c09a94ef328a1469d800c80f6fc2f prov:wasDerivedFrom niiri:39a3babf6ed520d78e67263717ca5dbb .
 
-niiri:d0393b0ebc9411a5d45ca86b90a5f75a
+niiri:0445099b3ad94f2a7bffd17b72c32178
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:32c57c9426babf3fe0244d15351d0daf ;
+    prov:atLocation niiri:d2747be6a82e62e1332bff6a58f4d7f5 ;
     prov:value "2.04988360404968"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32936904595179"^^xsd:float ;
     nidm_pValueUncorrected: "0.000435214929046523"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995547"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:32c57c9426babf3fe0244d15351d0daf
+niiri:d2747be6a82e62e1332bff6a58f4d7f5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[34,-54,52]"^^xsd:string .
 
-niiri:d0393b0ebc9411a5d45ca86b90a5f75a prov:wasDerivedFrom niiri:c29516aed6cf24b95d9653e2365e0ced .
+niiri:0445099b3ad94f2a7bffd17b72c32178 prov:wasDerivedFrom niiri:26ed93f97118482ea99f750276db5700 .
 
-niiri:603843b40d6d98501a421775119d3ad1
+niiri:6cf57566c63330551854cd41c76c7945
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:fcdba63eb7662475636125721f54320e ;
+    prov:atLocation niiri:2e98c4783a911189aca09f35a6897677 ;
     prov:value "1.17590498924255"^^xsd:float ;
     nidm_equivalentZStatistic: "2.18553018514689"^^xsd:float ;
     nidm_pValueUncorrected: "0.0144249976129074"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:fcdba63eb7662475636125721f54320e
+niiri:2e98c4783a911189aca09f35a6897677
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[26,-48,50]"^^xsd:string .
 
-niiri:603843b40d6d98501a421775119d3ad1 prov:wasDerivedFrom niiri:c29516aed6cf24b95d9653e2365e0ced .
+niiri:6cf57566c63330551854cd41c76c7945 prov:wasDerivedFrom niiri:26ed93f97118482ea99f750276db5700 .
 
-niiri:16b2952800d349d84a763795197c8b0b
+niiri:43ebe5004c0f1a88f50fa9cffeb58814
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:ac144f9a90591900cfb49f146349a1b8 ;
+    prov:atLocation niiri:f2579430fdf3f2f8395d1d9fb3007977 ;
     prov:value "1.17325437068939"^^xsd:float ;
     nidm_equivalentZStatistic: "2.18210185402812"^^xsd:float ;
     nidm_pValueUncorrected: "0.0145510082060974"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ac144f9a90591900cfb49f146349a1b8
+niiri:f2579430fdf3f2f8395d1d9fb3007977
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[32,-54,62]"^^xsd:string .
 
-niiri:16b2952800d349d84a763795197c8b0b prov:wasDerivedFrom niiri:c29516aed6cf24b95d9653e2365e0ced .
+niiri:43ebe5004c0f1a88f50fa9cffeb58814 prov:wasDerivedFrom niiri:26ed93f97118482ea99f750276db5700 .
 
-niiri:d7a85cf00dbcad11964be5f20d4b99ff
+niiri:d5d5aad603484d20a1db3818d3e3212c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:0de0e683dce5cc8a49c6c73eedac8c40 ;
+    prov:atLocation niiri:0fa634cf4f8cd761e5a8e1556dae51af ;
     prov:value "1.69681537151337"^^xsd:float ;
     nidm_equivalentZStatistic: "2.86519802999163"^^xsd:float ;
     nidm_pValueUncorrected: "0.00208374267085354"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0de0e683dce5cc8a49c6c73eedac8c40
+niiri:0fa634cf4f8cd761e5a8e1556dae51af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-28,50,36]"^^xsd:string .
 
-niiri:d7a85cf00dbcad11964be5f20d4b99ff prov:wasDerivedFrom niiri:1c26e68b379e5bd715e75014cca849ab .
+niiri:d5d5aad603484d20a1db3818d3e3212c prov:wasDerivedFrom niiri:c0faffa954cb5edf1bd166b3c13b64b6 .
 
-niiri:90e0ff48a341c849ccd5b511385d366a
+niiri:98d4353d19758293894ef727f5c50955
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:c1f676e8a11713f1a14d11da4d4c21cd ;
+    prov:atLocation niiri:f1befc6625b08ba88efdc7f2bfff4a08 ;
     prov:value "0.933988809585571"^^xsd:float ;
     nidm_equivalentZStatistic: "1.8747737054388"^^xsd:float ;
     nidm_pValueUncorrected: "0.0304119310280364"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c1f676e8a11713f1a14d11da4d4c21cd
+niiri:f1befc6625b08ba88efdc7f2bfff4a08
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-46,38,30]"^^xsd:string .
 
-niiri:90e0ff48a341c849ccd5b511385d366a prov:wasDerivedFrom niiri:1c26e68b379e5bd715e75014cca849ab .
+niiri:98d4353d19758293894ef727f5c50955 prov:wasDerivedFrom niiri:c0faffa954cb5edf1bd166b3c13b64b6 .
 
-niiri:d405f97c1debf6dfef53e4c341960b1c
+niiri:36a41856d01473f63c7c845ca39839d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:bac6269bd3bba27583f4d36c34dcbaf1 ;
+    prov:atLocation niiri:605d54e8c542405ec983a5d0a512106f ;
     prov:value "1.66940176486969"^^xsd:float ;
     nidm_equivalentZStatistic: "2.82922911554701"^^xsd:float ;
     nidm_pValueUncorrected: "0.00233301407977504"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:bac6269bd3bba27583f4d36c34dcbaf1
+niiri:605d54e8c542405ec983a5d0a512106f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[16,-94,-30]"^^xsd:string .
 
-niiri:d405f97c1debf6dfef53e4c341960b1c prov:wasDerivedFrom niiri:8b5d6e1bd5480bd6366d0094c92d4851 .
+niiri:36a41856d01473f63c7c845ca39839d6 prov:wasDerivedFrom niiri:1baee1eea0758a922f6c4f1f12441da6 .
 
-niiri:4e793a27eff6bd141a437820cd72dd10
+niiri:d8f65681bb1bfa31766963ffbe28cead
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:02f3a870411865e426e29828e46ed3f9 ;
+    prov:atLocation niiri:8e641bae5b55cb975397775ca4f1465e ;
     prov:value "1.5886458158493"^^xsd:float ;
     nidm_equivalentZStatistic: "2.72335979311329"^^xsd:float ;
     nidm_pValueUncorrected: "0.00323108192435606"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:02f3a870411865e426e29828e46ed3f9
+niiri:8e641bae5b55cb975397775ca4f1465e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[24,-92,-30]"^^xsd:string .
 
-niiri:4e793a27eff6bd141a437820cd72dd10 prov:wasDerivedFrom niiri:8b5d6e1bd5480bd6366d0094c92d4851 .
+niiri:d8f65681bb1bfa31766963ffbe28cead prov:wasDerivedFrom niiri:1baee1eea0758a922f6c4f1f12441da6 .
 
-niiri:7eccc401f6068789908f149147981921
+niiri:b277f286259eb04c946603cb6ba51822
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:371d66a66b29fdb967d17dd294dfe6e3 ;
+    prov:atLocation niiri:225f9a677dc138e3dd97c18cbf2884ef ;
     prov:value "1.51174938678741"^^xsd:float ;
     nidm_equivalentZStatistic: "2.62269482082508"^^xsd:float ;
     nidm_pValueUncorrected: "0.00436186877852962"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:371d66a66b29fdb967d17dd294dfe6e3
+niiri:225f9a677dc138e3dd97c18cbf2884ef
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[34,-84,-48]"^^xsd:string .
 
-niiri:7eccc401f6068789908f149147981921 prov:wasDerivedFrom niiri:8b5d6e1bd5480bd6366d0094c92d4851 .
+niiri:b277f286259eb04c946603cb6ba51822 prov:wasDerivedFrom niiri:1baee1eea0758a922f6c4f1f12441da6 .
 
-niiri:bc7a7d099b4aa5c027485a3f6e273f75
+niiri:cee39f86215489cfd805b4d5f5dab3a2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:05b822162b985baea86f5f76eaf274eb ;
+    prov:atLocation niiri:9d6418747114ca65b24a6f9e53156964 ;
     prov:value "1.6600536108017"^^xsd:float ;
     nidm_equivalentZStatistic: "2.81696686061887"^^xsd:float ;
     nidm_pValueUncorrected: "0.00242397637898328"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:05b822162b985baea86f5f76eaf274eb
+niiri:9d6418747114ca65b24a6f9e53156964
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-44,-56,-32]"^^xsd:string .
 
-niiri:bc7a7d099b4aa5c027485a3f6e273f75 prov:wasDerivedFrom niiri:7e631bc430702f08996bcc12a090f463 .
+niiri:cee39f86215489cfd805b4d5f5dab3a2 prov:wasDerivedFrom niiri:1aa58b6ce0025b1ec01cb8a983388e1d .
 
-niiri:5d6079cd009bcfed9d07102c8bf1cd64
+niiri:10d3d3d8948f818e3d2670f3b08476f8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:b5301e158adbbc221d5e73c472172d3e ;
+    prov:atLocation niiri:5c9455cedfce2a1f699bcd725ce4b27e ;
     prov:value "1.5787501335144"^^xsd:float ;
     nidm_equivalentZStatistic: "2.71039687336073"^^xsd:float ;
     nidm_pValueUncorrected: "0.00336013715292427"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b5301e158adbbc221d5e73c472172d3e
+niiri:5c9455cedfce2a1f699bcd725ce4b27e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-10,72,0]"^^xsd:string .
 
-niiri:5d6079cd009bcfed9d07102c8bf1cd64 prov:wasDerivedFrom niiri:c21e2ede0b4f245e2d9f679a7862569e .
+niiri:10d3d3d8948f818e3d2670f3b08476f8 prov:wasDerivedFrom niiri:3198b98e15c5c56654d8a4ffe4b44ce8 .
 
-niiri:67a82cc3c6fe87003f709a11853632a1
+niiri:fb4201c849e6cb24fb95b4ccf6b6e5b3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:be6a1b05017c497d1872f0ed60f8f931 ;
+    prov:atLocation niiri:76b9f21dd86f54f4686cb3f8ad313ccc ;
     prov:value "1.37760043144226"^^xsd:float ;
     nidm_equivalentZStatistic: "2.44750858968075"^^xsd:float ;
     nidm_pValueUncorrected: "0.0071923848185762"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:be6a1b05017c497d1872f0ed60f8f931
+niiri:76b9f21dd86f54f4686cb3f8ad313ccc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-24,68,10]"^^xsd:string .
 
-niiri:67a82cc3c6fe87003f709a11853632a1 prov:wasDerivedFrom niiri:c21e2ede0b4f245e2d9f679a7862569e .
+niiri:fb4201c849e6cb24fb95b4ccf6b6e5b3 prov:wasDerivedFrom niiri:3198b98e15c5c56654d8a4ffe4b44ce8 .
 
-niiri:8fbbec051d375de1ec30261a1f32f9a5
+niiri:50e767c1e55c55fd6f705e63b8194c22
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:9d8f2d489780f5c4762d7ff3891155a2 ;
+    prov:atLocation niiri:200e07f7941deec2e3926a00d9c097f1 ;
     prov:value "1.35886359214783"^^xsd:float ;
     nidm_equivalentZStatistic: "2.42309168524595"^^xsd:float ;
     nidm_pValueUncorrected: "0.00769452108984159"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9d8f2d489780f5c4762d7ff3891155a2
+niiri:200e07f7941deec2e3926a00d9c097f1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-14,64,28]"^^xsd:string .
 
-niiri:8fbbec051d375de1ec30261a1f32f9a5 prov:wasDerivedFrom niiri:c21e2ede0b4f245e2d9f679a7862569e .
+niiri:50e767c1e55c55fd6f705e63b8194c22 prov:wasDerivedFrom niiri:3198b98e15c5c56654d8a4ffe4b44ce8 .
 
-niiri:722e903ee5178a4981cc55266210bd89
+niiri:651e85007a5f5536ec2697c8749ec5f0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:9f719f92694484cd7261b1c6255b52c0 ;
+    prov:atLocation niiri:a825a8bc763b96a41ba63085944a53f5 ;
     prov:value "1.53290164470673"^^xsd:float ;
     nidm_equivalentZStatistic: "2.65036951622375"^^xsd:float ;
     nidm_pValueUncorrected: "0.00402018893002576"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9f719f92694484cd7261b1c6255b52c0
+niiri:a825a8bc763b96a41ba63085944a53f5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-32,-80,10]"^^xsd:string .
 
-niiri:722e903ee5178a4981cc55266210bd89 prov:wasDerivedFrom niiri:c8c6cee0456ea9b67ae74c71ec73d58a .
+niiri:651e85007a5f5536ec2697c8749ec5f0 prov:wasDerivedFrom niiri:7d6744d8bee9e326b4381ceb83e93c8d .
 
-niiri:43c73ccd4ff874b4159d8e343817709e
+niiri:97da40b69bc71f2a3cbe9bddb8d74db7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:d6269808ee48c8a2f54e9d917e97a97d ;
+    prov:atLocation niiri:92aaec6881a3d0f16d11925a7c0e8a35 ;
     prov:value "1.34681856632233"^^xsd:float ;
     nidm_equivalentZStatistic: "2.4074027844201"^^xsd:float ;
     nidm_pValueUncorrected: "0.00803321955273906"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d6269808ee48c8a2f54e9d917e97a97d
+niiri:92aaec6881a3d0f16d11925a7c0e8a35
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-32,-88,8]"^^xsd:string .
 
-niiri:43c73ccd4ff874b4159d8e343817709e prov:wasDerivedFrom niiri:c8c6cee0456ea9b67ae74c71ec73d58a .
+niiri:97da40b69bc71f2a3cbe9bddb8d74db7 prov:wasDerivedFrom niiri:7d6744d8bee9e326b4381ceb83e93c8d .
 
-niiri:5b402b3505886d69eee1da65259dfff5
+niiri:4a7114ba39dbababe80905fe47a8cbc5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:e3be3bddf8e8cf2bc774db0b5fd4ccf9 ;
+    prov:atLocation niiri:a5814c8553718d88d2b132f5baa18703 ;
     prov:value "1.31222748756409"^^xsd:float ;
     nidm_equivalentZStatistic: "2.36238178325093"^^xsd:float ;
     nidm_pValueUncorrected: "0.00907896581463363"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e3be3bddf8e8cf2bc774db0b5fd4ccf9
+niiri:a5814c8553718d88d2b132f5baa18703
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-30,-78,26]"^^xsd:string .
 
-niiri:5b402b3505886d69eee1da65259dfff5 prov:wasDerivedFrom niiri:c8c6cee0456ea9b67ae74c71ec73d58a .
+niiri:4a7114ba39dbababe80905fe47a8cbc5 prov:wasDerivedFrom niiri:7d6744d8bee9e326b4381ceb83e93c8d .
 
-niiri:5516b5835629ab543345d78e4c6e7f84
+niiri:891a014c9e49c38970fb24d2eaae740d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:5fa024f29ffd7dd65df2521965746c10 ;
+    prov:atLocation niiri:7d0bd7b1f39fd643840af9787a78ba95 ;
     prov:value "1.47698056697845"^^xsd:float ;
     nidm_equivalentZStatistic: "2.57723307746183"^^xsd:float ;
     nidm_pValueUncorrected: "0.00497973845037369"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5fa024f29ffd7dd65df2521965746c10
+niiri:7d0bd7b1f39fd643840af9787a78ba95
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[24,-64,62]"^^xsd:string .
 
-niiri:5516b5835629ab543345d78e4c6e7f84 prov:wasDerivedFrom niiri:b2fe5ac2a355fdcde56dd1f1b7fe2ba5 .
+niiri:891a014c9e49c38970fb24d2eaae740d prov:wasDerivedFrom niiri:1593dbfe6a27c4bfd6c7c865a55e6758 .
 
-niiri:b0048f0b19299e2890e2feec137562bd
+niiri:f4b89e59bc3ef696d8778bd6b6dea759
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:dfffa57a27812cbdb97937c604ce644d ;
+    prov:atLocation niiri:1d699923abf53a3abefc6961b7996e12 ;
     prov:value "1.47098410129547"^^xsd:float ;
     nidm_equivalentZStatistic: "2.56939616988394"^^xsd:float ;
     nidm_pValueUncorrected: "0.00509379579800051"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:dfffa57a27812cbdb97937c604ce644d
+niiri:1d699923abf53a3abefc6961b7996e12
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[42,2,42]"^^xsd:string .
 
-niiri:b0048f0b19299e2890e2feec137562bd prov:wasDerivedFrom niiri:c8915bbac48c4a94d3bf54f07d28091a .
+niiri:f4b89e59bc3ef696d8778bd6b6dea759 prov:wasDerivedFrom niiri:537cd4e035d031e1d96dcc9b62c35112 .
 
-niiri:44cc0c30dff2ae8e59814059b0d808d8
+niiri:6d3354cad50b2f85dd7cb7909270bbd9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:9cfb25b1548c7ea2a37d91c1cdc97937 ;
+    prov:atLocation niiri:a0853cb3b872dd490c0e659c3b8de3c5 ;
     prov:value "1.28529334068298"^^xsd:float ;
     nidm_equivalentZStatistic: "2.32736401858338"^^xsd:float ;
     nidm_pValueUncorrected: "0.00997294956075112"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9cfb25b1548c7ea2a37d91c1cdc97937
+niiri:a0853cb3b872dd490c0e659c3b8de3c5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[52,6,36]"^^xsd:string .
 
-niiri:44cc0c30dff2ae8e59814059b0d808d8 prov:wasDerivedFrom niiri:c8915bbac48c4a94d3bf54f07d28091a .
+niiri:6d3354cad50b2f85dd7cb7909270bbd9 prov:wasDerivedFrom niiri:537cd4e035d031e1d96dcc9b62c35112 .
 
-niiri:8f81caeadc613b2befe266e538a005b4
+niiri:c9fd614181dc2572b186e5053efcd59d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:192ea9c42130b9f2836346385ffa8ac6 ;
+    prov:atLocation niiri:f39a7e048d6696e150550855cdb219a4 ;
     prov:value "1.46635723114014"^^xsd:float ;
     nidm_equivalentZStatistic: "2.56334999311601"^^xsd:float ;
     nidm_pValueUncorrected: "0.00518337435668992"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:192ea9c42130b9f2836346385ffa8ac6
+niiri:f39a7e048d6696e150550855cdb219a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[-28,-60,54]"^^xsd:string .
 
-niiri:8f81caeadc613b2befe266e538a005b4 prov:wasDerivedFrom niiri:81f39aacce9db78e536cab5c96400969 .
+niiri:c9fd614181dc2572b186e5053efcd59d prov:wasDerivedFrom niiri:3330f53a36ff5c9ef2f20b1290e9d286 .
 
-niiri:49b88a38ee8eb23aa88417b585a3c019
+niiri:a16bea998c35dc62efc05b93e35b430f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:2e4756a1fc7f488d50c7e456c8606411 ;
+    prov:atLocation niiri:b2d449babe5545c90ba00fa714a59c65 ;
     prov:value "1.35919630527496"^^xsd:float ;
     nidm_equivalentZStatistic: "2.42352513638295"^^xsd:float ;
     nidm_pValueUncorrected: "0.00768534474692273"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2e4756a1fc7f488d50c7e456c8606411
+niiri:b2d449babe5545c90ba00fa714a59c65
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-30,-56,62]"^^xsd:string .
 
-niiri:49b88a38ee8eb23aa88417b585a3c019 prov:wasDerivedFrom niiri:81f39aacce9db78e536cab5c96400969 .
+niiri:a16bea998c35dc62efc05b93e35b430f prov:wasDerivedFrom niiri:3330f53a36ff5c9ef2f20b1290e9d286 .
 
-niiri:d526e3755e8ee1eb281731fad0d751f7
+niiri:0103dbc26eaf007da3744695bb9e0aa0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:7f8d1d4f81b26e2e937ef2c6c7065a2f ;
+    prov:atLocation niiri:cba23a81a0efa6d0d2133678dd3ac39f ;
     prov:value "1.3043509721756"^^xsd:float ;
     nidm_equivalentZStatistic: "2.35213781333103"^^xsd:float ;
     nidm_pValueUncorrected: "0.00933292892535331"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7f8d1d4f81b26e2e937ef2c6c7065a2f
+niiri:cba23a81a0efa6d0d2133678dd3ac39f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-18,-62,52]"^^xsd:string .
 
-niiri:d526e3755e8ee1eb281731fad0d751f7 prov:wasDerivedFrom niiri:81f39aacce9db78e536cab5c96400969 .
+niiri:0103dbc26eaf007da3744695bb9e0aa0 prov:wasDerivedFrom niiri:3330f53a36ff5c9ef2f20b1290e9d286 .
 
-niiri:803b5b1f8348b033ada171621cc5c167
+niiri:f75194d50d0d5b9cd1dcdbd886ebd682
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:a13a3d48a1429418bba0b99d4e9725bb ;
+    prov:atLocation niiri:1adec05c4ab0624228a2752245a4ad8b ;
     prov:value "1.45064067840576"^^xsd:float ;
     nidm_equivalentZStatistic: "2.54281750257153"^^xsd:float ;
     nidm_pValueUncorrected: "0.00549813229675677"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a13a3d48a1429418bba0b99d4e9725bb
+niiri:1adec05c4ab0624228a2752245a4ad8b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-30,-84,-48]"^^xsd:string .
 
-niiri:803b5b1f8348b033ada171621cc5c167 prov:wasDerivedFrom niiri:95cfa48491de3b2db8a60dc29bdeb6af .
+niiri:f75194d50d0d5b9cd1dcdbd886ebd682 prov:wasDerivedFrom niiri:9c973b3443bcab76e6ce5b021d6b1a13 .
 
-niiri:10252df0ea1e4565a8207dad73957039
+niiri:acc4812fde8a87c23d34ba26b370d53f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:6e55e818af807eb11d9ab4e1a7d892a8 ;
+    prov:atLocation niiri:886a9d589ec63742ed0ea381ebb81a8f ;
     prov:value "1.37874686717987"^^xsd:float ;
     nidm_equivalentZStatistic: "2.44900302114624"^^xsd:float ;
     nidm_pValueUncorrected: "0.00716261232865922"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6e55e818af807eb11d9ab4e1a7d892a8
+niiri:886a9d589ec63742ed0ea381ebb81a8f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-22,-84,-50]"^^xsd:string .
 
-niiri:10252df0ea1e4565a8207dad73957039 prov:wasDerivedFrom niiri:95cfa48491de3b2db8a60dc29bdeb6af .
+niiri:acc4812fde8a87c23d34ba26b370d53f prov:wasDerivedFrom niiri:9c973b3443bcab76e6ce5b021d6b1a13 .
 
-niiri:1b619cb22a788dbfcac8e6547b8cf9c3
+niiri:15ccd6b0b7514b3584e9c6b60bb007cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:a196ba726a6cf6e1af92ce4f926bddd6 ;
+    prov:atLocation niiri:156b51e696a83a537ee4ec10986ac2ce ;
     prov:value "1.1024569272995"^^xsd:float ;
     nidm_equivalentZStatistic: "2.09070134301333"^^xsd:float ;
     nidm_pValueUncorrected: "0.0182774222681363"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a196ba726a6cf6e1af92ce4f926bddd6
+niiri:156b51e696a83a537ee4ec10986ac2ce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-24,-90,-42]"^^xsd:string .
 
-niiri:1b619cb22a788dbfcac8e6547b8cf9c3 prov:wasDerivedFrom niiri:95cfa48491de3b2db8a60dc29bdeb6af .
+niiri:15ccd6b0b7514b3584e9c6b60bb007cb prov:wasDerivedFrom niiri:9c973b3443bcab76e6ce5b021d6b1a13 .
 
-niiri:e7bccdc00c0d8eba721b2ada820c74eb
+niiri:4777cf2071b7b41500a1f57022890df8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:07a292d3fca36fc7398026cd440e98ff ;
+    prov:atLocation niiri:1af93548bf2bbf22f69bc6640b686613 ;
     prov:value "1.43723428249359"^^xsd:float ;
     nidm_equivalentZStatistic: "2.52530953068747"^^xsd:float ;
     nidm_pValueUncorrected: "0.00577982121839438"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:07a292d3fca36fc7398026cd440e98ff
+niiri:1af93548bf2bbf22f69bc6640b686613
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-24,40,46]"^^xsd:string .
 
-niiri:e7bccdc00c0d8eba721b2ada820c74eb prov:wasDerivedFrom niiri:e7fc37cb04d1a3f58136cfb12f992f34 .
+niiri:4777cf2071b7b41500a1f57022890df8 prov:wasDerivedFrom niiri:27a3407fb41dee69924952963bf01095 .
 
-niiri:b04044222ee790cf55bdaa521739b13d
+niiri:eacfb263b90cde13ef784658cf25eb48
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:ee1d4ec9c2f0fec55c6dd0053012c88a ;
+    prov:atLocation niiri:7ac57d87a6011aa306f5300c51620b1f ;
     prov:value "1.11286687850952"^^xsd:float ;
     nidm_equivalentZStatistic: "2.10411930550185"^^xsd:float ;
     nidm_pValueUncorrected: "0.0176840206088169"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ee1d4ec9c2f0fec55c6dd0053012c88a
+niiri:7ac57d87a6011aa306f5300c51620b1f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-16,50,46]"^^xsd:string .
 
-niiri:b04044222ee790cf55bdaa521739b13d prov:wasDerivedFrom niiri:e7fc37cb04d1a3f58136cfb12f992f34 .
+niiri:eacfb263b90cde13ef784658cf25eb48 prov:wasDerivedFrom niiri:27a3407fb41dee69924952963bf01095 .
 
-niiri:2d1b96b3d3613decbd596f70088a278e
+niiri:f954f6180923bbe6c50483cd884c34cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:e1970f3d88404b41f93f350066b20ee5 ;
+    prov:atLocation niiri:7beb4ee855117da9771f3319e86d6926 ;
     prov:value "1.42738270759583"^^xsd:float ;
     nidm_equivalentZStatistic: "2.51244786328393"^^xsd:float ;
     nidm_pValueUncorrected: "0.00599484099495173"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e1970f3d88404b41f93f350066b20ee5
+niiri:7beb4ee855117da9771f3319e86d6926
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[40,32,42]"^^xsd:string .
 
-niiri:2d1b96b3d3613decbd596f70088a278e prov:wasDerivedFrom niiri:de5b4d0f5d84034ba5fd7975873cc2e6 .
+niiri:f954f6180923bbe6c50483cd884c34cb prov:wasDerivedFrom niiri:9c3f0991818d487326255d5ca7862e30 .
 
-niiri:7cd243c2f0efa2926ee101eb0ddaa71f
+niiri:f04690c008db60f141bbb5f8963ea62f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:2d93df4bc1c8bdc309f561183cf1d559 ;
+    prov:atLocation niiri:dc9d047e50802cd5dfea68f14c77fdb3 ;
     prov:value "1.05634605884552"^^xsd:float ;
     nidm_equivalentZStatistic: "2.03136304442869"^^xsd:float ;
     nidm_pValueUncorrected: "0.0211090901815698"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2d93df4bc1c8bdc309f561183cf1d559
+niiri:dc9d047e50802cd5dfea68f14c77fdb3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[38,40,36]"^^xsd:string .
 
-niiri:7cd243c2f0efa2926ee101eb0ddaa71f prov:wasDerivedFrom niiri:de5b4d0f5d84034ba5fd7975873cc2e6 .
+niiri:f04690c008db60f141bbb5f8963ea62f prov:wasDerivedFrom niiri:9c3f0991818d487326255d5ca7862e30 .
 
-niiri:af520ea7a2b622b616f138da20521f11
+niiri:f2927e668b305ce4095e4a1fae3d5ba5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:25eebb30f786b56bc44db03461f48217 ;
+    prov:atLocation niiri:ee21681844ab92db1f554ed686e6cb97 ;
     prov:value "1.40870463848114"^^xsd:float ;
     nidm_equivalentZStatistic: "2.4880722231724"^^xsd:float ;
     nidm_pValueUncorrected: "0.00642188235953201"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:25eebb30f786b56bc44db03461f48217
+niiri:ee21681844ab92db1f554ed686e6cb97
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-42,-84,-6]"^^xsd:string .
 
-niiri:af520ea7a2b622b616f138da20521f11 prov:wasDerivedFrom niiri:1d6209037825fb7ee168299aa10d5ad7 .
+niiri:f2927e668b305ce4095e4a1fae3d5ba5 prov:wasDerivedFrom niiri:73094daa238696f8de11ef4e56a95c30 .
 
-niiri:1296043c9bfe3127d5cc76c217e1e26d
+niiri:402e0d4048e6d12f11de0e3c9bdf055c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:21698b9502c51709153adfed9abb8986 ;
+    prov:atLocation niiri:9e67d185caabdc161e0d312461d9cdd0 ;
     prov:value "1.13220155239105"^^xsd:float ;
     nidm_equivalentZStatistic: "2.12906102075628"^^xsd:float ;
     nidm_pValueUncorrected: "0.0166246060871375"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:21698b9502c51709153adfed9abb8986
+niiri:9e67d185caabdc161e0d312461d9cdd0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-50,-78,0]"^^xsd:string .
 
-niiri:1296043c9bfe3127d5cc76c217e1e26d prov:wasDerivedFrom niiri:1d6209037825fb7ee168299aa10d5ad7 .
+niiri:402e0d4048e6d12f11de0e3c9bdf055c prov:wasDerivedFrom niiri:73094daa238696f8de11ef4e56a95c30 .
 
-niiri:23d6198c7c453ccfbd7fb701c34b6e26
+niiri:ce6f3e2f152234ea375751cc54fa9c85
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:28a96db39c58e234af2cc132fa98f4bc ;
+    prov:atLocation niiri:93fdcdaf5f69c6e135d078d6217da497 ;
     prov:value "1.34917068481445"^^xsd:float ;
     nidm_equivalentZStatistic: "2.41046599292312"^^xsd:float ;
     nidm_pValueUncorrected: "0.00796607827138629"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:28a96db39c58e234af2cc132fa98f4bc
+niiri:93fdcdaf5f69c6e135d078d6217da497
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[12,-20,80]"^^xsd:string .
 
-niiri:23d6198c7c453ccfbd7fb701c34b6e26 prov:wasDerivedFrom niiri:b1918e5ede22fa7e1d3a1399a34a2d45 .
+niiri:ce6f3e2f152234ea375751cc54fa9c85 prov:wasDerivedFrom niiri:35af8997746066bb4be8d3a9cebf0640 .
 
-niiri:2b724527e8d3c9b6e97424cd9b8d15aa
+niiri:b988b89ef13b4938653637ed36c2bc4d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:42b34ad9cce6394b101fbaa08a07f29f ;
+    prov:atLocation niiri:8bc4c3b0a3463c5ccd6748b60c01b1b7 ;
     prov:value "1.34354746341705"^^xsd:float ;
     nidm_equivalentZStatistic: "2.40314315325023"^^xsd:float ;
     nidm_pValueUncorrected: "0.0081274114265858"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:42b34ad9cce6394b101fbaa08a07f29f
+niiri:8bc4c3b0a3463c5ccd6748b60c01b1b7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[18,48,44]"^^xsd:string .
 
-niiri:2b724527e8d3c9b6e97424cd9b8d15aa prov:wasDerivedFrom niiri:5d9799711b35085d7a8bcba1641700b1 .
+niiri:b988b89ef13b4938653637ed36c2bc4d prov:wasDerivedFrom niiri:9d0b757e22fc3f0156790583744c1334 .
 
-niiri:4de941e56885958a7463bfabb4b85cf9
+niiri:1d5df79c27d668272e122666fca002b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:91689c74edc5692bdf656cdf4e590451 ;
+    prov:atLocation niiri:6429c604174465ae78baf35ecfc017c4 ;
     prov:value "1.14962959289551"^^xsd:float ;
     nidm_equivalentZStatistic: "2.15156492154198"^^xsd:float ;
     nidm_pValueUncorrected: "0.015715818709074"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:91689c74edc5692bdf656cdf4e590451
+niiri:6429c604174465ae78baf35ecfc017c4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[8,52,46]"^^xsd:string .
 
-niiri:4de941e56885958a7463bfabb4b85cf9 prov:wasDerivedFrom niiri:5d9799711b35085d7a8bcba1641700b1 .
+niiri:1d5df79c27d668272e122666fca002b8 prov:wasDerivedFrom niiri:9d0b757e22fc3f0156790583744c1334 .
 
-niiri:2a1e41375178ee6048cfe473ad850d9d
+niiri:3141b4c6e901f4ec1f5e0352c6d0360d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:d103ae494461197404d4d98c94ab55d0 ;
+    prov:atLocation niiri:65ae40d69c72f6ee264d19c45986f3b4 ;
     prov:value "1.33556091785431"^^xsd:float ;
     nidm_equivalentZStatistic: "2.39274498818401"^^xsd:float ;
     nidm_pValueUncorrected: "0.00836142979663967"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d103ae494461197404d4d98c94ab55d0
+niiri:65ae40d69c72f6ee264d19c45986f3b4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[64,-52,2]"^^xsd:string .
 
-niiri:2a1e41375178ee6048cfe473ad850d9d prov:wasDerivedFrom niiri:437180e47264cc4e09dc17b204fd0a89 .
+niiri:3141b4c6e901f4ec1f5e0352c6d0360d prov:wasDerivedFrom niiri:8d3362f5850c9379377b0d1f0b1c2735 .
 
-niiri:b2e28fc4cb7873bae7dfcec9c622a9c0
+niiri:469e72c7f14e92f86f0ec5262a435c39
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:d4322ad7c793d679b708c35788e9eb73 ;
+    prov:atLocation niiri:a51b4e8c46bf9aa3e74eadca19ad0968 ;
     prov:value "1.30518817901611"^^xsd:float ;
     nidm_equivalentZStatistic: "2.35322652463791"^^xsd:float ;
     nidm_pValueUncorrected: "0.00930564616578244"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d4322ad7c793d679b708c35788e9eb73
+niiri:a51b4e8c46bf9aa3e74eadca19ad0968
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[26,-74,-30]"^^xsd:string .
 
-niiri:b2e28fc4cb7873bae7dfcec9c622a9c0 prov:wasDerivedFrom niiri:1cd87c105e9a1996f42e3171bad089a8 .
+niiri:469e72c7f14e92f86f0ec5262a435c39 prov:wasDerivedFrom niiri:227019e17364687787db60a4a8267663 .
 
-niiri:4957f8f40371d5539e9b85697134e63f
+niiri:99a673bf7bd432cda404ddae34a3c146
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:5e9202a8879f71e2067d4c3d52dedb20 ;
+    prov:atLocation niiri:85071e33199bbf64537a2df42a3a1673 ;
     prov:value "1.30020189285278"^^xsd:float ;
     nidm_equivalentZStatistic: "2.34674279460019"^^xsd:float ;
     nidm_pValueUncorrected: "0.00946916148556731"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5e9202a8879f71e2067d4c3d52dedb20
+niiri:85071e33199bbf64537a2df42a3a1673
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-44,-82,-34]"^^xsd:string .
 
-niiri:4957f8f40371d5539e9b85697134e63f prov:wasDerivedFrom niiri:cc02b2de189bcf80b0afcbe487b0d1e8 .
+niiri:99a673bf7bd432cda404ddae34a3c146 prov:wasDerivedFrom niiri:8669f380bd303fec5b169e636d626ce3 .
 
-niiri:6c2bd69486f6f2fc98bdad9a9249cde9
+niiri:09715737634975b7e4a53926319b1bee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:372619818a34b671fccfef60836977b8 ;
+    prov:atLocation niiri:b8520f4b473a7db7a8a22098c02388df ;
     prov:value "1.2840074300766"^^xsd:float ;
     nidm_equivalentZStatistic: "2.32569303609441"^^xsd:float ;
     nidm_pValueUncorrected: "0.0100174661332294"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:372619818a34b671fccfef60836977b8
+niiri:b8520f4b473a7db7a8a22098c02388df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[-6,62,36]"^^xsd:string .
 
-niiri:6c2bd69486f6f2fc98bdad9a9249cde9 prov:wasDerivedFrom niiri:3ae2e3cf05ec7ac4b46544f268071134 .
+niiri:09715737634975b7e4a53926319b1bee prov:wasDerivedFrom niiri:f38934924fa68b3b9a71fb9c8171e8b6 .
 
-niiri:8bc88f0d5c04e29ab34863cd24e68863
+niiri:a950180a6b2d1ba6bd0c8453f6aa57c6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:ce40992a0b5e259f1b43758c5d68ea28 ;
+    prov:atLocation niiri:1f3bac07c06f6c4da947941a3e0d40d2 ;
     prov:value "1.26505351066589"^^xsd:float ;
     nidm_equivalentZStatistic: "2.30107272004429"^^xsd:float ;
     nidm_pValueUncorrected: "0.0106937605017341"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ce40992a0b5e259f1b43758c5d68ea28
+niiri:1f3bac07c06f6c4da947941a3e0d40d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-50,-2,50]"^^xsd:string .
 
-niiri:8bc88f0d5c04e29ab34863cd24e68863 prov:wasDerivedFrom niiri:3c84c74526e078ad8336fd968ec9d7f0 .
+niiri:a950180a6b2d1ba6bd0c8453f6aa57c6 prov:wasDerivedFrom niiri:1793504b32e2869dcb2fbd3af062f8bc .
 
-niiri:8a59a15e6d4b148aaa0593801d721b02
+niiri:a59a5d4bd11645916f5cb26b0edecf9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:4f32af48b33fc420912cf278bf0e8c3c ;
+    prov:atLocation niiri:686f5e6308163bd9a97c3148f494b7b8 ;
     prov:value "1.24030959606171"^^xsd:float ;
     nidm_equivalentZStatistic: "2.26895897281379"^^xsd:float ;
     nidm_pValueUncorrected: "0.0116354104606456"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4f32af48b33fc420912cf278bf0e8c3c
+niiri:686f5e6308163bd9a97c3148f494b7b8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-18,6,32]"^^xsd:string .
 
-niiri:8a59a15e6d4b148aaa0593801d721b02 prov:wasDerivedFrom niiri:8a1438a34faf87d03af2d9853b038bb2 .
+niiri:a59a5d4bd11645916f5cb26b0edecf9d prov:wasDerivedFrom niiri:55aacac3d3863ecd2c5789acfd6b261d .
 
-niiri:22b4df385352baee01307cab01764e69
+niiri:fb31a7b6c3f653a71eb02bc199c1c87d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:6b72057b1a69bb07b793d0aaa063f078 ;
+    prov:atLocation niiri:86d95b0aaa548888f11ac1f3260b8a14 ;
     prov:value "1.23086047172546"^^xsd:float ;
     nidm_equivalentZStatistic: "2.25670403369037"^^xsd:float ;
     nidm_pValueUncorrected: "0.0120132873197203"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6b72057b1a69bb07b793d0aaa063f078
+niiri:86d95b0aaa548888f11ac1f3260b8a14
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[32,-44,-30]"^^xsd:string .
 
-niiri:22b4df385352baee01307cab01764e69 prov:wasDerivedFrom niiri:5aecd2a653cabfaff01cc936a5319173 .
+niiri:fb31a7b6c3f653a71eb02bc199c1c87d prov:wasDerivedFrom niiri:03238c6a619b9f265421cbb7a0cda76e .
 
-niiri:6bd95507897b5f8465d65ded242e547c
+niiri:573a177d63d9c9f2fb4fa151422f89eb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:cb9c025473a7e46fa185ff9de6d2eecf ;
+    prov:atLocation niiri:d21d8383c2ef494476f34cb7efde4323 ;
     prov:value "1.22944271564484"^^xsd:float ;
     nidm_equivalentZStatistic: "2.25486570897048"^^xsd:float ;
     nidm_pValueUncorrected: "0.012070879644426"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:cb9c025473a7e46fa185ff9de6d2eecf
+niiri:d21d8383c2ef494476f34cb7efde4323
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-46,-10,58]"^^xsd:string .
 
-niiri:6bd95507897b5f8465d65ded242e547c prov:wasDerivedFrom niiri:04baa9610947313ff840ab800dc602ff .
+niiri:573a177d63d9c9f2fb4fa151422f89eb prov:wasDerivedFrom niiri:bc83f4e59851c0ed8424e3172a378ee4 .
 
-niiri:4143adeb44c98572c57b47081885265e
+niiri:9fac645dbbfbce2fe558862574fd138e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:4071d9d4ce99f6a6d655e297984278e8 ;
+    prov:atLocation niiri:df5af951356032bbf21dae5e4eafe818 ;
     prov:value "1.22471487522125"^^xsd:float ;
     nidm_equivalentZStatistic: "2.24873618228261"^^xsd:float ;
     nidm_pValueUncorrected: "0.0122646428654261"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4071d9d4ce99f6a6d655e297984278e8
+niiri:df5af951356032bbf21dae5e4eafe818
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-22,-94,26]"^^xsd:string .
 
-niiri:4143adeb44c98572c57b47081885265e prov:wasDerivedFrom niiri:bbf4ae108fc8903d38a040cb96a5f8c7 .
+niiri:9fac645dbbfbce2fe558862574fd138e prov:wasDerivedFrom niiri:c340f3ccccc1a020f9aef989954e51fc .
 
-niiri:677b1c427e116e323ccaeb43a4fcc8ea
+niiri:85c21df54812854d9dcc91de1c9501e3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:59ab9ec5ff9c6474e96185492d155b6a ;
+    prov:atLocation niiri:b1d19ddb93361faaef7a254dcfaf85f5 ;
     prov:value "1.21706402301788"^^xsd:float ;
     nidm_equivalentZStatistic: "2.23881967357295"^^xsd:float ;
     nidm_pValueUncorrected: "0.0125838258304741"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:59ab9ec5ff9c6474e96185492d155b6a
+niiri:b1d19ddb93361faaef7a254dcfaf85f5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[36,32,8]"^^xsd:string .
 
-niiri:677b1c427e116e323ccaeb43a4fcc8ea prov:wasDerivedFrom niiri:4df2335aa8db3e5be136eacbcea883d6 .
+niiri:85c21df54812854d9dcc91de1c9501e3 prov:wasDerivedFrom niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5 .
 
-niiri:5f1c8d3e35aa5357a031ef92edb5ec90
+niiri:419edd7ae0533f67f4b514cad51a7e40
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:a57e5490085c1d02f350a38c8affd373 ;
+    prov:atLocation niiri:9e821e6d86a5b665b7128c83d0b55b57 ;
     prov:value "1.1321427822113"^^xsd:float ;
     nidm_equivalentZStatistic: "2.12898516834439"^^xsd:float ;
     nidm_pValueUncorrected: "0.0166277437596988"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a57e5490085c1d02f350a38c8affd373
+niiri:9e821e6d86a5b665b7128c83d0b55b57
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[32,28,2]"^^xsd:string .
 
-niiri:5f1c8d3e35aa5357a031ef92edb5ec90 prov:wasDerivedFrom niiri:4df2335aa8db3e5be136eacbcea883d6 .
+niiri:419edd7ae0533f67f4b514cad51a7e40 prov:wasDerivedFrom niiri:3a76e70943c6e47ad2c9fcdb5a4d3dc5 .
 
-niiri:71e9024f0319e7ffdb91e7e9ef0f632b
+niiri:cbe78a0c214f75fee02b8f4215a8d050
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:05aeae1bb56c868f7f9ca3927fd6f960 ;
+    prov:atLocation niiri:61ea3aa03f07e52544d1f2c561b325f5 ;
     prov:value "1.21668255329132"^^xsd:float ;
     nidm_equivalentZStatistic: "2.23832532460858"^^xsd:float ;
     nidm_pValueUncorrected: "0.0125999239065135"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:05aeae1bb56c868f7f9ca3927fd6f960
+niiri:61ea3aa03f07e52544d1f2c561b325f5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-36,-42,38]"^^xsd:string .
 
-niiri:71e9024f0319e7ffdb91e7e9ef0f632b prov:wasDerivedFrom niiri:9d79a6339d6f2901fb1cf662d6f17331 .
+niiri:cbe78a0c214f75fee02b8f4215a8d050 prov:wasDerivedFrom niiri:cb85dd1324b2d86671b2fe868f4dafc0 .
 
-niiri:089018a569a6a201160974bff8392bfd
+niiri:0a98388a34991d9fe59b4a9cf396642c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:e27e392fffbf5a9a3177a7ac19ff9008 ;
+    prov:atLocation niiri:ef543ad68b3140441251e0efe0af7cd1 ;
     prov:value "1.19720852375031"^^xsd:float ;
     nidm_equivalentZStatistic: "2.21309986746215"^^xsd:float ;
     nidm_pValueUncorrected: "0.0134453806257753"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e27e392fffbf5a9a3177a7ac19ff9008
+niiri:ef543ad68b3140441251e0efe0af7cd1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[2,68,26]"^^xsd:string .
 
-niiri:089018a569a6a201160974bff8392bfd prov:wasDerivedFrom niiri:b8abe2a725005d9ab6e1e988f192f41c .
+niiri:0a98388a34991d9fe59b4a9cf396642c prov:wasDerivedFrom niiri:0dc11dbfea7cb1fef76a1c48d7f8750f .
 
-niiri:c4700a2462ced300c4a44bf88e97f271
+niiri:acf1658fdc834ef5f68e881f5de034af
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:1ded169ba4a3f3e742789782ebf9e21d ;
+    prov:atLocation niiri:ba2d9a0c93e36c103ea6c6300ded5fa8 ;
     prov:value "1.1896378993988"^^xsd:float ;
     nidm_equivalentZStatistic: "2.20329932117063"^^xsd:float ;
     nidm_pValueUncorrected: "0.013786829398946"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1ded169ba4a3f3e742789782ebf9e21d
+niiri:ba2d9a0c93e36c103ea6c6300ded5fa8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[46,14,2]"^^xsd:string .
 
-niiri:c4700a2462ced300c4a44bf88e97f271 prov:wasDerivedFrom niiri:483de03930aa5641b0fe297f66f6c4ed .
+niiri:acf1658fdc834ef5f68e881f5de034af prov:wasDerivedFrom niiri:6db75fb201d2decf706c9d2dd225cb5a .
 
-niiri:be0117fcc9b16f8118a34f6688a334a6
+niiri:82118381b7674f736b0f0cd125544fe3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:a404d8c08401c4552c6273afdc67726c ;
+    prov:atLocation niiri:d8f27c43af5b906ba5f0b6da34c9df35 ;
     prov:value "0.84699684381485"^^xsd:float ;
     nidm_equivalentZStatistic: "1.76435736331002"^^xsd:float ;
     nidm_pValueUncorrected: "0.0388359158916027"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a404d8c08401c4552c6273afdc67726c
+niiri:d8f27c43af5b906ba5f0b6da34c9df35
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[40,10,10]"^^xsd:string .
 
-niiri:be0117fcc9b16f8118a34f6688a334a6 prov:wasDerivedFrom niiri:483de03930aa5641b0fe297f66f6c4ed .
+niiri:82118381b7674f736b0f0cd125544fe3 prov:wasDerivedFrom niiri:6db75fb201d2decf706c9d2dd225cb5a .
 
-niiri:303d5f4df2d0d08184a8559af50bd6c1
+niiri:71125be49af0dc99c2e40193fb5e66b2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:070a4d4397d04007720d2af356c40f7a ;
+    prov:atLocation niiri:fdf68d1a3ec000d7fa998a7c58e56d5d ;
     prov:value "1.18655109405518"^^xsd:float ;
     nidm_equivalentZStatistic: "2.19930428061828"^^xsd:float ;
     nidm_pValueUncorrected: "0.0139281467706139"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:070a4d4397d04007720d2af356c40f7a
+niiri:fdf68d1a3ec000d7fa998a7c58e56d5d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-32,-28,-2]"^^xsd:string .
 
-niiri:303d5f4df2d0d08184a8559af50bd6c1 prov:wasDerivedFrom niiri:4f303edac6b82f93c47e1a6448e1cb52 .
+niiri:71125be49af0dc99c2e40193fb5e66b2 prov:wasDerivedFrom niiri:8fae62d51a220dbd34d1d3074ad97c80 .
 
-niiri:60e4d404f23dc518a79132762c323919
+niiri:4e602b57e82d39a3379ea0238f2f065a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:8c5cc76b2edcfc58bde42f3e4a12935f ;
+    prov:atLocation niiri:2f57e4ad9e363502818b5b7af383279e ;
     prov:value "1.17589449882507"^^xsd:float ;
     nidm_equivalentZStatistic: "2.18551661590201"^^xsd:float ;
     nidm_pValueUncorrected: "0.0144254945017301"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8c5cc76b2edcfc58bde42f3e4a12935f
+niiri:2f57e4ad9e363502818b5b7af383279e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-18,30,50]"^^xsd:string .
 
-niiri:60e4d404f23dc518a79132762c323919 prov:wasDerivedFrom niiri:d987cfa4a10011187d0a3eef178d5a46 .
+niiri:4e602b57e82d39a3379ea0238f2f065a prov:wasDerivedFrom niiri:1b3f6a9bf76e54ad12539e190c7c838c .
 
-niiri:b38281d4642204a1940b6ebe7b4e1531
+niiri:127254d5f8144e53a6000f178ba9832f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:3e550c577ebfcc9bdf25a911ee937fbe ;
+    prov:atLocation niiri:f78dbb802d360f040867d01f91280a3e ;
     prov:value "1.17159426212311"^^xsd:float ;
     nidm_equivalentZStatistic: "2.17995487813573"^^xsd:float ;
     nidm_pValueUncorrected: "0.0146304032058477"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:3e550c577ebfcc9bdf25a911ee937fbe
+niiri:f78dbb802d360f040867d01f91280a3e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-14,-26,66]"^^xsd:string .
 
-niiri:b38281d4642204a1940b6ebe7b4e1531 prov:wasDerivedFrom niiri:98d187b5c539ea98df7343b0d0821b17 .
+niiri:127254d5f8144e53a6000f178ba9832f prov:wasDerivedFrom niiri:dc2d50ba6c535742eed46213fc557f6a .
 
-niiri:e54beb18ffa5912f369d1f235557359f
+niiri:323e53e57a73eedef512b5baa864925b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:7e83d5be32f3ac082fae74d72a17293b ;
+    prov:atLocation niiri:e99f8650eabbc3b1cd1432e8b2374a82 ;
     prov:value "1.1714745759964"^^xsd:float ;
     nidm_equivalentZStatistic: "2.17980009775463"^^xsd:float ;
     nidm_pValueUncorrected: "0.0146361413495164"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7e83d5be32f3ac082fae74d72a17293b
+niiri:e99f8650eabbc3b1cd1432e8b2374a82
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[18,60,34]"^^xsd:string .
 
-niiri:e54beb18ffa5912f369d1f235557359f prov:wasDerivedFrom niiri:5c38b60ed820b070d98e016bc1431008 .
+niiri:323e53e57a73eedef512b5baa864925b prov:wasDerivedFrom niiri:416dfaa44bb6a7fe97539c984a9173c3 .
 
-niiri:5cdcba284a1740e0a95bf39bfc59090f
+niiri:617a5f940f4b8fb780b2b0fba6f13c31
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:4d1d923218a5a86f14b80c5d9024c436 ;
+    prov:atLocation niiri:45d2e869fd9ca2ba349709e3128b5308 ;
     prov:value "1.17128801345825"^^xsd:float ;
     nidm_equivalentZStatistic: "2.17955883330163"^^xsd:float ;
     nidm_pValueUncorrected: "0.0146450895624214"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4d1d923218a5a86f14b80c5d9024c436
+niiri:45d2e869fd9ca2ba349709e3128b5308
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-30,-72,-50]"^^xsd:string .
 
-niiri:5cdcba284a1740e0a95bf39bfc59090f prov:wasDerivedFrom niiri:a86e2297836b759380804c1713e267cd .
+niiri:617a5f940f4b8fb780b2b0fba6f13c31 prov:wasDerivedFrom niiri:31033e543fb9492bc06e61625ca6b410 .
 
-niiri:9608a0b9921f169205a67f91b0c8646d
+niiri:14ae1fa9257e4c53338274fcc108384b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:5ea0a149f7e30f52d50d149bf7dc7f86 ;
+    prov:atLocation niiri:f5920a1ad34f8b842af3e79ef81c8e61 ;
     prov:value "1.15287852287292"^^xsd:float ;
     nidm_equivalentZStatistic: "2.15576230673889"^^xsd:float ;
     nidm_pValueUncorrected: "0.0155511150762138"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5ea0a149f7e30f52d50d149bf7dc7f86
+niiri:f5920a1ad34f8b842af3e79ef81c8e61
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[10,6,74]"^^xsd:string .
 
-niiri:9608a0b9921f169205a67f91b0c8646d prov:wasDerivedFrom niiri:f4ed594992095609e2ba62eca01c9faf .
+niiri:14ae1fa9257e4c53338274fcc108384b prov:wasDerivedFrom niiri:7a8b21e9acaff0531c73c9fe0bfaeb53 .
 
-niiri:f8ec021e67601d83fa30a8d652cef986
+niiri:7eb75ab35a0ed1f5c8a184d8d88a9b5c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:8800f25bc9569134e36fe056c55dccea ;
+    prov:atLocation niiri:7e6b90a96f7d814724fd0f217cbe1716 ;
     prov:value "1.14964759349823"^^xsd:float ;
     nidm_equivalentZStatistic: "2.15158817513994"^^xsd:float ;
     nidm_pValueUncorrected: "0.0157149021414998"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8800f25bc9569134e36fe056c55dccea
+niiri:7e6b90a96f7d814724fd0f217cbe1716
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[-40,48,22]"^^xsd:string .
 
-niiri:f8ec021e67601d83fa30a8d652cef986 prov:wasDerivedFrom niiri:c8ce85b44b984de4fe78c06b64713bb8 .
+niiri:7eb75ab35a0ed1f5c8a184d8d88a9b5c prov:wasDerivedFrom niiri:5102964768a1c4313f8c0e48d48f8b40 .
 
-niiri:f317a0bc0be15c3af8b8f12eddef0171
+niiri:23a04d6d64ae1555176652a69477cb6e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:f23773c36e8aa842670cc820c8e3cf8e ;
+    prov:atLocation niiri:ceee7ccdc7c470b175dedd001c1ea7f6 ;
     prov:value "1.14813911914825"^^xsd:float ;
     nidm_equivalentZStatistic: "2.14963956628403"^^xsd:float ;
     nidm_pValueUncorrected: "0.0157918680840622"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f23773c36e8aa842670cc820c8e3cf8e
+niiri:ceee7ccdc7c470b175dedd001c1ea7f6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[10,-78,-40]"^^xsd:string .
 
-niiri:f317a0bc0be15c3af8b8f12eddef0171 prov:wasDerivedFrom niiri:55d04469f144e7c5053124929003df79 .
+niiri:23a04d6d64ae1555176652a69477cb6e prov:wasDerivedFrom niiri:256070c77a58b8b64913a5b6bfb81f60 .
 
-niiri:131fdfd62367b034e5115d813dae4043
+niiri:cf610736c17264f136dfe0eb89ee2a05
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:9d2a2a255f2ef73de9a55449d983e205 ;
+    prov:atLocation niiri:279a6a11962ed1f111fb8d7a02bb5d8a ;
     prov:value "1.14065408706665"^^xsd:float ;
     nidm_equivalentZStatistic: "2.13997280538058"^^xsd:float ;
     nidm_pValueUncorrected: "0.0161784822721924"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9d2a2a255f2ef73de9a55449d983e205
+niiri:279a6a11962ed1f111fb8d7a02bb5d8a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-12,2,70]"^^xsd:string .
 
-niiri:131fdfd62367b034e5115d813dae4043 prov:wasDerivedFrom niiri:895da0556b5b38697a9d4eacde3a587e .
+niiri:cf610736c17264f136dfe0eb89ee2a05 prov:wasDerivedFrom niiri:96604941a960daa1e224727cb5ba2d60 .
 
-niiri:411f4505c8a2beb209d54060d7e4a887
+niiri:515a57e55082e7aaafd8054cc4375e77
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:d9f9f53784b39c50a0d16feea151376a ;
+    prov:atLocation niiri:fe98447baa6baac51db022671fc048f4 ;
     prov:value "1.1338312625885"^^xsd:float ;
     nidm_equivalentZStatistic: "2.13116451819532"^^xsd:float ;
     nidm_pValueUncorrected: "0.0165377954988448"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d9f9f53784b39c50a0d16feea151376a
+niiri:fe98447baa6baac51db022671fc048f4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[22,-18,48]"^^xsd:string .
 
-niiri:411f4505c8a2beb209d54060d7e4a887 prov:wasDerivedFrom niiri:30470d6217b4a75fdd554906028c6670 .
+niiri:515a57e55082e7aaafd8054cc4375e77 prov:wasDerivedFrom niiri:529af4aecda9065e5cce8adf4cdfd5c6 .
 
-niiri:8fb2c69443ae1c39858b37ffc89e3b1a
+niiri:7d5fd522914b718d895ca04f556b7437
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:70474983d603f7935620a9ebd96f0f94 ;
+    prov:atLocation niiri:966a95b3241bbaf0d187fd1e341c79bf ;
     prov:value "1.11546647548676"^^xsd:float ;
     nidm_equivalentZStatistic: "2.10747127106409"^^xsd:float ;
     nidm_pValueUncorrected: "0.0175383747043093"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:70474983d603f7935620a9ebd96f0f94
+niiri:966a95b3241bbaf0d187fd1e341c79bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[30,-18,16]"^^xsd:string .
 
-niiri:8fb2c69443ae1c39858b37ffc89e3b1a prov:wasDerivedFrom niiri:62c58cbe35737a64415ff840b7810e7d .
+niiri:7d5fd522914b718d895ca04f556b7437 prov:wasDerivedFrom niiri:bdef3fee2464d33f021c131ff78646c7 .
 
-niiri:22b280391bbb882a2a96e664a5ba3c29
+niiri:3eefe07ca12961dd4d03965206e8cb06
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:1a565db1a9411cc339a617addf6cb2b3 ;
+    prov:atLocation niiri:a233e11baaca31ed80be42d76e85c346 ;
     prov:value "1.11363661289215"^^xsd:float ;
     nidm_equivalentZStatistic: "2.10511176477938"^^xsd:float ;
     nidm_pValueUncorrected: "0.0176407901931581"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1a565db1a9411cc339a617addf6cb2b3
+niiri:a233e11baaca31ed80be42d76e85c346
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[16,2,56]"^^xsd:string .
 
-niiri:22b280391bbb882a2a96e664a5ba3c29 prov:wasDerivedFrom niiri:ec26c7d95e0c041f81b882cd245b0915 .
+niiri:3eefe07ca12961dd4d03965206e8cb06 prov:wasDerivedFrom niiri:e8088392c69eb956afef92cedfa6aeb4 .
 
-niiri:dfa59695fa3a75f5938b98bd6d614080
+niiri:ec714042c4c04e8a27fea498c29a9f63
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:0fdedeb914d8a7a9aa38eebe69a60433 ;
+    prov:atLocation niiri:9467ed32fd2aaef55d31182b82d68662 ;
     prov:value "1.10444390773773"^^xsd:float ;
     nidm_equivalentZStatistic: "2.09326187305734"^^xsd:float ;
     nidm_pValueUncorrected: "0.0181628920812176"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0fdedeb914d8a7a9aa38eebe69a60433
+niiri:9467ed32fd2aaef55d31182b82d68662
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[-32,-52,14]"^^xsd:string .
 
-niiri:dfa59695fa3a75f5938b98bd6d614080 prov:wasDerivedFrom niiri:6750b72bbafd12ba75c6c383539599c6 .
+niiri:ec714042c4c04e8a27fea498c29a9f63 prov:wasDerivedFrom niiri:8b4322c153a15066be2583d11b23925c .
 
-niiri:95ed835f52649487e78cce778a0a0b58
+niiri:b5ad2afffcf7769dff075c2ad1bcfb1d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:0e6389f3c537bf47d48480692de843a2 ;
+    prov:atLocation niiri:1e589a760119fa51b33a0aee5879a1c9 ;
     prov:value "1.01987111568451"^^xsd:float ;
     nidm_equivalentZStatistic: "1.98454402904349"^^xsd:float ;
     nidm_pValueUncorrected: "0.0235976124289208"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0e6389f3c537bf47d48480692de843a2
+niiri:1e589a760119fa51b33a0aee5879a1c9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-32,-60,18]"^^xsd:string .
 
-niiri:95ed835f52649487e78cce778a0a0b58 prov:wasDerivedFrom niiri:6750b72bbafd12ba75c6c383539599c6 .
+niiri:b5ad2afffcf7769dff075c2ad1bcfb1d prov:wasDerivedFrom niiri:8b4322c153a15066be2583d11b23925c .
 
-niiri:142a7d0d29db608b63eb9837dffcce93
+niiri:82ce4d65f10bc5c571a676520fb3526a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:ce0896936b4f6f9d75172c347b6d85ae ;
+    prov:atLocation niiri:7edb55b74d2a34760e50cf1502d58c54 ;
     prov:value "0.951668322086334"^^xsd:float ;
     nidm_equivalentZStatistic: "1.89731313030669"^^xsd:float ;
     nidm_pValueUncorrected: "0.0288933115272303"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ce0896936b4f6f9d75172c347b6d85ae
+niiri:7edb55b74d2a34760e50cf1502d58c54
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-24,-50,20]"^^xsd:string .
 
-niiri:142a7d0d29db608b63eb9837dffcce93 prov:wasDerivedFrom niiri:6750b72bbafd12ba75c6c383539599c6 .
+niiri:82ce4d65f10bc5c571a676520fb3526a prov:wasDerivedFrom niiri:8b4322c153a15066be2583d11b23925c .
 
-niiri:49f19b782f800a88c614d1eb19240c3f
+niiri:51c84dd2b7a652dbbe29eec2ec10da45
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:b0ec65390cf89796648ae2492af92382 ;
+    prov:atLocation niiri:42bd98c846ed3e6b2f8267e9e359b51c ;
     prov:value "1.10060369968414"^^xsd:float ;
     nidm_equivalentZStatistic: "2.08831343102831"^^xsd:float ;
     nidm_pValueUncorrected: "0.0183847853440164"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b0ec65390cf89796648ae2492af92382
+niiri:42bd98c846ed3e6b2f8267e9e359b51c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[10,50,18]"^^xsd:string .
 
-niiri:49f19b782f800a88c614d1eb19240c3f prov:wasDerivedFrom niiri:ccbc770b946f9dfd1beecfa8843cb3fd .
+niiri:51c84dd2b7a652dbbe29eec2ec10da45 prov:wasDerivedFrom niiri:0c0e48a110ec2c20b75585b9e5372d67 .
 
-niiri:bd9ec3b420daeb84caf491e82d75c544
+niiri:4c431af959a928867e01e3773e1b88b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:b599d290461736cc005eec1c5e81ed4c ;
+    prov:atLocation niiri:84ebd2f1bc394a77f0212ac8234096da ;
     prov:value "1.09576165676117"^^xsd:float ;
     nidm_equivalentZStatistic: "2.08207556282094"^^xsd:float ;
     nidm_pValueUncorrected: "0.0186677841332979"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b599d290461736cc005eec1c5e81ed4c
+niiri:84ebd2f1bc394a77f0212ac8234096da
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-46,6,34]"^^xsd:string .
 
-niiri:bd9ec3b420daeb84caf491e82d75c544 prov:wasDerivedFrom niiri:daf3e2ea8bf3273801d2e921f611a23f .
+niiri:4c431af959a928867e01e3773e1b88b0 prov:wasDerivedFrom niiri:1bf866f2d8a1a832a120aa9c02c60efd .
 
-niiri:d2067075554add565f286f8aa6960f34
+niiri:35a5c8c115f0abfbfa3d921633f364a7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:5a8493408aba2205a6a5eccb4d185561 ;
+    prov:atLocation niiri:3018cf0b63274458035abe5fb99ee859 ;
     prov:value "1.09575474262238"^^xsd:float ;
     nidm_equivalentZStatistic: "2.08206665675352"^^xsd:float ;
     nidm_pValueUncorrected: "0.0186681908185171"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5a8493408aba2205a6a5eccb4d185561
+niiri:3018cf0b63274458035abe5fb99ee859
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[28,-8,70]"^^xsd:string .
 
-niiri:d2067075554add565f286f8aa6960f34 prov:wasDerivedFrom niiri:3df484ba108f4b88e1a4f123023bad18 .
+niiri:35a5c8c115f0abfbfa3d921633f364a7 prov:wasDerivedFrom niiri:a44aefad34ca2359e69bf6f9306bc2c6 .
 
-niiri:35a385cc559c54821f03c31abe4e3a40
+niiri:d9f041fefa100fdb8132c7a4b6108de0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:9c0fa7da9a830b1787be277dabdda98a ;
+    prov:atLocation niiri:b4abdf84c2b011481d11ad3d94001873 ;
     prov:value "1.07974576950073"^^xsd:float ;
     nidm_equivalentZStatistic: "2.06145507795256"^^xsd:float ;
     nidm_pValueUncorrected: "0.019629822462089"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9c0fa7da9a830b1787be277dabdda98a
+niiri:b4abdf84c2b011481d11ad3d94001873
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[-58,18,30]"^^xsd:string .
 
-niiri:35a385cc559c54821f03c31abe4e3a40 prov:wasDerivedFrom niiri:0b63cbadf7d3234250fdc4f399321ae5 .
+niiri:d9f041fefa100fdb8132c7a4b6108de0 prov:wasDerivedFrom niiri:ab78ea55fc7f212636dd2f73bdc99032 .
 
-niiri:cc689c4588c375b1d453ed77ddd6fb6d
+niiri:b1760aaa8500b6832a7af07d81d63e5d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:753bdbe5b8284958a521269d13a1e404 ;
+    prov:atLocation niiri:285bc9cc2ba32db7f5e98cd91fb2cfdc ;
     prov:value "1.07930290699005"^^xsd:float ;
     nidm_equivalentZStatistic: "2.06088516484109"^^xsd:float ;
     nidm_pValueUncorrected: "0.019656998463677"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:753bdbe5b8284958a521269d13a1e404
+niiri:285bc9cc2ba32db7f5e98cd91fb2cfdc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[-24,-66,24]"^^xsd:string .
 
-niiri:cc689c4588c375b1d453ed77ddd6fb6d prov:wasDerivedFrom niiri:16c6b9ef292ea8d86c2980e2bfee9806 .
+niiri:b1760aaa8500b6832a7af07d81d63e5d prov:wasDerivedFrom niiri:4128bacb45b84a2304aceeb9a3a06db7 .
 
-niiri:d1dbb47690cc5b2c83785482d78f16a7
+niiri:7e3b976cef84740109d0eb1268357e83
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:bf94253209f4ce76ed67120ac09947a0 ;
+    prov:atLocation niiri:926d256b539273b87002cdf595c1f8fd ;
     prov:value "1.07559859752655"^^xsd:float ;
     nidm_equivalentZStatistic: "2.05611872869022"^^xsd:float ;
     nidm_pValueUncorrected: "0.0198855367075194"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:bf94253209f4ce76ed67120ac09947a0
+niiri:926d256b539273b87002cdf595c1f8fd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[34,34,-20]"^^xsd:string .
 
-niiri:d1dbb47690cc5b2c83785482d78f16a7 prov:wasDerivedFrom niiri:0ed3ec94ec40aaf6a3a7f4e8dd8ee239 .
+niiri:7e3b976cef84740109d0eb1268357e83 prov:wasDerivedFrom niiri:282d81c6243a1094abf4c4787764df02 .
 
-niiri:2122013d54fe0ea832506bdf2d8540de
+niiri:73165ed86c4c250a74adde2ee20f14b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:c574ef3b9be61ebed55b8533b9f46810 ;
+    prov:atLocation niiri:c0f34ced902e532fff9b867f315ddc89 ;
     prov:value "1.07552266120911"^^xsd:float ;
     nidm_equivalentZStatistic: "2.05602103030259"^^xsd:float ;
     nidm_pValueUncorrected: "0.0198902445740951"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c574ef3b9be61ebed55b8533b9f46810
+niiri:c0f34ced902e532fff9b867f315ddc89
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-32,-10,4]"^^xsd:string .
 
-niiri:2122013d54fe0ea832506bdf2d8540de prov:wasDerivedFrom niiri:fb45985c130da20eafb7b2bc740e6b34 .
+niiri:73165ed86c4c250a74adde2ee20f14b8 prov:wasDerivedFrom niiri:0fae10cc8428bcd3ce91ddfbb9dad9bb .
 
-niiri:0d7fd935b6f12b8a45e5998c9e7df404
+niiri:9aafe36d107ae7055a61332c58a0078a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:cff65d718e4f4c00b6a73fca81e2a08a ;
+    prov:atLocation niiri:8884d81ec71e104a0c484f8f5375a98f ;
     prov:value "1.06592130661011"^^xsd:float ;
     nidm_equivalentZStatistic: "2.04367166566034"^^xsd:float ;
     nidm_pValueUncorrected: "0.0204929970846689"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:cff65d718e4f4c00b6a73fca81e2a08a
+niiri:8884d81ec71e104a0c484f8f5375a98f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[8,-70,-18]"^^xsd:string .
 
-niiri:0d7fd935b6f12b8a45e5998c9e7df404 prov:wasDerivedFrom niiri:65722b667917e9f42cf82ee2175b666b .
+niiri:9aafe36d107ae7055a61332c58a0078a prov:wasDerivedFrom niiri:e58cf8e24a087d5746f02fb59416d367 .
 
-niiri:9f539949d98077facdaf736080419084
+niiri:05e6dc235f43178bc7d691271ff32879
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:245a5e3a98a4a35d29a45725ace42bd7 ;
+    prov:atLocation niiri:35353ef550e7b9afa6ef357536b0eef1 ;
     prov:value "1.05881226062775"^^xsd:float ;
     nidm_equivalentZStatistic: "2.03453256202328"^^xsd:float ;
     nidm_pValueUncorrected: "0.0209489644915043"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:245a5e3a98a4a35d29a45725ace42bd7
+niiri:35353ef550e7b9afa6ef357536b0eef1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[18,-56,74]"^^xsd:string .
 
-niiri:9f539949d98077facdaf736080419084 prov:wasDerivedFrom niiri:59675618f95ad14de633584e8aa5881a .
+niiri:05e6dc235f43178bc7d691271ff32879 prov:wasDerivedFrom niiri:47a95f63466991d3e681c4886347a76b .
 
-niiri:fb1dc826dd07c70437b4e3753dad9238
+niiri:9dcb3cd8472b6b25eb1fbcfcb93000f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:8d1ef8a5bb276ca7bcbedc1eb36d2523 ;
+    prov:atLocation niiri:f3eeefc4c0d3dd27751aef22dbdb7c8c ;
     prov:value "1.05682730674744"^^xsd:float ;
     nidm_equivalentZStatistic: "2.03198149751153"^^xsd:float ;
     nidm_pValueUncorrected: "0.0210777645475412"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8d1ef8a5bb276ca7bcbedc1eb36d2523
+niiri:f3eeefc4c0d3dd27751aef22dbdb7c8c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[28,-2,6]"^^xsd:string .
 
-niiri:fb1dc826dd07c70437b4e3753dad9238 prov:wasDerivedFrom niiri:2efe263e1c4f04d8ddb54023002360d9 .
+niiri:9dcb3cd8472b6b25eb1fbcfcb93000f6 prov:wasDerivedFrom niiri:6a2d34c94894023a09a46d7ba699025b .
 
-niiri:b318391d5530313f8dbf1afdf06198b0
+niiri:e9806207a16169f3be4d10f35b194c85
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:f705d3b5969c62171b8d06eb1edb92c5 ;
+    prov:atLocation niiri:766104bfba8f24878b83241025cb8ce1 ;
     prov:value "1.05488443374634"^^xsd:float ;
     nidm_equivalentZStatistic: "2.02948481888272"^^xsd:float ;
     nidm_pValueUncorrected: "0.0212044668522343"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f705d3b5969c62171b8d06eb1edb92c5
+niiri:766104bfba8f24878b83241025cb8ce1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[12,-58,-26]"^^xsd:string .
 
-niiri:b318391d5530313f8dbf1afdf06198b0 prov:wasDerivedFrom niiri:fa0929f452cd3f13857c087a02f6da1f .
+niiri:e9806207a16169f3be4d10f35b194c85 prov:wasDerivedFrom niiri:6ac7ce35dfb3dcf2c2696278c805c40a .
 
-niiri:654841e54cd036eaea7a9254bc97bbae
+niiri:6c0046aab9a8b299190ccc8aaedee47d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:025393763cebc3e6ed872ebae1ed7c39 ;
+    prov:atLocation niiri:d186aa78992fc5d9cfe80768c6680e50 ;
     prov:value "1.05219066143036"^^xsd:float ;
     nidm_equivalentZStatistic: "2.02602370012315"^^xsd:float ;
     nidm_pValueUncorrected: "0.0213811780074668"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:025393763cebc3e6ed872ebae1ed7c39
+niiri:d186aa78992fc5d9cfe80768c6680e50
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[46,-60,-36]"^^xsd:string .
 
-niiri:654841e54cd036eaea7a9254bc97bbae prov:wasDerivedFrom niiri:4c6401bfd1d939fec8234ff093a37d0d .
+niiri:6c0046aab9a8b299190ccc8aaedee47d prov:wasDerivedFrom niiri:60e118fd5205eaa96f4b55808761eaf7 .
 
-niiri:4a63aa7cb3283e351b1f1db27351b99b
+niiri:08ed1b983e3a1203b8770d31cb409572
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:c9a40f2012163b6c974d796fd3afd59f ;
+    prov:atLocation niiri:c6cce78c32c1be7e581a855e903919a1 ;
     prov:value "1.02921843528748"^^xsd:float ;
     nidm_equivalentZStatistic: "1.9965316371229"^^xsd:float ;
     nidm_pValueUncorrected: "0.0229380428256576"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c9a40f2012163b6c974d796fd3afd59f
+niiri:c6cce78c32c1be7e581a855e903919a1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[56,10,22]"^^xsd:string .
 
-niiri:4a63aa7cb3283e351b1f1db27351b99b prov:wasDerivedFrom niiri:b40302277817265d7af623887ab2e22c .
+niiri:08ed1b983e3a1203b8770d31cb409572 prov:wasDerivedFrom niiri:afff6750152337d325f510f877cd2b9c .
 
-niiri:17f16c1d68762a38e70a1c58b234a67a
+niiri:c3a91a1145ae795e0275567c7afd4153
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:49e9405a1f52c29499902ca446cc4c53 ;
+    prov:atLocation niiri:3f578a0866ace4a3d5417fd1bda419bc ;
     prov:value "1.02376317977905"^^xsd:float ;
     nidm_equivalentZStatistic: "1.98953456023084"^^xsd:float ;
     nidm_pValueUncorrected: "0.0233211155368704"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:49e9405a1f52c29499902ca446cc4c53
+niiri:3f578a0866ace4a3d5417fd1bda419bc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[48,-40,48]"^^xsd:string .
 
-niiri:17f16c1d68762a38e70a1c58b234a67a prov:wasDerivedFrom niiri:e3091fadc7ff93e5e16f94b04590b938 .
+niiri:c3a91a1145ae795e0275567c7afd4153 prov:wasDerivedFrom niiri:c87d05b7d28080150c45409119a926f8 .
 
-niiri:23433a28a600a0042f6709ad738f2eb9
+niiri:b4d3685e07ada48df1c6167a6925950e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:47c5f8b5b08ae3c044df320c0c5c11c8 ;
+    prov:atLocation niiri:795be4dc59029fec477cb821024b0305 ;
     prov:value "1.01926970481873"^^xsd:float ;
     nidm_equivalentZStatistic: "1.98377299631032"^^xsd:float ;
     nidm_pValueUncorrected: "0.0236405758837211"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:47c5f8b5b08ae3c044df320c0c5c11c8
+niiri:795be4dc59029fec477cb821024b0305
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-6,-74,6]"^^xsd:string .
 
-niiri:23433a28a600a0042f6709ad738f2eb9 prov:wasDerivedFrom niiri:e36b80790f32a55a90c503e6f29918bb .
+niiri:b4d3685e07ada48df1c6167a6925950e prov:wasDerivedFrom niiri:f1bb918000bbcdd8562fb7b7887a394d .
 
-niiri:8799123eb9c654ee018726ee3931235b
+niiri:f80228783e894278ef084da2baf7ed31
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:bd086e9bb08a9f7d410c5f66d4534fb1 ;
+    prov:atLocation niiri:2ca83eae786b7fda7e22a5a70371af3d ;
     prov:value "1.01770269870758"^^xsd:float ;
     nidm_equivalentZStatistic: "1.9817641782018"^^xsd:float ;
     nidm_pValueUncorrected: "0.0237528202287247"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:bd086e9bb08a9f7d410c5f66d4534fb1
+niiri:2ca83eae786b7fda7e22a5a70371af3d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[20,60,-18]"^^xsd:string .
 
-niiri:8799123eb9c654ee018726ee3931235b prov:wasDerivedFrom niiri:6e8c86e4ccb82a0a6076eb58e14b07a6 .
+niiri:f80228783e894278ef084da2baf7ed31 prov:wasDerivedFrom niiri:00f0f421f5ee5bc9ff7e58ad4a2b042c .
 
-niiri:6ba4662560eeacf1805f42b92357c2d2
+niiri:d9eeefbbebdab2ca09c4160ffbf3de45
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:ec4549b9790223d5e2588c6af87cbf82 ;
+    prov:atLocation niiri:53f418da90a8fac39b172895c357d44a ;
     prov:value "0.994811475276947"^^xsd:float ;
     nidm_equivalentZStatistic: "1.95244337576045"^^xsd:float ;
     nidm_pValueUncorrected: "0.0254427937463042"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ec4549b9790223d5e2588c6af87cbf82
+niiri:53f418da90a8fac39b172895c357d44a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[6,-2,60]"^^xsd:string .
 
-niiri:6ba4662560eeacf1805f42b92357c2d2 prov:wasDerivedFrom niiri:42f7f7a26e0c7f6124775e7e757b315c .
+niiri:d9eeefbbebdab2ca09c4160ffbf3de45 prov:wasDerivedFrom niiri:cf22d6dcbc4b6d559ba3bbc8ffb1d15f .
 
-niiri:3bda2d8d3c0edb9b3f719a8dae269a32
+niiri:48c043bcf9f7016d4422cd1eb0275f46
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:a7cb0f2475eb4b3ff5c54ba281637639 ;
+    prov:atLocation niiri:6077c53ec3ce7550b6798aee6404ca8b ;
     prov:value "0.99255907535553"^^xsd:float ;
     nidm_equivalentZStatistic: "1.94956085899435"^^xsd:float ;
     nidm_pValueUncorrected: "0.0256142412083677"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:a7cb0f2475eb4b3ff5c54ba281637639
+niiri:6077c53ec3ce7550b6798aee6404ca8b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[10,-42,48]"^^xsd:string .
 
-niiri:3bda2d8d3c0edb9b3f719a8dae269a32 prov:wasDerivedFrom niiri:14ff66df771d191b9d2e8a3b0f78eda6 .
+niiri:48c043bcf9f7016d4422cd1eb0275f46 prov:wasDerivedFrom niiri:9e7cd816ef42776bf358bfe67f08f014 .
 
-niiri:5cc4fd8f0181f9da651d725a89ad5e16
+niiri:3cfe0ff468e6f850a19584472f45a4ca
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:d21ede16c4ae0337bd51853a10b823a9 ;
+    prov:atLocation niiri:64683e1e79d133f97706c9c14ce1de9a ;
     prov:value "0.984159111976624"^^xsd:float ;
     nidm_equivalentZStatistic: "1.93881506095718"^^xsd:float ;
     nidm_pValueUncorrected: "0.0262619307677786"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d21ede16c4ae0337bd51853a10b823a9
+niiri:64683e1e79d133f97706c9c14ce1de9a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[44,-2,-30]"^^xsd:string .
 
-niiri:5cc4fd8f0181f9da651d725a89ad5e16 prov:wasDerivedFrom niiri:912e881f26994ef7af5c7f0b222db9ea .
+niiri:3cfe0ff468e6f850a19584472f45a4ca prov:wasDerivedFrom niiri:712375a17d0ff43c9dca459517dff9b2 .
 
-niiri:2aa6a02038d33bce0ab53247bbf23d60
+niiri:4cbbdabb6d9ca2894ccd7d8bf83c4b92
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:722f766abf24b819064c7c6e42c70bea ;
+    prov:atLocation niiri:057307222fb1d6a12be4aac362eeba79 ;
     prov:value "0.981177926063538"^^xsd:float ;
     nidm_equivalentZStatistic: "1.93500289088164"^^xsd:float ;
     nidm_pValueUncorrected: "0.0264949704670242"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:722f766abf24b819064c7c6e42c70bea
+niiri:057307222fb1d6a12be4aac362eeba79
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[-16,-98,-6]"^^xsd:string .
 
-niiri:2aa6a02038d33bce0ab53247bbf23d60 prov:wasDerivedFrom niiri:9a1887d93b55705b2ff04804a00c27c3 .
+niiri:4cbbdabb6d9ca2894ccd7d8bf83c4b92 prov:wasDerivedFrom niiri:feddd730f38d65d4f1fd0e8616bcc9a5 .
 
-niiri:cec30b5da4341b39910fe9e39affefb2
+niiri:a8d461e1b05a579974c9fa442ca95335
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:332a4bdfcb6f14b5c9d4279cb47be873 ;
+    prov:atLocation niiri:f56cb3f0f78382ca1667d4c9cb2a5fa9 ;
     prov:value "0.979127943515778"^^xsd:float ;
     nidm_equivalentZStatistic: "1.93238197004834"^^xsd:float ;
     nidm_pValueUncorrected: "0.026656188878889"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:332a4bdfcb6f14b5c9d4279cb47be873
+niiri:f56cb3f0f78382ca1667d4c9cb2a5fa9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[18,-54,-16]"^^xsd:string .
 
-niiri:cec30b5da4341b39910fe9e39affefb2 prov:wasDerivedFrom niiri:e6e6da4cb58bd6ee501d8b5597467832 .
+niiri:a8d461e1b05a579974c9fa442ca95335 prov:wasDerivedFrom niiri:8041bc77682f50b65136018ca10c889c .
 
-niiri:19d11b85cd1659ff5c89792f9cde9c94
+niiri:422e9504c658a0894198e2bc2af7dc45
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:4a95f88e28460ccd588491bc3403c7b9 ;
+    prov:atLocation niiri:85068ba7ad3e2344be6218dbd67be2d4 ;
     prov:value "0.971426725387573"^^xsd:float ;
     nidm_equivalentZStatistic: "1.92253941721557"^^xsd:float ;
     nidm_pValueUncorrected: "0.0272689593644924"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4a95f88e28460ccd588491bc3403c7b9
+niiri:85068ba7ad3e2344be6218dbd67be2d4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[4,60,38]"^^xsd:string .
 
-niiri:19d11b85cd1659ff5c89792f9cde9c94 prov:wasDerivedFrom niiri:67fdba1e1ea9e1bb3cbfad269ac15cb0 .
+niiri:422e9504c658a0894198e2bc2af7dc45 prov:wasDerivedFrom niiri:e852e949acffc71ed6cce677c7be19d6 .
 
-niiri:d0eaf64ed42fd3f849b5e11ace433bd6
+niiri:5f72f791f7614242b4b6ad4e858c999a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:4bc70f64f7da756569d0cd25adc88adf ;
+    prov:atLocation niiri:dbc6a1f63f9fa825746e17ef6fa5f72a ;
     prov:value "0.967807769775391"^^xsd:float ;
     nidm_equivalentZStatistic: "1.91791614515868"^^xsd:float ;
     nidm_pValueUncorrected: "0.0275608223501947"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:4bc70f64f7da756569d0cd25adc88adf
+niiri:dbc6a1f63f9fa825746e17ef6fa5f72a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[20,18,-4]"^^xsd:string .
 
-niiri:d0eaf64ed42fd3f849b5e11ace433bd6 prov:wasDerivedFrom niiri:949a7d86dacbe35af10b6aad92fe2224 .
+niiri:5f72f791f7614242b4b6ad4e858c999a prov:wasDerivedFrom niiri:0d099ee69c96416336f843fd890da4a0 .
 
-niiri:b15e367317090ff6141a89644f5183f5
+niiri:de1fef4fc7d400efc2f44d0c30039c86
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:5f5788776577f486d7c0d234240362e9 ;
+    prov:atLocation niiri:c12b5e9466736ae0a4035530d53f806a ;
     prov:value "0.959724724292755"^^xsd:float ;
     nidm_equivalentZStatistic: "1.90759446601654"^^xsd:float ;
     nidm_pValueUncorrected: "0.0282218254783678"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5f5788776577f486d7c0d234240362e9
+niiri:c12b5e9466736ae0a4035530d53f806a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[30,-32,10]"^^xsd:string .
 
-niiri:b15e367317090ff6141a89644f5183f5 prov:wasDerivedFrom niiri:6cc27bdc40320dac88fe94690c9a2006 .
+niiri:de1fef4fc7d400efc2f44d0c30039c86 prov:wasDerivedFrom niiri:6d0ee7f5877dfa2620f95f47e06e2a9a .
 
-niiri:816a2af39c014a3eff563b63568227ba
+niiri:b8e4a8666a562187b667fd0000d52335
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:49d25efc3a1a6a15fd15ecbfc808987c ;
+    prov:atLocation niiri:bfa0701f0eb2a5270ae3e9b16ebfc296 ;
     prov:value "0.957907795906067"^^xsd:float ;
     nidm_equivalentZStatistic: "1.90527520238565"^^xsd:float ;
     nidm_pValueUncorrected: "0.0283721535699227"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:49d25efc3a1a6a15fd15ecbfc808987c
+niiri:bfa0701f0eb2a5270ae3e9b16ebfc296
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[10,12,-10]"^^xsd:string .
 
-niiri:816a2af39c014a3eff563b63568227ba prov:wasDerivedFrom niiri:c04d4059d5535de349435e25559a51cf .
+niiri:b8e4a8666a562187b667fd0000d52335 prov:wasDerivedFrom niiri:6ab419381418bd7fca0cb5bac6782b77 .
 
-niiri:35f059b4066985dec95a60afb4757fa5
+niiri:d331e521291249d8ba1e2d26ee0d6359
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:ae652a26b3559a00177ccb1d38ddf2ea ;
+    prov:atLocation niiri:2b7cd0cd9952e2971cceba9068ca4224 ;
     prov:value "0.95493882894516"^^xsd:float ;
     nidm_equivalentZStatistic: "1.90148608420821"^^xsd:float ;
     nidm_pValueUncorrected: "0.0286191867597474"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ae652a26b3559a00177ccb1d38ddf2ea
+niiri:2b7cd0cd9952e2971cceba9068ca4224
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[-26,-94,-10]"^^xsd:string .
 
-niiri:35f059b4066985dec95a60afb4757fa5 prov:wasDerivedFrom niiri:4b22fd081d5be6319a728e5343897301 .
+niiri:d331e521291249d8ba1e2d26ee0d6359 prov:wasDerivedFrom niiri:b19325ccb6192dba58545cbeb7bc92e1 .
 
-niiri:f01e638e0603ba7659f5763a2d8bc4dd
+niiri:8d11278149ef3ed6c1be32712cecb870
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:7f5fa73a008f806d34e4133d4c182481 ;
+    prov:atLocation niiri:444c6e0d2d8dae8e91a8b6fec5449cd8 ;
     prov:value "0.950750410556793"^^xsd:float ;
     nidm_equivalentZStatistic: "1.89614212461773"^^xsd:float ;
     nidm_pValueUncorrected: "0.0289706268368529"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7f5fa73a008f806d34e4133d4c182481
+niiri:444c6e0d2d8dae8e91a8b6fec5449cd8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-50,-18,0]"^^xsd:string .
 
-niiri:f01e638e0603ba7659f5763a2d8bc4dd prov:wasDerivedFrom niiri:f0f729dae8a39ee9247f706bc80f8df0 .
+niiri:8d11278149ef3ed6c1be32712cecb870 prov:wasDerivedFrom niiri:745fe95a68372701f2888393e817a23e .
 
-niiri:f28c4268c860430233ff3485efbc9bb1
+niiri:2c0d2607032810a81675ff4225065850
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:497cb86fef9441e29d59581837fa7a72 ;
+    prov:atLocation niiri:3e68989f6a6b2152794e95703c55559c ;
     prov:value "0.949834227561951"^^xsd:float ;
     nidm_equivalentZStatistic: "1.89497340726092"^^xsd:float ;
     nidm_pValueUncorrected: "0.0290479624174936"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:497cb86fef9441e29d59581837fa7a72
+niiri:3e68989f6a6b2152794e95703c55559c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[42,36,18]"^^xsd:string .
 
-niiri:f28c4268c860430233ff3485efbc9bb1 prov:wasDerivedFrom niiri:cd47d3687de0d428289d5ee8d941860d .
+niiri:2c0d2607032810a81675ff4225065850 prov:wasDerivedFrom niiri:b1a5489610b480473aa63e95806df7d1 .
 
-niiri:e78b40e65bb076e872f92f8886d6fb55
+niiri:47b2ce9b5be41d91dfa11f100ed3ad82
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:e7a5dbf5431a99354087860b2a10d16c ;
+    prov:atLocation niiri:eb5106a605d1357f4af29aa54137b817 ;
     prov:value "0.949459254741669"^^xsd:float ;
     nidm_equivalentZStatistic: "1.89449510188639"^^xsd:float ;
     nidm_pValueUncorrected: "0.0290796619499293"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e7a5dbf5431a99354087860b2a10d16c
+niiri:eb5106a605d1357f4af29aa54137b817
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[46,-78,16]"^^xsd:string .
 
-niiri:e78b40e65bb076e872f92f8886d6fb55 prov:wasDerivedFrom niiri:20959c12c3afc9ceb8477f395c0f1d11 .
+niiri:47b2ce9b5be41d91dfa11f100ed3ad82 prov:wasDerivedFrom niiri:f6763487f8266f7e66acb49862c0bfa1 .
 
-niiri:574b80e813133039f7edba5d74c437a7
+niiri:bffc483b3f0c4050ac78cd4ff4a4338e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:ec5e4ec4f22a9fe5061299186eb1a7df ;
+    prov:atLocation niiri:0cf2044fea597c136be141a7d8a4de31 ;
     prov:value "0.942987263202667"^^xsd:float ;
     nidm_equivalentZStatistic: "1.88624180999136"^^xsd:float ;
     nidm_pValueUncorrected: "0.0296311883673402"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ec5e4ec4f22a9fe5061299186eb1a7df
+niiri:0cf2044fea597c136be141a7d8a4de31
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[-52,40,8]"^^xsd:string .
 
-niiri:574b80e813133039f7edba5d74c437a7 prov:wasDerivedFrom niiri:4eb3e8fe236fda4e725ee89c277cccc8 .
+niiri:bffc483b3f0c4050ac78cd4ff4a4338e prov:wasDerivedFrom niiri:f1b9cbe1f5cc757318e116f47537c68e .
 
-niiri:73e1b25dd37be5347183ed76eca13450
+niiri:b2f0952d4932beebb348b8767e1b15d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:7d6edf93aed55973698b99ba16ef1865 ;
+    prov:atLocation niiri:7bb01c321a9f81f207675da840baca24 ;
     prov:value "0.937418699264526"^^xsd:float ;
     nidm_equivalentZStatistic: "1.87914396799602"^^xsd:float ;
     nidm_pValueUncorrected: "0.0301124189915838"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7d6edf93aed55973698b99ba16ef1865
+niiri:7bb01c321a9f81f207675da840baca24
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[-12,42,48]"^^xsd:string .
 
-niiri:73e1b25dd37be5347183ed76eca13450 prov:wasDerivedFrom niiri:4e2d4ab1f5cc1d2d7159b8aa5813acca .
+niiri:b2f0952d4932beebb348b8767e1b15d6 prov:wasDerivedFrom niiri:0299ab45ec018b51a01d2a8fe08bf4d0 .
 
-niiri:eb93d84a711109bd9b54c6b018d686d3
+niiri:6bbcdf18aa971f01e2cb61e2a276a0c1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0104" ;
-    prov:atLocation niiri:65fa8002172898322aa4954394e16e2d ;
+    prov:atLocation niiri:2cce387756fae768863a2b909443a366 ;
     prov:value "0.933299362659454"^^xsd:float ;
     nidm_equivalentZStatistic: "1.87389537802186"^^xsd:float ;
     nidm_pValueUncorrected: "0.0304724233227471"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:65fa8002172898322aa4954394e16e2d
+niiri:2cce387756fae768863a2b909443a366
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0104" ;
     nidm_coordinateVector: "[44,40,-20]"^^xsd:string .
 
-niiri:eb93d84a711109bd9b54c6b018d686d3 prov:wasDerivedFrom niiri:4fad08e49bad24baddc3d418f97db0ce .
+niiri:6bbcdf18aa971f01e2cb61e2a276a0c1 prov:wasDerivedFrom niiri:3bd0b694ec1e521a7072b15be74aa42c .
 
-niiri:14289e9dd02f6ca24827f1eb68744a10
+niiri:e76b9afc8d6f8323f6709346e8342328
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0105" ;
-    prov:atLocation niiri:b49fe1898121cadf26b62d7cef891fd4 ;
+    prov:atLocation niiri:6b6cd0eb3c448196f54b71c1dba6e4d6 ;
     prov:value "0.931596636772156"^^xsd:float ;
     nidm_equivalentZStatistic: "1.87172638333963"^^xsd:float ;
     nidm_pValueUncorrected: "0.0306222337565211"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b49fe1898121cadf26b62d7cef891fd4
+niiri:6b6cd0eb3c448196f54b71c1dba6e4d6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0105" ;
     nidm_coordinateVector: "[-20,-74,-42]"^^xsd:string .
 
-niiri:14289e9dd02f6ca24827f1eb68744a10 prov:wasDerivedFrom niiri:d9eee0810d67b936a31fa3c66d2e8721 .
+niiri:e76b9afc8d6f8323f6709346e8342328 prov:wasDerivedFrom niiri:af9bee597f1e82856f732971c03e4ba5 .
 
-niiri:ff6121b7a9f9dbe98a1c2aa743d5f4e8
+niiri:731e7e0e8812977914ca201d6ec12be9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0106" ;
-    prov:atLocation niiri:45e6af0f0dc689c25f2e728abf47ad38 ;
+    prov:atLocation niiri:b7cc5c0755b7af3c315c2d00ee88a4d2 ;
     prov:value "0.921256303787231"^^xsd:float ;
     nidm_equivalentZStatistic: "1.85856093332641"^^xsd:float ;
     nidm_pValueUncorrected: "0.031544699452275"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:45e6af0f0dc689c25f2e728abf47ad38
+niiri:b7cc5c0755b7af3c315c2d00ee88a4d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0106" ;
     nidm_coordinateVector: "[-10,-26,78]"^^xsd:string .
 
-niiri:ff6121b7a9f9dbe98a1c2aa743d5f4e8 prov:wasDerivedFrom niiri:c8715267e94716796c464182b4ba6959 .
+niiri:731e7e0e8812977914ca201d6ec12be9 prov:wasDerivedFrom niiri:7a01ea3f3b5332ecf281a7f277911529 .
 
-niiri:e90e1fca92a0e22c713f9682392e7f12
+niiri:d920f5295c82c34ffdb61a212ac97bda
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0107" ;
-    prov:atLocation niiri:fbbb756202b6d0be6eafa6dc866cd8c3 ;
+    prov:atLocation niiri:b9e3cdf7fa9c85cc1bd3ef2b223e5f10 ;
     prov:value "0.913095474243164"^^xsd:float ;
     nidm_equivalentZStatistic: "1.84817837718658"^^xsd:float ;
     nidm_pValueUncorrected: "0.0322882711892066"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:fbbb756202b6d0be6eafa6dc866cd8c3
+niiri:b9e3cdf7fa9c85cc1bd3ef2b223e5f10
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0107" ;
     nidm_coordinateVector: "[-22,-34,-42]"^^xsd:string .
 
-niiri:e90e1fca92a0e22c713f9682392e7f12 prov:wasDerivedFrom niiri:8f90bd7cc0deb45b7b7bd4b560274456 .
+niiri:d920f5295c82c34ffdb61a212ac97bda prov:wasDerivedFrom niiri:8d9244867124b8976a02c802025ebf7a .
 
-niiri:b40b3acb742819cbaef72868cf6ef19a
+niiri:60cd8b72aba218010406e59a4d283f22
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0108" ;
-    prov:atLocation niiri:0c0e1df808ce80ff1bf83deb70997dda ;
+    prov:atLocation niiri:83348a06a08a490ee2ad27ad5f88b837 ;
     prov:value "0.910208523273468"^^xsd:float ;
     nidm_equivalentZStatistic: "1.84450717202411"^^xsd:float ;
     nidm_pValueUncorrected: "0.0325546307872665"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0c0e1df808ce80ff1bf83deb70997dda
+niiri:83348a06a08a490ee2ad27ad5f88b837
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0108" ;
     nidm_coordinateVector: "[-34,-52,40]"^^xsd:string .
 
-niiri:b40b3acb742819cbaef72868cf6ef19a prov:wasDerivedFrom niiri:38f5a60345c88d7c9e0484d8735d5ffe .
+niiri:60cd8b72aba218010406e59a4d283f22 prov:wasDerivedFrom niiri:1acfcd5791fd893baf49e6750646bcbc .
 
-niiri:25eb200bd03f426290a68a7c2b8e19fe
+niiri:598d2ba06bdf7b67f6b54a339b88c029
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0109" ;
-    prov:atLocation niiri:711f57ca8088fe4976d46723159bf11a ;
+    prov:atLocation niiri:df28a935119bc1a9fe922acf6abc9791 ;
     prov:value "0.909155905246735"^^xsd:float ;
     nidm_equivalentZStatistic: "1.84316882767473"^^xsd:float ;
     nidm_pValueUncorrected: "0.0326521823346975"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:711f57ca8088fe4976d46723159bf11a
+niiri:df28a935119bc1a9fe922acf6abc9791
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0109" ;
     nidm_coordinateVector: "[12,-70,-24]"^^xsd:string .
 
-niiri:25eb200bd03f426290a68a7c2b8e19fe prov:wasDerivedFrom niiri:e6b43073ea58d734c57cff5767e3921f .
+niiri:598d2ba06bdf7b67f6b54a339b88c029 prov:wasDerivedFrom niiri:6bafc27afb06adc8274b4e85b0eb95cc .
 
-niiri:f22a9c0971a349a072973dd922cf0da5
+niiri:a6db2f879c2f570c76c4c4fd60f93003
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0110" ;
-    prov:atLocation niiri:06bc6317f5dd0e19d7b2145cfc317c31 ;
+    prov:atLocation niiri:040670c2a1baf229dd4a840108736964 ;
     prov:value "0.907121956348419"^^xsd:float ;
     nidm_equivalentZStatistic: "1.84058311467862"^^xsd:float ;
     nidm_pValueUncorrected: "0.0328413370266359"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:06bc6317f5dd0e19d7b2145cfc317c31
+niiri:040670c2a1baf229dd4a840108736964
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0110" ;
     nidm_coordinateVector: "[56,-36,52]"^^xsd:string .
 
-niiri:f22a9c0971a349a072973dd922cf0da5 prov:wasDerivedFrom niiri:1cdb6dbe1bc79e13d52d0d3c171bab06 .
+niiri:a6db2f879c2f570c76c4c4fd60f93003 prov:wasDerivedFrom niiri:ee5baff089dc6387c53821c05a9e9154 .
 
-niiri:922af964cb0b1e93f68e8fa36f07f1ce
+niiri:069b63564a99aa9ff6d1ddb584fbf1db
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0111" ;
-    prov:atLocation niiri:bf0370f8604a56c53402a8729aefae6b ;
+    prov:atLocation niiri:bfd62b4d2231ff667c215ff1fe989844 ;
     prov:value "0.904614567756653"^^xsd:float ;
     nidm_equivalentZStatistic: "1.83739614411337"^^xsd:float ;
     nidm_pValueUncorrected: "0.0330757178223472"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:bf0370f8604a56c53402a8729aefae6b
+niiri:bfd62b4d2231ff667c215ff1fe989844
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0111" ;
     nidm_coordinateVector: "[36,-54,16]"^^xsd:string .
 
-niiri:922af964cb0b1e93f68e8fa36f07f1ce prov:wasDerivedFrom niiri:ee19df6f4d0113ba7e7f064a4048e753 .
+niiri:069b63564a99aa9ff6d1ddb584fbf1db prov:wasDerivedFrom niiri:e4e0f746d182d60a55906480bc82791f .
 
-niiri:3ba3e2d5a8b08d5f3408511de2fcea57
+niiri:ac8fabc6b095c00007fab8d02fe6ad74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0112" ;
-    prov:atLocation niiri:24965870248323c4385441c6aa85db8e ;
+    prov:atLocation niiri:fc4540b0a0db5dceda1b71fe564a0d94 ;
     prov:value "0.902757167816162"^^xsd:float ;
     nidm_equivalentZStatistic: "1.83503576989372"^^xsd:float ;
     nidm_pValueUncorrected: "0.0332501948262349"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:24965870248323c4385441c6aa85db8e
+niiri:fc4540b0a0db5dceda1b71fe564a0d94
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0112" ;
     nidm_coordinateVector: "[14,50,12]"^^xsd:string .
 
-niiri:3ba3e2d5a8b08d5f3408511de2fcea57 prov:wasDerivedFrom niiri:71af61a5c3e3beaf82f85e9971911d0f .
+niiri:ac8fabc6b095c00007fab8d02fe6ad74 prov:wasDerivedFrom niiri:07ef8bc1f56adef8bb96bf2e4e871509 .
 
-niiri:c2e1702c643d5c90a4a81f48e223bd8e
+niiri:28e9ce4572be1966c1b7c8d5fcec989e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0113" ;
-    prov:atLocation niiri:500217872b9641815f5c9ecf02da9de8 ;
+    prov:atLocation niiri:4b30382d1e4ea48108691076704ac047 ;
     prov:value "0.901206791400909"^^xsd:float ;
     nidm_equivalentZStatistic: "1.83306584752486"^^xsd:float ;
     nidm_pValueUncorrected: "0.0333963896408318"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:500217872b9641815f5c9ecf02da9de8
+niiri:4b30382d1e4ea48108691076704ac047
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0113" ;
     nidm_coordinateVector: "[-10,-70,-2]"^^xsd:string .
 
-niiri:c2e1702c643d5c90a4a81f48e223bd8e prov:wasDerivedFrom niiri:46c8b3f4803e6bb0b2862d8598ece061 .
+niiri:28e9ce4572be1966c1b7c8d5fcec989e prov:wasDerivedFrom niiri:4909c1eb824545b47aa0943b33200588 .
 
-niiri:9554f50419ea4f396d53059910e8f01c
+niiri:9b95918d4848aaeb3e55a87a62ab7a3e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0114" ;
-    prov:atLocation niiri:ebfb05b2fc04e2d96ab9a666523e58b8 ;
+    prov:atLocation niiri:fa0cc76b071f87753c14060810d31dfe ;
     prov:value "0.797126054763794"^^xsd:float ;
     nidm_equivalentZStatistic: "1.70146355236453"^^xsd:float ;
     nidm_pValueUncorrected: "0.0444279881500879"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:ebfb05b2fc04e2d96ab9a666523e58b8
+niiri:fa0cc76b071f87753c14060810d31dfe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0114" ;
     nidm_coordinateVector: "[-16,-64,-2]"^^xsd:string .
 
-niiri:9554f50419ea4f396d53059910e8f01c prov:wasDerivedFrom niiri:46c8b3f4803e6bb0b2862d8598ece061 .
+niiri:9b95918d4848aaeb3e55a87a62ab7a3e prov:wasDerivedFrom niiri:4909c1eb824545b47aa0943b33200588 .
 
-niiri:7b3ef4930118f8730b06d784120ed132
+niiri:5629d46077dec98c74dfbc8e049ea517
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0115" ;
-    prov:atLocation niiri:1c34ff628baa6e5b4cebfc783d6f6235 ;
+    prov:atLocation niiri:55609d261623909025c92a20fcf0610b ;
     prov:value "0.899936437606812"^^xsd:float ;
     nidm_equivalentZStatistic: "1.83145192034408"^^xsd:float ;
     nidm_pValueUncorrected: "0.0335165588882574"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1c34ff628baa6e5b4cebfc783d6f6235
+niiri:55609d261623909025c92a20fcf0610b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0115" ;
     nidm_coordinateVector: "[10,-18,-14]"^^xsd:string .
 
-niiri:7b3ef4930118f8730b06d784120ed132 prov:wasDerivedFrom niiri:5e385b701ab7f21285e4ab5006f3b0cc .
+niiri:5629d46077dec98c74dfbc8e049ea517 prov:wasDerivedFrom niiri:9c28e7c0288f5d8601280d59308426e4 .
 
-niiri:2b60d3a424b67aec66f9f99b0fccbb0d
+niiri:0a467b6ecf94f5f6b8b6165d58bc65c5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0116" ;
-    prov:atLocation niiri:65f8612f3ec48ab25895d29bc35e3436 ;
+    prov:atLocation niiri:d4bc30138d04a5bbe3454b95ec405b94 ;
     prov:value "0.895962595939636"^^xsd:float ;
     nidm_equivalentZStatistic: "1.8264044782252"^^xsd:float ;
     nidm_pValueUncorrected: "0.0338946789087741"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:65f8612f3ec48ab25895d29bc35e3436
+niiri:d4bc30138d04a5bbe3454b95ec405b94
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0116" ;
     nidm_coordinateVector: "[-42,-50,-42]"^^xsd:string .
 
-niiri:2b60d3a424b67aec66f9f99b0fccbb0d prov:wasDerivedFrom niiri:9b4e4e9b57eb3e981b1ba74aae8a7114 .
+niiri:0a467b6ecf94f5f6b8b6165d58bc65c5 prov:wasDerivedFrom niiri:49c7e8d7404b8a93cc2dc6a52274f6ef .
 
-niiri:1b85cec52ecc08fb6123be4911d70832
+niiri:9d771fa523b8607b56815b45270a4e93
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0117" ;
-    prov:atLocation niiri:87e9ae97ab2460fd67bf107c00b14f4d ;
+    prov:atLocation niiri:82448dc2205297fdbefd6f106d891759 ;
     prov:value "0.893008887767792"^^xsd:float ;
     nidm_equivalentZStatistic: "1.8226539056953"^^xsd:float ;
     nidm_pValueUncorrected: "0.0341779128567976"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:87e9ae97ab2460fd67bf107c00b14f4d
+niiri:82448dc2205297fdbefd6f106d891759
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0117" ;
     nidm_coordinateVector: "[-60,-32,46]"^^xsd:string .
 
-niiri:1b85cec52ecc08fb6123be4911d70832 prov:wasDerivedFrom niiri:6d27ace5181c44103420a9d6058ab0d2 .
+niiri:9d771fa523b8607b56815b45270a4e93 prov:wasDerivedFrom niiri:5bc798e43cab1c880a412761cd0dabce .
 
-niiri:1d5890d8c4a830c8c8f1f464ee06b062
+niiri:adb6b0a235ccc5b03f4e7c9f7dad9160
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0118" ;
-    prov:atLocation niiri:23b41b3bc0b16ebee53dd102abdb11d4 ;
+    prov:atLocation niiri:6f9fcf9029f665cf15d3412ed80b3a63 ;
     prov:value "0.888202428817749"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81655281460242"^^xsd:float ;
     nidm_pValueUncorrected: "0.0346428070130568"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:23b41b3bc0b16ebee53dd102abdb11d4
+niiri:6f9fcf9029f665cf15d3412ed80b3a63
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0118" ;
     nidm_coordinateVector: "[56,-42,24]"^^xsd:string .
 
-niiri:1d5890d8c4a830c8c8f1f464ee06b062 prov:wasDerivedFrom niiri:315d7b893c25221ef60daf1e43984066 .
+niiri:adb6b0a235ccc5b03f4e7c9f7dad9160 prov:wasDerivedFrom niiri:d5f0da3a07b3d47197bf039d8d42b58f .
 
-niiri:2565e317445870947786d1813b8bf01d
+niiri:0024155386338cfcf3a295b23bf9be12
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0119" ;
-    prov:atLocation niiri:f0a8bf2c4bce9536b2e34cad8fad2f2e ;
+    prov:atLocation niiri:366db76495f9bc35da783cfa4d85aaad ;
     prov:value "0.886661469936371"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81459734206643"^^xsd:float ;
     nidm_pValueUncorrected: "0.034792905633808"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f0a8bf2c4bce9536b2e34cad8fad2f2e
+niiri:366db76495f9bc35da783cfa4d85aaad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0119" ;
     nidm_coordinateVector: "[-34,-90,-30]"^^xsd:string .
 
-niiri:2565e317445870947786d1813b8bf01d prov:wasDerivedFrom niiri:34f88b9c2c80714dbe516b3f7ef092bb .
+niiri:0024155386338cfcf3a295b23bf9be12 prov:wasDerivedFrom niiri:a57d901560addc33f414ddaed9a0c7fb .
 
-niiri:e73954e3237244d481bbcd6dc6911176
+niiri:8a1311806bb1778b621397b5a41dfd96
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0120" ;
-    prov:atLocation niiri:d5854cc9ae10a2a740a4698cfa6ad761 ;
+    prov:atLocation niiri:b2b9b27d97fee31d70e759096f5c996a ;
     prov:value "0.88604724407196"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81381796560484"^^xsd:float ;
     nidm_pValueUncorrected: "0.0348528778271762"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d5854cc9ae10a2a740a4698cfa6ad761
+niiri:b2b9b27d97fee31d70e759096f5c996a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0120" ;
     nidm_coordinateVector: "[-6,-72,-20]"^^xsd:string .
 
-niiri:e73954e3237244d481bbcd6dc6911176 prov:wasDerivedFrom niiri:c07d0db5466c33ca960e3dd77f21333c .
+niiri:8a1311806bb1778b621397b5a41dfd96 prov:wasDerivedFrom niiri:01d84a7c8c63b90d178c8c7623156c7d .
 
-niiri:65e5e429d1c98e7a5de78ee327bfe175
+niiri:e2c16c6d913d0c2d6e9c5d0d27602288
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0121" ;
-    prov:atLocation niiri:9e7452e38b1a293e96d87620eeb74352 ;
+    prov:atLocation niiri:70af9ae3e7f3d4faa43eb79a9091469f ;
     prov:value "0.884565353393555"^^xsd:float ;
     nidm_equivalentZStatistic: "1.81193780520014"^^xsd:float ;
     nidm_pValueUncorrected: "0.0349979035410456"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9e7452e38b1a293e96d87620eeb74352
+niiri:70af9ae3e7f3d4faa43eb79a9091469f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0121" ;
     nidm_coordinateVector: "[62,-24,46]"^^xsd:string .
 
-niiri:65e5e429d1c98e7a5de78ee327bfe175 prov:wasDerivedFrom niiri:90645273f08ccfc7b9bf300a122cc2af .
+niiri:e2c16c6d913d0c2d6e9c5d0d27602288 prov:wasDerivedFrom niiri:99056f1d754fd9f25d80632f06577e33 .
 
-niiri:5eb9c920dba7f075a9df90020235c1a9
+niiri:85d9117015506ddb0393f7b060018584
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0122" ;
-    prov:atLocation niiri:c6ecfbf5d1e362ea14e87e5b5f48caf5 ;
+    prov:atLocation niiri:a6e58394345941bac6a450ad0153b497 ;
     prov:value "0.882052361965179"^^xsd:float ;
     nidm_equivalentZStatistic: "1.80874999534025"^^xsd:float ;
     nidm_pValueUncorrected: "0.0352449260120304"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c6ecfbf5d1e362ea14e87e5b5f48caf5
+niiri:a6e58394345941bac6a450ad0153b497
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0122" ;
     nidm_coordinateVector: "[-16,34,12]"^^xsd:string .
 
-niiri:5eb9c920dba7f075a9df90020235c1a9 prov:wasDerivedFrom niiri:c12f0aee596eddb11ad8e3268c4eb077 .
+niiri:85d9117015506ddb0393f7b060018584 prov:wasDerivedFrom niiri:a0ee8183a98a000be01c4577a35a0d8c .
 
-niiri:506119698918e1fef046ce6c81d77ebe
+niiri:cbd89dfc1ee38e3c17f96850cd7295e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0123" ;
-    prov:atLocation niiri:09cff2c449ad605890a3ec72e7672784 ;
+    prov:atLocation niiri:5741a80cbff4ef218f24ec536bddbc1f ;
     prov:value "0.878161370754242"^^xsd:float ;
     nidm_equivalentZStatistic: "1.8038155651472"^^xsd:float ;
     nidm_pValueUncorrected: "0.0356301124625072"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:09cff2c449ad605890a3ec72e7672784
+niiri:5741a80cbff4ef218f24ec536bddbc1f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0123" ;
     nidm_coordinateVector: "[-20,-46,76]"^^xsd:string .
 
-niiri:506119698918e1fef046ce6c81d77ebe prov:wasDerivedFrom niiri:b74b40058d530ee5632e1df25f911065 .
+niiri:cbd89dfc1ee38e3c17f96850cd7295e4 prov:wasDerivedFrom niiri:40c9456923bb7d18a8a4ec203aeea09d .
 
-niiri:d2d194c38029ea3cc730205928385128
+niiri:37d38fb5427bb518c234bcdb93146792
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0124" ;
-    prov:atLocation niiri:205f90e44f29beb0016b33f7cd420e9d ;
+    prov:atLocation niiri:6ba75280f16989f0413cff07c5ae28d4 ;
     prov:value "0.875840246677399"^^xsd:float ;
     nidm_equivalentZStatistic: "1.80087281439492"^^xsd:float ;
     nidm_pValueUncorrected: "0.0358614643888427"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:205f90e44f29beb0016b33f7cd420e9d
+niiri:6ba75280f16989f0413cff07c5ae28d4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0124" ;
     nidm_coordinateVector: "[-40,-6,34]"^^xsd:string .
 
-niiri:d2d194c38029ea3cc730205928385128 prov:wasDerivedFrom niiri:169fad64b64219293f6c913c296583bc .
+niiri:37d38fb5427bb518c234bcdb93146792 prov:wasDerivedFrom niiri:3cd64da8230af3c597bfb4e11e589670 .
 
-niiri:743c6582a5009b8dc4efb633233a4535
+niiri:4b5895493ed07bacb9952f039a51b8f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0125" ;
-    prov:atLocation niiri:bcb2bb47914ac9215957ebf283630732 ;
+    prov:atLocation niiri:0edef54b9fb2741aebc7cda42a57bcf8 ;
     prov:value "0.875353574752808"^^xsd:float ;
     nidm_equivalentZStatistic: "1.80025588397551"^^xsd:float ;
     nidm_pValueUncorrected: "0.0359101216845089"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:bcb2bb47914ac9215957ebf283630732
+niiri:0edef54b9fb2741aebc7cda42a57bcf8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0125" ;
     nidm_coordinateVector: "[-20,-12,8]"^^xsd:string .
 
-niiri:743c6582a5009b8dc4efb633233a4535 prov:wasDerivedFrom niiri:c9ba05614242ea84b1cd6a9c5ec414e4 .
+niiri:4b5895493ed07bacb9952f039a51b8f6 prov:wasDerivedFrom niiri:32e5e0304b5a2c92b091fa83edcab359 .
 
-niiri:c71bc3fe49c5d5a474cc15dc6dffb62d
+niiri:5390aed5563081e77badfd3ed3e58844
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0126" ;
-    prov:atLocation niiri:b96787f5a81fc13105fb48a6fd5ea1a0 ;
+    prov:atLocation niiri:9fb7d9fa270614bdf589782a12b43645 ;
     prov:value "0.87107241153717"^^xsd:float ;
     nidm_equivalentZStatistic: "1.79483003828998"^^xsd:float ;
     nidm_pValueUncorrected: "0.0363403916799833"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b96787f5a81fc13105fb48a6fd5ea1a0
+niiri:9fb7d9fa270614bdf589782a12b43645
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0126" ;
     nidm_coordinateVector: "[12,-44,-14]"^^xsd:string .
 
-niiri:c71bc3fe49c5d5a474cc15dc6dffb62d prov:wasDerivedFrom niiri:be38e2f5b8c4edd116eb0a55684fdab2 .
+niiri:5390aed5563081e77badfd3ed3e58844 prov:wasDerivedFrom niiri:bf704e8aea1497f2136b7d0b3dde0bf6 .
 
-niiri:f05e911e91200fba2a69c0dbec52ed46
+niiri:6c566805e06c1caea5ba64a10caf0bd5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0127" ;
-    prov:atLocation niiri:2d89278f9562ee144eb9d57189b71a2e ;
+    prov:atLocation niiri:7401db25a618931a21c1bd66336f51bb ;
     prov:value "0.865115165710449"^^xsd:float ;
     nidm_equivalentZStatistic: "1.78728350813392"^^xsd:float ;
     nidm_pValueUncorrected: "0.0369458390734643"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2d89278f9562ee144eb9d57189b71a2e
+niiri:7401db25a618931a21c1bd66336f51bb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0127" ;
     nidm_coordinateVector: "[2,56,-22]"^^xsd:string .
 
-niiri:f05e911e91200fba2a69c0dbec52ed46 prov:wasDerivedFrom niiri:9506dd108b62896cd6d8225dfc0e2e59 .
+niiri:6c566805e06c1caea5ba64a10caf0bd5 prov:wasDerivedFrom niiri:316701aef465a5778181dd76a5331844 .
 
-niiri:718114da93378acb4349a929b4418bb3
+niiri:6ab52d2779f2688ce41178fdd09b1849
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0128" ;
-    prov:atLocation niiri:76adcb2ddad656b23a665afa9087a907 ;
+    prov:atLocation niiri:3886ebad71d47a06506e87cdb3d33fee ;
     prov:value "0.864862859249115"^^xsd:float ;
     nidm_equivalentZStatistic: "1.78696398255915"^^xsd:float ;
     nidm_pValueUncorrected: "0.0369716550398422"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:76adcb2ddad656b23a665afa9087a907
+niiri:3886ebad71d47a06506e87cdb3d33fee
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0128" ;
     nidm_coordinateVector: "[-4,12,50]"^^xsd:string .
 
-niiri:718114da93378acb4349a929b4418bb3 prov:wasDerivedFrom niiri:f404d574847ee68f9dc6bd08393bd9a1 .
+niiri:6ab52d2779f2688ce41178fdd09b1849 prov:wasDerivedFrom niiri:90bdcb5fb7ef48121124edfe5e0439e6 .
 
-niiri:03fc56b39e281ca8fbd18fd8b73b3a30
+niiri:49c821b0d9d061981dc68b1e3e6abfea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0129" ;
-    prov:atLocation niiri:655c697c890d155ad920137ad8bbdd3a ;
+    prov:atLocation niiri:050099abcdfa23d375e581da2db19230 ;
     prov:value "0.864512741565704"^^xsd:float ;
     nidm_equivalentZStatistic: "1.78652059943143"^^xsd:float ;
     nidm_pValueUncorrected: "0.0370075024642879"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:655c697c890d155ad920137ad8bbdd3a
+niiri:050099abcdfa23d375e581da2db19230
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0129" ;
     nidm_coordinateVector: "[-30,-78,-8]"^^xsd:string .
 
-niiri:03fc56b39e281ca8fbd18fd8b73b3a30 prov:wasDerivedFrom niiri:99948f53ace7073cd3002a5850ecd361 .
+niiri:49c821b0d9d061981dc68b1e3e6abfea prov:wasDerivedFrom niiri:d1db945756296f3d178c9d95312fcba1 .
 
-niiri:9fe346931ab5bee817eaea36f0a39a81
+niiri:d51ddcc544b96cfa8316116f60aeb9d7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0130" ;
-    prov:atLocation niiri:1a069cea9796d88418c354fa8b495668 ;
+    prov:atLocation niiri:577fa5fdf942816d72dee2d7adba9c04 ;
     prov:value "0.860980033874512"^^xsd:float ;
     nidm_equivalentZStatistic: "1.7820476459466"^^xsd:float ;
     nidm_pValueUncorrected: "0.0373707311326116"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1a069cea9796d88418c354fa8b495668
+niiri:577fa5fdf942816d72dee2d7adba9c04
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0130" ;
     nidm_coordinateVector: "[12,-92,28]"^^xsd:string .
 
-niiri:9fe346931ab5bee817eaea36f0a39a81 prov:wasDerivedFrom niiri:c8c7dba5be58cecd8f14593ccfb69e4b .
+niiri:d51ddcc544b96cfa8316116f60aeb9d7 prov:wasDerivedFrom niiri:2c6edb141fb6e62904e7d3ee0f1b7f1a .
 
-niiri:1957ce020c99ce3df85faf2ec5078f77
+niiri:fa45d096c7906fe9ce12107ae864f03d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0131" ;
-    prov:atLocation niiri:98d11bc4b0ace2128270a5af1f3a8e18 ;
+    prov:atLocation niiri:c322d812103d8b149095968fc937209e ;
     prov:value "0.854242324829102"^^xsd:float ;
     nidm_equivalentZStatistic: "1.77352076998315"^^xsd:float ;
     nidm_pValueUncorrected: "0.0380712266728884"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:98d11bc4b0ace2128270a5af1f3a8e18
+niiri:c322d812103d8b149095968fc937209e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0131" ;
     nidm_coordinateVector: "[44,-50,-4]"^^xsd:string .
 
-niiri:1957ce020c99ce3df85faf2ec5078f77 prov:wasDerivedFrom niiri:a56ce0c60fde3ec8bf474d645a951d38 .
+niiri:fa45d096c7906fe9ce12107ae864f03d prov:wasDerivedFrom niiri:85b929eb3e4dd46a7e86bb62d3ac9f0c .
 
-niiri:66c1e77cf01db1d64aa08bccb30f1ff7
+niiri:98d08117d5c59bca3961e8d0d91fb482
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0132" ;
-    prov:atLocation niiri:8f8663ded34d0a964fe049c0fc2e394e ;
+    prov:atLocation niiri:17735795c02954ed333e3e53d28b146c ;
     prov:value "0.853475153446198"^^xsd:float ;
     nidm_equivalentZStatistic: "1.77255022378467"^^xsd:float ;
     nidm_pValueUncorrected: "0.0381516330201062"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8f8663ded34d0a964fe049c0fc2e394e
+niiri:17735795c02954ed333e3e53d28b146c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0132" ;
     nidm_coordinateVector: "[20,48,8]"^^xsd:string .
 
-niiri:66c1e77cf01db1d64aa08bccb30f1ff7 prov:wasDerivedFrom niiri:82e02fb05b18c0c2a70d55d5e415aee5 .
+niiri:98d08117d5c59bca3961e8d0d91fb482 prov:wasDerivedFrom niiri:9304b0681f39be2e136e7d42baff625c .
 
-niiri:b889d456c0879821e4ba3febfc7cbcc0
+niiri:99903325b32dacf464eb78e914073565
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0133" ;
-    prov:atLocation niiri:7dea8bfc01118debf10f84544e468a5c ;
+    prov:atLocation niiri:4ac846381c96ad6a617444612779bfc0 ;
     prov:value "0.848101913928986"^^xsd:float ;
     nidm_equivalentZStatistic: "1.76575454216401"^^xsd:float ;
     nidm_pValueUncorrected: "0.0387185189613873"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:7dea8bfc01118debf10f84544e468a5c
+niiri:4ac846381c96ad6a617444612779bfc0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0133" ;
     nidm_coordinateVector: "[22,-10,68]"^^xsd:string .
 
-niiri:b889d456c0879821e4ba3febfc7cbcc0 prov:wasDerivedFrom niiri:8d8ac9fae20babb989f7c367a4c4a609 .
+niiri:99903325b32dacf464eb78e914073565 prov:wasDerivedFrom niiri:c4a9ab38a5b5faf27a110372a76b690b .
 
-niiri:97a3bf83baba0ea813905300ee82fe23
+niiri:d04d5d2d100ceb80264f8137772a93bb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0134" ;
-    prov:atLocation niiri:1b9230ed2c839aa6d24e8d83c79d5dd6 ;
+    prov:atLocation niiri:5ebd6bd9f56805b7a73b57e890d2c9d3 ;
     prov:value "0.845535814762115"^^xsd:float ;
     nidm_equivalentZStatistic: "1.76251036116829"^^xsd:float ;
     nidm_pValueUncorrected: "0.038991553676096"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1b9230ed2c839aa6d24e8d83c79d5dd6
+niiri:5ebd6bd9f56805b7a73b57e890d2c9d3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0134" ;
     nidm_coordinateVector: "[10,16,62]"^^xsd:string .
 
-niiri:97a3bf83baba0ea813905300ee82fe23 prov:wasDerivedFrom niiri:1a41584c1187bb4a87d3cc1af9993773 .
+niiri:d04d5d2d100ceb80264f8137772a93bb prov:wasDerivedFrom niiri:b08c64db49c2acab9dde84fc5aaafee1 .
 
-niiri:6fbe9b8954c9f730c642daa8c4847b4a
+niiri:82bb09e80a51ba7c7cad776e0c839658
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0135" ;
-    prov:atLocation niiri:d1448e12a92a065f7e0cabf0e49e1ad3 ;
+    prov:atLocation niiri:8dfe0d34ef5e5740012a8bc214f3f619 ;
     prov:value "0.845024406909943"^^xsd:float ;
     nidm_equivalentZStatistic: "1.76186391162221"^^xsd:float ;
     nidm_pValueUncorrected: "0.0390461466343727"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:d1448e12a92a065f7e0cabf0e49e1ad3
+niiri:8dfe0d34ef5e5740012a8bc214f3f619
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0135" ;
     nidm_coordinateVector: "[-30,-60,-28]"^^xsd:string .
 
-niiri:6fbe9b8954c9f730c642daa8c4847b4a prov:wasDerivedFrom niiri:43ed38ee11c52db758569877faabd695 .
+niiri:82bb09e80a51ba7c7cad776e0c839658 prov:wasDerivedFrom niiri:a8f46a35300a709894debac1a5c7d877 .
 
-niiri:2549eeee38c0e38dc94943a1ee2e5a72
+niiri:ced019c79dabd92179f8a23ffb66322f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0136" ;
-    prov:atLocation niiri:c7735a5f5f10a0bd82c11474f8038741 ;
+    prov:atLocation niiri:b1f6f0554f2caf5a79e8f085d690f134 ;
     prov:value "0.842050552368164"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75810541868522"^^xsd:float ;
     nidm_pValueUncorrected: "0.0393647869826912"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:c7735a5f5f10a0bd82c11474f8038741
+niiri:b1f6f0554f2caf5a79e8f085d690f134
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0136" ;
     nidm_coordinateVector: "[20,6,44]"^^xsd:string .
 
-niiri:2549eeee38c0e38dc94943a1ee2e5a72 prov:wasDerivedFrom niiri:ee629aca5d18e60c2724bfd2e1b3fc6b .
+niiri:ced019c79dabd92179f8a23ffb66322f prov:wasDerivedFrom niiri:147fb623ae052dca9733d6d1d2297af8 .
 
-niiri:b8cf304e8ace22648efb5f4a9981bb03
+niiri:8c53fc407776cbf3f06af1e7d0d3050b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0137" ;
-    prov:atLocation niiri:04749d474e0bfc0ede32e54c5c11feca ;
+    prov:atLocation niiri:b14a5b57d07a5a949fbf0748f7fedeff ;
     prov:value "0.837220907211304"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75200380991823"^^xsd:float ;
     nidm_pValueUncorrected: "0.0398865764002145"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:04749d474e0bfc0ede32e54c5c11feca
+niiri:b14a5b57d07a5a949fbf0748f7fedeff
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0137" ;
     nidm_coordinateVector: "[-4,-100,4]"^^xsd:string .
 
-niiri:b8cf304e8ace22648efb5f4a9981bb03 prov:wasDerivedFrom niiri:8b0a58d02f59556fa0151651c6d40cc0 .
+niiri:8c53fc407776cbf3f06af1e7d0d3050b prov:wasDerivedFrom niiri:eb257014e1b6b6961786c8543836a579 .
 
-niiri:95679c7d59594699386070848d7545e6
+niiri:daa38cc1c0f9bbbca8083b6dc150874a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0138" ;
-    prov:atLocation niiri:55bb0fca7b0a040e7258ea87a9d4c539 ;
+    prov:atLocation niiri:d8a9aa94958b15cdbfa143422db3e409 ;
     prov:value "0.83669376373291"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75133800938073"^^xsd:float ;
     nidm_pValueUncorrected: "0.0399438520830083"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:55bb0fca7b0a040e7258ea87a9d4c539
+niiri:d8a9aa94958b15cdbfa143422db3e409
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0138" ;
     nidm_coordinateVector: "[26,36,-8]"^^xsd:string .
 
-niiri:95679c7d59594699386070848d7545e6 prov:wasDerivedFrom niiri:eeb7c0ae3047601cda9c179c68e75d65 .
+niiri:daa38cc1c0f9bbbca8083b6dc150874a prov:wasDerivedFrom niiri:3c0db86cde8ac7aa1cb1f7b208b617e8 .
 
-niiri:972eb6a3d099f2c00c6eb4bbaa70ac1b
+niiri:e6ccc430058b7e6f4734a533b0653ecd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0139" ;
-    prov:atLocation niiri:eeb8c0cd15d6d5c6bc694fdae27267b2 ;
+    prov:atLocation niiri:f7d532abb738d329ed77cfa4ca9d829d ;
     prov:value "0.835819184780121"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75023346183694"^^xsd:float ;
     nidm_pValueUncorrected: "0.0400390185167846"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:eeb8c0cd15d6d5c6bc694fdae27267b2
+niiri:f7d532abb738d329ed77cfa4ca9d829d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0139" ;
     nidm_coordinateVector: "[30,-36,28]"^^xsd:string .
 
-niiri:972eb6a3d099f2c00c6eb4bbaa70ac1b prov:wasDerivedFrom niiri:543214dac714341af8aeaa4b70f41266 .
+niiri:e6ccc430058b7e6f4734a533b0653ecd prov:wasDerivedFrom niiri:e578dd3a170f088e47efd39f45837f4e .
 
-niiri:5be765fc7b710cbdb2e1d4bd46ecce60
+niiri:c0c01149ce0c0a7325cb0911837c39c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0140" ;
-    prov:atLocation niiri:60dea246d45afec73eaabe894de2e0d3 ;
+    prov:atLocation niiri:f81887eda1e93b996e6c64febcb68a9f ;
     prov:value "0.835755825042725"^^xsd:float ;
     nidm_equivalentZStatistic: "1.75015344548878"^^xsd:float ;
     nidm_pValueUncorrected: "0.0400459197758659"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:60dea246d45afec73eaabe894de2e0d3
+niiri:f81887eda1e93b996e6c64febcb68a9f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0140" ;
     nidm_coordinateVector: "[16,48,10]"^^xsd:string .
 
-niiri:5be765fc7b710cbdb2e1d4bd46ecce60 prov:wasDerivedFrom niiri:86191fa377232381128e79c2a57a4af6 .
+niiri:c0c01149ce0c0a7325cb0911837c39c0 prov:wasDerivedFrom niiri:ab7f882f69e9de3fd22bc39f3519003d .
 
-niiri:af472b64871726e5127b3c3b9738e96f
+niiri:46a1c5dc61e2d7b3c894f451385aef85
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0141" ;
-    prov:atLocation niiri:1d48f9534397006412e809a8ce1f6646 ;
+    prov:atLocation niiri:0fd17548f87f46ceba800b4df8d45ffc ;
     prov:value "0.827520847320557"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73975784824994"^^xsd:float ;
     nidm_pValueUncorrected: "0.0409507734302569"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1d48f9534397006412e809a8ce1f6646
+niiri:0fd17548f87f46ceba800b4df8d45ffc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0141" ;
     nidm_coordinateVector: "[24,34,2]"^^xsd:string .
 
-niiri:af472b64871726e5127b3c3b9738e96f prov:wasDerivedFrom niiri:6f236184b94e16d3fb82cdd60cd19a6d .
+niiri:46a1c5dc61e2d7b3c894f451385aef85 prov:wasDerivedFrom niiri:ca827c13c9bc5f06b55e3bd1cd175793 .
 
-niiri:652faa5c53b766d8b0cf903c07dea641
+niiri:82a28d110b435fed75bd1e9374b294b2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0142" ;
-    prov:atLocation niiri:74cfe0dca1f5419de1c3a172a2352d1c ;
+    prov:atLocation niiri:9b4eccb2dece33b68e724e1fd45e6e19 ;
     prov:value "0.825629651546478"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73737166192306"^^xsd:float ;
     nidm_pValueUncorrected: "0.0411607949360844"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:74cfe0dca1f5419de1c3a172a2352d1c
+niiri:9b4eccb2dece33b68e724e1fd45e6e19
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0142" ;
     nidm_coordinateVector: "[62,-42,44]"^^xsd:string .
 
-niiri:652faa5c53b766d8b0cf903c07dea641 prov:wasDerivedFrom niiri:9ae54c5470ad002b7ae47f7b67b248ad .
+niiri:82a28d110b435fed75bd1e9374b294b2 prov:wasDerivedFrom niiri:8472115c12bd571d534dfe5bac960c80 .
 
-niiri:d26b4b3fb5276da558b2ded4146aecb4
+niiri:2d3f5ec418b92bf3ca61148f66079396
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0143" ;
-    prov:atLocation niiri:88d33018c3f9dbc230683ee47c7f469a ;
+    prov:atLocation niiri:3dbcf5a5ae42f6e1526aa0d8720cdb8a ;
     prov:value "0.82505863904953"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73665128497546"^^xsd:float ;
     nidm_pValueUncorrected: "0.0412243706597636"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:88d33018c3f9dbc230683ee47c7f469a
+niiri:3dbcf5a5ae42f6e1526aa0d8720cdb8a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0143" ;
     nidm_coordinateVector: "[-46,-40,38]"^^xsd:string .
 
-niiri:d26b4b3fb5276da558b2ded4146aecb4 prov:wasDerivedFrom niiri:0104fa6d88bd50793a3b65b47635e2c6 .
+niiri:2d3f5ec418b92bf3ca61148f66079396 prov:wasDerivedFrom niiri:812c44e9a98ad090a6f8b72ffea8eb49 .
 
-niiri:5cc50ec6e00023b323ad96ff05dca350
+niiri:3514e869d053964fca5f28a8c09f4e91
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0144" ;
-    prov:atLocation niiri:b5c4ea65f2f942e5c79bd59f2797e844 ;
+    prov:atLocation niiri:fb4af523bacf868c90bee16373434943 ;
     prov:value "0.824967801570892"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73653669020128"^^xsd:float ;
     nidm_pValueUncorrected: "0.0412344913749479"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b5c4ea65f2f942e5c79bd59f2797e844
+niiri:fb4af523bacf868c90bee16373434943
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0144" ;
     nidm_coordinateVector: "[-12,-58,-54]"^^xsd:string .
 
-niiri:5cc50ec6e00023b323ad96ff05dca350 prov:wasDerivedFrom niiri:1ff5ea3ca56fb13894e4e43c39a861c9 .
+niiri:3514e869d053964fca5f28a8c09f4e91 prov:wasDerivedFrom niiri:eb1e036b54bfd5155015ad5c924a62ce .
 
-niiri:9e195ae526df87602b1a5980eb32f1a3
+niiri:aee96554789220edfb0c2a5cb3e5dbcf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0145" ;
-    prov:atLocation niiri:09ab1d1db3cfbdd5ba683bbafc0a37e6 ;
+    prov:atLocation niiri:e3ed6f4e37e26c035620e0009be1898c ;
     prov:value "0.824692487716675"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73618937818564"^^xsd:float ;
     nidm_pValueUncorrected: "0.0412651773815628"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:09ab1d1db3cfbdd5ba683bbafc0a37e6
+niiri:e3ed6f4e37e26c035620e0009be1898c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0145" ;
     nidm_coordinateVector: "[26,-72,14]"^^xsd:string .
 
-niiri:9e195ae526df87602b1a5980eb32f1a3 prov:wasDerivedFrom niiri:9e02c41cd62cc06c92b5e2b56a706886 .
+niiri:aee96554789220edfb0c2a5cb3e5dbcf prov:wasDerivedFrom niiri:8bac0f00c0d1f0f9f5c118004ab17321 .
 
-niiri:9c93b5c306aacac5c321fe8b406ca25c
+niiri:cc8b982d26d7b3eda03f32ed426ee111
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0146" ;
-    prov:atLocation niiri:87a6b40994dc4f90c9f3ccee7834c6b4 ;
+    prov:atLocation niiri:ed883e8d69ce8310e32c0e8becfe841e ;
     prov:value "0.822546482086182"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73348249441809"^^xsd:float ;
     nidm_pValueUncorrected: "0.0415049731433188"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:87a6b40994dc4f90c9f3ccee7834c6b4
+niiri:ed883e8d69ce8310e32c0e8becfe841e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0146" ;
     nidm_coordinateVector: "[-40,-10,40]"^^xsd:string .
 
-niiri:9c93b5c306aacac5c321fe8b406ca25c prov:wasDerivedFrom niiri:a5e308239dff195e8c67ca5b964d553a .
+niiri:cc8b982d26d7b3eda03f32ed426ee111 prov:wasDerivedFrom niiri:4f4b190235fbb136b1bb7467b78730d6 .
 
-niiri:87be53fc52f329c31a4bbf852d8d96af
+niiri:5f5a39c0ec9f402ad6c7b83cd3403cc8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0147" ;
-    prov:atLocation niiri:8a23632000b73752391bf7b0889bdc03 ;
+    prov:atLocation niiri:6f15a47567306fd72eb97be297c7405b ;
     prov:value "0.821757972240448"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73248804772578"^^xsd:float ;
     nidm_pValueUncorrected: "0.0415933516734939"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8a23632000b73752391bf7b0889bdc03
+niiri:6f15a47567306fd72eb97be297c7405b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0147" ;
     nidm_coordinateVector: "[54,-52,42]"^^xsd:string .
 
-niiri:87be53fc52f329c31a4bbf852d8d96af prov:wasDerivedFrom niiri:aeffc3536799596ea12e2467fc52bd65 .
+niiri:5f5a39c0ec9f402ad6c7b83cd3403cc8 prov:wasDerivedFrom niiri:d04d2676281bca09e8a782500650e993 .
 
-niiri:522075dd68ebe791546a697684de5db9
+niiri:21c2f0806b69f7a2007d792897684387
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0148" ;
-    prov:atLocation niiri:45539f048650428b2f89835fd4f28adf ;
+    prov:atLocation niiri:8c75ae64ad9880eeb66c7dfdeca370d8 ;
     prov:value "0.821538865566254"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73221173057204"^^xsd:float ;
     nidm_pValueUncorrected: "0.0416179355971084"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:45539f048650428b2f89835fd4f28adf
+niiri:8c75ae64ad9880eeb66c7dfdeca370d8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0148" ;
     nidm_coordinateVector: "[-10,-66,8]"^^xsd:string .
 
-niiri:522075dd68ebe791546a697684de5db9 prov:wasDerivedFrom niiri:3e987521ad9deca092879412707ea491 .
+niiri:21c2f0806b69f7a2007d792897684387 prov:wasDerivedFrom niiri:59c6e585fc56ebce5a5d95b959cc120d .
 
-niiri:322277ddac27387b3f1cf8caca630a5d
+niiri:4f107ffd42ea6e3a3e3d2968400fa620
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0149" ;
-    prov:atLocation niiri:dbba800ccf20410cbd8b17d4e7e3d71f ;
+    prov:atLocation niiri:e296ec0027943c32f1d63187ca884faf ;
     prov:value "0.821337878704071"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73195826984928"^^xsd:float ;
     nidm_pValueUncorrected: "0.0416404963346692"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:dbba800ccf20410cbd8b17d4e7e3d71f
+niiri:e296ec0027943c32f1d63187ca884faf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0149" ;
     nidm_coordinateVector: "[20,-16,70]"^^xsd:string .
 
-niiri:322277ddac27387b3f1cf8caca630a5d prov:wasDerivedFrom niiri:f54f30ee52ac26f6dae0749e096ea6c1 .
+niiri:4f107ffd42ea6e3a3e3d2968400fa620 prov:wasDerivedFrom niiri:a4d82c21752d17f68b6fbf41caa89a4b .
 
-niiri:c61ef0dd46c1c75dde8b0ff1cd46ff2a
+niiri:52953fe00c54e610f78c8e2bd72debb1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0150" ;
-    prov:atLocation niiri:e6913f677376e8f8d0cbf5768e2b2957 ;
+    prov:atLocation niiri:d4f42ae011a1b1bcdfd446d63c416728 ;
     prov:value "0.821269989013672"^^xsd:float ;
     nidm_equivalentZStatistic: "1.73187265661373"^^xsd:float ;
     nidm_pValueUncorrected: "0.0416481190738193"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e6913f677376e8f8d0cbf5768e2b2957
+niiri:d4f42ae011a1b1bcdfd446d63c416728
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0150" ;
     nidm_coordinateVector: "[34,-56,18]"^^xsd:string .
 
-niiri:c61ef0dd46c1c75dde8b0ff1cd46ff2a prov:wasDerivedFrom niiri:692bc9543cbfc2b98e06dde4c8e7603f .
+niiri:52953fe00c54e610f78c8e2bd72debb1 prov:wasDerivedFrom niiri:9c09ac30035d9617daad1f111fa1b47f .
 
-niiri:a80bb377de34b37212750ae3db10e20a
+niiri:b8bb24c25ece9a10c4a32995fda538dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0151" ;
-    prov:atLocation niiri:0458d3c1e0559783e4029b2a4be03a14 ;
+    prov:atLocation niiri:48f70704159960814be91b72a9bd2859 ;
     prov:value "0.82093757390976"^^xsd:float ;
     nidm_equivalentZStatistic: "1.7314534684428"^^xsd:float ;
     nidm_pValueUncorrected: "0.0416854586174026"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0458d3c1e0559783e4029b2a4be03a14
+niiri:48f70704159960814be91b72a9bd2859
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0151" ;
     nidm_coordinateVector: "[58,32,22]"^^xsd:string .
 
-niiri:a80bb377de34b37212750ae3db10e20a prov:wasDerivedFrom niiri:be235801557e66b2190c98cd649588c0 .
+niiri:b8bb24c25ece9a10c4a32995fda538dd prov:wasDerivedFrom niiri:b5d02c34e634c7f52d94137fbd9f8813 .
 
-niiri:9fc68b058dc6ee748e78bc0342d26c9f
+niiri:553be5643aa7f566f5428ca1f18a7e99
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0152" ;
-    prov:atLocation niiri:243d348e8bb24e528c34f0f61a042268 ;
+    prov:atLocation niiri:793abb325ad9de1bede5b50108624f36 ;
     prov:value "0.817427694797516"^^xsd:float ;
     nidm_equivalentZStatistic: "1.72702824070669"^^xsd:float ;
     nidm_pValueUncorrected: "0.0420812958690475"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:243d348e8bb24e528c34f0f61a042268
+niiri:793abb325ad9de1bede5b50108624f36
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0152" ;
     nidm_coordinateVector: "[-28,-74,18]"^^xsd:string .
 
-niiri:9fc68b058dc6ee748e78bc0342d26c9f prov:wasDerivedFrom niiri:baf9fc0b69478678bb8ed7430b24c094 .
+niiri:553be5643aa7f566f5428ca1f18a7e99 prov:wasDerivedFrom niiri:fc91a408c252d8e2b7beb4005554eaf8 .
 
-niiri:b25ee7d26cd1e25affee2f1c6bc4278f
+niiri:50446d0a8adcadede38bdf0d08c3a7c9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0153" ;
-    prov:atLocation niiri:f793261af421559e7bb8429a67afd216 ;
+    prov:atLocation niiri:4691db3191597b7338e7c95c4a8f87e2 ;
     prov:value "0.816389560699463"^^xsd:float ;
     nidm_equivalentZStatistic: "1.72571967296696"^^xsd:float ;
     nidm_pValueUncorrected: "0.0421989285126135"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f793261af421559e7bb8429a67afd216
+niiri:4691db3191597b7338e7c95c4a8f87e2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0153" ;
     nidm_coordinateVector: "[28,-30,34]"^^xsd:string .
 
-niiri:b25ee7d26cd1e25affee2f1c6bc4278f prov:wasDerivedFrom niiri:27343a380f46da81b03903d4cf6193dc .
+niiri:50446d0a8adcadede38bdf0d08c3a7c9 prov:wasDerivedFrom niiri:9b0591f2b854d2643aaf1afaa93cb549 .
 
-niiri:b9cefb671f41cdcd2b2e4c69d6b7b359
+niiri:65d8e0c0cee7cb9aedc8b05b70798526
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0154" ;
-    prov:atLocation niiri:e532ce509b03d476f34fbe3e3016c83c ;
+    prov:atLocation niiri:a8791185dbb796dbe126d712ae2b55e4 ;
     prov:value "0.810877442359924"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71877398514755"^^xsd:float ;
     nidm_pValueUncorrected: "0.0428277671196435"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:e532ce509b03d476f34fbe3e3016c83c
+niiri:a8791185dbb796dbe126d712ae2b55e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0154" ;
     nidm_coordinateVector: "[-4,-92,4]"^^xsd:string .
 
-niiri:b9cefb671f41cdcd2b2e4c69d6b7b359 prov:wasDerivedFrom niiri:158f1d535951e2b7d78ea10b066c15f3 .
+niiri:65d8e0c0cee7cb9aedc8b05b70798526 prov:wasDerivedFrom niiri:d54744a8017e84d7adb355fc9412fba3 .
 
-niiri:2ad984f6f188e95e289d863a3dc28223
+niiri:ac42ea1cc64c6d5a7de30ab94c30ef98
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0155" ;
-    prov:atLocation niiri:9a5b03d3a41f3e346f8f366b062b7b4b ;
+    prov:atLocation niiri:e8237ec0f9d80f45182261107f27d393 ;
     prov:value "0.810260891914368"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71799733032142"^^xsd:float ;
     nidm_pValueUncorrected: "0.0428985511130971"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:9a5b03d3a41f3e346f8f366b062b7b4b
+niiri:e8237ec0f9d80f45182261107f27d393
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0155" ;
     nidm_coordinateVector: "[-18,-22,44]"^^xsd:string .
 
-niiri:2ad984f6f188e95e289d863a3dc28223 prov:wasDerivedFrom niiri:842d2062c93ff252780aae9939a20111 .
+niiri:ac42ea1cc64c6d5a7de30ab94c30ef98 prov:wasDerivedFrom niiri:e49a03f4d60a11688f798fc5bc43c1b2 .
 
-niiri:3271f178664f3539edaa018f6f207fa8
+niiri:69ee373828c471312b7a98ecd9d058a9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0156" ;
-    prov:atLocation niiri:90a5129a6c43a75a468beb3757198213 ;
+    prov:atLocation niiri:c8b68f98c5cfe0ac5c2cdefaedfdf163 ;
     prov:value "0.809625387191772"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71719685114941"^^xsd:float ;
     nidm_pValueUncorrected: "0.042971605350922"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:90a5129a6c43a75a468beb3757198213
+niiri:c8b68f98c5cfe0ac5c2cdefaedfdf163
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0156" ;
     nidm_coordinateVector: "[-8,-88,-48]"^^xsd:string .
 
-niiri:3271f178664f3539edaa018f6f207fa8 prov:wasDerivedFrom niiri:d27fbf9c8044e6b188c300c4990f6f54 .
+niiri:69ee373828c471312b7a98ecd9d058a9 prov:wasDerivedFrom niiri:b04a187086857b7422c8096db14ee613 .
 
-niiri:e89619f00261dd896c5e6b49b91ad9fa
+niiri:b43fdbd7e0791111185f3e004a40b90f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0157" ;
-    prov:atLocation niiri:cb30d0dcf44e480e9d546d120872d8b2 ;
+    prov:atLocation niiri:70a5abbded05158ae55374c9e47f8da2 ;
     prov:value "0.807083547115326"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71399568809748"^^xsd:float ;
     nidm_pValueUncorrected: "0.0432647588890963"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:cb30d0dcf44e480e9d546d120872d8b2
+niiri:70a5abbded05158ae55374c9e47f8da2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0157" ;
     nidm_coordinateVector: "[-28,-90,-14]"^^xsd:string .
 
-niiri:e89619f00261dd896c5e6b49b91ad9fa prov:wasDerivedFrom niiri:2a4965b8fc709556c2aa1abb6adf5441 .
+niiri:b43fdbd7e0791111185f3e004a40b90f prov:wasDerivedFrom niiri:39ce93dd6abab662ab6da84a046a56bd .
 
-niiri:d514e4693dd32deec29d4b4747f44ab2
+niiri:74b1e30b0b85916615db0f4c7da8ca2a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0158" ;
-    prov:atLocation niiri:b4bd0cc943eb4c6123bcaa4505ed1439 ;
+    prov:atLocation niiri:8b947c980b68849b563e6a600eb6f25e ;
     prov:value "0.804524898529053"^^xsd:float ;
     nidm_equivalentZStatistic: "1.71077421355999"^^xsd:float ;
     nidm_pValueUncorrected: "0.0435614007800803"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:b4bd0cc943eb4c6123bcaa4505ed1439
+niiri:8b947c980b68849b563e6a600eb6f25e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0158" ;
     nidm_coordinateVector: "[54,18,14]"^^xsd:string .
 
-niiri:d514e4693dd32deec29d4b4747f44ab2 prov:wasDerivedFrom niiri:9cc63018305b210a50122f137d979802 .
+niiri:74b1e30b0b85916615db0f4c7da8ca2a prov:wasDerivedFrom niiri:8cbff6b6be8842b3c0ca8a7ac0a0554e .
 
-niiri:56f159e4b339f215b07ab529dcb6afe5
+niiri:6630427441c8fc15cc3a64424eb38ad1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0159" ;
-    prov:atLocation niiri:0e2f64a7d2cf43118af0d523a1045abf ;
+    prov:atLocation niiri:2352aa9bc768856664d6689721c07c97 ;
     prov:value "0.801611304283142"^^xsd:float ;
     nidm_equivalentZStatistic: "1.70710689586196"^^xsd:float ;
     nidm_pValueUncorrected: "0.0439010928174099"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0e2f64a7d2cf43118af0d523a1045abf
+niiri:2352aa9bc768856664d6689721c07c97
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0159" ;
     nidm_coordinateVector: "[38,-48,18]"^^xsd:string .
 
-niiri:56f159e4b339f215b07ab529dcb6afe5 prov:wasDerivedFrom niiri:965ac0d53ae837b608d6841eb6671ec5 .
+niiri:6630427441c8fc15cc3a64424eb38ad1 prov:wasDerivedFrom niiri:ca20dee3ba6bf36049f99642c710470d .
 
-niiri:3775e9935ca298404180c033594cef47
+niiri:8292bd6d405860cc9e98ea0f6c90807b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0160" ;
-    prov:atLocation niiri:974a061454302498849b51020d3bcaf0 ;
+    prov:atLocation niiri:a2593a5375fecb7c266042738db0862e ;
     prov:value "0.801064372062683"^^xsd:float ;
     nidm_equivalentZStatistic: "1.70641860205681"^^xsd:float ;
     nidm_pValueUncorrected: "0.0439650847967754"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:974a061454302498849b51020d3bcaf0
+niiri:a2593a5375fecb7c266042738db0862e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0160" ;
     nidm_coordinateVector: "[-32,-70,28]"^^xsd:string .
 
-niiri:3775e9935ca298404180c033594cef47 prov:wasDerivedFrom niiri:d20a800c34ef4ebbc2c9d064007ca5a5 .
+niiri:8292bd6d405860cc9e98ea0f6c90807b prov:wasDerivedFrom niiri:26fa7a82c298f218eb7fd282cfbf7a81 .
 
-niiri:67775b1fe689aac8a236bd5098ede3ac
+niiri:40736270f2699f261bc17555c7292552
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0161" ;
-    prov:atLocation niiri:2c52525c383497b335b50a9120c734ec ;
+    prov:atLocation niiri:f1dfb9a6e43d0bb924ebeb2df5b8754b ;
     prov:value "0.796977043151855"^^xsd:float ;
     nidm_equivalentZStatistic: "1.70127611195347"^^xsd:float ;
     nidm_pValueUncorrected: "0.0444455757271468"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:2c52525c383497b335b50a9120c734ec
+niiri:f1dfb9a6e43d0bb924ebeb2df5b8754b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0161" ;
     nidm_coordinateVector: "[40,-8,-32]"^^xsd:string .
 
-niiri:67775b1fe689aac8a236bd5098ede3ac prov:wasDerivedFrom niiri:0a26619869c6304390cf220d86997062 .
+niiri:40736270f2699f261bc17555c7292552 prov:wasDerivedFrom niiri:e518dd980ffdb694adcf472695d5a40a .
 
-niiri:5338ab94ade7000ed4f4bdf7d9d76d2b
+niiri:0f9175ee5293a19900d9c265070230b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0162" ;
-    prov:atLocation niiri:f70d129d0d7c22e30869fb59d6e5cc46 ;
+    prov:atLocation niiri:a2480bf60f7e38c86231bf76032bf596 ;
     prov:value "0.795195400714874"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69903522990177"^^xsd:float ;
     nidm_pValueUncorrected: "0.044656272931023"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f70d129d0d7c22e30869fb59d6e5cc46
+niiri:a2480bf60f7e38c86231bf76032bf596
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0162" ;
     nidm_coordinateVector: "[10,-10,4]"^^xsd:string .
 
-niiri:5338ab94ade7000ed4f4bdf7d9d76d2b prov:wasDerivedFrom niiri:6a5b8fb86c67c0eb5b9c606e6b810510 .
+niiri:0f9175ee5293a19900d9c265070230b1 prov:wasDerivedFrom niiri:5f278b6b11fae0c4b4f9690852a71d0c .
 
-niiri:47f63f9dd57bbc2ec925efae82f98e54
+niiri:9288e365e8e166d1d7201abdec31d34d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0163" ;
-    prov:atLocation niiri:f5fa7f06451efb337a56d65fce6310d4 ;
+    prov:atLocation niiri:360956c141f1348efb9ba6e9bda173e8 ;
     prov:value "0.793771862983704"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69724506469093"^^xsd:float ;
     nidm_pValueUncorrected: "0.0448251692331177"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f5fa7f06451efb337a56d65fce6310d4
+niiri:360956c141f1348efb9ba6e9bda173e8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0163" ;
     nidm_coordinateVector: "[36,-38,16]"^^xsd:string .
 
-niiri:47f63f9dd57bbc2ec925efae82f98e54 prov:wasDerivedFrom niiri:99f3a2d8e7661135dd74892e7227bd72 .
+niiri:9288e365e8e166d1d7201abdec31d34d prov:wasDerivedFrom niiri:87f8233f1c48acf6ecdd7339055182ae .
 
-niiri:e057cf1a39f015eb9f597ecf60c28d8d
+niiri:5eefd7306b4387e0f534121efebdd08c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0164" ;
-    prov:atLocation niiri:408e388806b9aac265fd41d04872e446 ;
+    prov:atLocation niiri:c6bbb6da467f04755510516c59db89cc ;
     prov:value "0.791125535964966"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69391791067376"^^xsd:float ;
     nidm_pValueUncorrected: "0.0451404415013222"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:408e388806b9aac265fd41d04872e446
+niiri:c6bbb6da467f04755510516c59db89cc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0164" ;
     nidm_coordinateVector: "[36,-58,-34]"^^xsd:string .
 
-niiri:e057cf1a39f015eb9f597ecf60c28d8d prov:wasDerivedFrom niiri:64a5de9f75df294ee267e34b2597bc84 .
+niiri:5eefd7306b4387e0f534121efebdd08c prov:wasDerivedFrom niiri:0189728b5aaa10d4eb4ff53d1fbc5843 .
 
-niiri:f4707b696468bcd21beacb40c56d4112
+niiri:0d043095f5b8ce7d202f6fc55b3238bc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0165" ;
-    prov:atLocation niiri:8770aec72d29d54ccbc74852e6556723 ;
+    prov:atLocation niiri:00bfef980e3b46b82577ed05a18e2998 ;
     prov:value "0.790164232254028"^^xsd:float ;
     nidm_equivalentZStatistic: "1.69270952448475"^^xsd:float ;
     nidm_pValueUncorrected: "0.0452553857167721"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:8770aec72d29d54ccbc74852e6556723
+niiri:00bfef980e3b46b82577ed05a18e2998
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0165" ;
     nidm_coordinateVector: "[-24,-68,40]"^^xsd:string .
 
-niiri:f4707b696468bcd21beacb40c56d4112 prov:wasDerivedFrom niiri:2c98abbba202c2ed1fa8e08549a97cb1 .
+niiri:0d043095f5b8ce7d202f6fc55b3238bc prov:wasDerivedFrom niiri:453f1919d7df3d7e610709f6fdecbf62 .
 
-niiri:0855ebe4c0e33757d2de5fe5b72c3aa4
+niiri:d3837181ec2883710db3c1e102047902
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0166" ;
-    prov:atLocation niiri:1304b6c03fd823e5f08127fb56383466 ;
+    prov:atLocation niiri:6839436079db4de6e679f679c75a4c7e ;
     prov:value "0.789975047111511"^^xsd:float ;
     nidm_equivalentZStatistic: "1.6924717281141"^^xsd:float ;
     nidm_pValueUncorrected: "0.045278033108256"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:1304b6c03fd823e5f08127fb56383466
+niiri:6839436079db4de6e679f679c75a4c7e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0166" ;
     nidm_coordinateVector: "[-32,-66,-54]"^^xsd:string .
 
-niiri:0855ebe4c0e33757d2de5fe5b72c3aa4 prov:wasDerivedFrom niiri:35bfc5987aa4a1eba01be33e4c1ee7f2 .
+niiri:d3837181ec2883710db3c1e102047902 prov:wasDerivedFrom niiri:5b21dda7a2823d1c7efeff7947020767 .
 
-niiri:767f2a4a4176e20fbe7980bfd92d4d37
+niiri:7ada6738ac4a3476b738b4b0994fd916
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0167" ;
-    prov:atLocation niiri:48c823ec7d05b841c28208a512ace325 ;
+    prov:atLocation niiri:0e72b69c8d3905c21cb76f5d803a0e4d ;
     prov:value "0.785030126571655"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68625793462611"^^xsd:float ;
     nidm_pValueUncorrected: "0.0458730647233518"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:48c823ec7d05b841c28208a512ace325
+niiri:0e72b69c8d3905c21cb76f5d803a0e4d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0167" ;
     nidm_coordinateVector: "[-38,-4,36]"^^xsd:string .
 
-niiri:767f2a4a4176e20fbe7980bfd92d4d37 prov:wasDerivedFrom niiri:33395b862a603ee1373735759fed1bcb .
+niiri:7ada6738ac4a3476b738b4b0994fd916 prov:wasDerivedFrom niiri:a6dc495a077e17aa8f96566659037e0b .
 
-niiri:efc75d1d378ad8d8e290d9c8d692030e
+niiri:9c5822f4331f39fcb128f71e39c9a258
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0168" ;
-    prov:atLocation niiri:cf847ee221aa1a3ba5ad8ab6ceda969c ;
+    prov:atLocation niiri:ff06c430dadf64ca774b3086a78659e3 ;
     prov:value "0.783349096775055"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68414631143602"^^xsd:float ;
     nidm_pValueUncorrected: "0.0460766980434556"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:cf847ee221aa1a3ba5ad8ab6ceda969c
+niiri:ff06c430dadf64ca774b3086a78659e3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0168" ;
     nidm_coordinateVector: "[-50,10,-6]"^^xsd:string .
 
-niiri:efc75d1d378ad8d8e290d9c8d692030e prov:wasDerivedFrom niiri:635a4fc24d89b14d261b42d568e53ac8 .
+niiri:9c5822f4331f39fcb128f71e39c9a258 prov:wasDerivedFrom niiri:e5e5eeee288ec088072a80af972a3638 .
 
-niiri:f23899f7631f3a7071c3337dd7fc2238
+niiri:ccb323d69fd85ace7df2130c0f358f1e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0169" ;
-    prov:atLocation niiri:0bb4251c6e182321ff1b00b360bea5db ;
+    prov:atLocation niiri:217b8e666093093f4b98080437a0d243 ;
     prov:value "0.780271351337433"^^xsd:float ;
     nidm_equivalentZStatistic: "1.68028121266012"^^xsd:float ;
     nidm_pValueUncorrected: "0.046451307319556"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:0bb4251c6e182321ff1b00b360bea5db
+niiri:217b8e666093093f4b98080437a0d243
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0169" ;
     nidm_coordinateVector: "[-18,-22,34]"^^xsd:string .
 
-niiri:f23899f7631f3a7071c3337dd7fc2238 prov:wasDerivedFrom niiri:55b4eeddb69bb03436464cf696dd593b .
+niiri:ccb323d69fd85ace7df2130c0f358f1e prov:wasDerivedFrom niiri:4c1ed2fd0a9cff0132d3ce4586c8bbd1 .
 
-niiri:e0c716598553c866132acb9e00a99269
+niiri:cf35bc5d34495239fdb3d14ae313539a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0170" ;
-    prov:atLocation niiri:bd016d0a131f74cd47766a37849f8af4 ;
+    prov:atLocation niiri:6a7144a67e64589dcd898f89b4f5a115 ;
     prov:value "0.778013467788696"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67744654581037"^^xsd:float ;
     nidm_pValueUncorrected: "0.046727596979824"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:bd016d0a131f74cd47766a37849f8af4
+niiri:6a7144a67e64589dcd898f89b4f5a115
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0170" ;
     nidm_coordinateVector: "[-20,-22,38]"^^xsd:string .
 
-niiri:e0c716598553c866132acb9e00a99269 prov:wasDerivedFrom niiri:493898a476d4ce4bf533682e007422c5 .
+niiri:cf35bc5d34495239fdb3d14ae313539a prov:wasDerivedFrom niiri:66cf0dbeb1aa03edbab1a35c2d527a55 .
 
-niiri:23993fd78665c8c8cea4bbea816aa847
+niiri:8a057d875ec99d9bc03c3b517547b1ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0171" ;
-    prov:atLocation niiri:34c3f1555e908f480a1cd6c4105ace9b ;
+    prov:atLocation niiri:074b47096ccc51be98dbe94fdd69bdea ;
     prov:value "0.775993704795837"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67491142741087"^^xsd:float ;
     nidm_pValueUncorrected: "0.0469758055929785"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:34c3f1555e908f480a1cd6c4105ace9b
+niiri:074b47096ccc51be98dbe94fdd69bdea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0171" ;
     nidm_coordinateVector: "[12,-92,2]"^^xsd:string .
 
-niiri:23993fd78665c8c8cea4bbea816aa847 prov:wasDerivedFrom niiri:b841eb2677ab2ad59ce73103265cdee0 .
+niiri:8a057d875ec99d9bc03c3b517547b1ea prov:wasDerivedFrom niiri:09d8898196c5c40aec6f995a2b0c383d .
 
-niiri:2f0c7a7defde925468925744ec810146
+niiri:136d5427f1933a243c7f06af362e36ee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0172" ;
-    prov:atLocation niiri:da9b38041402957b6d2f062656d107ff ;
+    prov:atLocation niiri:78b0fee3f9559ef3905e7bf963b53e38 ;
     prov:value "0.774858772754669"^^xsd:float ;
     nidm_equivalentZStatistic: "1.67348715940063"^^xsd:float ;
     nidm_pValueUncorrected: "0.0471157161396256"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:da9b38041402957b6d2f062656d107ff
+niiri:78b0fee3f9559ef3905e7bf963b53e38
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0172" ;
     nidm_coordinateVector: "[52,-44,58]"^^xsd:string .
 
-niiri:2f0c7a7defde925468925744ec810146 prov:wasDerivedFrom niiri:4c7ec0be40515b0eae812fe9befe02f1 .
+niiri:136d5427f1933a243c7f06af362e36ee prov:wasDerivedFrom niiri:bfe644ea717165d3b6b50431d8e57c87 .
 
-niiri:f05db93a343d1865fd10001c92a30d32
+niiri:f4fabce2608abd82f4cb41cc5b313112
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0173" ;
-    prov:atLocation niiri:5a77aafacf3c36dfd821f2078711b553 ;
+    prov:atLocation niiri:907619d79ece58eff1df517e0cbd5f78 ;
     prov:value "0.766564428806305"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66308376386524"^^xsd:float ;
     nidm_pValueUncorrected: "0.0481478347201374"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:5a77aafacf3c36dfd821f2078711b553
+niiri:907619d79ece58eff1df517e0cbd5f78
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0173" ;
     nidm_coordinateVector: "[46,30,-8]"^^xsd:string .
 
-niiri:f05db93a343d1865fd10001c92a30d32 prov:wasDerivedFrom niiri:8ace0ff7ab5e55ab5d2ecb2bb9f30e22 .
+niiri:f4fabce2608abd82f4cb41cc5b313112 prov:wasDerivedFrom niiri:0d278ee0d105de3a7319a5acaa11c631 .
 
-niiri:8185514955cc636d4b50aa7fd9985960
+niiri:f47917da4ed2d8c7e7324d2c0d02a46d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0174" ;
-    prov:atLocation niiri:59906cc8f0c4f1ad9a16e5f64ecc97e9 ;
+    prov:atLocation niiri:4c0ec437ff4662e7d0eac4dcd51885cb ;
     prov:value "0.766485750675201"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66298512623431"^^xsd:float ;
     nidm_pValueUncorrected: "0.0481577064245639"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:59906cc8f0c4f1ad9a16e5f64ecc97e9
+niiri:4c0ec437ff4662e7d0eac4dcd51885cb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0174" ;
     nidm_coordinateVector: "[20,-72,-22]"^^xsd:string .
 
-niiri:8185514955cc636d4b50aa7fd9985960 prov:wasDerivedFrom niiri:9d494c09341573a6df3c044f6f353a5a .
+niiri:f47917da4ed2d8c7e7324d2c0d02a46d prov:wasDerivedFrom niiri:9a54b30308f71d0c474dab56acec5885 .
 
-niiri:f82c4e460ed68891672a882b6ca47ce7
+niiri:8e9351607907220ceb9c4d03fd181a94
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0175" ;
-    prov:atLocation niiri:6b08822f4f84a3704fb33481c32938e7 ;
+    prov:atLocation niiri:35e7e4f379992bd20464a3fd82e6925c ;
     prov:value "0.764753878116608"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66081412523685"^^xsd:float ;
     nidm_pValueUncorrected: "0.0483753916847881"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6b08822f4f84a3704fb33481c32938e7
+niiri:35e7e4f379992bd20464a3fd82e6925c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0175" ;
     nidm_coordinateVector: "[30,-32,14]"^^xsd:string .
 
-niiri:f82c4e460ed68891672a882b6ca47ce7 prov:wasDerivedFrom niiri:630ac6074dee24b42295002659ee6cd4 .
+niiri:8e9351607907220ceb9c4d03fd181a94 prov:wasDerivedFrom niiri:f219989ec875846cc4815fffc10bd118 .
 
-niiri:085070c6b1c81a70c7d9316dc333c5af
+niiri:33b88df2af789585f536f999c5e3786b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0176" ;
-    prov:atLocation niiri:f2d70aea1159517722dc1f0e96049f7f ;
+    prov:atLocation niiri:753a6ac393f5e043a90380ea38ab0569 ;
     prov:value "0.764399468898773"^^xsd:float ;
     nidm_equivalentZStatistic: "1.66036990560998"^^xsd:float ;
     nidm_pValueUncorrected: "0.0484200302267611"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:f2d70aea1159517722dc1f0e96049f7f
+niiri:753a6ac393f5e043a90380ea38ab0569
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0176" ;
     nidm_coordinateVector: "[-8,-2,66]"^^xsd:string .
 
-niiri:085070c6b1c81a70c7d9316dc333c5af prov:wasDerivedFrom niiri:97f9982dca21f34e7ea0fcb977fcf50b .
+niiri:33b88df2af789585f536f999c5e3786b prov:wasDerivedFrom niiri:4b37375a8d01d1d9009b430352062714 .
 
-niiri:35df629079347c6c083f74c21c155794
+niiri:bb74269075716d4be58818314e11eb5f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0177" ;
-    prov:atLocation niiri:6c5f4e78e250aba08a965b5ca9cce21d ;
+    prov:atLocation niiri:750f7b5e0fd142e4019c35e2387fbbba ;
     prov:value "0.763978481292725"^^xsd:float ;
     nidm_equivalentZStatistic: "1.65984225927592"^^xsd:float ;
     nidm_pValueUncorrected: "0.0484730949107541"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:6c5f4e78e250aba08a965b5ca9cce21d
+niiri:750f7b5e0fd142e4019c35e2387fbbba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0177" ;
     nidm_coordinateVector: "[-20,10,-22]"^^xsd:string .
 
-niiri:35df629079347c6c083f74c21c155794 prov:wasDerivedFrom niiri:b7588b8a823a7341bbdb4d3e8686e040 .
+niiri:bb74269075716d4be58818314e11eb5f prov:wasDerivedFrom niiri:0f0a4015dd42d89522302ce792b20d6d .
 
-niiri:81ebc55180aab5f90eb8e98ffc27a319
+niiri:3ad00aa4ff8a097302d4f9fa2f588f84
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0178" ;
-    prov:atLocation niiri:82ba696cda1e7d2d87bd5e1ac789e9b4 ;
+    prov:atLocation niiri:35bb5e6863e088834438d69e3f1e49f6 ;
     prov:value "0.763044834136963"^^xsd:float ;
     nidm_equivalentZStatistic: "1.65867215934383"^^xsd:float ;
     nidm_pValueUncorrected: "0.0485909362055301"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:82ba696cda1e7d2d87bd5e1ac789e9b4
+niiri:35bb5e6863e088834438d69e3f1e49f6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0178" ;
     nidm_coordinateVector: "[-62,2,14]"^^xsd:string .
 
-niiri:81ebc55180aab5f90eb8e98ffc27a319 prov:wasDerivedFrom niiri:31b704c584e2aae3b394c52754216fae .
+niiri:3ad00aa4ff8a097302d4f9fa2f588f84 prov:wasDerivedFrom niiri:80d4bc9228eef4ea8ae8e5eb951e1c4a .
 
-niiri:21c18d8c769fb0c198241386ba803d0e
+niiri:fad858bb75eed0c28b072161552a6ba5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0179" ;
-    prov:atLocation niiri:38c7639cf73f14cd5fd84daa5a16b606 ;
+    prov:atLocation niiri:5bb50d8540759ebdbe65ef922e6b9009 ;
     prov:value "0.762995421886444"^^xsd:float ;
     nidm_equivalentZStatistic: "1.65861023655314"^^xsd:float ;
     nidm_pValueUncorrected: "0.0485971788535396"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.928284605381944"^^xsd:float .
 
-niiri:38c7639cf73f14cd5fd84daa5a16b606
+niiri:5bb50d8540759ebdbe65ef922e6b9009
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0179" ;
     nidm_coordinateVector: "[-12,-28,80]"^^xsd:string .
 
-niiri:21c18d8c769fb0c198241386ba803d0e prov:wasDerivedFrom niiri:2eff95031f5301f6a29990e69708dce1 .
+niiri:fad858bb75eed0c28b072161552a6ba5 prov:wasDerivedFrom niiri:f6e36041fd68625d6c7813fe63387c51 .
 

--- a/spmexport/ex_spm_t_test/config.json
+++ b/spmexport/ex_spm_t_test/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["t_test/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_t_test/nidm.provn
+++ b/spmexport/ex_spm_t_test/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:1b00cc9eddb72e8298ae831abf8242a8,
+  entity(niiri:0912ef5e7651a34c983f4ed45de3d308,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:37ae388b351e24eff092878ed6c627e8,
+  agent(niiri:b18851d58fa1ff2313b6177c4f070859,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:9fd2af475544e59d923f455813a60f9e,
+  activity(niiri:f0b42854b0e7b708416cf70b7c8fedd1,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:9fd2af475544e59d923f455813a60f9e, niiri:37ae388b351e24eff092878ed6c627e8, -)
-  wasGeneratedBy(niiri:1b00cc9eddb72e8298ae831abf8242a8, niiri:9fd2af475544e59d923f455813a60f9e, 2016-01-11T10:12:11)
-  bundle niiri:1b00cc9eddb72e8298ae831abf8242a8
+  wasAssociatedWith(niiri:f0b42854b0e7b708416cf70b7c8fedd1, niiri:b18851d58fa1ff2313b6177c4f070859, -)
+  wasGeneratedBy(niiri:0912ef5e7651a34c983f4ed45de3d308, niiri:f0b42854b0e7b708416cf70b7c8fedd1, 2016-01-11T10:34:29)
+  bundle niiri:0912ef5e7651a34c983f4ed45de3d308
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -118,12 +118,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:a035080de4f5f70d7392a1a791404523,
+    agent(niiri:c51db428dc8ee9bf707d42093e3d3377,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd,
+    entity(niiri:6db7cc02a5d65d98ca2f4e6e802b59cd,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -132,120 +132,120 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:91c9c55e5f9fc572da5b4bf19a331220,
+    entity(niiri:a322de38d0ea077b76fbeb115a3d6f03,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "false" %% xsd:boolean])
-    entity(niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0,
+    entity(niiri:1e206e0f7ca8761333a5f8c2e84dda5b,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:175b9210819e919a439d88ac4bc2ab57',
+        dc:description = 'niiri:32e030b2b9eb8c5f3fc532b16c3a8fa0',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"mean\"]" %% xsd:string])
-    entity(niiri:175b9210819e919a439d88ac4bc2ab57,
+    entity(niiri:32e030b2b9eb8c5f3fc532b16c3a8fa0,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:84b8dfaa3fa67fbd8f4c852110a04531,
+    entity(niiri:22cef4703417a75639fda532c16cf80d,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'nidm_IndependentError:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean])
-    activity(niiri:b416890bf96d1dbb804f2efa4fda2d95,
+    activity(niiri:a230dbc0ad05bf076dbd69b21f01dd10,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_OLS:'])
-    wasAssociatedWith(niiri:b416890bf96d1dbb804f2efa4fda2d95, niiri:a035080de4f5f70d7392a1a791404523, -)
-    used(niiri:b416890bf96d1dbb804f2efa4fda2d95, niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0, -)
-    used(niiri:b416890bf96d1dbb804f2efa4fda2d95, niiri:91c9c55e5f9fc572da5b4bf19a331220, -)
-    used(niiri:b416890bf96d1dbb804f2efa4fda2d95, niiri:84b8dfaa3fa67fbd8f4c852110a04531, -)
-    entity(niiri:a99fcafea3bdd16053d3fbef6194f56c,
+    wasAssociatedWith(niiri:a230dbc0ad05bf076dbd69b21f01dd10, niiri:c51db428dc8ee9bf707d42093e3d3377, -)
+    used(niiri:a230dbc0ad05bf076dbd69b21f01dd10, niiri:1e206e0f7ca8761333a5f8c2e84dda5b, -)
+    used(niiri:a230dbc0ad05bf076dbd69b21f01dd10, niiri:a322de38d0ea077b76fbeb115a3d6f03, -)
+    used(niiri:a230dbc0ad05bf076dbd69b21f01dd10, niiri:22cef4703417a75639fda532c16cf80d, -)
+    entity(niiri:be07ca5d1a4babb35995fdf04899fb32,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
-    entity(niiri:6079f21d5530fd7507553a99cd6bfac7,
+    entity(niiri:7c74c0d0b2c4f48fa050e438562326f8,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e" %% xsd:string])
-    wasDerivedFrom(niiri:a99fcafea3bdd16053d3fbef6194f56c, niiri:6079f21d5530fd7507553a99cd6bfac7, -, -, -)
-    wasGeneratedBy(niiri:a99fcafea3bdd16053d3fbef6194f56c, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
-    entity(niiri:92fe3ceea82b9387c2e8a74870e1ff03,
+    wasDerivedFrom(niiri:be07ca5d1a4babb35995fdf04899fb32, niiri:7c74c0d0b2c4f48fa050e438562326f8, -, -, -)
+    wasGeneratedBy(niiri:be07ca5d1a4babb35995fdf04899fb32, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
+    entity(niiri:d7f6f2a0365232d977b7db0afaf9a5fb,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "0.0584948938339949" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         crypto:sha512 = "504d2b5e17e73690caae29eafdc0448a1d5ac6d66af811a3fcbab8eec9f904820f0610d985a6f04e8808fcd8f77def3c063bfb11df56679b0b28261cdc2856f9" %% xsd:string])
-    wasGeneratedBy(niiri:92fe3ceea82b9387c2e8a74870e1ff03, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
-    entity(niiri:a5219921c3bcca062f97bd37da42f0f6,
+    wasGeneratedBy(niiri:d7f6f2a0365232d977b7db0afaf9a5fb, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
+    entity(niiri:ef79850e03bdae0e1923acf92832ca93,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd'])
-    entity(niiri:758caf4a74ea7c64784615391d3d8bb9,
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd'])
+    entity(niiri:a887854143325483e34db878814c8082,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "9a22064d78683e5b5375b6d3708584d2bb24dd434f40b311f06e185e10c9492d976c35967cc2545e3d7aefa2b83f7e433c957bd8dc87c22392e334027d0b438b" %% xsd:string])
-    wasDerivedFrom(niiri:a5219921c3bcca062f97bd37da42f0f6, niiri:758caf4a74ea7c64784615391d3d8bb9, -, -, -)
-    wasGeneratedBy(niiri:a5219921c3bcca062f97bd37da42f0f6, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
-    entity(niiri:42d6ab087f72abda2ef3d164d74b2af0,
+    wasDerivedFrom(niiri:ef79850e03bdae0e1923acf92832ca93, niiri:a887854143325483e34db878814c8082, -, -, -)
+    wasGeneratedBy(niiri:ef79850e03bdae0e1923acf92832ca93, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
+    entity(niiri:4df94669c28a6f6a636b1bbaa6a0d0f7,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         crypto:sha512 = "5796b765989869d8ad685aee159b41c06538552c8a91ed6cfa9dc7a334df02e91dd83703fd5d9be4a7fc8a27943157d2cf29f457aa1cf4a3d01ce813480ddaaa" %% xsd:string])
-    entity(niiri:794d510acaf63dceb059cc9ba8dab5d2,
+    entity(niiri:db622461201dc3fe743fb5d1e2b95c19,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "bd6687fb4b5d5af30fa322a8b6b6df29ead2c1e0ebe8e1962c3716c2c05a23365fe0428be1d420ef8b013c4c342c0d5efe704fec31b6e956c2b4d15a630b1c98" %% xsd:string])
-    wasDerivedFrom(niiri:42d6ab087f72abda2ef3d164d74b2af0, niiri:794d510acaf63dceb059cc9ba8dab5d2, -, -, -)
-    wasGeneratedBy(niiri:42d6ab087f72abda2ef3d164d74b2af0, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
-    entity(niiri:3aa3da07651e9afc3c6c5a49b7b97170,
+    wasDerivedFrom(niiri:4df94669c28a6f6a636b1bbaa6a0d0f7, niiri:db622461201dc3fe743fb5d1e2b95c19, -, -, -)
+    wasGeneratedBy(niiri:4df94669c28a6f6a636b1bbaa6a0d0f7, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
+    entity(niiri:de9f181e681892d8a4cecf00f081b937,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         crypto:sha512 = "7090223b1a196dba349a102d5d369808fa90203f67c9021d2113b323996c67506be3e49d5e848a4f38a6ff78038478dee1401d2a7cd9ee5e6496f3d0313c6eb6" %% xsd:string])
-    entity(niiri:9b2bfe67b8475d87b43e4e93e350f76e,
+    entity(niiri:4bc17018182371ce2299d53dda370a88,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "95b2ccdef4496cd3830f817f9d8893924091b302a09c66b1581f7ee4721c618a1d95d56e509e8f1537af7ea437bc5f3fbf7f69037f13203b6c98733647911d8d" %% xsd:string])
-    wasDerivedFrom(niiri:3aa3da07651e9afc3c6c5a49b7b97170, niiri:9b2bfe67b8475d87b43e4e93e350f76e, -, -, -)
-    wasGeneratedBy(niiri:3aa3da07651e9afc3c6c5a49b7b97170, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
-    entity(niiri:04b578701cf4564a0a334f46af3d16fa,
+    wasDerivedFrom(niiri:de9f181e681892d8a4cecf00f081b937, niiri:4bc17018182371ce2299d53dda370a88, -, -, -)
+    wasGeneratedBy(niiri:de9f181e681892d8a4cecf00f081b937, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
+    entity(niiri:6bde2d077439c82e001fb48426475a91,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
         prov:label = "Contrast: Con1: mr vs plain" %% xsd:string,
         prov:value = "1" %% xsd:string])
-    activity(niiri:f8fa21d3adf52266399255440cb7dbde,
+    activity(niiri:130277e2f55ac12e05a80fbef35bd105,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:a035080de4f5f70d7392a1a791404523, -)
-    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:a99fcafea3bdd16053d3fbef6194f56c, -)
-    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:42d6ab087f72abda2ef3d164d74b2af0, -)
-    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0, -)
-    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:04b578701cf4564a0a334f46af3d16fa, -)
-    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:a5219921c3bcca062f97bd37da42f0f6, -)
-    entity(niiri:b925226ebcfaf81953c6c8d86b12edbe,
+    wasAssociatedWith(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:c51db428dc8ee9bf707d42093e3d3377, -)
+    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:be07ca5d1a4babb35995fdf04899fb32, -)
+    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:4df94669c28a6f6a636b1bbaa6a0d0f7, -)
+    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:1e206e0f7ca8761333a5f8c2e84dda5b, -)
+    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:6bde2d077439c82e001fb48426475a91, -)
+    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:ef79850e03bdae0e1923acf92832ca93, -)
+    entity(niiri:ad092c1420d338bff2feebb61bee6605,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -255,103 +255,103 @@ document
         nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "13" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         crypto:sha512 = "2eec11aca8e4898cb44b0e535e3abecde8d46ea6e5fe05bb26e2dee72769fcb985c90c0ed86b9dcaf260d502b34559700f7a3c0f944f020a4beb20042153d26f" %% xsd:string])
-    entity(niiri:c7968123d4a2445f2cc5efd45678f874,
+    entity(niiri:fe88d5b09130483c026b50e13977e412,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "291b6fbfe377046689fa404484c99e68b419966665af4294ca5348faf3ee9e3e4ea972ccb9c17fc697c42c58d915fda6300a540027b872eccd1403215cd2e075" %% xsd:string])
-    wasDerivedFrom(niiri:b925226ebcfaf81953c6c8d86b12edbe, niiri:c7968123d4a2445f2cc5efd45678f874, -, -, -)
-    wasGeneratedBy(niiri:b925226ebcfaf81953c6c8d86b12edbe, niiri:f8fa21d3adf52266399255440cb7dbde, -)
-    entity(niiri:0d474a910bcd3d0f50d6a1c63d2c2081,
+    wasDerivedFrom(niiri:ad092c1420d338bff2feebb61bee6605, niiri:fe88d5b09130483c026b50e13977e412, -, -, -)
+    wasGeneratedBy(niiri:ad092c1420d338bff2feebb61bee6605, niiri:130277e2f55ac12e05a80fbef35bd105, -)
+    entity(niiri:b3dc79d8ad2eb32d47956780781c51d6,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: Con1: mr vs plain" %% xsd:string,
         nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         crypto:sha512 = "d907fef7984f59a008b8963e5fb6d2386968ffcde54e31fabe7ed8b0e1a32e4410475271e4fa903e1aa6c01ef4903209fb61660bd47a5709a5c5c91bccc8b426" %% xsd:string])
-    entity(niiri:0f1eef5a71e2e8c320c07d47aaf5faa2,
+    entity(niiri:6941db4ab0e9730a24b012b3310d0f8a,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "66e00621b81bef508ca685a72a398d532276891ec8b2abc489af8f6105099ca9a54f52697ea83360eed53387ba6bec3ae1fc7f882ca4f3c8f944ee9a15f099ba" %% xsd:string])
-    wasDerivedFrom(niiri:0d474a910bcd3d0f50d6a1c63d2c2081, niiri:0f1eef5a71e2e8c320c07d47aaf5faa2, -, -, -)
-    wasGeneratedBy(niiri:0d474a910bcd3d0f50d6a1c63d2c2081, niiri:f8fa21d3adf52266399255440cb7dbde, -)
-    entity(niiri:9ad91a55a933509c23c194d606e537a6,
+    wasDerivedFrom(niiri:b3dc79d8ad2eb32d47956780781c51d6, niiri:6941db4ab0e9730a24b012b3310d0f8a, -, -, -)
+    wasGeneratedBy(niiri:b3dc79d8ad2eb32d47956780781c51d6, niiri:130277e2f55ac12e05a80fbef35bd105, -)
+    entity(niiri:1ef03434814308215299edd166a251be,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         crypto:sha512 = "4fed4edb0da80cd11916dccc511db465d9a42101a08318ca494f751102dfed9e4ccf557dbb4eaef9d792f662864bfe3a77670a1c78dbbf144974e8866d9640f0" %% xsd:string])
-    wasGeneratedBy(niiri:9ad91a55a933509c23c194d606e537a6, niiri:f8fa21d3adf52266399255440cb7dbde, -)
-    entity(niiri:2b631fcf63e9820fbd2e40503305547d,
+    wasGeneratedBy(niiri:1ef03434814308215299edd166a251be, niiri:130277e2f55ac12e05a80fbef35bd105, -)
+    entity(niiri:aa34765c622ec88209dbca1ddf40b225,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500181305457" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:850496eee671baa44ef30a3c14bbc01f',
-        nidm_equivalentThreshold: = 'niiri:39e5898c4b517eee39c871cfc90544ea'])
-    entity(niiri:850496eee671baa44ef30a3c14bbc01f,
+        nidm_equivalentThreshold: = 'niiri:66fda984913d6a14877915720b65e6ca',
+        nidm_equivalentThreshold: = 'niiri:802a4095edf055d7da2eb939ea257d85'])
+    entity(niiri:66fda984913d6a14877915720b65e6ca,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.85198238341593" %% xsd:float])
-    entity(niiri:39e5898c4b517eee39c871cfc90544ea,
+    entity(niiri:802a4095edf055d7da2eb939ea257d85,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999999997" %% xsd:float])
-    entity(niiri:5f8ed8ba67e188085e5ae8dd56f0fd87,
+    entity(niiri:2735f4f85b2c1346a8849aa3723fed30,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:737e308a8a329df56e3800195e6a5520',
-        nidm_equivalentThreshold: = 'niiri:f3fad5b99b15cd5fa5fcf64d81b5c413'])
-    entity(niiri:737e308a8a329df56e3800195e6a5520,
+        nidm_equivalentThreshold: = 'niiri:511e0e85d0615cf4311996169a6e8221',
+        nidm_equivalentThreshold: = 'niiri:5a25669dc1de6e55ec1edcdeb918c132'])
+    entity(niiri:511e0e85d0615cf4311996169a6e8221,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:f3fad5b99b15cd5fa5fcf64d81b5c413,
+    entity(niiri:5a25669dc1de6e55ec1edcdeb918c132,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:7a9d521a4e66bf249cf7ba064524933f,
+    entity(niiri:1ba31b971ce92f322556ea50dd1da5aa,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:3f2044246932375109f3634cdd1b9da7,
+    entity(niiri:59d671f65af3f2e501782f35d0cb64e3,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b,
+    activity(niiri:292b1e1f2538029aed5f141c52538889,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:a035080de4f5f70d7392a1a791404523, -)
-    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:2b631fcf63e9820fbd2e40503305547d, -)
-    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:5f8ed8ba67e188085e5ae8dd56f0fd87, -)
-    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:b925226ebcfaf81953c6c8d86b12edbe, -)
-    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:3aa3da07651e9afc3c6c5a49b7b97170, -)
-    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:a99fcafea3bdd16053d3fbef6194f56c, -)
-    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:7a9d521a4e66bf249cf7ba064524933f, -)
-    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:3f2044246932375109f3634cdd1b9da7, -)
-    entity(niiri:b8b1c6bd8a121e50549c32ca3ea169ca,
+    wasAssociatedWith(niiri:292b1e1f2538029aed5f141c52538889, niiri:c51db428dc8ee9bf707d42093e3d3377, -)
+    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:aa34765c622ec88209dbca1ddf40b225, -)
+    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:2735f4f85b2c1346a8849aa3723fed30, -)
+    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:ad092c1420d338bff2feebb61bee6605, -)
+    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:de9f181e681892d8a4cecf00f081b937, -)
+    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:be07ca5d1a4babb35995fdf04899fb32, -)
+    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:1ba31b971ce92f322556ea50dd1da5aa, -)
+    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:59d671f65af3f2e501782f35d0cb64e3, -)
+    entity(niiri:e45c455fef5d8cb108c1651352a3a733,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         nidm_searchVolumeInVoxels: = "167222" %% xsd:int,
         nidm_searchVolumeInUnits: = "1337776" %% xsd:float,
         nidm_reselSizeInVoxels: = "83.1545653831017" %% xsd:float,
@@ -367,8 +367,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "70" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "59" %% xsd:int,
         crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
-    wasGeneratedBy(niiri:b8b1c6bd8a121e50549c32ca3ea169ca, niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, -)
-    entity(niiri:04e3f1275db373d13cac82285a23f702,
+    wasGeneratedBy(niiri:e45c455fef5d8cb108c1651352a3a733, niiri:292b1e1f2538029aed5f141c52538889, -)
+    entity(niiri:b92de8901b2a05ad20e537b7d45bcded,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -376,22 +376,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "57" %% xsd:int,
         nidm_pValue: = "0.000126072725041393" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:3651b3bac0c9746240cd1f49bb29caf5',
-        nidm_hasMaximumIntensityProjection: = 'niiri:8c55faf85816666e5ce4f7e8047a35de',
-        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_hasClusterLabelsMap: = 'niiri:d0125669d7f73a1dd58eac955bc608c1',
+        nidm_hasMaximumIntensityProjection: = 'niiri:33e32bf5515a00f9b1224cdca9d36d84',
+        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
         crypto:sha512 = "9bef1b01e85eeddf2e747ceba7ade799597c7837064cb2f65dd700a59f52a84d33bd06d9b28b57b0669461e4ff28c39b9df7e09752b27d653bc515d887e4927e" %% xsd:string])
-    entity(niiri:3651b3bac0c9746240cd1f49bb29caf5,
+    entity(niiri:d0125669d7f73a1dd58eac955bc608c1,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:8c55faf85816666e5ce4f7e8047a35de,
+    entity(niiri:33e32bf5515a00f9b1224cdca9d36d84,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:04e3f1275db373d13cac82285a23f702, niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, -)
-    entity(niiri:1cf06d93f4aed03ee50d587421161410,
+    wasGeneratedBy(niiri:b92de8901b2a05ad20e537b7d45bcded, niiri:292b1e1f2538029aed5f141c52538889, -)
+    entity(niiri:46ce368f726925043d0fdf11d3ce812c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3171" %% xsd:int,
@@ -400,8 +400,8 @@ document
         nidm_pValueFWER: = "0" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:1cf06d93f4aed03ee50d587421161410, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:1a7642317b9c235ad3c8606f26710b96,
+    wasDerivedFrom(niiri:46ce368f726925043d0fdf11d3ce812c, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:a121a3d6c11f9c710a28e61253277933,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1543" %% xsd:int,
@@ -410,8 +410,8 @@ document
         nidm_pValueFWER: = "0" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:1a7642317b9c235ad3c8606f26710b96, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8,
+    wasDerivedFrom(niiri:a121a3d6c11f9c710a28e61253277933, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:46ae5678b67f432a5739e26d30b8b9fc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1032" %% xsd:int,
@@ -420,8 +420,8 @@ document
         nidm_pValueFWER: = "1.11022302462516e-16" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:57b5c372ef2a2b5e726b538a4a5d80db,
+    wasDerivedFrom(niiri:46ae5678b67f432a5739e26d30b8b9fc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:ac8f8138199a2f60489cb1fe2bc4c070,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "70" %% xsd:int,
@@ -430,8 +430,8 @@ document
         nidm_pValueFWER: = "0.0414106244319472" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:57b5c372ef2a2b5e726b538a4a5d80db, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:2260abfbc92b3918f8c4e115273811bc,
+    wasDerivedFrom(niiri:ac8f8138199a2f60489cb1fe2bc4c070, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:3dfc00b52233c69b59012bb4e4590bd6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "250" %% xsd:int,
@@ -440,8 +440,8 @@ document
         nidm_pValueFWER: = "5.6737414573238e-06" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:2260abfbc92b3918f8c4e115273811bc, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:428e3b496b74c693be37a9557e535f44,
+    wasDerivedFrom(niiri:3dfc00b52233c69b59012bb4e4590bd6, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:e17a558d17c93c4d23cebfdb241952ae,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "96" %% xsd:int,
@@ -450,8 +450,8 @@ document
         nidm_pValueFWER: = "0.00881525009559059" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:428e3b496b74c693be37a9557e535f44, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:f2233fa4afd02fcceeb05d8f7c4801ff,
+    wasDerivedFrom(niiri:e17a558d17c93c4d23cebfdb241952ae, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:2ee06584880d716387a7002834742906,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -460,8 +460,8 @@ document
         nidm_pValueFWER: = "0.936564091808241" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:f2233fa4afd02fcceeb05d8f7c4801ff, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:b1ef2839e620d66c14bd83deb3aec390,
+    wasDerivedFrom(niiri:2ee06584880d716387a7002834742906, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:0a170fb537c25a43d335a98102d35aeb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "320" %% xsd:int,
@@ -470,8 +470,8 @@ document
         nidm_pValueFWER: = "3.48987900022912e-07" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:b1ef2839e620d66c14bd83deb3aec390, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:6a1143e807a7221c10cbd94b8f352cb3,
+    wasDerivedFrom(niiri:0a170fb537c25a43d335a98102d35aeb, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:0b191a1bce28484b4d509f123468cafc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "64" %% xsd:int,
@@ -480,8 +480,8 @@ document
         nidm_pValueFWER: = "0.0603727115804786" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:6a1143e807a7221c10cbd94b8f352cb3, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:17a361a6af9be1a09623d4875d9de272,
+    wasDerivedFrom(niiri:0b191a1bce28484b4d509f123468cafc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:03c0220efd2c203f65a22694082f5442,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "161" %% xsd:int,
@@ -490,8 +490,8 @@ document
         nidm_pValueFWER: = "0.000298588701553082" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:17a361a6af9be1a09623d4875d9de272, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:646a3e8aac6f4eee8e8562e0616d65ba,
+    wasDerivedFrom(niiri:03c0220efd2c203f65a22694082f5442, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:847c108abc6d60c3422f305d80cbe544,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "31" %% xsd:int,
@@ -500,8 +500,8 @@ document
         nidm_pValueFWER: = "0.499582648292263" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:646a3e8aac6f4eee8e8562e0616d65ba, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:8e53fdbcd507f29fa491c0ee30766820,
+    wasDerivedFrom(niiri:847c108abc6d60c3422f305d80cbe544, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:89f5194a4b0e2d5f67db04f10c0882ac,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "71" %% xsd:int,
@@ -510,8 +510,8 @@ document
         nidm_pValueFWER: = "0.0389172719454809" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:8e53fdbcd507f29fa491c0ee30766820, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:caa24947392807e9fd656eb7e677bb90,
+    wasDerivedFrom(niiri:89f5194a4b0e2d5f67db04f10c0882ac, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:d97dd5148291142c057785550af3eb2d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -520,8 +520,8 @@ document
         nidm_pValueFWER: = "0.999031882554387" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:caa24947392807e9fd656eb7e677bb90, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:aa6f6ac422b272159fb670d4c6c75fe8,
+    wasDerivedFrom(niiri:d97dd5148291142c057785550af3eb2d, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:50d0f0b594a3407fd672472426d8a80a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -530,8 +530,8 @@ document
         nidm_pValueFWER: = "0.985901993992134" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:aa6f6ac422b272159fb670d4c6c75fe8, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:62026e05a2a2355fc124787b15505315,
+    wasDerivedFrom(niiri:50d0f0b594a3407fd672472426d8a80a, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:5663af6390cbe1661580022d9cd1db76,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -540,8 +540,8 @@ document
         nidm_pValueFWER: = "0.999031882554387" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:62026e05a2a2355fc124787b15505315, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:93450961f0d8d0f6a3b90a5894e1f87b,
+    wasDerivedFrom(niiri:5663af6390cbe1661580022d9cd1db76, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:936e9ee0499c3d068e7444f367b65d20,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -550,8 +550,8 @@ document
         nidm_pValueFWER: = "0.719628852078667" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:93450961f0d8d0f6a3b90a5894e1f87b, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:9b5ca13a3d263c59792e6e86be4a2e34,
+    wasDerivedFrom(niiri:936e9ee0499c3d068e7444f367b65d20, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:37eed9b79d7a2993d16feb7189856a02,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -560,8 +560,8 @@ document
         nidm_pValueFWER: = "0.997766550775957" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:9b5ca13a3d263c59792e6e86be4a2e34, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:bb0785359fefadd70b1adaaaac3b7884,
+    wasDerivedFrom(niiri:37eed9b79d7a2993d16feb7189856a02, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:9d921e2cb3a8abbe97013ee4bc904c3e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -570,8 +570,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:bb0785359fefadd70b1adaaaac3b7884, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:000e7e06128006bf16d2f8dd28c288f0,
+    wasDerivedFrom(niiri:9d921e2cb3a8abbe97013ee4bc904c3e, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:ba889b1413156c8c9b392f582f507018,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "15" %% xsd:int,
@@ -580,8 +580,8 @@ document
         nidm_pValueFWER: = "0.953259370207355" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:000e7e06128006bf16d2f8dd28c288f0, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:fea4f2ec59548d5d8b403064bc42fcd3,
+    wasDerivedFrom(niiri:ba889b1413156c8c9b392f582f507018, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:51665d1fb0cfb8bda978b620ef449077,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "22" %% xsd:int,
@@ -590,8 +590,8 @@ document
         nidm_pValueFWER: = "0.78320832600297" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:fea4f2ec59548d5d8b403064bc42fcd3, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:56aff3268c9efc59ac3dd1fccbb1e940,
+    wasDerivedFrom(niiri:51665d1fb0cfb8bda978b620ef449077, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:a24fb25342ea5df100b3c9f26c07ccf7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -600,8 +600,8 @@ document
         nidm_pValueFWER: = "0.995456797062611" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:56aff3268c9efc59ac3dd1fccbb1e940, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:30c41fd03e0e9666df9d194fbe412b52,
+    wasDerivedFrom(niiri:a24fb25342ea5df100b3c9f26c07ccf7, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:6b3e2550575959313eec60bd44a6b445,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -610,8 +610,8 @@ document
         nidm_pValueFWER: = "0.936564091808241" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:30c41fd03e0e9666df9d194fbe412b52, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:195a3dcb7bf220b60a464a21245d4ee4,
+    wasDerivedFrom(niiri:6b3e2550575959313eec60bd44a6b445, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:92cf9681c5af88815bed46d4f69484fe,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "59" %% xsd:int,
@@ -620,8 +620,8 @@ document
         nidm_pValueFWER: = "0.0831119677765624" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:195a3dcb7bf220b60a464a21245d4ee4, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:d09f25e397a79ba3820081611e196ed7,
+    wasDerivedFrom(niiri:92cf9681c5af88815bed46d4f69484fe, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:c8b8db45e94c74708104298c433fecd6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -630,8 +630,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:d09f25e397a79ba3820081611e196ed7, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:2d07cb807cba69cb83d125ad8a6d9589,
+    wasDerivedFrom(niiri:c8b8db45e94c74708104298c433fecd6, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:e9cca2166adb51f5ec340f78e542f76f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -640,8 +640,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:2d07cb807cba69cb83d125ad8a6d9589, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:2d69939d531eb0168273379f7ce52907,
+    wasDerivedFrom(niiri:e9cca2166adb51f5ec340f78e542f76f, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:4ce2f04f5e11fd9609173ed79e458866,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -650,8 +650,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:2d69939d531eb0168273379f7ce52907, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:1c2323d93891a0ddf5ac87752d859519,
+    wasDerivedFrom(niiri:4ce2f04f5e11fd9609173ed79e458866, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -660,8 +660,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:1c2323d93891a0ddf5ac87752d859519, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:dc7f564798bbb1fc05334954d8385ba1,
+    wasDerivedFrom(niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:18aa725ff182239ce52a92cec8c831fe,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -670,8 +670,8 @@ document
         nidm_pValueFWER: = "0.991654577641533" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:dc7f564798bbb1fc05334954d8385ba1, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:62a9cd07b50b07a1142d53889b87fd97,
+    wasDerivedFrom(niiri:18aa725ff182239ce52a92cec8c831fe, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:7cf7dba6eb11ba3d163885cbe5c660cd,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -680,8 +680,8 @@ document
         nidm_pValueFWER: = "0.977783945749582" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:62a9cd07b50b07a1142d53889b87fd97, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:12880301a0a653ca67efd232a37a486b,
+    wasDerivedFrom(niiri:7cf7dba6eb11ba3d163885cbe5c660cd, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:f2aa94f4ac2fd9ce977533852312353d,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -690,8 +690,8 @@ document
         nidm_pValueFWER: = "0.99999593370769" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:12880301a0a653ca67efd232a37a486b, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:7b940b3f554bfd8086ef06ec3a4c5e36,
+    wasDerivedFrom(niiri:f2aa94f4ac2fd9ce977533852312353d, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:b9d2c5e57e73184c133167c21e549e31,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -700,8 +700,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "31" %% xsd:int])
-    wasDerivedFrom(niiri:7b940b3f554bfd8086ef06ec3a4c5e36, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:4364ea14ae541a4b5530d0fc11478f4d,
+    wasDerivedFrom(niiri:b9d2c5e57e73184c133167c21e549e31, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:0fff44688bc869513d097e59a8311b54,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -710,8 +710,8 @@ document
         nidm_pValueFWER: = "0.999891594677731" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "32" %% xsd:int])
-    wasDerivedFrom(niiri:4364ea14ae541a4b5530d0fc11478f4d, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:cad9672114cca77d75274be4de17ab9c,
+    wasDerivedFrom(niiri:0fff44688bc869513d097e59a8311b54, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:6b373e69fdc37c9c1e68cb0b96d5160c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -720,8 +720,8 @@ document
         nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "33" %% xsd:int])
-    wasDerivedFrom(niiri:cad9672114cca77d75274be4de17ab9c, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:9373fb96b8dcda6b9ae13dbf76afcaa6,
+    wasDerivedFrom(niiri:6b373e69fdc37c9c1e68cb0b96d5160c, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:739e3f4c274d5eac94fb06c09bd419a0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -730,8 +730,8 @@ document
         nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "34" %% xsd:int])
-    wasDerivedFrom(niiri:9373fb96b8dcda6b9ae13dbf76afcaa6, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:7737094062d61c5fc0d500987f11bda9,
+    wasDerivedFrom(niiri:739e3f4c274d5eac94fb06c09bd419a0, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:bf0f6f227a5f1dede37450defacf4ee4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -740,8 +740,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "35" %% xsd:int])
-    wasDerivedFrom(niiri:7737094062d61c5fc0d500987f11bda9, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:454d2ddee840a6eed8f9885efabde318,
+    wasDerivedFrom(niiri:bf0f6f227a5f1dede37450defacf4ee4, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:27828afab99d35c7e234991a120cb219,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -750,8 +750,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "36" %% xsd:int])
-    wasDerivedFrom(niiri:454d2ddee840a6eed8f9885efabde318, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:b2f3ddd032f5ca78054f0eca8d0c8769,
+    wasDerivedFrom(niiri:27828afab99d35c7e234991a120cb219, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:61fab5ab040124b4935fd160bc4c75c2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -760,8 +760,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "37" %% xsd:int])
-    wasDerivedFrom(niiri:b2f3ddd032f5ca78054f0eca8d0c8769, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:cf4b88bff59c1a33cd867e9422f84011,
+    wasDerivedFrom(niiri:61fab5ab040124b4935fd160bc4c75c2, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:3e195e76e0011bcbca16974bc51df875,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -770,8 +770,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "38" %% xsd:int])
-    wasDerivedFrom(niiri:cf4b88bff59c1a33cd867e9422f84011, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:3283422abdc309a208995369231fe32a,
+    wasDerivedFrom(niiri:3e195e76e0011bcbca16974bc51df875, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:efb3b3e5edd63741aa95f90f1a73c855,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -780,8 +780,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "39" %% xsd:int])
-    wasDerivedFrom(niiri:3283422abdc309a208995369231fe32a, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:c9c180c62d3cd262bcb7bb862a2e2d3e,
+    wasDerivedFrom(niiri:efb3b3e5edd63741aa95f90f1a73c855, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:e3b33814b86cd485564e0a0928f90e0f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -790,8 +790,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "40" %% xsd:int])
-    wasDerivedFrom(niiri:c9c180c62d3cd262bcb7bb862a2e2d3e, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:f67691de01cdab9987a52d4efd6796df,
+    wasDerivedFrom(niiri:e3b33814b86cd485564e0a0928f90e0f, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:cfdf88b2a941aeba3fcc1f4b45b10448,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -800,8 +800,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "41" %% xsd:int])
-    wasDerivedFrom(niiri:f67691de01cdab9987a52d4efd6796df, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:ef91e7140c5dbe4c9303f8f1e0cd8673,
+    wasDerivedFrom(niiri:cfdf88b2a941aeba3fcc1f4b45b10448, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:8053ffdd2903523517c32abc5eed6805,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -810,8 +810,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "42" %% xsd:int])
-    wasDerivedFrom(niiri:ef91e7140c5dbe4c9303f8f1e0cd8673, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:dcd5d7321bb4d36d468ecf53edb77243,
+    wasDerivedFrom(niiri:8053ffdd2903523517c32abc5eed6805, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:be2669b1217c5497ae7583e9f37e889f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -820,8 +820,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "43" %% xsd:int])
-    wasDerivedFrom(niiri:dcd5d7321bb4d36d468ecf53edb77243, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:049381a7f67019f13a2b75b205f87af1,
+    wasDerivedFrom(niiri:be2669b1217c5497ae7583e9f37e889f, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:345d8154c25e6bc91b83c7a570393c32,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -830,8 +830,8 @@ document
         nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "44" %% xsd:int])
-    wasDerivedFrom(niiri:049381a7f67019f13a2b75b205f87af1, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:6231cdc1c30543959e82f342e7f7c028,
+    wasDerivedFrom(niiri:345d8154c25e6bc91b83c7a570393c32, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:0feb21dbaab7759d1a095b10570dbcbb,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -840,8 +840,8 @@ document
         nidm_pValueFWER: = "0.99999593370769" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "45" %% xsd:int])
-    wasDerivedFrom(niiri:6231cdc1c30543959e82f342e7f7c028, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:d078d2a64b3eee365a7318a424f3d55f,
+    wasDerivedFrom(niiri:0feb21dbaab7759d1a095b10570dbcbb, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:4867e698cc576f0b80c177fdf37912bc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -850,8 +850,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "46" %% xsd:int])
-    wasDerivedFrom(niiri:d078d2a64b3eee365a7318a424f3d55f, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:b07d53658c12f0d165aec1cf959f1eb5,
+    wasDerivedFrom(niiri:4867e698cc576f0b80c177fdf37912bc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:dbd7ff1039cc058a9180d3a6b19c0d65,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -860,8 +860,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "47" %% xsd:int])
-    wasDerivedFrom(niiri:b07d53658c12f0d165aec1cf959f1eb5, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:5e501329a485d9e81bca69bd136264fb,
+    wasDerivedFrom(niiri:dbd7ff1039cc058a9180d3a6b19c0d65, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:9a04edbbfec2046f6e63a9808f7e31be,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -870,8 +870,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "48" %% xsd:int])
-    wasDerivedFrom(niiri:5e501329a485d9e81bca69bd136264fb, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097,
+    wasDerivedFrom(niiri:9a04edbbfec2046f6e63a9808f7e31be, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:4802981400c706074d7089aa4f606c7a,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -880,8 +880,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "49" %% xsd:int])
-    wasDerivedFrom(niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:f19fc244e1ad9fb88396e6dc5d62c29b,
+    wasDerivedFrom(niiri:4802981400c706074d7089aa4f606c7a, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:0c9c1006b093a8cc91c759baf58575ee,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -890,8 +890,8 @@ document
         nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "50" %% xsd:int])
-    wasDerivedFrom(niiri:f19fc244e1ad9fb88396e6dc5d62c29b, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:8a6f880f7b8eaf62148b54fef7844b09,
+    wasDerivedFrom(niiri:0c9c1006b093a8cc91c759baf58575ee, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:9e9eebffba744c379bca54d713a85d3b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -900,8 +900,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "51" %% xsd:int])
-    wasDerivedFrom(niiri:8a6f880f7b8eaf62148b54fef7844b09, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:de48b7494a3d45a8a57e155aeea2f132,
+    wasDerivedFrom(niiri:9e9eebffba744c379bca54d713a85d3b, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:2ef2320c7a264cf13420c161d25ff5cc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -910,8 +910,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "52" %% xsd:int])
-    wasDerivedFrom(niiri:de48b7494a3d45a8a57e155aeea2f132, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:c60f3aab1eee7d78c6850a16c38162dc,
+    wasDerivedFrom(niiri:2ef2320c7a264cf13420c161d25ff5cc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:53b5e166978251c052e00c9a4fe81fdc,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -920,8 +920,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "53" %% xsd:int])
-    wasDerivedFrom(niiri:c60f3aab1eee7d78c6850a16c38162dc, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:859e657235309e3db15ccb1f14c1e7ba,
+    wasDerivedFrom(niiri:53b5e166978251c052e00c9a4fe81fdc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:de88c64838ddf5de0155dcdce61cf6c0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -930,8 +930,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "54" %% xsd:int])
-    wasDerivedFrom(niiri:859e657235309e3db15ccb1f14c1e7ba, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:065fb1288e613aa1089a803ba4b13d87,
+    wasDerivedFrom(niiri:de88c64838ddf5de0155dcdce61cf6c0, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:02344c7a7b0c9af7c25dbcd3cbd09300,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -940,8 +940,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "55" %% xsd:int])
-    wasDerivedFrom(niiri:065fb1288e613aa1089a803ba4b13d87, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:021e14b3f5e58d6dd1904bdbad37b113,
+    wasDerivedFrom(niiri:02344c7a7b0c9af7c25dbcd3cbd09300, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:22648332b0e4fb9a38556afd35646c42,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -950,8 +950,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "56" %% xsd:int])
-    wasDerivedFrom(niiri:021e14b3f5e58d6dd1904bdbad37b113, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:7fa11ca3554a75156c897f72b0a338ac,
+    wasDerivedFrom(niiri:22648332b0e4fb9a38556afd35646c42, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:3b46a57f86b33c173fe10a245389f4ff,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -960,1146 +960,1146 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "57" %% xsd:int])
-    wasDerivedFrom(niiri:7fa11ca3554a75156c897f72b0a338ac, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
-    entity(niiri:b3b769322ee6f2728df46b1d7e729a2c,
+    wasDerivedFrom(niiri:3b46a57f86b33c173fe10a245389f4ff, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
+    entity(niiri:bbac0b57ed4deddd70eb50803fb36999,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:2cc8cbc51d2e2dd1d34f08891cbe366d',
+        prov:location = 'niiri:253372e924e130c4a5343ebb6faf24b0',
         prov:value = "13.6061105728149" %% xsd:float,
         nidm_equivalentZStatistic: = "5.86214047392852" %% xsd:float,
         nidm_pValueUncorrected: = "2.28469099194939e-09" %% xsd:float,
         nidm_pValueFWER: = "0.000382050559925018" %% xsd:float,
         nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
-    entity(niiri:2cc8cbc51d2e2dd1d34f08891cbe366d,
+    entity(niiri:253372e924e130c4a5343ebb6faf24b0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[34,-86,0]" %% xsd:string])
-    wasDerivedFrom(niiri:b3b769322ee6f2728df46b1d7e729a2c, niiri:1cf06d93f4aed03ee50d587421161410, -, -, -)
-    entity(niiri:0962722c2fe8603177b631a54d2747fd,
+    wasDerivedFrom(niiri:bbac0b57ed4deddd70eb50803fb36999, niiri:46ce368f726925043d0fdf11d3ce812c, -, -, -)
+    entity(niiri:1c9824886d035515f910ce93f1becb24,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:12b4490a7a2a9265c0fb5c1cad432626',
+        prov:location = 'niiri:6560dc3c0cedd518d2e9c8d22200d849',
         prov:value = "11.9614944458008" %% xsd:float,
         nidm_equivalentZStatistic: = "5.59772141079875" %% xsd:float,
         nidm_pValueUncorrected: = "1.08593692926817e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00181592543329545" %% xsd:float,
         nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
-    entity(niiri:12b4490a7a2a9265c0fb5c1cad432626,
+    entity(niiri:6560dc3c0cedd518d2e9c8d22200d849,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[30,-78,36]" %% xsd:string])
-    wasDerivedFrom(niiri:0962722c2fe8603177b631a54d2747fd, niiri:1cf06d93f4aed03ee50d587421161410, -, -, -)
-    entity(niiri:56e9acaa44092839074f4fe2f1cbeb87,
+    wasDerivedFrom(niiri:1c9824886d035515f910ce93f1becb24, niiri:46ce368f726925043d0fdf11d3ce812c, -, -, -)
+    entity(niiri:64b80549819f8dfbe67bba4d26272007,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:95c264e1e21bd313ad9649cc29570602',
+        prov:location = 'niiri:bf5b57a2467e79a41847b729706bb7f7',
         prov:value = "10.5961866378784" %% xsd:float,
         nidm_equivalentZStatistic: = "5.34279531222125" %% xsd:float,
         nidm_pValueUncorrected: = "4.5762046707587e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00765242110449371" %% xsd:float,
         nidm_qValueFDR: = "0.000248881974141536" %% xsd:float])
-    entity(niiri:95c264e1e21bd313ad9649cc29570602,
+    entity(niiri:bf5b57a2467e79a41847b729706bb7f7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[34,-48,44]" %% xsd:string])
-    wasDerivedFrom(niiri:56e9acaa44092839074f4fe2f1cbeb87, niiri:1cf06d93f4aed03ee50d587421161410, -, -, -)
-    entity(niiri:5a1c78a3e12360263792a811b8b793e7,
+    wasDerivedFrom(niiri:64b80549819f8dfbe67bba4d26272007, niiri:46ce368f726925043d0fdf11d3ce812c, -, -, -)
+    entity(niiri:4d0e94437b61697668b47fdb1b75b33c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:fe2447910ca73bf4173a0bc09b5c82ef',
+        prov:location = 'niiri:53107adcc0ef1666a9861e881bf02340',
         prov:value = "11.9789819717407" %% xsd:float,
         nidm_equivalentZStatistic: = "5.6007582829493" %% xsd:float,
         nidm_pValueUncorrected: = "1.06708079039564e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00178439382075002" %% xsd:float,
         nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
-    entity(niiri:fe2447910ca73bf4173a0bc09b5c82ef,
+    entity(niiri:53107adcc0ef1666a9861e881bf02340,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[-46,-54,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:5a1c78a3e12360263792a811b8b793e7, niiri:1a7642317b9c235ad3c8606f26710b96, -, -, -)
-    entity(niiri:579e3d2553a1f65ce2b443a85f7f7e78,
+    wasDerivedFrom(niiri:4d0e94437b61697668b47fdb1b75b33c, niiri:a121a3d6c11f9c710a28e61253277933, -, -, -)
+    entity(niiri:c72107be6be92b5977ee1b066d2ed2df,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:38e45fd9e8f667e140bcb4cd465dff2a',
+        prov:location = 'niiri:340954c4fec53251517830b22ef6060f',
         prov:value = "11.3053674697876" %% xsd:float,
         nidm_equivalentZStatistic: = "5.47978759981232" %% xsd:float,
         nidm_pValueUncorrected: = "2.12918364050907e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00356046346733208" %% xsd:float,
         nidm_qValueFDR: = "0.000225699919390338" %% xsd:float])
-    entity(niiri:38e45fd9e8f667e140bcb4cd465dff2a,
+    entity(niiri:340954c4fec53251517830b22ef6060f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[-48,-64,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:579e3d2553a1f65ce2b443a85f7f7e78, niiri:1a7642317b9c235ad3c8606f26710b96, -, -, -)
-    entity(niiri:8fde575882a0e0c286f85ce29ad62c58,
+    wasDerivedFrom(niiri:c72107be6be92b5977ee1b066d2ed2df, niiri:a121a3d6c11f9c710a28e61253277933, -, -, -)
+    entity(niiri:544ba6228591b8c8ffd1e693b78fb571,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:ea247c88d42d40da9044ae0523463ac4',
+        prov:location = 'niiri:beb47d7b86e9956408d6e84a62a2df4a',
         prov:value = "9.59214210510254" %% xsd:float,
         nidm_equivalentZStatistic: = "5.12915279008791" %% xsd:float,
         nidm_pValueUncorrected: = "1.45524525096974e-07" %% xsd:float,
         nidm_pValueFWER: = "0.0243349038623457" %% xsd:float,
         nidm_qValueFDR: = "0.000374773184801466" %% xsd:float])
-    entity(niiri:ea247c88d42d40da9044ae0523463ac4,
+    entity(niiri:beb47d7b86e9956408d6e84a62a2df4a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[-46,-72,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:8fde575882a0e0c286f85ce29ad62c58, niiri:1a7642317b9c235ad3c8606f26710b96, -, -, -)
-    entity(niiri:5620f2a9a83f08e4e4e2e452ed521bfb,
+    wasDerivedFrom(niiri:544ba6228591b8c8ffd1e693b78fb571, niiri:a121a3d6c11f9c710a28e61253277933, -, -, -)
+    entity(niiri:45d7b72f120c5a905c74b6ef035179d1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:807ce33ed88a8e53dcb621151ae91a66',
+        prov:location = 'niiri:fb524a7a97d8dc293563afed5235a273',
         prov:value = "8.26132202148438" %% xsd:float,
         nidm_equivalentZStatistic: = "4.8021068311854" %% xsd:float,
         nidm_pValueUncorrected: = "7.85024427352177e-07" %% xsd:float,
         nidm_pValueFWER: = "0.131273406272461" %% xsd:float,
         nidm_qValueFDR: = "0.000714072820754613" %% xsd:float])
-    entity(niiri:807ce33ed88a8e53dcb621151ae91a66,
+    entity(niiri:fb524a7a97d8dc293563afed5235a273,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[-26,-76,32]" %% xsd:string])
-    wasDerivedFrom(niiri:5620f2a9a83f08e4e4e2e452ed521bfb, niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8, -, -, -)
-    entity(niiri:49d7d90f66e4da833c690cd5883a10e7,
+    wasDerivedFrom(niiri:45d7b72f120c5a905c74b6ef035179d1, niiri:46ae5678b67f432a5739e26d30b8b9fc, -, -, -)
+    entity(niiri:750f947db3f44470b84b8a0b7262e50c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:a9a21ab8f48ab130ada7bc6efcded96d',
+        prov:location = 'niiri:8bc38c5d28a6e5a22576873242e357d3',
         prov:value = "7.54039764404297" %% xsd:float,
         nidm_equivalentZStatistic: = "4.59887376341391" %% xsd:float,
         nidm_pValueUncorrected: = "2.12390533416151e-06" %% xsd:float,
         nidm_pValueFWER: = "0.355164074926112" %% xsd:float,
         nidm_qValueFDR: = "0.00112750499976544" %% xsd:float])
-    entity(niiri:a9a21ab8f48ab130ada7bc6efcded96d,
+    entity(niiri:8bc38c5d28a6e5a22576873242e357d3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[-38,-46,44]" %% xsd:string])
-    wasDerivedFrom(niiri:49d7d90f66e4da833c690cd5883a10e7, niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8, -, -, -)
-    entity(niiri:27fde605695ea87f488e331274bbffb0,
+    wasDerivedFrom(niiri:750f947db3f44470b84b8a0b7262e50c, niiri:46ae5678b67f432a5739e26d30b8b9fc, -, -, -)
+    entity(niiri:89ab361e0947ad2cd7741823700a026b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:1f9cb7e030174f7f9631db464ceecffe',
+        prov:location = 'niiri:1e831d7963c01a6b5512e380dfc42b04',
         prov:value = "7.09534215927124" %% xsd:float,
         nidm_equivalentZStatistic: = "4.46234965259847" %% xsd:float,
         nidm_pValueUncorrected: = "4.05329024755208e-06" %% xsd:float,
         nidm_pValueFWER: = "0.550389997209789" %% xsd:float,
         nidm_qValueFDR: = "0.00152026219003999" %% xsd:float])
-    entity(niiri:1f9cb7e030174f7f9631db464ceecffe,
+    entity(niiri:1e831d7963c01a6b5512e380dfc42b04,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[-24,-72,44]" %% xsd:string])
-    wasDerivedFrom(niiri:27fde605695ea87f488e331274bbffb0, niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8, -, -, -)
-    entity(niiri:9a3c595e0ddc14214f4c9c93eb68dd36,
+    wasDerivedFrom(niiri:89ab361e0947ad2cd7741823700a026b, niiri:46ae5678b67f432a5739e26d30b8b9fc, -, -, -)
+    entity(niiri:04a53addf635f1622be8ce7e4b4fd46f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:07d77ef1ba5bc8952fe942d5c9b7efd7',
+        prov:location = 'niiri:bfc78fed76fb0cda1dc19ea85be43504',
         prov:value = "7.53033494949341" %% xsd:float,
         nidm_equivalentZStatistic: = "4.59588573954922" %% xsd:float,
         nidm_pValueUncorrected: = "2.15457400010166e-06" %% xsd:float,
         nidm_pValueFWER: = "0.36029256155409" %% xsd:float,
         nidm_qValueFDR: = "0.00113656959480786" %% xsd:float])
-    entity(niiri:07d77ef1ba5bc8952fe942d5c9b7efd7,
+    entity(niiri:bfc78fed76fb0cda1dc19ea85be43504,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[-20,-10,48]" %% xsd:string])
-    wasDerivedFrom(niiri:9a3c595e0ddc14214f4c9c93eb68dd36, niiri:57b5c372ef2a2b5e726b538a4a5d80db, -, -, -)
-    entity(niiri:b0acf117bc223f33dfefb698485fdbbc,
+    wasDerivedFrom(niiri:04a53addf635f1622be8ce7e4b4fd46f, niiri:ac8f8138199a2f60489cb1fe2bc4c070, -, -, -)
+    entity(niiri:37fedcc605762daab25ba3d15823f4f6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:45e55c7dc0c0ad9a7b5a0041cc5079ac',
+        prov:location = 'niiri:97810d5af81d5e9362e02d4fd86a848e',
         prov:value = "4.24029636383057" %% xsd:float,
         nidm_equivalentZStatistic: = "3.30076820538094" %% xsd:float,
         nidm_pValueUncorrected: = "0.000482102531686568" %% xsd:float,
         nidm_pValueFWER: = "0.999999999415186" %% xsd:float,
         nidm_qValueFDR: = "0.015845468443456" %% xsd:float])
-    entity(niiri:45e55c7dc0c0ad9a7b5a0041cc5079ac,
+    entity(niiri:97810d5af81d5e9362e02d4fd86a848e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[-26,0,56]" %% xsd:string])
-    wasDerivedFrom(niiri:b0acf117bc223f33dfefb698485fdbbc, niiri:57b5c372ef2a2b5e726b538a4a5d80db, -, -, -)
-    entity(niiri:7f38de5b18de7d50cf6bbab3de7ed61d,
+    wasDerivedFrom(niiri:37fedcc605762daab25ba3d15823f4f6, niiri:ac8f8138199a2f60489cb1fe2bc4c070, -, -, -)
+    entity(niiri:4d986a80344be2abfcf5c339af16638a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:549cbc20d7a3347bd507c93a62cb962d',
+        prov:location = 'niiri:2a40d83993773c6f1e5ebc1385fd442d',
         prov:value = "7.17061138153076" %% xsd:float,
         nidm_equivalentZStatistic: = "4.48608583316407" %% xsd:float,
         nidm_pValueUncorrected: = "3.62717632940157e-06" %% xsd:float,
         nidm_pValueFWER: = "0.521824836713063" %% xsd:float,
         nidm_qValueFDR: = "0.00145106406730833" %% xsd:float])
-    entity(niiri:549cbc20d7a3347bd507c93a62cb962d,
+    entity(niiri:2a40d83993773c6f1e5ebc1385fd442d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[46,6,28]" %% xsd:string])
-    wasDerivedFrom(niiri:7f38de5b18de7d50cf6bbab3de7ed61d, niiri:2260abfbc92b3918f8c4e115273811bc, -, -, -)
-    entity(niiri:737d6891167edd5697898729334b6f23,
+    wasDerivedFrom(niiri:4d986a80344be2abfcf5c339af16638a, niiri:3dfc00b52233c69b59012bb4e4590bd6, -, -, -)
+    entity(niiri:0fc5cc3b06805b359990af6af9b7de2c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:d13e6a0e17e641c4dd7a920619e27556',
+        prov:location = 'niiri:c348bcf295bbfcc12359afcb0fe8f75b',
         prov:value = "5.89265918731689" %% xsd:float,
         nidm_equivalentZStatistic: = "4.04200617451887" %% xsd:float,
         nidm_pValueUncorrected: = "2.64979184040337e-05" %% xsd:float,
         nidm_pValueFWER: = "0.95205805171536" %% xsd:float,
         nidm_qValueFDR: = "0.00357309996201585" %% xsd:float])
-    entity(niiri:d13e6a0e17e641c4dd7a920619e27556,
+    entity(niiri:c348bcf295bbfcc12359afcb0fe8f75b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[52,12,26]" %% xsd:string])
-    wasDerivedFrom(niiri:737d6891167edd5697898729334b6f23, niiri:2260abfbc92b3918f8c4e115273811bc, -, -, -)
-    entity(niiri:7fb07c54f710b892820adb154f5437c2,
+    wasDerivedFrom(niiri:0fc5cc3b06805b359990af6af9b7de2c, niiri:3dfc00b52233c69b59012bb4e4590bd6, -, -, -)
+    entity(niiri:53295d63fe3c3e2da20993fcb585d43a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:b15b1251bcf12c164abd2f8d5036175d',
+        prov:location = 'niiri:7aa7d0132011ee94a14b377939be3510',
         prov:value = "5.21978235244751" %% xsd:float,
         nidm_equivalentZStatistic: = "3.76688098065344" %% xsd:float,
         nidm_pValueUncorrected: = "8.26498774630924e-05" %% xsd:float,
         nidm_pValueFWER: = "0.998715750644301" %% xsd:float,
         nidm_qValueFDR: = "0.00632560594393137" %% xsd:float])
-    entity(niiri:b15b1251bcf12c164abd2f8d5036175d,
+    entity(niiri:7aa7d0132011ee94a14b377939be3510,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[40,-2,30]" %% xsd:string])
-    wasDerivedFrom(niiri:7fb07c54f710b892820adb154f5437c2, niiri:2260abfbc92b3918f8c4e115273811bc, -, -, -)
-    entity(niiri:d196f3f4c50dd1d93b2bd4cae01fbd44,
+    wasDerivedFrom(niiri:53295d63fe3c3e2da20993fcb585d43a, niiri:3dfc00b52233c69b59012bb4e4590bd6, -, -, -)
+    entity(niiri:998b270ff5f29f350d50cfa5c76e8ad7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:d867aea23af72afb3d824134fd7bb62e',
+        prov:location = 'niiri:87d8215adb89a7807d1b78b73a28d6f1',
         prov:value = "6.82257699966431" %% xsd:float,
         nidm_equivalentZStatistic: = "4.3739930910033" %% xsd:float,
         nidm_pValueUncorrected: = "6.09971206799731e-06" %% xsd:float,
         nidm_pValueFWER: = "0.657888162568606" %% xsd:float,
         nidm_qValueFDR: = "0.00180198082091417" %% xsd:float])
-    entity(niiri:d867aea23af72afb3d824134fd7bb62e,
+    entity(niiri:87d8215adb89a7807d1b78b73a28d6f1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[-10,24,12]" %% xsd:string])
-    wasDerivedFrom(niiri:d196f3f4c50dd1d93b2bd4cae01fbd44, niiri:428e3b496b74c693be37a9557e535f44, -, -, -)
-    entity(niiri:a87c684980a741cdd7c3d90c8cbe99df,
+    wasDerivedFrom(niiri:998b270ff5f29f350d50cfa5c76e8ad7, niiri:e17a558d17c93c4d23cebfdb241952ae, -, -, -)
+    entity(niiri:a209c7cd2db8d53b5b130f27b9322d0f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:497bf13cc6e31e241c2961c960131d00',
+        prov:location = 'niiri:21b4eea73e16e09c4881b4a5dc18afc5',
         prov:value = "4.99530935287476" %% xsd:float,
         nidm_equivalentZStatistic: = "3.66747111912266" %% xsd:float,
         nidm_pValueUncorrected: = "0.000122480604349273" %% xsd:float,
         nidm_pValueFWER: = "0.999830619862512" %% xsd:float,
         nidm_qValueFDR: = "0.00775152511109977" %% xsd:float])
-    entity(niiri:497bf13cc6e31e241c2961c960131d00,
+    entity(niiri:21b4eea73e16e09c4881b4a5dc18afc5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[-24,28,4]" %% xsd:string])
-    wasDerivedFrom(niiri:a87c684980a741cdd7c3d90c8cbe99df, niiri:428e3b496b74c693be37a9557e535f44, -, -, -)
-    entity(niiri:f3bc13cbd3d6523a4cd20f41c8e6a115,
+    wasDerivedFrom(niiri:a209c7cd2db8d53b5b130f27b9322d0f, niiri:e17a558d17c93c4d23cebfdb241952ae, -, -, -)
+    entity(niiri:693ea803be290552513560b1a7fef0bf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:3f00e702d729fe98e37d25e45791f4e9',
+        prov:location = 'niiri:aea6c3f2722e9910b54ddf00cebc5cee',
         prov:value = "6.34009504318237" %% xsd:float,
         nidm_equivalentZStatistic: = "4.20806884695295" %% xsd:float,
         nidm_pValueUncorrected: = "1.28781200698924e-05" %% xsd:float,
         nidm_pValueFWER: = "0.839224226046397" %% xsd:float,
         nidm_qValueFDR: = "0.00253613065643777" %% xsd:float])
-    entity(niiri:3f00e702d729fe98e37d25e45791f4e9,
+    entity(niiri:aea6c3f2722e9910b54ddf00cebc5cee,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[10,-74,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:f3bc13cbd3d6523a4cd20f41c8e6a115, niiri:f2233fa4afd02fcceeb05d8f7c4801ff, -, -, -)
-    entity(niiri:65f048f0e7c5732f5773ecc174b71f67,
+    wasDerivedFrom(niiri:693ea803be290552513560b1a7fef0bf, niiri:2ee06584880d716387a7002834742906, -, -, -)
+    entity(niiri:f536b5609348be9036fb10330e373e3f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:ca3f9e37a3e82369bdea4d8f85916a5d',
+        prov:location = 'niiri:f90062339ac75c1a5a7bd5460360006e',
         prov:value = "5.96963739395142" %% xsd:float,
         nidm_equivalentZStatistic: = "4.07147450951934" %% xsd:float,
         nidm_pValueUncorrected: = "2.3358237619564e-05" %% xsd:float,
         nidm_pValueFWER: = "0.938028702807278" %% xsd:float,
         nidm_qValueFDR: = "0.00332713529017219" %% xsd:float])
-    entity(niiri:ca3f9e37a3e82369bdea4d8f85916a5d,
+    entity(niiri:f90062339ac75c1a5a7bd5460360006e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[-50,2,26]" %% xsd:string])
-    wasDerivedFrom(niiri:65f048f0e7c5732f5773ecc174b71f67, niiri:b1ef2839e620d66c14bd83deb3aec390, -, -, -)
-    entity(niiri:9743d512bbbe9718ac3fa1edbe7c8695,
+    wasDerivedFrom(niiri:f536b5609348be9036fb10330e373e3f, niiri:0a170fb537c25a43d335a98102d35aeb, -, -, -)
+    entity(niiri:44a31bb2492c4d22b1d559091f48eefa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:fdded5d9c86faca9be4e46d670dd39dd',
+        prov:location = 'niiri:1da6912641096977dda7267c40fe4107',
         prov:value = "5.75492286682129" %% xsd:float,
         nidm_equivalentZStatistic: = "3.98829870240338" %% xsd:float,
         nidm_pValueUncorrected: = "3.32744188140666e-05" %% xsd:float,
         nidm_pValueFWER: = "0.971577838301208" %% xsd:float,
         nidm_qValueFDR: = "0.00400598087684945" %% xsd:float])
-    entity(niiri:fdded5d9c86faca9be4e46d670dd39dd,
+    entity(niiri:1da6912641096977dda7267c40fe4107,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[-50,-4,50]" %% xsd:string])
-    wasDerivedFrom(niiri:9743d512bbbe9718ac3fa1edbe7c8695, niiri:b1ef2839e620d66c14bd83deb3aec390, -, -, -)
-    entity(niiri:ee644a0b74bfd447b2b2b3dbc440d5f2,
+    wasDerivedFrom(niiri:44a31bb2492c4d22b1d559091f48eefa, niiri:0a170fb537c25a43d335a98102d35aeb, -, -, -)
+    entity(niiri:75cd1f4a8537e15fd6b96e3da0abf348,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:1249869c1dfb98c3e618a1f06d22a1ea',
+        prov:location = 'niiri:e2d566acff4bd4ebe5d3246828cbfc6d',
         prov:value = "5.52769041061401" %% xsd:float,
         nidm_equivalentZStatistic: = "3.89683707514784" %% xsd:float,
         nidm_pValueUncorrected: = "4.87285666391779e-05" %% xsd:float,
         nidm_pValueFWER: = "0.990314755199069" %% xsd:float,
         nidm_qValueFDR: = "0.00479616651502499" %% xsd:float])
-    entity(niiri:1249869c1dfb98c3e618a1f06d22a1ea,
+    entity(niiri:e2d566acff4bd4ebe5d3246828cbfc6d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[-52,0,40]" %% xsd:string])
-    wasDerivedFrom(niiri:ee644a0b74bfd447b2b2b3dbc440d5f2, niiri:b1ef2839e620d66c14bd83deb3aec390, -, -, -)
-    entity(niiri:d870f02cb19a7c9c70e01dfea7cef689,
+    wasDerivedFrom(niiri:75cd1f4a8537e15fd6b96e3da0abf348, niiri:0a170fb537c25a43d335a98102d35aeb, -, -, -)
+    entity(niiri:3575c3d4f244e7bf282358585a84906c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:cf09b331b6ecf92a4276fede122052dd',
+        prov:location = 'niiri:7b573b4dd63bc077dfe4dd6768191656',
         prov:value = "5.91596412658691" %% xsd:float,
         nidm_equivalentZStatistic: = "4.05096850425873" %% xsd:float,
         nidm_pValueUncorrected: = "2.55030367465325e-05" %% xsd:float,
         nidm_pValueFWER: = "0.948053549525439" %% xsd:float,
         nidm_qValueFDR: = "0.00348881065430462" %% xsd:float])
-    entity(niiri:cf09b331b6ecf92a4276fede122052dd,
+    entity(niiri:7b573b4dd63bc077dfe4dd6768191656,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[6,18,6]" %% xsd:string])
-    wasDerivedFrom(niiri:d870f02cb19a7c9c70e01dfea7cef689, niiri:6a1143e807a7221c10cbd94b8f352cb3, -, -, -)
-    entity(niiri:93eee431f407818d7a288b7a68d56d3b,
+    wasDerivedFrom(niiri:3575c3d4f244e7bf282358585a84906c, niiri:0b191a1bce28484b4d509f123468cafc, -, -, -)
+    entity(niiri:4cc4b89c15af11852dd0fdf83661eab7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:08dd0be6761b0981da82cbc6c136514c',
+        prov:location = 'niiri:12ad0a85c946e3ba0ee32ec6ca9d30df',
         prov:value = "4.54182481765747" %% xsd:float,
         nidm_equivalentZStatistic: = "3.45355045258419" %% xsd:float,
         nidm_pValueUncorrected: = "0.000276629401356199" %% xsd:float,
         nidm_pValueFWER: = "0.999999655761857" %% xsd:float,
         nidm_qValueFDR: = "0.0116903072898716" %% xsd:float])
-    entity(niiri:08dd0be6761b0981da82cbc6c136514c,
+    entity(niiri:12ad0a85c946e3ba0ee32ec6ca9d30df,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[14,24,4]" %% xsd:string])
-    wasDerivedFrom(niiri:93eee431f407818d7a288b7a68d56d3b, niiri:6a1143e807a7221c10cbd94b8f352cb3, -, -, -)
-    entity(niiri:d0dd419634f950cbbc6664604d2bfae1,
+    wasDerivedFrom(niiri:4cc4b89c15af11852dd0fdf83661eab7, niiri:0b191a1bce28484b4d509f123468cafc, -, -, -)
+    entity(niiri:38d59cc816cec77fb882cd2fdd15a9bd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:5073a8f82b87e9f0bec1f05cbf454d90',
+        prov:location = 'niiri:a2d5f7682067f7ac13c86ed08bac1fc2',
         prov:value = "5.72671985626221" %% xsd:float,
         nidm_equivalentZStatistic: = "3.97714309813652" %% xsd:float,
         nidm_pValueUncorrected: = "3.48740977119677e-05" %% xsd:float,
         nidm_pValueFWER: = "0.974745203823651" %% xsd:float,
         nidm_qValueFDR: = "0.00410957672904248" %% xsd:float])
-    entity(niiri:5073a8f82b87e9f0bec1f05cbf454d90,
+    entity(niiri:a2d5f7682067f7ac13c86ed08bac1fc2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-6,0,58]" %% xsd:string])
-    wasDerivedFrom(niiri:d0dd419634f950cbbc6664604d2bfae1, niiri:17a361a6af9be1a09623d4875d9de272, -, -, -)
-    entity(niiri:1595c393eed7051abc16cafee4ac6ae9,
+    wasDerivedFrom(niiri:38d59cc816cec77fb882cd2fdd15a9bd, niiri:03c0220efd2c203f65a22694082f5442, -, -, -)
+    entity(niiri:03b70a255fbe5aaeb503141abdf77e01,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:5f9783b56cea07afdad963e78526eb93',
+        prov:location = 'niiri:b2a905dcae5e518e954d4e5ca2afbf39',
         prov:value = "5.25150108337402" %% xsd:float,
         nidm_equivalentZStatistic: = "3.78060278170665" %% xsd:float,
         nidm_pValueUncorrected: = "7.82245573558438e-05" %% xsd:float,
         nidm_pValueFWER: = "0.998359989376909" %% xsd:float,
         nidm_qValueFDR: = "0.00612998059012206" %% xsd:float])
-    entity(niiri:5f9783b56cea07afdad963e78526eb93,
+    entity(niiri:b2a905dcae5e518e954d4e5ca2afbf39,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[0,6,56]" %% xsd:string])
-    wasDerivedFrom(niiri:1595c393eed7051abc16cafee4ac6ae9, niiri:17a361a6af9be1a09623d4875d9de272, -, -, -)
-    entity(niiri:cdf7c013da79b02373eb314d67b328ca,
+    wasDerivedFrom(niiri:03b70a255fbe5aaeb503141abdf77e01, niiri:03c0220efd2c203f65a22694082f5442, -, -, -)
+    entity(niiri:4157309e78d7ded58b0c0e0ead87a224,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:6e2c760a2125a3b04227107745989f35',
+        prov:location = 'niiri:2bd2a2878ad3f221f0ec6abeed136ca3',
         prov:value = "4.54090023040771" %% xsd:float,
         nidm_equivalentZStatistic: = "3.45309533835059" %% xsd:float,
         nidm_pValueUncorrected: = "0.00027709654919561" %% xsd:float,
         nidm_pValueFWER: = "0.99999966134203" %% xsd:float,
         nidm_qValueFDR: = "0.0116998384744116" %% xsd:float])
-    entity(niiri:6e2c760a2125a3b04227107745989f35,
+    entity(niiri:2bd2a2878ad3f221f0ec6abeed136ca3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[-4,0,66]" %% xsd:string])
-    wasDerivedFrom(niiri:cdf7c013da79b02373eb314d67b328ca, niiri:17a361a6af9be1a09623d4875d9de272, -, -, -)
-    entity(niiri:1af924931744ebf87d5aa4d7b639a169,
+    wasDerivedFrom(niiri:4157309e78d7ded58b0c0e0ead87a224, niiri:03c0220efd2c203f65a22694082f5442, -, -, -)
+    entity(niiri:f81e942c055a87ae23697653d0f9e931,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:9be6eab29ca29ed5a1bda8a4751ab3e1',
+        prov:location = 'niiri:01b426c0493efdc5de3e1ee498c74e3a',
         prov:value = "5.37388372421265" %% xsd:float,
         nidm_equivalentZStatistic: = "3.83281667931374" %% xsd:float,
         nidm_pValueUncorrected: = "6.33421799035583e-05" %% xsd:float,
         nidm_pValueFWER: = "0.996123053382791" %% xsd:float,
         nidm_qValueFDR: = "0.00547832540919611" %% xsd:float])
-    entity(niiri:9be6eab29ca29ed5a1bda8a4751ab3e1,
+    entity(niiri:01b426c0493efdc5de3e1ee498c74e3a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[6,-12,14]" %% xsd:string])
-    wasDerivedFrom(niiri:1af924931744ebf87d5aa4d7b639a169, niiri:646a3e8aac6f4eee8e8562e0616d65ba, -, -, -)
-    entity(niiri:063ac2e37579cf1830838723135ef892,
+    wasDerivedFrom(niiri:f81e942c055a87ae23697653d0f9e931, niiri:847c108abc6d60c3422f305d80cbe544, -, -, -)
+    entity(niiri:558b717a6eaaf2aaa2613f2e2d87fd7e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:17cc9a7d147c38df0908ed91f50ffed6',
+        prov:location = 'niiri:0be6fd36a7a88597550e5298744761b6',
         prov:value = "5.16269016265869" %% xsd:float,
         nidm_equivalentZStatistic: = "3.74198250168727" %% xsd:float,
         nidm_pValueUncorrected: = "9.12871154093997e-05" %% xsd:float,
         nidm_pValueFWER: = "0.999192871962629" %% xsd:float,
         nidm_qValueFDR: = "0.00669851286267874" %% xsd:float])
-    entity(niiri:17cc9a7d147c38df0908ed91f50ffed6,
+    entity(niiri:0be6fd36a7a88597550e5298744761b6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[36,20,4]" %% xsd:string])
-    wasDerivedFrom(niiri:063ac2e37579cf1830838723135ef892, niiri:8e53fdbcd507f29fa491c0ee30766820, -, -, -)
-    entity(niiri:0222a75a9a5232dac912eb7326478415,
+    wasDerivedFrom(niiri:558b717a6eaaf2aaa2613f2e2d87fd7e, niiri:89f5194a4b0e2d5f67db04f10c0882ac, -, -, -)
+    entity(niiri:3c7a990e35408ee2e2bc41f141132134,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:f59f2ef887c5f35ca37e79a29a172929',
+        prov:location = 'niiri:efc8c79d2c3cdc3e0c280b1398a1831b',
         prov:value = "4.8655366897583" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60809771461691" %% xsd:float,
         nidm_pValueUncorrected: = "0.000154225162826815" %% xsd:float,
         nidm_pValueFWER: = "0.9999601230968" %% xsd:float,
         nidm_qValueFDR: = "0.00861184257857328" %% xsd:float])
-    entity(niiri:f59f2ef887c5f35ca37e79a29a172929,
+    entity(niiri:efc8c79d2c3cdc3e0c280b1398a1831b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[30,24,0]" %% xsd:string])
-    wasDerivedFrom(niiri:0222a75a9a5232dac912eb7326478415, niiri:8e53fdbcd507f29fa491c0ee30766820, -, -, -)
-    entity(niiri:8453d293e50b367bb3a49f7533014a86,
+    wasDerivedFrom(niiri:3c7a990e35408ee2e2bc41f141132134, niiri:89f5194a4b0e2d5f67db04f10c0882ac, -, -, -)
+    entity(niiri:a4c025afba5ca5234ab79d7354c091c7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:24146062d9114b1e61245629356d88ea',
+        prov:location = 'niiri:9c3802455fb925cb9f3bbd7949a49033',
         prov:value = "5.15075159072876" %% xsd:float,
         nidm_equivalentZStatistic: = "3.73674319192816" %% xsd:float,
         nidm_pValueUncorrected: = "9.3209572512909e-05" %% xsd:float,
         nidm_pValueFWER: = "0.999270580432391" %% xsd:float,
         nidm_qValueFDR: = "0.00676830985421939" %% xsd:float])
-    entity(niiri:24146062d9114b1e61245629356d88ea,
+    entity(niiri:9c3802455fb925cb9f3bbd7949a49033,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[0,-50,-28]" %% xsd:string])
-    wasDerivedFrom(niiri:8453d293e50b367bb3a49f7533014a86, niiri:caa24947392807e9fd656eb7e677bb90, -, -, -)
-    entity(niiri:2776c7b9e158c2ca4c466f45748a27ad,
+    wasDerivedFrom(niiri:a4c025afba5ca5234ab79d7354c091c7, niiri:d97dd5148291142c057785550af3eb2d, -, -, -)
+    entity(niiri:c132ce6a3b937fda0d16d0ee8cf1c129,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:5d350af686c7181e6779f8105a3c4356',
+        prov:location = 'niiri:c291ec5fb390da072831c070b623bd2b',
         prov:value = "5.12083530426025" %% xsd:float,
         nidm_equivalentZStatistic: = "3.7235640261549" %% xsd:float,
         nidm_pValueUncorrected: = "9.82150082137201e-05" %% xsd:float,
         nidm_pValueFWER: = "0.999437677420886" %% xsd:float,
         nidm_qValueFDR: = "0.00690105743012952" %% xsd:float])
-    entity(niiri:5d350af686c7181e6779f8105a3c4356,
+    entity(niiri:c291ec5fb390da072831c070b623bd2b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[52,10,40]" %% xsd:string])
-    wasDerivedFrom(niiri:2776c7b9e158c2ca4c466f45748a27ad, niiri:aa6f6ac422b272159fb670d4c6c75fe8, -, -, -)
-    entity(niiri:36b9e15a4f579cb8b8c094d8019239d3,
+    wasDerivedFrom(niiri:c132ce6a3b937fda0d16d0ee8cf1c129, niiri:50d0f0b594a3407fd672472426d8a80a, -, -, -)
+    entity(niiri:66f1d389f91b7542af2830f2d003e0a0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:3cfe07192bdf278215f377f5cb477db4',
+        prov:location = 'niiri:0cffbb433a9a0d0427187a49d93a7e65',
         prov:value = "5.10948324203491" %% xsd:float,
         nidm_equivalentZStatistic: = "3.71854416501836" %% xsd:float,
         nidm_pValueUncorrected: = "0.000100187131384155" %% xsd:float,
         nidm_pValueFWER: = "0.999491804107717" %% xsd:float,
         nidm_qValueFDR: = "0.00699662698174139" %% xsd:float])
-    entity(niiri:3cfe07192bdf278215f377f5cb477db4,
+    entity(niiri:0cffbb433a9a0d0427187a49d93a7e65,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[22,-14,12]" %% xsd:string])
-    wasDerivedFrom(niiri:36b9e15a4f579cb8b8c094d8019239d3, niiri:62026e05a2a2355fc124787b15505315, -, -, -)
-    entity(niiri:36d0607dbf3edae0ba7ee6f15811e9ec,
+    wasDerivedFrom(niiri:66f1d389f91b7542af2830f2d003e0a0, niiri:5663af6390cbe1661580022d9cd1db76, -, -, -)
+    entity(niiri:97841d29b10ded1b99b8ce22449c5e38,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:43aa1b5aa2a65fcc758b9161fbb691f9',
+        prov:location = 'niiri:028379c32508bb74af9ecf4bf7c28dc2',
         prov:value = "4.99403047561646" %% xsd:float,
         nidm_equivalentZStatistic: = "3.66689294332376" %% xsd:float,
         nidm_pValueUncorrected: = "0.00012275776099846" %% xsd:float,
         nidm_pValueFWER: = "0.999832837977675" %% xsd:float,
         nidm_qValueFDR: = "0.00775559440349761" %% xsd:float])
-    entity(niiri:43aa1b5aa2a65fcc758b9161fbb691f9,
+    entity(niiri:028379c32508bb74af9ecf4bf7c28dc2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[-14,-2,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:36d0607dbf3edae0ba7ee6f15811e9ec, niiri:93450961f0d8d0f6a3b90a5894e1f87b, -, -, -)
-    entity(niiri:9244cd1d0c66ad9346c4da15cf625887,
+    wasDerivedFrom(niiri:97841d29b10ded1b99b8ce22449c5e38, niiri:936e9ee0499c3d068e7444f367b65d20, -, -, -)
+    entity(niiri:b6a3564f5f97cb6a6c26c428c3cf7fdd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0033" %% xsd:string,
-        prov:location = 'niiri:ba4f669757b7f20b7868b405af9297ec',
+        prov:location = 'niiri:fb5948c52087fade7dc0a3c08e1c25b1',
         prov:value = "4.99324655532837" %% xsd:float,
         nidm_equivalentZStatistic: = "3.66653846830519" %% xsd:float,
         nidm_pValueUncorrected: = "0.000122927974348652" %% xsd:float,
         nidm_pValueFWER: = "0.99983418490596" %% xsd:float,
         nidm_qValueFDR: = "0.00775759422864875" %% xsd:float])
-    entity(niiri:ba4f669757b7f20b7868b405af9297ec,
+    entity(niiri:fb5948c52087fade7dc0a3c08e1c25b1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0033" %% xsd:string,
         nidm_coordinateVector: = "[8,-26,14]" %% xsd:string])
-    wasDerivedFrom(niiri:9244cd1d0c66ad9346c4da15cf625887, niiri:9b5ca13a3d263c59792e6e86be4a2e34, -, -, -)
-    entity(niiri:19366255ed63a36546b8f1ee872bddf0,
+    wasDerivedFrom(niiri:b6a3564f5f97cb6a6c26c428c3cf7fdd, niiri:37eed9b79d7a2993d16feb7189856a02, -, -, -)
+    entity(niiri:5323176e6096d153507b38ceb176512b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0034" %% xsd:string,
-        prov:location = 'niiri:9082f78e97efa65c4dcb194c56ec70fd',
+        prov:location = 'niiri:e45c7da465b7b04138d0aa7007b2b615',
         prov:value = "4.89655494689941" %% xsd:float,
         nidm_equivalentZStatistic: = "3.62241950165507" %% xsd:float,
         nidm_pValueUncorrected: = "0.000145930150219908" %% xsd:float,
         nidm_pValueFWER: = "0.999942473649405" %% xsd:float,
         nidm_qValueFDR: = "0.0083498973939701" %% xsd:float])
-    entity(niiri:9082f78e97efa65c4dcb194c56ec70fd,
+    entity(niiri:e45c7da465b7b04138d0aa7007b2b615,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0034" %% xsd:string,
         nidm_coordinateVector: = "[14,8,72]" %% xsd:string])
-    wasDerivedFrom(niiri:19366255ed63a36546b8f1ee872bddf0, niiri:bb0785359fefadd70b1adaaaac3b7884, -, -, -)
-    entity(niiri:7f57e213d8d5aad8818c2534a203dafb,
+    wasDerivedFrom(niiri:5323176e6096d153507b38ceb176512b, niiri:9d921e2cb3a8abbe97013ee4bc904c3e, -, -, -)
+    entity(niiri:a44a0f94f9fe2aaccb70c1503033e39b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0035" %% xsd:string,
-        prov:location = 'niiri:14712e03d1bd30c666abef48eaba5f35',
+        prov:location = 'niiri:3303e5e553ccfb344b281bdf1fda0643',
         prov:value = "4.86036062240601" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60569974829148" %% xsd:float,
         nidm_pValueUncorrected: = "0.000155656460372522" %% xsd:float,
         nidm_pValueFWER: = "0.999962538559828" %% xsd:float,
         nidm_qValueFDR: = "0.00864250020982424" %% xsd:float])
-    entity(niiri:14712e03d1bd30c666abef48eaba5f35,
+    entity(niiri:3303e5e553ccfb344b281bdf1fda0643,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0035" %% xsd:string,
         nidm_coordinateVector: = "[-24,-42,-38]" %% xsd:string])
-    wasDerivedFrom(niiri:7f57e213d8d5aad8818c2534a203dafb, niiri:000e7e06128006bf16d2f8dd28c288f0, -, -, -)
-    entity(niiri:9b84b4a69aa3f9ede37b824a44d7ad2b,
+    wasDerivedFrom(niiri:a44a0f94f9fe2aaccb70c1503033e39b, niiri:ba889b1413156c8c9b392f582f507018, -, -, -)
+    entity(niiri:5e9f9523049af6068781e26c745db894,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0036" %% xsd:string,
-        prov:location = 'niiri:abf6dcaaaa3aa218ffa6b3f8dd51d903',
+        prov:location = 'niiri:af5219cdfc791f4e67e12be2e6c60fbe',
         prov:value = "4.81803417205811" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58600360944639" %% xsd:float,
         nidm_pValueUncorrected: = "0.00016789215592794" %% xsd:float,
         nidm_pValueFWER: = "0.999977855811547" %% xsd:float,
         nidm_qValueFDR: = "0.00900212220920404" %% xsd:float])
-    entity(niiri:abf6dcaaaa3aa218ffa6b3f8dd51d903,
+    entity(niiri:af5219cdfc791f4e67e12be2e6c60fbe,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0036" %% xsd:string,
         nidm_coordinateVector: = "[-54,30,14]" %% xsd:string])
-    wasDerivedFrom(niiri:9b84b4a69aa3f9ede37b824a44d7ad2b, niiri:fea4f2ec59548d5d8b403064bc42fcd3, -, -, -)
-    entity(niiri:7f9d189889ab743749e30fd6a45392f5,
+    wasDerivedFrom(niiri:5e9f9523049af6068781e26c745db894, niiri:51665d1fb0cfb8bda978b620ef449077, -, -, -)
+    entity(niiri:85a6db12151f29eba6c03ad052f455a9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0037" %% xsd:string,
-        prov:location = 'niiri:a2eab965b389db1da335e25f6dbc3ef3',
+        prov:location = 'niiri:29cb11c342497725682c33295a8a3469',
         prov:value = "4.77066373825073" %% xsd:float,
         nidm_equivalentZStatistic: = "3.56377460375569" %% xsd:float,
         nidm_pValueUncorrected: = "0.000182779942677791" %% xsd:float,
         nidm_pValueFWER: = "0.999988096830174" %% xsd:float,
         nidm_qValueFDR: = "0.00940067644112613" %% xsd:float])
-    entity(niiri:a2eab965b389db1da335e25f6dbc3ef3,
+    entity(niiri:29cb11c342497725682c33295a8a3469,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0037" %% xsd:string,
         nidm_coordinateVector: = "[-46,30,16]" %% xsd:string])
-    wasDerivedFrom(niiri:7f9d189889ab743749e30fd6a45392f5, niiri:fea4f2ec59548d5d8b403064bc42fcd3, -, -, -)
-    entity(niiri:6c13004b183580300b78177ee70c0f04,
+    wasDerivedFrom(niiri:85a6db12151f29eba6c03ad052f455a9, niiri:51665d1fb0cfb8bda978b620ef449077, -, -, -)
+    entity(niiri:a42893da4696ee8d301da513c039bb33,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0038" %% xsd:string,
-        prov:location = 'niiri:3cad6d43185f053748a6c03d25147aac',
+        prov:location = 'niiri:0d6f26980a7c82addcff37e277d37f87',
         prov:value = "4.8089394569397" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58175111371795" %% xsd:float,
         nidm_pValueUncorrected: = "0.00017064943193823" %% xsd:float,
         nidm_pValueFWER: = "0.999980290560917" %% xsd:float,
         nidm_qValueFDR: = "0.00906568438361755" %% xsd:float])
-    entity(niiri:3cad6d43185f053748a6c03d25147aac,
+    entity(niiri:0d6f26980a7c82addcff37e277d37f87,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0038" %% xsd:string,
         nidm_coordinateVector: = "[0,-58,-38]" %% xsd:string])
-    wasDerivedFrom(niiri:6c13004b183580300b78177ee70c0f04, niiri:56aff3268c9efc59ac3dd1fccbb1e940, -, -, -)
-    entity(niiri:ca7f28f36d471bfff7d6cf2d7ec5bc5c,
+    wasDerivedFrom(niiri:a42893da4696ee8d301da513c039bb33, niiri:a24fb25342ea5df100b3c9f26c07ccf7, -, -, -)
+    entity(niiri:248a55c19c0892c52e726aa851cb8bdd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0039" %% xsd:string,
-        prov:location = 'niiri:5313dfeff4ad8a69948aefe317a1ff63',
+        prov:location = 'niiri:51a0bd12c442e02fba73ae2922f15a79',
         prov:value = "4.80026483535767" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57768829524451" %% xsd:float,
         nidm_pValueUncorrected: = "0.000173323244094692" %% xsd:float,
         nidm_pValueFWER: = "0.999982383849948" %% xsd:float,
         nidm_qValueFDR: = "0.00914672501351889" %% xsd:float])
-    entity(niiri:5313dfeff4ad8a69948aefe317a1ff63,
+    entity(niiri:51a0bd12c442e02fba73ae2922f15a79,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0039" %% xsd:string,
         nidm_coordinateVector: = "[-54,12,0]" %% xsd:string])
-    wasDerivedFrom(niiri:ca7f28f36d471bfff7d6cf2d7ec5bc5c, niiri:30c41fd03e0e9666df9d194fbe412b52, -, -, -)
-    entity(niiri:49ab596dceb78a958aa318a733a8e5ff,
+    wasDerivedFrom(niiri:248a55c19c0892c52e726aa851cb8bdd, niiri:6b3e2550575959313eec60bd44a6b445, -, -, -)
+    entity(niiri:759c0b26a71be25fa07292239859245d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0040" %% xsd:string,
-        prov:location = 'niiri:a31fc51cce93b04af96388a0f734c45f',
+        prov:location = 'niiri:b56fb9e5f57ce68403a9901ac11d45a4',
         prov:value = "4.77761936187744" %% xsd:float,
         nidm_equivalentZStatistic: = "3.56705096724501" %% xsd:float,
         nidm_pValueUncorrected: = "0.000180510641497822" %% xsd:float,
         nidm_pValueFWER: = "0.999986932005675" %% xsd:float,
         nidm_qValueFDR: = "0.00934466092947769" %% xsd:float])
-    entity(niiri:a31fc51cce93b04af96388a0f734c45f,
+    entity(niiri:b56fb9e5f57ce68403a9901ac11d45a4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0040" %% xsd:string,
         nidm_coordinateVector: = "[28,2,60]" %% xsd:string])
-    wasDerivedFrom(niiri:49ab596dceb78a958aa318a733a8e5ff, niiri:195a3dcb7bf220b60a464a21245d4ee4, -, -, -)
-    entity(niiri:b1871e034d8d5ec7ff867d722b86b6bb,
+    wasDerivedFrom(niiri:759c0b26a71be25fa07292239859245d, niiri:92cf9681c5af88815bed46d4f69484fe, -, -, -)
+    entity(niiri:31be7f0e3a63c3b71e9774b599f0525b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0041" %% xsd:string,
-        prov:location = 'niiri:bb7833ec8cf5f8d5f4136884a1503263',
+        prov:location = 'niiri:942ddb276df261f58059a9ab77022724',
         prov:value = "4.67176485061646" %% xsd:float,
         nidm_equivalentZStatistic: = "3.51672280482077" %% xsd:float,
         nidm_pValueUncorrected: = "0.000218454899154397" %% xsd:float,
         nidm_pValueFWER: = "0.999997106974601" %% xsd:float,
         nidm_qValueFDR: = "0.0103643846403155" %% xsd:float])
-    entity(niiri:bb7833ec8cf5f8d5f4136884a1503263,
+    entity(niiri:942ddb276df261f58059a9ab77022724,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0041" %% xsd:string,
         nidm_coordinateVector: = "[26,-4,54]" %% xsd:string])
-    wasDerivedFrom(niiri:b1871e034d8d5ec7ff867d722b86b6bb, niiri:195a3dcb7bf220b60a464a21245d4ee4, -, -, -)
-    entity(niiri:c63bd3dd97f6db465634edf0fe3e6d7f,
+    wasDerivedFrom(niiri:31be7f0e3a63c3b71e9774b599f0525b, niiri:92cf9681c5af88815bed46d4f69484fe, -, -, -)
+    entity(niiri:be9f62ae29bc1bf6f51eea46b13a7a57,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0042" %% xsd:string,
-        prov:location = 'niiri:a7b543fd3444c95cdeddfd292b01c7d4',
+        prov:location = 'niiri:9185d52c29fec95f3943cb1408fe38ac',
         prov:value = "4.62480688095093" %% xsd:float,
         nidm_equivalentZStatistic: = "3.49407291194222" %% xsd:float,
         nidm_pValueUncorrected: = "0.000237855539300003" %% xsd:float,
         nidm_pValueFWER: = "0.999998608516906" %% xsd:float,
         nidm_qValueFDR: = "0.0108449863840995" %% xsd:float])
-    entity(niiri:a7b543fd3444c95cdeddfd292b01c7d4,
+    entity(niiri:9185d52c29fec95f3943cb1408fe38ac,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0042" %% xsd:string,
         nidm_coordinateVector: = "[20,-4,60]" %% xsd:string])
-    wasDerivedFrom(niiri:c63bd3dd97f6db465634edf0fe3e6d7f, niiri:195a3dcb7bf220b60a464a21245d4ee4, -, -, -)
-    entity(niiri:04edadfd4de6a98b1755ebbb982ffdc5,
+    wasDerivedFrom(niiri:be9f62ae29bc1bf6f51eea46b13a7a57, niiri:92cf9681c5af88815bed46d4f69484fe, -, -, -)
+    entity(niiri:5e5d7e7b87311887d80aece0fcc725f1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0043" %% xsd:string,
-        prov:location = 'niiri:3acb438e18302dca6ecfb8f09cc3b8c2',
+        prov:location = 'niiri:a731413b420d2d57b872cb88cfeef28b',
         prov:value = "4.67917585372925" %% xsd:float,
         nidm_equivalentZStatistic: = "3.5202791175394" %% xsd:float,
         nidm_pValueUncorrected: = "0.000215546442763337" %% xsd:float,
         nidm_pValueFWER: = "0.99999676461456" %% xsd:float,
         nidm_qValueFDR: = "0.0102906058805538" %% xsd:float])
-    entity(niiri:3acb438e18302dca6ecfb8f09cc3b8c2,
+    entity(niiri:a731413b420d2d57b872cb88cfeef28b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0043" %% xsd:string,
         nidm_coordinateVector: = "[-34,-12,42]" %% xsd:string])
-    wasDerivedFrom(niiri:04edadfd4de6a98b1755ebbb982ffdc5, niiri:d09f25e397a79ba3820081611e196ed7, -, -, -)
-    entity(niiri:738c518c78aeab009d62d16106762ec8,
+    wasDerivedFrom(niiri:5e5d7e7b87311887d80aece0fcc725f1, niiri:c8b8db45e94c74708104298c433fecd6, -, -, -)
+    entity(niiri:eda03e9ad53b2d5ffc1d87c948b5c073,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0044" %% xsd:string,
-        prov:location = 'niiri:34e4d39ae426eddd8106a75fdb93df16',
+        prov:location = 'niiri:0a64737dfbc36713dca9405841ec7e26',
         prov:value = "4.5969614982605" %% xsd:float,
         nidm_equivalentZStatistic: = "3.48054638647577" %% xsd:float,
         nidm_pValueUncorrected: = "0.000250196083839915" %% xsd:float,
         nidm_pValueFWER: = "0.999999115925319" %% xsd:float,
         nidm_qValueFDR: = "0.0111238765457046" %% xsd:float])
-    entity(niiri:34e4d39ae426eddd8106a75fdb93df16,
+    entity(niiri:0a64737dfbc36713dca9405841ec7e26,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0044" %% xsd:string,
         nidm_coordinateVector: = "[36,-40,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:738c518c78aeab009d62d16106762ec8, niiri:2d07cb807cba69cb83d125ad8a6d9589, -, -, -)
-    entity(niiri:b67b4596018aff50f75474b1bc7cec26,
+    wasDerivedFrom(niiri:eda03e9ad53b2d5ffc1d87c948b5c073, niiri:e9cca2166adb51f5ec340f78e542f76f, -, -, -)
+    entity(niiri:286d94947c4e1787b77f00b0b7114d06,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0045" %% xsd:string,
-        prov:location = 'niiri:df63022294b12ffbb4ab2b6e51db3a61',
+        prov:location = 'niiri:f7eff259178a3f65efdc696ad7a247a6',
         prov:value = "4.58732891082764" %% xsd:float,
         nidm_equivalentZStatistic: = "3.47585047258978" %% xsd:float,
         nidm_pValueUncorrected: = "0.000254618063707635" %% xsd:float,
         nidm_pValueFWER: = "0.999999246946643" %% xsd:float,
         nidm_qValueFDR: = "0.0112304749683021" %% xsd:float])
-    entity(niiri:df63022294b12ffbb4ab2b6e51db3a61,
+    entity(niiri:f7eff259178a3f65efdc696ad7a247a6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0045" %% xsd:string,
         nidm_coordinateVector: = "[36,-10,48]" %% xsd:string])
-    wasDerivedFrom(niiri:b67b4596018aff50f75474b1bc7cec26, niiri:2d69939d531eb0168273379f7ce52907, -, -, -)
-    entity(niiri:872525eb5016723dc3c4e0b0f2f2a5c5,
+    wasDerivedFrom(niiri:286d94947c4e1787b77f00b0b7114d06, niiri:4ce2f04f5e11fd9609173ed79e458866, -, -, -)
+    entity(niiri:41f1a29b28047c513dad04890f92ea62,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0046" %% xsd:string,
-        prov:location = 'niiri:5dffb2412c5920c035fa3d65f898aca6',
+        prov:location = 'niiri:ca4d257e28c11e95eac69d8434cf5d21',
         prov:value = "4.46814107894897" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41702777537423" %% xsd:float,
         nidm_pValueUncorrected: = "0.000316544101057636" %% xsd:float,
         nidm_pValueFWER: = "0.999999911601577" %% xsd:float,
         nidm_qValueFDR: = "0.0126051231599175" %% xsd:float])
-    entity(niiri:5dffb2412c5920c035fa3d65f898aca6,
+    entity(niiri:ca4d257e28c11e95eac69d8434cf5d21,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0046" %% xsd:string,
         nidm_coordinateVector: = "[-20,-38,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:872525eb5016723dc3c4e0b0f2f2a5c5, niiri:1c2323d93891a0ddf5ac87752d859519, -, -, -)
-    entity(niiri:27b211c70e2f7e9bd4a55df3443c4d04,
+    wasDerivedFrom(niiri:41f1a29b28047c513dad04890f92ea62, niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b, -, -, -)
+    entity(niiri:644473757bdf4f53de672927c317f640,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0047" %% xsd:string,
-        prov:location = 'niiri:f784d0452f15f23ba0c472ca2c2957c8',
+        prov:location = 'niiri:91812858ace028392052bc61b2ec057f',
         prov:value = "4.46168184280396" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41380155002305" %% xsd:float,
         nidm_pValueUncorrected: = "0.000320316101733442" %% xsd:float,
         nidm_pValueFWER: = "0.999999921976257" %% xsd:float,
         nidm_qValueFDR: = "0.0126738773801948" %% xsd:float])
-    entity(niiri:f784d0452f15f23ba0c472ca2c2957c8,
+    entity(niiri:91812858ace028392052bc61b2ec057f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0047" %% xsd:string,
         nidm_coordinateVector: = "[-12,-14,8]" %% xsd:string])
-    wasDerivedFrom(niiri:27b211c70e2f7e9bd4a55df3443c4d04, niiri:dc7f564798bbb1fc05334954d8385ba1, -, -, -)
-    entity(niiri:8bf11b8dd19ff2763b1d679fcc567bdd,
+    wasDerivedFrom(niiri:644473757bdf4f53de672927c317f640, niiri:18aa725ff182239ce52a92cec8c831fe, -, -, -)
+    entity(niiri:118e5465f1cdaee5740cf125155fe7b3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0048" %% xsd:string,
-        prov:location = 'niiri:69636daf4c95840e35d2278cb2ddf6a2',
+        prov:location = 'niiri:3ff8424d596938b11ad96560eee5df78',
         prov:value = "4.44263553619385" %% xsd:float,
         nidm_equivalentZStatistic: = "3.40426513461447" %% xsd:float,
         nidm_pValueUncorrected: = "0.000331711624065423" %% xsd:float,
         nidm_pValueFWER: = "0.999999946301375" %% xsd:float,
         nidm_qValueFDR: = "0.012902019341921" %% xsd:float])
-    entity(niiri:69636daf4c95840e35d2278cb2ddf6a2,
+    entity(niiri:3ff8424d596938b11ad96560eee5df78,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0048" %% xsd:string,
         nidm_coordinateVector: = "[-4,-28,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:8bf11b8dd19ff2763b1d679fcc567bdd, niiri:62a9cd07b50b07a1142d53889b87fd97, -, -, -)
-    entity(niiri:46c603d6044a9577f4f0e9b3938e4700,
+    wasDerivedFrom(niiri:118e5465f1cdaee5740cf125155fe7b3, niiri:7cf7dba6eb11ba3d163885cbe5c660cd, -, -, -)
+    entity(niiri:2aab067e93eed87166d2a6bcb0988f7f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0049" %% xsd:string,
-        prov:location = 'niiri:7f03bb810e2aa3de38abd130b42d0740',
+        prov:location = 'niiri:c035874bdf6e7d3a175e1e3e4dfd592f',
         prov:value = "4.4201717376709" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39297275478629" %% xsd:float,
         nidm_pValueUncorrected: = "0.00034569257259931" %% xsd:float,
         nidm_pValueFWER: = "0.999999965808818" %% xsd:float,
         nidm_qValueFDR: = "0.01320481591718" %% xsd:float])
-    entity(niiri:7f03bb810e2aa3de38abd130b42d0740,
+    entity(niiri:c035874bdf6e7d3a175e1e3e4dfd592f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0049" %% xsd:string,
         nidm_coordinateVector: = "[46,-42,54]" %% xsd:string])
-    wasDerivedFrom(niiri:46c603d6044a9577f4f0e9b3938e4700, niiri:12880301a0a653ca67efd232a37a486b, -, -, -)
-    entity(niiri:2fc0e632c6c67d632d879e25c94e0526,
+    wasDerivedFrom(niiri:2aab067e93eed87166d2a6bcb0988f7f, niiri:f2aa94f4ac2fd9ce977533852312353d, -, -, -)
+    entity(niiri:182e9fe46ed363f9769a906bff3f1e65,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0050" %% xsd:string,
-        prov:location = 'niiri:d1793ebb335efe18e8ce493107704c93',
+        prov:location = 'niiri:5f08c4860ac9853a3ac9f667b9bea6f5',
         prov:value = "4.41310739517212" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38941149263013" %% xsd:float,
         nidm_pValueUncorrected: = "0.000350214079416045" %% xsd:float,
         nidm_pValueFWER: = "0.999999970406353" %% xsd:float,
         nidm_qValueFDR: = "0.0133062974642806" %% xsd:float])
-    entity(niiri:d1793ebb335efe18e8ce493107704c93,
+    entity(niiri:5f08c4860ac9853a3ac9f667b9bea6f5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0050" %% xsd:string,
         nidm_coordinateVector: = "[-6,10,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:2fc0e632c6c67d632d879e25c94e0526, niiri:7b940b3f554bfd8086ef06ec3a4c5e36, -, -, -)
-    entity(niiri:edea735fc405e897d60c9a150d58fdbd,
+    wasDerivedFrom(niiri:182e9fe46ed363f9769a906bff3f1e65, niiri:b9d2c5e57e73184c133167c21e549e31, -, -, -)
+    entity(niiri:3963967f131dd75149db4432a7e47df4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0051" %% xsd:string,
-        prov:location = 'niiri:ad6a5c6e9111ff2cd4961836c59aeee8',
+        prov:location = 'niiri:f6bec0e10961c94d25f2bde5fedfbbf8',
         prov:value = "4.36529922485352" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36518306130387" %% xsd:float,
         nidm_pValueUncorrected: = "0.000382464451876507" %% xsd:float,
         nidm_pValueFWER: = "0.999999989209637" %% xsd:float,
         nidm_qValueFDR: = "0.0139415542247477" %% xsd:float])
-    entity(niiri:ad6a5c6e9111ff2cd4961836c59aeee8,
+    entity(niiri:f6bec0e10961c94d25f2bde5fedfbbf8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0051" %% xsd:string,
         nidm_coordinateVector: = "[42,42,30]" %% xsd:string])
-    wasDerivedFrom(niiri:edea735fc405e897d60c9a150d58fdbd, niiri:4364ea14ae541a4b5530d0fc11478f4d, -, -, -)
-    entity(niiri:7b7f99b7f4133520004acf23cad3c6d2,
+    wasDerivedFrom(niiri:3963967f131dd75149db4432a7e47df4, niiri:0fff44688bc869513d097e59a8311b54, -, -, -)
+    entity(niiri:90bcd9cecdebdfc1bc653e4a5ce6fdd4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0052" %% xsd:string,
-        prov:location = 'niiri:6e740b892faab2ae5c18dda6b0263f44',
+        prov:location = 'niiri:5dfa4e8409ebc190fafb2e54b42bf770',
         prov:value = "4.33874082565308" %% xsd:float,
         nidm_equivalentZStatistic: = "3.35162706179118" %% xsd:float,
         nidm_pValueUncorrected: = "0.00040169081443242" %% xsd:float,
         nidm_pValueFWER: = "0.999999993988362" %% xsd:float,
         nidm_qValueFDR: = "0.014354585034373" %% xsd:float])
-    entity(niiri:6e740b892faab2ae5c18dda6b0263f44,
+    entity(niiri:5dfa4e8409ebc190fafb2e54b42bf770,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0052" %% xsd:string,
         nidm_coordinateVector: = "[54,-38,50]" %% xsd:string])
-    wasDerivedFrom(niiri:7b7f99b7f4133520004acf23cad3c6d2, niiri:cad9672114cca77d75274be4de17ab9c, -, -, -)
-    entity(niiri:6c1b3ff879fa04561531f81912615e99,
+    wasDerivedFrom(niiri:90bcd9cecdebdfc1bc653e4a5ce6fdd4, niiri:6b373e69fdc37c9c1e68cb0b96d5160c, -, -, -)
+    entity(niiri:aef32c45bff8af696f74dfdd1d985ea3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0053" %% xsd:string,
-        prov:location = 'niiri:376e1f563f89dca353cf7c8e7afe031d',
+        prov:location = 'niiri:5a1c6065723c47791b00a4157d8e72fb',
         prov:value = "4.31020069122314" %% xsd:float,
         nidm_equivalentZStatistic: = "3.33698195919922" %% xsd:float,
         nidm_pValueUncorrected: = "0.000423467227465446" %% xsd:float,
         nidm_pValueFWER: = "0.999999996857889" %% xsd:float,
         nidm_qValueFDR: = "0.01478592692513" %% xsd:float])
-    entity(niiri:376e1f563f89dca353cf7c8e7afe031d,
+    entity(niiri:5a1c6065723c47791b00a4157d8e72fb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0053" %% xsd:string,
         nidm_coordinateVector: = "[8,4,64]" %% xsd:string])
-    wasDerivedFrom(niiri:6c1b3ff879fa04561531f81912615e99, niiri:9373fb96b8dcda6b9ae13dbf76afcaa6, -, -, -)
-    entity(niiri:d59e59cdaec7a9b385642f94b162a141,
+    wasDerivedFrom(niiri:aef32c45bff8af696f74dfdd1d985ea3, niiri:739e3f4c274d5eac94fb06c09bd419a0, -, -, -)
+    entity(niiri:7c5846f0d310409dc36078590abc73fc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0054" %% xsd:string,
-        prov:location = 'niiri:0faea80bec78d784e33b772fec951abe',
+        prov:location = 'niiri:c6f8740e94fe4f1ac8fa83677062dddf',
         prov:value = "4.30184555053711" %% xsd:float,
         nidm_equivalentZStatistic: = "3.33267930931343" %% xsd:float,
         nidm_pValueUncorrected: = "0.000430070120942982" %% xsd:float,
         nidm_pValueFWER: = "0.999999997411931" %% xsd:float,
         nidm_qValueFDR: = "0.0148953189902244" %% xsd:float])
-    entity(niiri:0faea80bec78d784e33b772fec951abe,
+    entity(niiri:c6f8740e94fe4f1ac8fa83677062dddf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0054" %% xsd:string,
         nidm_coordinateVector: = "[-10,24,32]" %% xsd:string])
-    wasDerivedFrom(niiri:d59e59cdaec7a9b385642f94b162a141, niiri:7737094062d61c5fc0d500987f11bda9, -, -, -)
-    entity(niiri:14a69d6faff4a3b2af4d85d34b889f0b,
+    wasDerivedFrom(niiri:7c5846f0d310409dc36078590abc73fc, niiri:bf0f6f227a5f1dede37450defacf4ee4, -, -, -)
+    entity(niiri:cd504b882f3f5530c78f2f6fdf37a17a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0055" %% xsd:string,
-        prov:location = 'niiri:e37bac689137c25c10888265d0e08602',
+        prov:location = 'niiri:fbe560ba493337b0e163bb49250b595c',
         prov:value = "4.27150821685791" %% xsd:float,
         nidm_equivalentZStatistic: = "3.31699794762384" %% xsd:float,
         nidm_pValueUncorrected: = "0.000454951424559202" %% xsd:float,
         nidm_pValueFWER: = "0.999999998740386" %% xsd:float,
         nidm_qValueFDR: = "0.0153518195589701" %% xsd:float])
-    entity(niiri:e37bac689137c25c10888265d0e08602,
+    entity(niiri:fbe560ba493337b0e163bb49250b595c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0055" %% xsd:string,
         nidm_coordinateVector: = "[-14,-2,72]" %% xsd:string])
-    wasDerivedFrom(niiri:14a69d6faff4a3b2af4d85d34b889f0b, niiri:454d2ddee840a6eed8f9885efabde318, -, -, -)
-    entity(niiri:7031b6f01d04b3aa346e5d15b9d75e4d,
+    wasDerivedFrom(niiri:cd504b882f3f5530c78f2f6fdf37a17a, niiri:27828afab99d35c7e234991a120cb219, -, -, -)
+    entity(niiri:2241ef49d05e5f1d71db21c706159ef1,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0056" %% xsd:string,
-        prov:location = 'niiri:f5b1c1485206e295c6ee4401f24e8fea',
+        prov:location = 'niiri:2eedc6f2b2f210a352180ba9bf836bdb',
         prov:value = "4.25738191604614" %% xsd:float,
         nidm_equivalentZStatistic: = "3.30966460961956" %% xsd:float,
         nidm_pValueUncorrected: = "0.000467039117525991" %% xsd:float,
         nidm_pValueFWER: = "0.999999999106929" %% xsd:float,
         nidm_qValueFDR: = "0.0155581475175598" %% xsd:float])
-    entity(niiri:f5b1c1485206e295c6ee4401f24e8fea,
+    entity(niiri:2eedc6f2b2f210a352180ba9bf836bdb,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0056" %% xsd:string,
         nidm_coordinateVector: = "[56,26,26]" %% xsd:string])
-    wasDerivedFrom(niiri:7031b6f01d04b3aa346e5d15b9d75e4d, niiri:b2f3ddd032f5ca78054f0eca8d0c8769, -, -, -)
-    entity(niiri:9de3e3776111574cff8aedaff0068b73,
+    wasDerivedFrom(niiri:2241ef49d05e5f1d71db21c706159ef1, niiri:61fab5ab040124b4935fd160bc4c75c2, -, -, -)
+    entity(niiri:de1ef49da56b6d1ffb63fe6c57d93f44,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0057" %% xsd:string,
-        prov:location = 'niiri:35e6921502f4efac1ec19702a6773271',
+        prov:location = 'niiri:810f41807fafc1e5eaa827e6a868c17c',
         prov:value = "4.23224687576294" %% xsd:float,
         nidm_equivalentZStatistic: = "3.29656664149817" %% xsd:float,
         nidm_pValueUncorrected: = "0.000489371958441343" %% xsd:float,
         nidm_pValueFWER: = "0.999999999522306" %% xsd:float,
         nidm_qValueFDR: = "0.0159527943368947" %% xsd:float])
-    entity(niiri:35e6921502f4efac1ec19702a6773271,
+    entity(niiri:810f41807fafc1e5eaa827e6a868c17c,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0057" %% xsd:string,
         nidm_coordinateVector: = "[14,-30,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:9de3e3776111574cff8aedaff0068b73, niiri:cf4b88bff59c1a33cd867e9422f84011, -, -, -)
-    entity(niiri:bc149e6b113081f115e5a5ea364f34d0,
+    wasDerivedFrom(niiri:de1ef49da56b6d1ffb63fe6c57d93f44, niiri:3e195e76e0011bcbca16974bc51df875, -, -, -)
+    entity(niiri:c444ee8f429895614ebda9dbf5fbd1fb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0058" %% xsd:string,
-        prov:location = 'niiri:1f636960ef3619fc8aec226fb7543fcf',
+        prov:location = 'niiri:5a6eb1a0f188a666a4aaaecea6d678fa',
         prov:value = "4.21795654296875" %% xsd:float,
         nidm_equivalentZStatistic: = "3.28909139477101" %% xsd:float,
         nidm_pValueUncorrected: = "0.000502556899069861" %% xsd:float,
         nidm_pValueFWER: = "0.999999999667972" %% xsd:float,
         nidm_qValueFDR: = "0.0162089652787187" %% xsd:float])
-    entity(niiri:1f636960ef3619fc8aec226fb7543fcf,
+    entity(niiri:5a6eb1a0f188a666a4aaaecea6d678fa,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0058" %% xsd:string,
         nidm_coordinateVector: = "[46,-54,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:bc149e6b113081f115e5a5ea364f34d0, niiri:3283422abdc309a208995369231fe32a, -, -, -)
-    entity(niiri:2bb4c41e8f9c06be5b3747cb28574b9a,
+    wasDerivedFrom(niiri:c444ee8f429895614ebda9dbf5fbd1fb, niiri:efb3b3e5edd63741aa95f90f1a73c855, -, -, -)
+    entity(niiri:5baaf3257c1f9338a03f1372087336aa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0059" %% xsd:string,
-        prov:location = 'niiri:22ee550046229aa65e9420876ed6f5a0',
+        prov:location = 'niiri:8288b9701fe4611f125b1363a4414e5a',
         prov:value = "4.19331645965576" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27615344058961" %% xsd:float,
         nidm_pValueUncorrected: = "0.000526156861805016" %% xsd:float,
         nidm_pValueFWER: = "0.999999999825125" %% xsd:float,
         nidm_qValueFDR: = "0.0165459969587672" %% xsd:float])
-    entity(niiri:22ee550046229aa65e9420876ed6f5a0,
+    entity(niiri:8288b9701fe4611f125b1363a4414e5a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0059" %% xsd:string,
         nidm_coordinateVector: = "[28,22,16]" %% xsd:string])
-    wasDerivedFrom(niiri:2bb4c41e8f9c06be5b3747cb28574b9a, niiri:c9c180c62d3cd262bcb7bb862a2e2d3e, -, -, -)
-    entity(niiri:7c426e29ff0188e4df4277d19017ee63,
+    wasDerivedFrom(niiri:5baaf3257c1f9338a03f1372087336aa, niiri:e3b33814b86cd485564e0a0928f90e0f, -, -, -)
+    entity(niiri:280fd372fb559f3177b6e1256a306389,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0060" %% xsd:string,
-        prov:location = 'niiri:20dcc56b68ae8b6b4c9741adb0b43549',
+        prov:location = 'niiri:2335841ec513e02901317171950e6e7e',
         prov:value = "4.164222240448" %% xsd:float,
         nidm_equivalentZStatistic: = "3.26079679766555" %% xsd:float,
         nidm_pValueUncorrected: = "0.000555498136877608" %% xsd:float,
         nidm_pValueFWER: = "0.999999999919858" %% xsd:float,
         nidm_qValueFDR: = "0.017023135244014" %% xsd:float])
-    entity(niiri:20dcc56b68ae8b6b4c9741adb0b43549,
+    entity(niiri:2335841ec513e02901317171950e6e7e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0060" %% xsd:string,
         nidm_coordinateVector: = "[32,-46,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:7c426e29ff0188e4df4277d19017ee63, niiri:f67691de01cdab9987a52d4efd6796df, -, -, -)
-    entity(niiri:58b42fca78cd1d10deeed8bba2e7180a,
+    wasDerivedFrom(niiri:280fd372fb559f3177b6e1256a306389, niiri:cfdf88b2a941aeba3fcc1f4b45b10448, -, -, -)
+    entity(niiri:68691392db8be62d02ad17ca0283c776,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0061" %% xsd:string,
-        prov:location = 'niiri:6f1505b8bbcfb75633a016754afd0dbb',
+        prov:location = 'niiri:007cea7d2370bfd078d23d8eba7e3a4d',
         prov:value = "4.1354022026062" %% xsd:float,
         nidm_equivalentZStatistic: = "3.24549898327499" %% xsd:float,
         nidm_pValueUncorrected: = "0.000586224915903544" %% xsd:float,
         nidm_pValueFWER: = "0.999999999963932" %% xsd:float,
         nidm_qValueFDR: = "0.0175104371158769" %% xsd:float])
-    entity(niiri:6f1505b8bbcfb75633a016754afd0dbb,
+    entity(niiri:007cea7d2370bfd078d23d8eba7e3a4d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0061" %% xsd:string,
         nidm_coordinateVector: = "[12,18,32]" %% xsd:string])
-    wasDerivedFrom(niiri:58b42fca78cd1d10deeed8bba2e7180a, niiri:ef91e7140c5dbe4c9303f8f1e0cd8673, -, -, -)
-    entity(niiri:360283f26ce5bb979d1d53571784870e,
+    wasDerivedFrom(niiri:68691392db8be62d02ad17ca0283c776, niiri:8053ffdd2903523517c32abc5eed6805, -, -, -)
+    entity(niiri:e0dc036274a57f0fe2d89e9ced584377,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0062" %% xsd:string,
-        prov:location = 'niiri:e7f5f89929f3b52930ffb8fb16c0e839',
+        prov:location = 'niiri:6964785c365b99534b9ed5d158738905',
         prov:value = "4.09669637680054" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22481821343066" %% xsd:float,
         nidm_pValueUncorrected: = "0.000630263410459797" %% xsd:float,
         nidm_pValueFWER: = "0.999999999988153" %% xsd:float,
         nidm_qValueFDR: = "0.0182494607837458" %% xsd:float])
-    entity(niiri:e7f5f89929f3b52930ffb8fb16c0e839,
+    entity(niiri:6964785c365b99534b9ed5d158738905,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0062" %% xsd:string,
         nidm_coordinateVector: = "[6,-60,64]" %% xsd:string])
-    wasDerivedFrom(niiri:360283f26ce5bb979d1d53571784870e, niiri:dcd5d7321bb4d36d468ecf53edb77243, -, -, -)
-    entity(niiri:c8fd6993b937babaf1f8c2135d3b7f1e,
+    wasDerivedFrom(niiri:e0dc036274a57f0fe2d89e9ced584377, niiri:be2669b1217c5497ae7583e9f37e889f, -, -, -)
+    entity(niiri:171d6b4dfd03d1048a1523ac6ab16c51,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0063" %% xsd:string,
-        prov:location = 'niiri:836a956234439c9358b6ebe000e3dcc2',
+        prov:location = 'niiri:0c042f9715d9ee75592c3572982a0982',
         prov:value = "4.06586408615112" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20823228054844" %% xsd:float,
         nidm_pValueUncorrected: = "0.000667767930319307" %% xsd:float,
         nidm_pValueFWER: = "0.999999999995287" %% xsd:float,
         nidm_qValueFDR: = "0.018874773548645" %% xsd:float])
-    entity(niiri:836a956234439c9358b6ebe000e3dcc2,
+    entity(niiri:0c042f9715d9ee75592c3572982a0982,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0063" %% xsd:string,
         nidm_coordinateVector: = "[-20,-66,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:c8fd6993b937babaf1f8c2135d3b7f1e, niiri:049381a7f67019f13a2b75b205f87af1, -, -, -)
-    entity(niiri:ee630cfc618eede368be76300de9d971,
+    wasDerivedFrom(niiri:171d6b4dfd03d1048a1523ac6ab16c51, niiri:345d8154c25e6bc91b83c7a570393c32, -, -, -)
+    entity(niiri:a7098f4e7d792337d036f494fb50b3e4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0064" %% xsd:string,
-        prov:location = 'niiri:b1b6a55493eae042a995758df3cd1afd',
+        prov:location = 'niiri:52a60ec1c4d123189f7f1133afcaa6c6',
         prov:value = "4.05021715164185" %% xsd:float,
         nidm_equivalentZStatistic: = "3.19977690410182" %% xsd:float,
         nidm_pValueUncorrected: = "0.000687670008111763" %% xsd:float,
         nidm_pValueFWER: = "0.999999999997083" %% xsd:float,
         nidm_qValueFDR: = "0.0191721851735585" %% xsd:float])
-    entity(niiri:b1b6a55493eae042a995758df3cd1afd,
+    entity(niiri:52a60ec1c4d123189f7f1133afcaa6c6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0064" %% xsd:string,
         nidm_coordinateVector: = "[-8,-72,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:ee630cfc618eede368be76300de9d971, niiri:6231cdc1c30543959e82f342e7f7c028, -, -, -)
-    entity(niiri:aaf4f8141ee78e9a09556843acd95064,
+    wasDerivedFrom(niiri:a7098f4e7d792337d036f494fb50b3e4, niiri:0feb21dbaab7759d1a095b10570dbcbb, -, -, -)
+    entity(niiri:36b86426126175a8096c29f1919ba51d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0065" %% xsd:string,
-        prov:location = 'niiri:d17d2fa54d9211851a0ef3ebd18a78f0',
+        prov:location = 'niiri:5490e18e279668b30172e0e8f638ec06',
         prov:value = "4.02814960479736" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18780790473987" %% xsd:float,
         nidm_pValueUncorrected: = "0.000716778694212938" %% xsd:float,
         nidm_pValueFWER: = "0.999999999998538" %% xsd:float,
         nidm_qValueFDR: = "0.0196630402446738" %% xsd:float])
-    entity(niiri:d17d2fa54d9211851a0ef3ebd18a78f0,
+    entity(niiri:5490e18e279668b30172e0e8f638ec06,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0065" %% xsd:string,
         nidm_coordinateVector: = "[-26,-36,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:aaf4f8141ee78e9a09556843acd95064, niiri:d078d2a64b3eee365a7318a424f3d55f, -, -, -)
-    entity(niiri:122d4d1496fd61336c1b2e14c2eb7b08,
+    wasDerivedFrom(niiri:36b86426126175a8096c29f1919ba51d, niiri:4867e698cc576f0b80c177fdf37912bc, -, -, -)
+    entity(niiri:68fbcfdade2d23e2a8f7038c87eb5cff,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0066" %% xsd:string,
-        prov:location = 'niiri:e058fbd337495ddaef29dc0ea8a04073',
+        prov:location = 'niiri:77d8894d4ae1110ed28592a6314d05e6',
         prov:value = "4.0194239616394" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18306102742152" %% xsd:float,
         nidm_pValueUncorrected: = "0.000728634479518986" %% xsd:float,
         nidm_pValueFWER: = "0.999999999998893" %% xsd:float,
         nidm_qValueFDR: = "0.019829947388337" %% xsd:float])
-    entity(niiri:e058fbd337495ddaef29dc0ea8a04073,
+    entity(niiri:77d8894d4ae1110ed28592a6314d05e6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0066" %% xsd:string,
         nidm_coordinateVector: = "[-26,6,66]" %% xsd:string])
-    wasDerivedFrom(niiri:122d4d1496fd61336c1b2e14c2eb7b08, niiri:b07d53658c12f0d165aec1cf959f1eb5, -, -, -)
-    entity(niiri:fdbadebbe5948d7060701cca85b9ec3c,
+    wasDerivedFrom(niiri:68fbcfdade2d23e2a8f7038c87eb5cff, niiri:dbd7ff1039cc058a9180d3a6b19c0d65, -, -, -)
+    entity(niiri:00465a63053242b2dffac6ee659b2354,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0067" %% xsd:string,
-        prov:location = 'niiri:bb35e3e75e4774ac32be8c7e9af072a0',
+        prov:location = 'niiri:f450ec4d266f33c1b6d2eb7b93ec2c9b',
         prov:value = "4.01476430892944" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18052278869165" %% xsd:float,
         nidm_pValueUncorrected: = "0.000735047880785378" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999046" %% xsd:float,
         nidm_qValueFDR: = "0.0199399671265334" %% xsd:float])
-    entity(niiri:bb35e3e75e4774ac32be8c7e9af072a0,
+    entity(niiri:f450ec4d266f33c1b6d2eb7b93ec2c9b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0067" %% xsd:string,
         nidm_coordinateVector: = "[-32,-6,66]" %% xsd:string])
-    wasDerivedFrom(niiri:fdbadebbe5948d7060701cca85b9ec3c, niiri:5e501329a485d9e81bca69bd136264fb, -, -, -)
-    entity(niiri:bac46c7751735f78e1059a5ed0f4d21a,
+    wasDerivedFrom(niiri:00465a63053242b2dffac6ee659b2354, niiri:9a04edbbfec2046f6e63a9808f7e31be, -, -, -)
+    entity(niiri:d1e53c6e21728e567ad7d5efc7526f76,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0068" %% xsd:string,
-        prov:location = 'niiri:30f30dcc3a862edc1cc78ec4115bd0e9',
+        prov:location = 'niiri:2f0f52f74919616dd5ecdc47bdf7662d',
         prov:value = "4.01372337341309" %% xsd:float,
         nidm_equivalentZStatistic: = "3.17995544681479" %% xsd:float,
         nidm_pValueUncorrected: = "0.000736488485902353" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999078" %% xsd:float,
         nidm_qValueFDR: = "0.0199550456355793" %% xsd:float])
-    entity(niiri:30f30dcc3a862edc1cc78ec4115bd0e9,
+    entity(niiri:2f0f52f74919616dd5ecdc47bdf7662d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0068" %% xsd:string,
         nidm_coordinateVector: = "[56,-4,46]" %% xsd:string])
-    wasDerivedFrom(niiri:bac46c7751735f78e1059a5ed0f4d21a, niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097, -, -, -)
-    entity(niiri:2bfd75fa4bfe77aa205c149b2fec102a,
+    wasDerivedFrom(niiri:d1e53c6e21728e567ad7d5efc7526f76, niiri:4802981400c706074d7089aa4f606c7a, -, -, -)
+    entity(niiri:590d2d1c331312707acd1dd13cad86a4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0069" %% xsd:string,
-        prov:location = 'niiri:6c5e7793c3c3b5878682a31efb3d04b2',
+        prov:location = 'niiri:e13abed58503558f5419d66eb9a3daab',
         prov:value = "3.99763154983521" %% xsd:float,
         nidm_equivalentZStatistic: = "3.17117019350021" %% xsd:float,
         nidm_pValueUncorrected: = "0.000759130810004449" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999453" %% xsd:float,
         nidm_qValueFDR: = "0.0202312537871442" %% xsd:float])
-    entity(niiri:6c5e7793c3c3b5878682a31efb3d04b2,
+    entity(niiri:e13abed58503558f5419d66eb9a3daab,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0069" %% xsd:string,
         nidm_coordinateVector: = "[10,-20,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:2bfd75fa4bfe77aa205c149b2fec102a, niiri:f19fc244e1ad9fb88396e6dc5d62c29b, -, -, -)
-    entity(niiri:089ac9f5b2b657c00a34b4ab8eaee4d1,
+    wasDerivedFrom(niiri:590d2d1c331312707acd1dd13cad86a4, niiri:0c9c1006b093a8cc91c759baf58575ee, -, -, -)
+    entity(niiri:d6a41ae2f605bfe0ffcfcdd41c571806,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0070" %% xsd:string,
-        prov:location = 'niiri:af1872b1d428bd30ce24b10511479e0f',
+        prov:location = 'niiri:b52aa1bb12ceb0dd758b5674ba71269e',
         prov:value = "3.96427512168884" %% xsd:float,
         nidm_equivalentZStatistic: = "3.15287103994341" %% xsd:float,
         nidm_pValueUncorrected: = "0.000808366063659971" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999982" %% xsd:float,
         nidm_qValueFDR: = "0.0208863381686101" %% xsd:float])
-    entity(niiri:af1872b1d428bd30ce24b10511479e0f,
+    entity(niiri:b52aa1bb12ceb0dd758b5674ba71269e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0070" %% xsd:string,
         nidm_coordinateVector: = "[-52,20,36]" %% xsd:string])
-    wasDerivedFrom(niiri:089ac9f5b2b657c00a34b4ab8eaee4d1, niiri:8a6f880f7b8eaf62148b54fef7844b09, -, -, -)
-    entity(niiri:8cdecc19343e1178e26e45853c9023ed,
+    wasDerivedFrom(niiri:d6a41ae2f605bfe0ffcfcdd41c571806, niiri:9e9eebffba744c379bca54d713a85d3b, -, -, -)
+    entity(niiri:f48cec3f59920d1e0aef1e5edb72b3ae,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0071" %% xsd:string,
-        prov:location = 'niiri:77adc2dd71b080ae0c496d60454bd8e0',
+        prov:location = 'niiri:28e17599c65fb7c18cd3eb6c92fcdf63',
         prov:value = "3.94705867767334" %% xsd:float,
         nidm_equivalentZStatistic: = "3.14337930633102" %% xsd:float,
         nidm_pValueUncorrected: = "0.000835046362340219" %% xsd:float,
         nidm_pValueFWER: = "0.9999999999999" %% xsd:float,
         nidm_qValueFDR: = "0.0212745029430363" %% xsd:float])
-    entity(niiri:77adc2dd71b080ae0c496d60454bd8e0,
+    entity(niiri:28e17599c65fb7c18cd3eb6c92fcdf63,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0071" %% xsd:string,
         nidm_coordinateVector: = "[10,-24,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:8cdecc19343e1178e26e45853c9023ed, niiri:de48b7494a3d45a8a57e155aeea2f132, -, -, -)
-    entity(niiri:be6866429745ec8fceee0123965bf9be,
+    wasDerivedFrom(niiri:f48cec3f59920d1e0aef1e5edb72b3ae, niiri:2ef2320c7a264cf13420c161d25ff5cc, -, -, -)
+    entity(niiri:0bf03c97edd7b117b1111cf0cfa73c96,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0072" %% xsd:string,
-        prov:location = 'niiri:baa063c02b5a1e3acbac348c6e7f4f8f',
+        prov:location = 'niiri:05eb28fd11ef4f85b5b7fccadd23374f',
         prov:value = "3.93684697151184" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13773425766756" %% xsd:float,
         nidm_pValueUncorrected: = "0.00085129580940857" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999993" %% xsd:float,
         nidm_qValueFDR: = "0.0215142897882816" %% xsd:float])
-    entity(niiri:baa063c02b5a1e3acbac348c6e7f4f8f,
+    entity(niiri:05eb28fd11ef4f85b5b7fccadd23374f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0072" %% xsd:string,
         nidm_coordinateVector: = "[-32,18,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:be6866429745ec8fceee0123965bf9be, niiri:c60f3aab1eee7d78c6850a16c38162dc, -, -, -)
-    entity(niiri:ad9707602adb5afb0acaa4237ca4f979,
+    wasDerivedFrom(niiri:0bf03c97edd7b117b1111cf0cfa73c96, niiri:53b5e166978251c052e00c9a4fe81fdc, -, -, -)
+    entity(niiri:bb138c83a7f0b859be01107344c7d312,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0073" %% xsd:string,
-        prov:location = 'niiri:01154cd48f33a76a138d224c14ee2d42',
+        prov:location = 'niiri:e83ab329851a7f93c2f57864f4abe3b3',
         prov:value = "3.93397641181946" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13614537112983" %% xsd:float,
         nidm_pValueUncorrected: = "0.000855921637752388" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999937" %% xsd:float,
         nidm_qValueFDR: = "0.0215615444445258" %% xsd:float])
-    entity(niiri:01154cd48f33a76a138d224c14ee2d42,
+    entity(niiri:e83ab329851a7f93c2f57864f4abe3b3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0073" %% xsd:string,
         nidm_coordinateVector: = "[52,10,18]" %% xsd:string])
-    wasDerivedFrom(niiri:ad9707602adb5afb0acaa4237ca4f979, niiri:859e657235309e3db15ccb1f14c1e7ba, -, -, -)
-    entity(niiri:11ba1d6f38fb1b63a2f74b7601766c83,
+    wasDerivedFrom(niiri:bb138c83a7f0b859be01107344c7d312, niiri:de88c64838ddf5de0155dcdce61cf6c0, -, -, -)
+    entity(niiri:86b5d287e5e443c1262f0ad80f006282,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0074" %% xsd:string,
-        prov:location = 'niiri:6d498f6e4c82a7d741b60a62a8092e8b',
+        prov:location = 'niiri:9544cd35baa3055df29785d0cba7563e',
         prov:value = "3.92871356010437" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13323000033267" %% xsd:float,
         nidm_pValueUncorrected: = "0.000864469518982003" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999947" %% xsd:float,
         nidm_qValueFDR: = "0.0216822850176731" %% xsd:float])
-    entity(niiri:6d498f6e4c82a7d741b60a62a8092e8b,
+    entity(niiri:9544cd35baa3055df29785d0cba7563e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0074" %% xsd:string,
         nidm_coordinateVector: = "[34,-52,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:11ba1d6f38fb1b63a2f74b7601766c83, niiri:065fb1288e613aa1089a803ba4b13d87, -, -, -)
-    entity(niiri:ed629eddf9cc975359669c19b33ac397,
+    wasDerivedFrom(niiri:86b5d287e5e443c1262f0ad80f006282, niiri:02344c7a7b0c9af7c25dbcd3cbd09300, -, -, -)
+    entity(niiri:a659cc920974b885b011950336fdb2e6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0075" %% xsd:string,
-        prov:location = 'niiri:58e5368187096a105a3cad65343f1be3',
+        prov:location = 'niiri:82c89a91afac0227805c920ac46780b4',
         prov:value = "3.91936802864075" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12804559569402" %% xsd:float,
         nidm_pValueUncorrected: = "0.000879864400760821" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999962" %% xsd:float,
         nidm_qValueFDR: = "0.0218781120126672" %% xsd:float])
-    entity(niiri:58e5368187096a105a3cad65343f1be3,
+    entity(niiri:82c89a91afac0227805c920ac46780b4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0075" %% xsd:string,
         nidm_coordinateVector: = "[16,-32,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:ed629eddf9cc975359669c19b33ac397, niiri:021e14b3f5e58d6dd1904bdbad37b113, -, -, -)
-    entity(niiri:15eec198bb6cca7b798e1e7a4e6de3b6,
+    wasDerivedFrom(niiri:a659cc920974b885b011950336fdb2e6, niiri:22648332b0e4fb9a38556afd35646c42, -, -, -)
+    entity(niiri:8f404f298d64974fc27f83332fc6d68e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0076" %% xsd:string,
-        prov:location = 'niiri:63bfb114a4b23a3d0d57b8802a082634',
+        prov:location = 'niiri:6a1d3251cb160a559caa1932f4e6e20d',
         prov:value = "3.8760769367218" %% xsd:float,
         nidm_equivalentZStatistic: = "3.1039055725094" %% xsd:float,
         nidm_pValueUncorrected: = "0.000954921373033768" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999992" %% xsd:float,
         nidm_qValueFDR: = "0.0229044690727897" %% xsd:float])
-    entity(niiri:63bfb114a4b23a3d0d57b8802a082634,
+    entity(niiri:6a1d3251cb160a559caa1932f4e6e20d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0076" %% xsd:string,
         nidm_coordinateVector: = "[18,8,34]" %% xsd:string])
-    wasDerivedFrom(niiri:15eec198bb6cca7b798e1e7a4e6de3b6, niiri:7fa11ca3554a75156c897f72b0a338ac, -, -, -)
+    wasDerivedFrom(niiri:8f404f298d64974fc27f83332fc6d68e, niiri:3b46a57f86b33c173fe10a245389f4ff, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_t_test/nidm.provn
+++ b/spmexport/ex_spm_t_test/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:0912ef5e7651a34c983f4ed45de3d308,
+  entity(niiri:d3620d9b9dba21e55b8611d04687ee57,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:b18851d58fa1ff2313b6177c4f070859,
+  agent(niiri:8bc0ef5e8cf743c84980e54ca732c862,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:f0b42854b0e7b708416cf70b7c8fedd1,
+  activity(niiri:776fbf4cc67a6b80aadea0237f1fcc66,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:f0b42854b0e7b708416cf70b7c8fedd1, niiri:b18851d58fa1ff2313b6177c4f070859, -)
-  wasGeneratedBy(niiri:0912ef5e7651a34c983f4ed45de3d308, niiri:f0b42854b0e7b708416cf70b7c8fedd1, 2016-01-11T10:34:29)
-  bundle niiri:0912ef5e7651a34c983f4ed45de3d308
+  wasAssociatedWith(niiri:776fbf4cc67a6b80aadea0237f1fcc66, niiri:8bc0ef5e8cf743c84980e54ca732c862, -)
+  wasGeneratedBy(niiri:d3620d9b9dba21e55b8611d04687ee57, niiri:776fbf4cc67a6b80aadea0237f1fcc66, 2016-01-11T10:45:12)
+  bundle niiri:d3620d9b9dba21e55b8611d04687ee57
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -118,12 +118,12 @@ document
     prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
     prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
 
-    agent(niiri:c51db428dc8ee9bf707d42093e3d3377,
+    agent(niiri:96198474ba98869050cdd078306a74e2,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:6db7cc02a5d65d98ca2f4e6e802b59cd,
+    entity(niiri:04fbe324d49c159deb6e56f717129eed,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -132,120 +132,120 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:a322de38d0ea077b76fbeb115a3d6f03,
+    entity(niiri:4e487628f2f5dadc26c514f0fc01a044,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "false" %% xsd:boolean])
-    entity(niiri:1e206e0f7ca8761333a5f8c2e84dda5b,
+    entity(niiri:6198b51780af8d8f54862261a6e71c82,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:32e030b2b9eb8c5f3fc532b16c3a8fa0',
+        dc:description = 'niiri:9cfa77b06d7c3e52c75bd1be4b4e5064',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"mean\"]" %% xsd:string])
-    entity(niiri:32e030b2b9eb8c5f3fc532b16c3a8fa0,
+    entity(niiri:9cfa77b06d7c3e52c75bd1be4b4e5064,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:22cef4703417a75639fda532c16cf80d,
+    entity(niiri:00a2d205839a2804eac5a33befd84f81,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'nidm_IndependentError:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean])
-    activity(niiri:a230dbc0ad05bf076dbd69b21f01dd10,
+    activity(niiri:d1485b7f2748b3d29cb54551ff2cb41f,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_OLS:'])
-    wasAssociatedWith(niiri:a230dbc0ad05bf076dbd69b21f01dd10, niiri:c51db428dc8ee9bf707d42093e3d3377, -)
-    used(niiri:a230dbc0ad05bf076dbd69b21f01dd10, niiri:1e206e0f7ca8761333a5f8c2e84dda5b, -)
-    used(niiri:a230dbc0ad05bf076dbd69b21f01dd10, niiri:a322de38d0ea077b76fbeb115a3d6f03, -)
-    used(niiri:a230dbc0ad05bf076dbd69b21f01dd10, niiri:22cef4703417a75639fda532c16cf80d, -)
-    entity(niiri:be07ca5d1a4babb35995fdf04899fb32,
+    wasAssociatedWith(niiri:d1485b7f2748b3d29cb54551ff2cb41f, niiri:96198474ba98869050cdd078306a74e2, -)
+    used(niiri:d1485b7f2748b3d29cb54551ff2cb41f, niiri:6198b51780af8d8f54862261a6e71c82, -)
+    used(niiri:d1485b7f2748b3d29cb54551ff2cb41f, niiri:4e487628f2f5dadc26c514f0fc01a044, -)
+    used(niiri:d1485b7f2748b3d29cb54551ff2cb41f, niiri:00a2d205839a2804eac5a33befd84f81, -)
+    entity(niiri:7d4bc018981da17a2708e9aa1d5b9adf,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
-    entity(niiri:7c74c0d0b2c4f48fa050e438562326f8,
+    entity(niiri:f85f2b6d3a2b40d6fa37f164cd8461f5,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e" %% xsd:string])
-    wasDerivedFrom(niiri:be07ca5d1a4babb35995fdf04899fb32, niiri:7c74c0d0b2c4f48fa050e438562326f8, -, -, -)
-    wasGeneratedBy(niiri:be07ca5d1a4babb35995fdf04899fb32, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
-    entity(niiri:d7f6f2a0365232d977b7db0afaf9a5fb,
+    wasDerivedFrom(niiri:7d4bc018981da17a2708e9aa1d5b9adf, niiri:f85f2b6d3a2b40d6fa37f164cd8461f5, -, -, -)
+    wasGeneratedBy(niiri:7d4bc018981da17a2708e9aa1d5b9adf, niiri:d1485b7f2748b3d29cb54551ff2cb41f, -)
+    entity(niiri:74d4f7b4f324a17ecdd18d2ea997d1e0,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "0.0584948938339949" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         crypto:sha512 = "504d2b5e17e73690caae29eafdc0448a1d5ac6d66af811a3fcbab8eec9f904820f0610d985a6f04e8808fcd8f77def3c063bfb11df56679b0b28261cdc2856f9" %% xsd:string])
-    wasGeneratedBy(niiri:d7f6f2a0365232d977b7db0afaf9a5fb, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
-    entity(niiri:ef79850e03bdae0e1923acf92832ca93,
+    wasGeneratedBy(niiri:74d4f7b4f324a17ecdd18d2ea997d1e0, niiri:d1485b7f2748b3d29cb54551ff2cb41f, -)
+    entity(niiri:828d5d9fb555db8dd16ea37e38271b14,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd'])
-    entity(niiri:a887854143325483e34db878814c8082,
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed'])
+    entity(niiri:627d8cb492bf8813020a3fdf5e0d2732,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "9a22064d78683e5b5375b6d3708584d2bb24dd434f40b311f06e185e10c9492d976c35967cc2545e3d7aefa2b83f7e433c957bd8dc87c22392e334027d0b438b" %% xsd:string])
-    wasDerivedFrom(niiri:ef79850e03bdae0e1923acf92832ca93, niiri:a887854143325483e34db878814c8082, -, -, -)
-    wasGeneratedBy(niiri:ef79850e03bdae0e1923acf92832ca93, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
-    entity(niiri:4df94669c28a6f6a636b1bbaa6a0d0f7,
+    wasDerivedFrom(niiri:828d5d9fb555db8dd16ea37e38271b14, niiri:627d8cb492bf8813020a3fdf5e0d2732, -, -, -)
+    wasGeneratedBy(niiri:828d5d9fb555db8dd16ea37e38271b14, niiri:d1485b7f2748b3d29cb54551ff2cb41f, -)
+    entity(niiri:61634d07c3a3f501827bc58fbbe9fda1,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         crypto:sha512 = "5796b765989869d8ad685aee159b41c06538552c8a91ed6cfa9dc7a334df02e91dd83703fd5d9be4a7fc8a27943157d2cf29f457aa1cf4a3d01ce813480ddaaa" %% xsd:string])
-    entity(niiri:db622461201dc3fe743fb5d1e2b95c19,
+    entity(niiri:93393dbc324f2290abe13206c556317a,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "bd6687fb4b5d5af30fa322a8b6b6df29ead2c1e0ebe8e1962c3716c2c05a23365fe0428be1d420ef8b013c4c342c0d5efe704fec31b6e956c2b4d15a630b1c98" %% xsd:string])
-    wasDerivedFrom(niiri:4df94669c28a6f6a636b1bbaa6a0d0f7, niiri:db622461201dc3fe743fb5d1e2b95c19, -, -, -)
-    wasGeneratedBy(niiri:4df94669c28a6f6a636b1bbaa6a0d0f7, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
-    entity(niiri:de9f181e681892d8a4cecf00f081b937,
+    wasDerivedFrom(niiri:61634d07c3a3f501827bc58fbbe9fda1, niiri:93393dbc324f2290abe13206c556317a, -, -, -)
+    wasGeneratedBy(niiri:61634d07c3a3f501827bc58fbbe9fda1, niiri:d1485b7f2748b3d29cb54551ff2cb41f, -)
+    entity(niiri:5826139507aacbfc3d4d420eae1b5252,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         crypto:sha512 = "7090223b1a196dba349a102d5d369808fa90203f67c9021d2113b323996c67506be3e49d5e848a4f38a6ff78038478dee1401d2a7cd9ee5e6496f3d0313c6eb6" %% xsd:string])
-    entity(niiri:4bc17018182371ce2299d53dda370a88,
+    entity(niiri:ff2e93be5a46fc6c0206e44008773a88,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "95b2ccdef4496cd3830f817f9d8893924091b302a09c66b1581f7ee4721c618a1d95d56e509e8f1537af7ea437bc5f3fbf7f69037f13203b6c98733647911d8d" %% xsd:string])
-    wasDerivedFrom(niiri:de9f181e681892d8a4cecf00f081b937, niiri:4bc17018182371ce2299d53dda370a88, -, -, -)
-    wasGeneratedBy(niiri:de9f181e681892d8a4cecf00f081b937, niiri:a230dbc0ad05bf076dbd69b21f01dd10, -)
-    entity(niiri:6bde2d077439c82e001fb48426475a91,
+    wasDerivedFrom(niiri:5826139507aacbfc3d4d420eae1b5252, niiri:ff2e93be5a46fc6c0206e44008773a88, -, -, -)
+    wasGeneratedBy(niiri:5826139507aacbfc3d4d420eae1b5252, niiri:d1485b7f2748b3d29cb54551ff2cb41f, -)
+    entity(niiri:1112cf8b4737fbd5c27d443eb9e8637c,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
         prov:label = "Contrast: Con1: mr vs plain" %% xsd:string,
         prov:value = "1" %% xsd:string])
-    activity(niiri:130277e2f55ac12e05a80fbef35bd105,
+    activity(niiri:8d0a21cc2e9836a5ff80b0438d25714a,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:c51db428dc8ee9bf707d42093e3d3377, -)
-    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:be07ca5d1a4babb35995fdf04899fb32, -)
-    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:4df94669c28a6f6a636b1bbaa6a0d0f7, -)
-    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:1e206e0f7ca8761333a5f8c2e84dda5b, -)
-    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:6bde2d077439c82e001fb48426475a91, -)
-    used(niiri:130277e2f55ac12e05a80fbef35bd105, niiri:ef79850e03bdae0e1923acf92832ca93, -)
-    entity(niiri:ad092c1420d338bff2feebb61bee6605,
+    wasAssociatedWith(niiri:8d0a21cc2e9836a5ff80b0438d25714a, niiri:96198474ba98869050cdd078306a74e2, -)
+    used(niiri:8d0a21cc2e9836a5ff80b0438d25714a, niiri:7d4bc018981da17a2708e9aa1d5b9adf, -)
+    used(niiri:8d0a21cc2e9836a5ff80b0438d25714a, niiri:61634d07c3a3f501827bc58fbbe9fda1, -)
+    used(niiri:8d0a21cc2e9836a5ff80b0438d25714a, niiri:6198b51780af8d8f54862261a6e71c82, -)
+    used(niiri:8d0a21cc2e9836a5ff80b0438d25714a, niiri:1112cf8b4737fbd5c27d443eb9e8637c, -)
+    used(niiri:8d0a21cc2e9836a5ff80b0438d25714a, niiri:828d5d9fb555db8dd16ea37e38271b14, -)
+    entity(niiri:75a864a5bb3a9315e23f3a7d3ce2f902,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -255,103 +255,103 @@ document
         nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "13" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         crypto:sha512 = "2eec11aca8e4898cb44b0e535e3abecde8d46ea6e5fe05bb26e2dee72769fcb985c90c0ed86b9dcaf260d502b34559700f7a3c0f944f020a4beb20042153d26f" %% xsd:string])
-    entity(niiri:fe88d5b09130483c026b50e13977e412,
+    entity(niiri:9f7b6f46b0180335525f9631e8c420f6,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "291b6fbfe377046689fa404484c99e68b419966665af4294ca5348faf3ee9e3e4ea972ccb9c17fc697c42c58d915fda6300a540027b872eccd1403215cd2e075" %% xsd:string])
-    wasDerivedFrom(niiri:ad092c1420d338bff2feebb61bee6605, niiri:fe88d5b09130483c026b50e13977e412, -, -, -)
-    wasGeneratedBy(niiri:ad092c1420d338bff2feebb61bee6605, niiri:130277e2f55ac12e05a80fbef35bd105, -)
-    entity(niiri:b3dc79d8ad2eb32d47956780781c51d6,
+    wasDerivedFrom(niiri:75a864a5bb3a9315e23f3a7d3ce2f902, niiri:9f7b6f46b0180335525f9631e8c420f6, -, -, -)
+    wasGeneratedBy(niiri:75a864a5bb3a9315e23f3a7d3ce2f902, niiri:8d0a21cc2e9836a5ff80b0438d25714a, -)
+    entity(niiri:3706554d9a0557214a89435bbaf15c65,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: Con1: mr vs plain" %% xsd:string,
         nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         crypto:sha512 = "d907fef7984f59a008b8963e5fb6d2386968ffcde54e31fabe7ed8b0e1a32e4410475271e4fa903e1aa6c01ef4903209fb61660bd47a5709a5c5c91bccc8b426" %% xsd:string])
-    entity(niiri:6941db4ab0e9730a24b012b3310d0f8a,
+    entity(niiri:c2816cbcca305cfd8a2ae01ee68dfbaa,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "66e00621b81bef508ca685a72a398d532276891ec8b2abc489af8f6105099ca9a54f52697ea83360eed53387ba6bec3ae1fc7f882ca4f3c8f944ee9a15f099ba" %% xsd:string])
-    wasDerivedFrom(niiri:b3dc79d8ad2eb32d47956780781c51d6, niiri:6941db4ab0e9730a24b012b3310d0f8a, -, -, -)
-    wasGeneratedBy(niiri:b3dc79d8ad2eb32d47956780781c51d6, niiri:130277e2f55ac12e05a80fbef35bd105, -)
-    entity(niiri:1ef03434814308215299edd166a251be,
+    wasDerivedFrom(niiri:3706554d9a0557214a89435bbaf15c65, niiri:c2816cbcca305cfd8a2ae01ee68dfbaa, -, -, -)
+    wasGeneratedBy(niiri:3706554d9a0557214a89435bbaf15c65, niiri:8d0a21cc2e9836a5ff80b0438d25714a, -)
+    entity(niiri:d0391616d3211341e5cef588713b179b,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         crypto:sha512 = "4fed4edb0da80cd11916dccc511db465d9a42101a08318ca494f751102dfed9e4ccf557dbb4eaef9d792f662864bfe3a77670a1c78dbbf144974e8866d9640f0" %% xsd:string])
-    wasGeneratedBy(niiri:1ef03434814308215299edd166a251be, niiri:130277e2f55ac12e05a80fbef35bd105, -)
-    entity(niiri:aa34765c622ec88209dbca1ddf40b225,
+    wasGeneratedBy(niiri:d0391616d3211341e5cef588713b179b, niiri:8d0a21cc2e9836a5ff80b0438d25714a, -)
+    entity(niiri:2385d9825a21ef12f87f56c0390fcf54,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500181305457" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:66fda984913d6a14877915720b65e6ca',
-        nidm_equivalentThreshold: = 'niiri:802a4095edf055d7da2eb939ea257d85'])
-    entity(niiri:66fda984913d6a14877915720b65e6ca,
+        nidm_equivalentThreshold: = 'niiri:d241b46d63e6a3d40e6e9c5f3ce30109',
+        nidm_equivalentThreshold: = 'niiri:e007aaa3cd10e5f5fb11901a850a522f'])
+    entity(niiri:d241b46d63e6a3d40e6e9c5f3ce30109,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.85198238341593" %% xsd:float])
-    entity(niiri:802a4095edf055d7da2eb939ea257d85,
+    entity(niiri:e007aaa3cd10e5f5fb11901a850a522f,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999999997" %% xsd:float])
-    entity(niiri:2735f4f85b2c1346a8849aa3723fed30,
+    entity(niiri:1bb19ad21632cfbd79ccb1eec4d22fc1,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:511e0e85d0615cf4311996169a6e8221',
-        nidm_equivalentThreshold: = 'niiri:5a25669dc1de6e55ec1edcdeb918c132'])
-    entity(niiri:511e0e85d0615cf4311996169a6e8221,
+        nidm_equivalentThreshold: = 'niiri:c972ecd11cbafdfd88b65d82f1f4fb7b',
+        nidm_equivalentThreshold: = 'niiri:b4215c470da5f16e85576273b7f9173c'])
+    entity(niiri:c972ecd11cbafdfd88b65d82f1f4fb7b,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:5a25669dc1de6e55ec1edcdeb918c132,
+    entity(niiri:b4215c470da5f16e85576273b7f9173c,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:1ba31b971ce92f322556ea50dd1da5aa,
+    entity(niiri:408e227b2049079df41fd4de56121bf8,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:59d671f65af3f2e501782f35d0cb64e3,
+    entity(niiri:77b187d9f51e36eeff7db5a09c82ef24,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:292b1e1f2538029aed5f141c52538889,
+    activity(niiri:82842b70a847c053a12e2c5786adc9d0,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:292b1e1f2538029aed5f141c52538889, niiri:c51db428dc8ee9bf707d42093e3d3377, -)
-    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:aa34765c622ec88209dbca1ddf40b225, -)
-    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:2735f4f85b2c1346a8849aa3723fed30, -)
-    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:ad092c1420d338bff2feebb61bee6605, -)
-    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:de9f181e681892d8a4cecf00f081b937, -)
-    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:be07ca5d1a4babb35995fdf04899fb32, -)
-    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:1ba31b971ce92f322556ea50dd1da5aa, -)
-    used(niiri:292b1e1f2538029aed5f141c52538889, niiri:59d671f65af3f2e501782f35d0cb64e3, -)
-    entity(niiri:e45c455fef5d8cb108c1651352a3a733,
+    wasAssociatedWith(niiri:82842b70a847c053a12e2c5786adc9d0, niiri:96198474ba98869050cdd078306a74e2, -)
+    used(niiri:82842b70a847c053a12e2c5786adc9d0, niiri:2385d9825a21ef12f87f56c0390fcf54, -)
+    used(niiri:82842b70a847c053a12e2c5786adc9d0, niiri:1bb19ad21632cfbd79ccb1eec4d22fc1, -)
+    used(niiri:82842b70a847c053a12e2c5786adc9d0, niiri:75a864a5bb3a9315e23f3a7d3ce2f902, -)
+    used(niiri:82842b70a847c053a12e2c5786adc9d0, niiri:5826139507aacbfc3d4d420eae1b5252, -)
+    used(niiri:82842b70a847c053a12e2c5786adc9d0, niiri:7d4bc018981da17a2708e9aa1d5b9adf, -)
+    used(niiri:82842b70a847c053a12e2c5786adc9d0, niiri:408e227b2049079df41fd4de56121bf8, -)
+    used(niiri:82842b70a847c053a12e2c5786adc9d0, niiri:77b187d9f51e36eeff7db5a09c82ef24, -)
+    entity(niiri:0b0948acd1b3bc01fc2d5c02d6c0a1b4,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         nidm_searchVolumeInVoxels: = "167222" %% xsd:int,
         nidm_searchVolumeInUnits: = "1337776" %% xsd:float,
         nidm_reselSizeInVoxels: = "83.1545653831017" %% xsd:float,
@@ -367,8 +367,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "70" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "59" %% xsd:int,
         crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
-    wasGeneratedBy(niiri:e45c455fef5d8cb108c1651352a3a733, niiri:292b1e1f2538029aed5f141c52538889, -)
-    entity(niiri:b92de8901b2a05ad20e537b7d45bcded,
+    wasGeneratedBy(niiri:0b0948acd1b3bc01fc2d5c02d6c0a1b4, niiri:82842b70a847c053a12e2c5786adc9d0, -)
+    entity(niiri:e9ed0af535df635441b4855cd563907f,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -376,22 +376,22 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "57" %% xsd:int,
         nidm_pValue: = "0.000126072725041393" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:d0125669d7f73a1dd58eac955bc608c1',
-        nidm_hasMaximumIntensityProjection: = 'niiri:33e32bf5515a00f9b1224cdca9d36d84',
-        nidm_inCoordinateSpace: = 'niiri:6db7cc02a5d65d98ca2f4e6e802b59cd',
+        nidm_hasClusterLabelsMap: = 'niiri:66d5b456d84920a48a31b01750d8a432',
+        nidm_hasMaximumIntensityProjection: = 'niiri:6b2c7d129b65de53efdd562da4f554eb',
+        nidm_inCoordinateSpace: = 'niiri:04fbe324d49c159deb6e56f717129eed',
         crypto:sha512 = "9bef1b01e85eeddf2e747ceba7ade799597c7837064cb2f65dd700a59f52a84d33bd06d9b28b57b0669461e4ff28c39b9df7e09752b27d653bc515d887e4927e" %% xsd:string])
-    entity(niiri:d0125669d7f73a1dd58eac955bc608c1,
+    entity(niiri:66d5b456d84920a48a31b01750d8a432,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:33e32bf5515a00f9b1224cdca9d36d84,
+    entity(niiri:6b2c7d129b65de53efdd562da4f554eb,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:b92de8901b2a05ad20e537b7d45bcded, niiri:292b1e1f2538029aed5f141c52538889, -)
-    entity(niiri:46ce368f726925043d0fdf11d3ce812c,
+    wasGeneratedBy(niiri:e9ed0af535df635441b4855cd563907f, niiri:82842b70a847c053a12e2c5786adc9d0, -)
+    entity(niiri:215cf61bffa077f54837e2f6abb74357,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3171" %% xsd:int,
@@ -400,8 +400,8 @@ document
         nidm_pValueFWER: = "0" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "1" %% xsd:int])
-    wasDerivedFrom(niiri:46ce368f726925043d0fdf11d3ce812c, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:a121a3d6c11f9c710a28e61253277933,
+    wasDerivedFrom(niiri:215cf61bffa077f54837e2f6abb74357, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:ffb620ba0971608a9222d31cc4937dc9,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1543" %% xsd:int,
@@ -410,8 +410,8 @@ document
         nidm_pValueFWER: = "0" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "2" %% xsd:int])
-    wasDerivedFrom(niiri:a121a3d6c11f9c710a28e61253277933, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:46ae5678b67f432a5739e26d30b8b9fc,
+    wasDerivedFrom(niiri:ffb620ba0971608a9222d31cc4937dc9, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:827f9e23c57be3072b3c3434a71afc3c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1032" %% xsd:int,
@@ -420,8 +420,8 @@ document
         nidm_pValueFWER: = "1.11022302462516e-16" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "3" %% xsd:int])
-    wasDerivedFrom(niiri:46ae5678b67f432a5739e26d30b8b9fc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:ac8f8138199a2f60489cb1fe2bc4c070,
+    wasDerivedFrom(niiri:827f9e23c57be3072b3c3434a71afc3c, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:31f0c8a35e1f97bfc50658b184c91a4e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
         nidm_clusterSizeInVoxels: = "70" %% xsd:int,
@@ -430,8 +430,8 @@ document
         nidm_pValueFWER: = "0.0414106244319472" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "4" %% xsd:int])
-    wasDerivedFrom(niiri:ac8f8138199a2f60489cb1fe2bc4c070, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:3dfc00b52233c69b59012bb4e4590bd6,
+    wasDerivedFrom(niiri:31f0c8a35e1f97bfc50658b184c91a4e, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:b6d1a5338f79d387e625261c1a5fc9a7,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
         nidm_clusterSizeInVoxels: = "250" %% xsd:int,
@@ -440,8 +440,8 @@ document
         nidm_pValueFWER: = "5.6737414573238e-06" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "5" %% xsd:int])
-    wasDerivedFrom(niiri:3dfc00b52233c69b59012bb4e4590bd6, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:e17a558d17c93c4d23cebfdb241952ae,
+    wasDerivedFrom(niiri:b6d1a5338f79d387e625261c1a5fc9a7, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:fdaeca1296f778d816f1b7c0961e6d62,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
         nidm_clusterSizeInVoxels: = "96" %% xsd:int,
@@ -450,8 +450,8 @@ document
         nidm_pValueFWER: = "0.00881525009559059" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "6" %% xsd:int])
-    wasDerivedFrom(niiri:e17a558d17c93c4d23cebfdb241952ae, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:2ee06584880d716387a7002834742906,
+    wasDerivedFrom(niiri:fdaeca1296f778d816f1b7c0961e6d62, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:6d0e6a1098242b9a42aa86b60dc1c165,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -460,8 +460,8 @@ document
         nidm_pValueFWER: = "0.936564091808241" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "7" %% xsd:int])
-    wasDerivedFrom(niiri:2ee06584880d716387a7002834742906, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:0a170fb537c25a43d335a98102d35aeb,
+    wasDerivedFrom(niiri:6d0e6a1098242b9a42aa86b60dc1c165, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:21e31a1448c8fbeee17661915c5bfa21,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
         nidm_clusterSizeInVoxels: = "320" %% xsd:int,
@@ -470,8 +470,8 @@ document
         nidm_pValueFWER: = "3.48987900022912e-07" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "8" %% xsd:int])
-    wasDerivedFrom(niiri:0a170fb537c25a43d335a98102d35aeb, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:0b191a1bce28484b4d509f123468cafc,
+    wasDerivedFrom(niiri:21e31a1448c8fbeee17661915c5bfa21, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:432d988b9e7ab5b924110baf9a663199,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
         nidm_clusterSizeInVoxels: = "64" %% xsd:int,
@@ -480,8 +480,8 @@ document
         nidm_pValueFWER: = "0.0603727115804786" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "9" %% xsd:int])
-    wasDerivedFrom(niiri:0b191a1bce28484b4d509f123468cafc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:03c0220efd2c203f65a22694082f5442,
+    wasDerivedFrom(niiri:432d988b9e7ab5b924110baf9a663199, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:967f3e474d0f75f9f771a026048f7938,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
         nidm_clusterSizeInVoxels: = "161" %% xsd:int,
@@ -490,8 +490,8 @@ document
         nidm_pValueFWER: = "0.000298588701553082" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "10" %% xsd:int])
-    wasDerivedFrom(niiri:03c0220efd2c203f65a22694082f5442, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:847c108abc6d60c3422f305d80cbe544,
+    wasDerivedFrom(niiri:967f3e474d0f75f9f771a026048f7938, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:19214f2395b9d0fe87fea1042712b844,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
         nidm_clusterSizeInVoxels: = "31" %% xsd:int,
@@ -500,8 +500,8 @@ document
         nidm_pValueFWER: = "0.499582648292263" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "11" %% xsd:int])
-    wasDerivedFrom(niiri:847c108abc6d60c3422f305d80cbe544, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:89f5194a4b0e2d5f67db04f10c0882ac,
+    wasDerivedFrom(niiri:19214f2395b9d0fe87fea1042712b844, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:ea4fc41e78afb758775fdca881eec44e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
         nidm_clusterSizeInVoxels: = "71" %% xsd:int,
@@ -510,8 +510,8 @@ document
         nidm_pValueFWER: = "0.0389172719454809" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "12" %% xsd:int])
-    wasDerivedFrom(niiri:89f5194a4b0e2d5f67db04f10c0882ac, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:d97dd5148291142c057785550af3eb2d,
+    wasDerivedFrom(niiri:ea4fc41e78afb758775fdca881eec44e, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:f07aa9c81d91e47a941582b5a886f55f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -520,8 +520,8 @@ document
         nidm_pValueFWER: = "0.999031882554387" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "13" %% xsd:int])
-    wasDerivedFrom(niiri:d97dd5148291142c057785550af3eb2d, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:50d0f0b594a3407fd672472426d8a80a,
+    wasDerivedFrom(niiri:f07aa9c81d91e47a941582b5a886f55f, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:ddf14aef4dbd07683d036e006e3ca075,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
         nidm_clusterSizeInVoxels: = "12" %% xsd:int,
@@ -530,8 +530,8 @@ document
         nidm_pValueFWER: = "0.985901993992134" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "14" %% xsd:int])
-    wasDerivedFrom(niiri:50d0f0b594a3407fd672472426d8a80a, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:5663af6390cbe1661580022d9cd1db76,
+    wasDerivedFrom(niiri:ddf14aef4dbd07683d036e006e3ca075, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:fa453a18169e54396c5e1d3685158f71,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
         nidm_clusterSizeInVoxels: = "8" %% xsd:int,
@@ -540,8 +540,8 @@ document
         nidm_pValueFWER: = "0.999031882554387" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "15" %% xsd:int])
-    wasDerivedFrom(niiri:5663af6390cbe1661580022d9cd1db76, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:936e9ee0499c3d068e7444f367b65d20,
+    wasDerivedFrom(niiri:fa453a18169e54396c5e1d3685158f71, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:cfc18ee1d82cfc55f82dba0b483526cf,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
         nidm_clusterSizeInVoxels: = "24" %% xsd:int,
@@ -550,8 +550,8 @@ document
         nidm_pValueFWER: = "0.719628852078667" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "16" %% xsd:int])
-    wasDerivedFrom(niiri:936e9ee0499c3d068e7444f367b65d20, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:37eed9b79d7a2993d16feb7189856a02,
+    wasDerivedFrom(niiri:cfc18ee1d82cfc55f82dba0b483526cf, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:96e895ca671bf9512c361332af4e5112,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
         nidm_clusterSizeInVoxels: = "9" %% xsd:int,
@@ -560,8 +560,8 @@ document
         nidm_pValueFWER: = "0.997766550775957" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "17" %% xsd:int])
-    wasDerivedFrom(niiri:37eed9b79d7a2993d16feb7189856a02, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:9d921e2cb3a8abbe97013ee4bc904c3e,
+    wasDerivedFrom(niiri:96e895ca671bf9512c361332af4e5112, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:260c691d30c80806cf5f518fece69ec2,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -570,8 +570,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "18" %% xsd:int])
-    wasDerivedFrom(niiri:9d921e2cb3a8abbe97013ee4bc904c3e, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:ba889b1413156c8c9b392f582f507018,
+    wasDerivedFrom(niiri:260c691d30c80806cf5f518fece69ec2, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:e108cef37b66653f5877ad74ee875b20,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
         nidm_clusterSizeInVoxels: = "15" %% xsd:int,
@@ -580,8 +580,8 @@ document
         nidm_pValueFWER: = "0.953259370207355" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "19" %% xsd:int])
-    wasDerivedFrom(niiri:ba889b1413156c8c9b392f582f507018, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:51665d1fb0cfb8bda978b620ef449077,
+    wasDerivedFrom(niiri:e108cef37b66653f5877ad74ee875b20, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:c4022d4c96fbeee42de7e3b591fc1985,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
         nidm_clusterSizeInVoxels: = "22" %% xsd:int,
@@ -590,8 +590,8 @@ document
         nidm_pValueFWER: = "0.78320832600297" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "20" %% xsd:int])
-    wasDerivedFrom(niiri:51665d1fb0cfb8bda978b620ef449077, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:a24fb25342ea5df100b3c9f26c07ccf7,
+    wasDerivedFrom(niiri:c4022d4c96fbeee42de7e3b591fc1985, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:0bf968a5bd587c050f6fd1233760911c,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
         nidm_clusterSizeInVoxels: = "10" %% xsd:int,
@@ -600,8 +600,8 @@ document
         nidm_pValueFWER: = "0.995456797062611" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "21" %% xsd:int])
-    wasDerivedFrom(niiri:a24fb25342ea5df100b3c9f26c07ccf7, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:6b3e2550575959313eec60bd44a6b445,
+    wasDerivedFrom(niiri:0bf968a5bd587c050f6fd1233760911c, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:c69936a9fe388c221c2512207fe7a647,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
         nidm_clusterSizeInVoxels: = "16" %% xsd:int,
@@ -610,8 +610,8 @@ document
         nidm_pValueFWER: = "0.936564091808241" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "22" %% xsd:int])
-    wasDerivedFrom(niiri:6b3e2550575959313eec60bd44a6b445, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:92cf9681c5af88815bed46d4f69484fe,
+    wasDerivedFrom(niiri:c69936a9fe388c221c2512207fe7a647, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:6a73a70fccc4a55d2a2871c14348d86b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
         nidm_clusterSizeInVoxels: = "59" %% xsd:int,
@@ -620,8 +620,8 @@ document
         nidm_pValueFWER: = "0.0831119677765624" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "23" %% xsd:int])
-    wasDerivedFrom(niiri:92cf9681c5af88815bed46d4f69484fe, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:c8b8db45e94c74708104298c433fecd6,
+    wasDerivedFrom(niiri:6a73a70fccc4a55d2a2871c14348d86b, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:00d620a61a740b07661ceef12972b9ca,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -630,8 +630,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "24" %% xsd:int])
-    wasDerivedFrom(niiri:c8b8db45e94c74708104298c433fecd6, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:e9cca2166adb51f5ec340f78e542f76f,
+    wasDerivedFrom(niiri:00d620a61a740b07661ceef12972b9ca, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:5e8860ba68ee4852a37847e9d3243844,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -640,8 +640,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "25" %% xsd:int])
-    wasDerivedFrom(niiri:e9cca2166adb51f5ec340f78e542f76f, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:4ce2f04f5e11fd9609173ed79e458866,
+    wasDerivedFrom(niiri:5e8860ba68ee4852a37847e9d3243844, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:58aca5806af4df61d00fa77e5299f356,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -650,8 +650,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "26" %% xsd:int])
-    wasDerivedFrom(niiri:4ce2f04f5e11fd9609173ed79e458866, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b,
+    wasDerivedFrom(niiri:58aca5806af4df61d00fa77e5299f356, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:f964bc523e6702ec9bc3c985a3616110,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -660,8 +660,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "27" %% xsd:int])
-    wasDerivedFrom(niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:18aa725ff182239ce52a92cec8c831fe,
+    wasDerivedFrom(niiri:f964bc523e6702ec9bc3c985a3616110, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:f628a53c50b9d4110abc982b7e3ea4b8,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
         nidm_clusterSizeInVoxels: = "11" %% xsd:int,
@@ -670,8 +670,8 @@ document
         nidm_pValueFWER: = "0.991654577641533" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "28" %% xsd:int])
-    wasDerivedFrom(niiri:18aa725ff182239ce52a92cec8c831fe, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:7cf7dba6eb11ba3d163885cbe5c660cd,
+    wasDerivedFrom(niiri:f628a53c50b9d4110abc982b7e3ea4b8, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:ce1ba8634c321921e4a4aaa4b9eb59d6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
         nidm_clusterSizeInVoxels: = "13" %% xsd:int,
@@ -680,8 +680,8 @@ document
         nidm_pValueFWER: = "0.977783945749582" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "29" %% xsd:int])
-    wasDerivedFrom(niiri:7cf7dba6eb11ba3d163885cbe5c660cd, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:f2aa94f4ac2fd9ce977533852312353d,
+    wasDerivedFrom(niiri:ce1ba8634c321921e4a4aaa4b9eb59d6, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:49fb64dfbc518d7a1856ea507a08539e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -690,8 +690,8 @@ document
         nidm_pValueFWER: = "0.99999593370769" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "30" %% xsd:int])
-    wasDerivedFrom(niiri:f2aa94f4ac2fd9ce977533852312353d, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:b9d2c5e57e73184c133167c21e549e31,
+    wasDerivedFrom(niiri:49fb64dfbc518d7a1856ea507a08539e, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:491b37db8347bcb337cac114d7c28332,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -700,8 +700,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "31" %% xsd:int])
-    wasDerivedFrom(niiri:b9d2c5e57e73184c133167c21e549e31, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:0fff44688bc869513d097e59a8311b54,
+    wasDerivedFrom(niiri:491b37db8347bcb337cac114d7c28332, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:2285d72bdbca74c3ffd05a878b326441,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
         nidm_clusterSizeInVoxels: = "6" %% xsd:int,
@@ -710,8 +710,8 @@ document
         nidm_pValueFWER: = "0.999891594677731" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "32" %% xsd:int])
-    wasDerivedFrom(niiri:0fff44688bc869513d097e59a8311b54, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:6b373e69fdc37c9c1e68cb0b96d5160c,
+    wasDerivedFrom(niiri:2285d72bdbca74c3ffd05a878b326441, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:0caba67a7c80988ff6802b01d2bd2008,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -720,8 +720,8 @@ document
         nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "33" %% xsd:int])
-    wasDerivedFrom(niiri:6b373e69fdc37c9c1e68cb0b96d5160c, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:739e3f4c274d5eac94fb06c09bd419a0,
+    wasDerivedFrom(niiri:0caba67a7c80988ff6802b01d2bd2008, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:fa32ab50c48787013e9f7686116ae370,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -730,8 +730,8 @@ document
         nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "34" %% xsd:int])
-    wasDerivedFrom(niiri:739e3f4c274d5eac94fb06c09bd419a0, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:bf0f6f227a5f1dede37450defacf4ee4,
+    wasDerivedFrom(niiri:fa32ab50c48787013e9f7686116ae370, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:fd6e415702cd4c776cd6424ad207625b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -740,8 +740,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "35" %% xsd:int])
-    wasDerivedFrom(niiri:bf0f6f227a5f1dede37450defacf4ee4, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:27828afab99d35c7e234991a120cb219,
+    wasDerivedFrom(niiri:fd6e415702cd4c776cd6424ad207625b, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:1d0df51c88ee8bc083b5d2008437074e,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -750,8 +750,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "36" %% xsd:int])
-    wasDerivedFrom(niiri:27828afab99d35c7e234991a120cb219, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:61fab5ab040124b4935fd160bc4c75c2,
+    wasDerivedFrom(niiri:1d0df51c88ee8bc083b5d2008437074e, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:5c3fa5d9240ba93377acc27266386ab6,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -760,8 +760,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "37" %% xsd:int])
-    wasDerivedFrom(niiri:61fab5ab040124b4935fd160bc4c75c2, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:3e195e76e0011bcbca16974bc51df875,
+    wasDerivedFrom(niiri:5c3fa5d9240ba93377acc27266386ab6, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:3b1453b375b54b291f7345abbe23ea62,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -770,8 +770,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "38" %% xsd:int])
-    wasDerivedFrom(niiri:3e195e76e0011bcbca16974bc51df875, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:efb3b3e5edd63741aa95f90f1a73c855,
+    wasDerivedFrom(niiri:3b1453b375b54b291f7345abbe23ea62, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:2ce833531fec9f54b7fd4cabb582abb4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
         nidm_clusterSizeInVoxels: = "5" %% xsd:int,
@@ -780,8 +780,8 @@ document
         nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "39" %% xsd:int])
-    wasDerivedFrom(niiri:efb3b3e5edd63741aa95f90f1a73c855, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:e3b33814b86cd485564e0a0928f90e0f,
+    wasDerivedFrom(niiri:2ce833531fec9f54b7fd4cabb582abb4, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:4e8a04cb57e27c1354da0f9221cefad4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -790,8 +790,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "40" %% xsd:int])
-    wasDerivedFrom(niiri:e3b33814b86cd485564e0a0928f90e0f, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:cfdf88b2a941aeba3fcc1f4b45b10448,
+    wasDerivedFrom(niiri:4e8a04cb57e27c1354da0f9221cefad4, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:a5bc72d93b1628741579fb91fca4ac04,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -800,8 +800,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "41" %% xsd:int])
-    wasDerivedFrom(niiri:cfdf88b2a941aeba3fcc1f4b45b10448, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:8053ffdd2903523517c32abc5eed6805,
+    wasDerivedFrom(niiri:a5bc72d93b1628741579fb91fca4ac04, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:67829b13c9a254ab8e5e036dfe81f295,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -810,8 +810,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "42" %% xsd:int])
-    wasDerivedFrom(niiri:8053ffdd2903523517c32abc5eed6805, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:be2669b1217c5497ae7583e9f37e889f,
+    wasDerivedFrom(niiri:67829b13c9a254ab8e5e036dfe81f295, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:c7ba4fe69a7060d041b8a1bd8e9abeb1,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -820,8 +820,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "43" %% xsd:int])
-    wasDerivedFrom(niiri:be2669b1217c5497ae7583e9f37e889f, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:345d8154c25e6bc91b83c7a570393c32,
+    wasDerivedFrom(niiri:c7ba4fe69a7060d041b8a1bd8e9abeb1, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:d5ee6f1a9ca6bdd4f96fd93bea1b27d0,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -830,8 +830,8 @@ document
         nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "44" %% xsd:int])
-    wasDerivedFrom(niiri:345d8154c25e6bc91b83c7a570393c32, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:0feb21dbaab7759d1a095b10570dbcbb,
+    wasDerivedFrom(niiri:d5ee6f1a9ca6bdd4f96fd93bea1b27d0, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:33b6b88c9f8662328644ad657a54d41f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
         nidm_clusterSizeInVoxels: = "4" %% xsd:int,
@@ -840,8 +840,8 @@ document
         nidm_pValueFWER: = "0.99999593370769" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "45" %% xsd:int])
-    wasDerivedFrom(niiri:0feb21dbaab7759d1a095b10570dbcbb, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:4867e698cc576f0b80c177fdf37912bc,
+    wasDerivedFrom(niiri:33b6b88c9f8662328644ad657a54d41f, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:5f796a80c868cc4e07db3893075e2ab5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -850,8 +850,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "46" %% xsd:int])
-    wasDerivedFrom(niiri:4867e698cc576f0b80c177fdf37912bc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:dbd7ff1039cc058a9180d3a6b19c0d65,
+    wasDerivedFrom(niiri:5f796a80c868cc4e07db3893075e2ab5, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:66c5c4f7aab02ec57f99c4903c0d0d24,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
         nidm_clusterSizeInVoxels: = "2" %% xsd:int,
@@ -860,8 +860,8 @@ document
         nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "47" %% xsd:int])
-    wasDerivedFrom(niiri:dbd7ff1039cc058a9180d3a6b19c0d65, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:9a04edbbfec2046f6e63a9808f7e31be,
+    wasDerivedFrom(niiri:66c5c4f7aab02ec57f99c4903c0d0d24, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:dd22a79353aa6df10199cb87a8c73432,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -870,8 +870,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "48" %% xsd:int])
-    wasDerivedFrom(niiri:9a04edbbfec2046f6e63a9808f7e31be, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:4802981400c706074d7089aa4f606c7a,
+    wasDerivedFrom(niiri:dd22a79353aa6df10199cb87a8c73432, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:620e2ba10d624da22f1d1ffc75882c40,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -880,8 +880,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "49" %% xsd:int])
-    wasDerivedFrom(niiri:4802981400c706074d7089aa4f606c7a, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:0c9c1006b093a8cc91c759baf58575ee,
+    wasDerivedFrom(niiri:620e2ba10d624da22f1d1ffc75882c40, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:528d2a201077a9f036630cf90c25a2e4,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
         nidm_clusterSizeInVoxels: = "3" %% xsd:int,
@@ -890,8 +890,8 @@ document
         nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "50" %% xsd:int])
-    wasDerivedFrom(niiri:0c9c1006b093a8cc91c759baf58575ee, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:9e9eebffba744c379bca54d713a85d3b,
+    wasDerivedFrom(niiri:528d2a201077a9f036630cf90c25a2e4, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:b6a501a185ba123c5d8ae0428a609570,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -900,8 +900,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "51" %% xsd:int])
-    wasDerivedFrom(niiri:9e9eebffba744c379bca54d713a85d3b, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:2ef2320c7a264cf13420c161d25ff5cc,
+    wasDerivedFrom(niiri:b6a501a185ba123c5d8ae0428a609570, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:ac078cd746e0c0e589efde6d868f9503,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -910,8 +910,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "52" %% xsd:int])
-    wasDerivedFrom(niiri:2ef2320c7a264cf13420c161d25ff5cc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:53b5e166978251c052e00c9a4fe81fdc,
+    wasDerivedFrom(niiri:ac078cd746e0c0e589efde6d868f9503, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:67a0a2929818d60014e2d343e4dd0e9f,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -920,8 +920,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "53" %% xsd:int])
-    wasDerivedFrom(niiri:53b5e166978251c052e00c9a4fe81fdc, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:de88c64838ddf5de0155dcdce61cf6c0,
+    wasDerivedFrom(niiri:67a0a2929818d60014e2d343e4dd0e9f, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:48c77f140153e04f3768726af76bae9b,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -930,8 +930,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "54" %% xsd:int])
-    wasDerivedFrom(niiri:de88c64838ddf5de0155dcdce61cf6c0, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:02344c7a7b0c9af7c25dbcd3cbd09300,
+    wasDerivedFrom(niiri:48c77f140153e04f3768726af76bae9b, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:8d5fab1550256921e7e64a7712e48bae,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -940,8 +940,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "55" %% xsd:int])
-    wasDerivedFrom(niiri:02344c7a7b0c9af7c25dbcd3cbd09300, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:22648332b0e4fb9a38556afd35646c42,
+    wasDerivedFrom(niiri:8d5fab1550256921e7e64a7712e48bae, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:9302cebb2f2f594519eb7868350332d5,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -950,8 +950,8 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "56" %% xsd:int])
-    wasDerivedFrom(niiri:22648332b0e4fb9a38556afd35646c42, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:3b46a57f86b33c173fe10a245389f4ff,
+    wasDerivedFrom(niiri:9302cebb2f2f594519eb7868350332d5, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:96084c5a0a8645a35c364d23198e7b84,
         [prov:type = 'nidm_SupraThresholdCluster:',
         prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
         nidm_clusterSizeInVoxels: = "1" %% xsd:int,
@@ -960,1146 +960,1146 @@ document
         nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
         nidm_qValueFDR: = "[]" %% xsd:float,
         nidm_clusterLabelId: = "57" %% xsd:int])
-    wasDerivedFrom(niiri:3b46a57f86b33c173fe10a245389f4ff, niiri:b92de8901b2a05ad20e537b7d45bcded, -, -, -)
-    entity(niiri:bbac0b57ed4deddd70eb50803fb36999,
+    wasDerivedFrom(niiri:96084c5a0a8645a35c364d23198e7b84, niiri:e9ed0af535df635441b4855cd563907f, -, -, -)
+    entity(niiri:421f593cb8cdeb245041c97e2272fe53,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0001" %% xsd:string,
-        prov:location = 'niiri:253372e924e130c4a5343ebb6faf24b0',
+        prov:location = 'niiri:a345f9d98fa0a27293de7a6a7d8b9f1a',
         prov:value = "13.6061105728149" %% xsd:float,
         nidm_equivalentZStatistic: = "5.86214047392852" %% xsd:float,
         nidm_pValueUncorrected: = "2.28469099194939e-09" %% xsd:float,
         nidm_pValueFWER: = "0.000382050559925018" %% xsd:float,
         nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
-    entity(niiri:253372e924e130c4a5343ebb6faf24b0,
+    entity(niiri:a345f9d98fa0a27293de7a6a7d8b9f1a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0001" %% xsd:string,
         nidm_coordinateVector: = "[34,-86,0]" %% xsd:string])
-    wasDerivedFrom(niiri:bbac0b57ed4deddd70eb50803fb36999, niiri:46ce368f726925043d0fdf11d3ce812c, -, -, -)
-    entity(niiri:1c9824886d035515f910ce93f1becb24,
+    wasDerivedFrom(niiri:421f593cb8cdeb245041c97e2272fe53, niiri:215cf61bffa077f54837e2f6abb74357, -, -, -)
+    entity(niiri:9b185bcb23e4c9275a21cfad622f9e0f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0002" %% xsd:string,
-        prov:location = 'niiri:6560dc3c0cedd518d2e9c8d22200d849',
+        prov:location = 'niiri:c4de60cedb7def5d2895d25b10d9bc09',
         prov:value = "11.9614944458008" %% xsd:float,
         nidm_equivalentZStatistic: = "5.59772141079875" %% xsd:float,
         nidm_pValueUncorrected: = "1.08593692926817e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00181592543329545" %% xsd:float,
         nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
-    entity(niiri:6560dc3c0cedd518d2e9c8d22200d849,
+    entity(niiri:c4de60cedb7def5d2895d25b10d9bc09,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0002" %% xsd:string,
         nidm_coordinateVector: = "[30,-78,36]" %% xsd:string])
-    wasDerivedFrom(niiri:1c9824886d035515f910ce93f1becb24, niiri:46ce368f726925043d0fdf11d3ce812c, -, -, -)
-    entity(niiri:64b80549819f8dfbe67bba4d26272007,
+    wasDerivedFrom(niiri:9b185bcb23e4c9275a21cfad622f9e0f, niiri:215cf61bffa077f54837e2f6abb74357, -, -, -)
+    entity(niiri:71bd49b63bf9414c7519bf64bd7f26f7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0003" %% xsd:string,
-        prov:location = 'niiri:bf5b57a2467e79a41847b729706bb7f7',
+        prov:location = 'niiri:ce211af06478f3ae4508614668309311',
         prov:value = "10.5961866378784" %% xsd:float,
         nidm_equivalentZStatistic: = "5.34279531222125" %% xsd:float,
         nidm_pValueUncorrected: = "4.5762046707587e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00765242110449371" %% xsd:float,
         nidm_qValueFDR: = "0.000248881974141536" %% xsd:float])
-    entity(niiri:bf5b57a2467e79a41847b729706bb7f7,
+    entity(niiri:ce211af06478f3ae4508614668309311,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0003" %% xsd:string,
         nidm_coordinateVector: = "[34,-48,44]" %% xsd:string])
-    wasDerivedFrom(niiri:64b80549819f8dfbe67bba4d26272007, niiri:46ce368f726925043d0fdf11d3ce812c, -, -, -)
-    entity(niiri:4d0e94437b61697668b47fdb1b75b33c,
+    wasDerivedFrom(niiri:71bd49b63bf9414c7519bf64bd7f26f7, niiri:215cf61bffa077f54837e2f6abb74357, -, -, -)
+    entity(niiri:840c8d55fde200dab5895ef707a336cc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0004" %% xsd:string,
-        prov:location = 'niiri:53107adcc0ef1666a9861e881bf02340',
+        prov:location = 'niiri:06c6799120741194d5241c872733bb29',
         prov:value = "11.9789819717407" %% xsd:float,
         nidm_equivalentZStatistic: = "5.6007582829493" %% xsd:float,
         nidm_pValueUncorrected: = "1.06708079039564e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00178439382075002" %% xsd:float,
         nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
-    entity(niiri:53107adcc0ef1666a9861e881bf02340,
+    entity(niiri:06c6799120741194d5241c872733bb29,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0004" %% xsd:string,
         nidm_coordinateVector: = "[-46,-54,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:4d0e94437b61697668b47fdb1b75b33c, niiri:a121a3d6c11f9c710a28e61253277933, -, -, -)
-    entity(niiri:c72107be6be92b5977ee1b066d2ed2df,
+    wasDerivedFrom(niiri:840c8d55fde200dab5895ef707a336cc, niiri:ffb620ba0971608a9222d31cc4937dc9, -, -, -)
+    entity(niiri:e9a40a85d0b3e8c696a8e384fd583177,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0005" %% xsd:string,
-        prov:location = 'niiri:340954c4fec53251517830b22ef6060f',
+        prov:location = 'niiri:ea494070725631aa09872881ecbc9a20',
         prov:value = "11.3053674697876" %% xsd:float,
         nidm_equivalentZStatistic: = "5.47978759981232" %% xsd:float,
         nidm_pValueUncorrected: = "2.12918364050907e-08" %% xsd:float,
         nidm_pValueFWER: = "0.00356046346733208" %% xsd:float,
         nidm_qValueFDR: = "0.000225699919390338" %% xsd:float])
-    entity(niiri:340954c4fec53251517830b22ef6060f,
+    entity(niiri:ea494070725631aa09872881ecbc9a20,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0005" %% xsd:string,
         nidm_coordinateVector: = "[-48,-64,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:c72107be6be92b5977ee1b066d2ed2df, niiri:a121a3d6c11f9c710a28e61253277933, -, -, -)
-    entity(niiri:544ba6228591b8c8ffd1e693b78fb571,
+    wasDerivedFrom(niiri:e9a40a85d0b3e8c696a8e384fd583177, niiri:ffb620ba0971608a9222d31cc4937dc9, -, -, -)
+    entity(niiri:08239743576aaf3a8a607b12797debe9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0006" %% xsd:string,
-        prov:location = 'niiri:beb47d7b86e9956408d6e84a62a2df4a',
+        prov:location = 'niiri:30b02ec41b21c32c024c70c88eefa861',
         prov:value = "9.59214210510254" %% xsd:float,
         nidm_equivalentZStatistic: = "5.12915279008791" %% xsd:float,
         nidm_pValueUncorrected: = "1.45524525096974e-07" %% xsd:float,
         nidm_pValueFWER: = "0.0243349038623457" %% xsd:float,
         nidm_qValueFDR: = "0.000374773184801466" %% xsd:float])
-    entity(niiri:beb47d7b86e9956408d6e84a62a2df4a,
+    entity(niiri:30b02ec41b21c32c024c70c88eefa861,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0006" %% xsd:string,
         nidm_coordinateVector: = "[-46,-72,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:544ba6228591b8c8ffd1e693b78fb571, niiri:a121a3d6c11f9c710a28e61253277933, -, -, -)
-    entity(niiri:45d7b72f120c5a905c74b6ef035179d1,
+    wasDerivedFrom(niiri:08239743576aaf3a8a607b12797debe9, niiri:ffb620ba0971608a9222d31cc4937dc9, -, -, -)
+    entity(niiri:d9c266a0a7d6f258146d0b2dbc92be88,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0007" %% xsd:string,
-        prov:location = 'niiri:fb524a7a97d8dc293563afed5235a273',
+        prov:location = 'niiri:072859c1bbe8323807123bd58f0339e5',
         prov:value = "8.26132202148438" %% xsd:float,
         nidm_equivalentZStatistic: = "4.8021068311854" %% xsd:float,
         nidm_pValueUncorrected: = "7.85024427352177e-07" %% xsd:float,
         nidm_pValueFWER: = "0.131273406272461" %% xsd:float,
         nidm_qValueFDR: = "0.000714072820754613" %% xsd:float])
-    entity(niiri:fb524a7a97d8dc293563afed5235a273,
+    entity(niiri:072859c1bbe8323807123bd58f0339e5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0007" %% xsd:string,
         nidm_coordinateVector: = "[-26,-76,32]" %% xsd:string])
-    wasDerivedFrom(niiri:45d7b72f120c5a905c74b6ef035179d1, niiri:46ae5678b67f432a5739e26d30b8b9fc, -, -, -)
-    entity(niiri:750f947db3f44470b84b8a0b7262e50c,
+    wasDerivedFrom(niiri:d9c266a0a7d6f258146d0b2dbc92be88, niiri:827f9e23c57be3072b3c3434a71afc3c, -, -, -)
+    entity(niiri:9ff2cbaf49a1a6d0b379b7ac434e52ce,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0008" %% xsd:string,
-        prov:location = 'niiri:8bc38c5d28a6e5a22576873242e357d3',
+        prov:location = 'niiri:f4eec5d9c1eb912c0b265c377493a799',
         prov:value = "7.54039764404297" %% xsd:float,
         nidm_equivalentZStatistic: = "4.59887376341391" %% xsd:float,
         nidm_pValueUncorrected: = "2.12390533416151e-06" %% xsd:float,
         nidm_pValueFWER: = "0.355164074926112" %% xsd:float,
         nidm_qValueFDR: = "0.00112750499976544" %% xsd:float])
-    entity(niiri:8bc38c5d28a6e5a22576873242e357d3,
+    entity(niiri:f4eec5d9c1eb912c0b265c377493a799,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0008" %% xsd:string,
         nidm_coordinateVector: = "[-38,-46,44]" %% xsd:string])
-    wasDerivedFrom(niiri:750f947db3f44470b84b8a0b7262e50c, niiri:46ae5678b67f432a5739e26d30b8b9fc, -, -, -)
-    entity(niiri:89ab361e0947ad2cd7741823700a026b,
+    wasDerivedFrom(niiri:9ff2cbaf49a1a6d0b379b7ac434e52ce, niiri:827f9e23c57be3072b3c3434a71afc3c, -, -, -)
+    entity(niiri:ad7761e7a8c3e26ebd7f73ba089dcb7b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0009" %% xsd:string,
-        prov:location = 'niiri:1e831d7963c01a6b5512e380dfc42b04',
+        prov:location = 'niiri:b3330dbc824e6962076fa07a7b039f98',
         prov:value = "7.09534215927124" %% xsd:float,
         nidm_equivalentZStatistic: = "4.46234965259847" %% xsd:float,
         nidm_pValueUncorrected: = "4.05329024755208e-06" %% xsd:float,
         nidm_pValueFWER: = "0.550389997209789" %% xsd:float,
         nidm_qValueFDR: = "0.00152026219003999" %% xsd:float])
-    entity(niiri:1e831d7963c01a6b5512e380dfc42b04,
+    entity(niiri:b3330dbc824e6962076fa07a7b039f98,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0009" %% xsd:string,
         nidm_coordinateVector: = "[-24,-72,44]" %% xsd:string])
-    wasDerivedFrom(niiri:89ab361e0947ad2cd7741823700a026b, niiri:46ae5678b67f432a5739e26d30b8b9fc, -, -, -)
-    entity(niiri:04a53addf635f1622be8ce7e4b4fd46f,
+    wasDerivedFrom(niiri:ad7761e7a8c3e26ebd7f73ba089dcb7b, niiri:827f9e23c57be3072b3c3434a71afc3c, -, -, -)
+    entity(niiri:7535ee52d97e0bc1c5d6bbdca3559059,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0010" %% xsd:string,
-        prov:location = 'niiri:bfc78fed76fb0cda1dc19ea85be43504',
+        prov:location = 'niiri:cfc19c68318aa2c092b0225c45df57a3',
         prov:value = "7.53033494949341" %% xsd:float,
         nidm_equivalentZStatistic: = "4.59588573954922" %% xsd:float,
         nidm_pValueUncorrected: = "2.15457400010166e-06" %% xsd:float,
         nidm_pValueFWER: = "0.36029256155409" %% xsd:float,
         nidm_qValueFDR: = "0.00113656959480786" %% xsd:float])
-    entity(niiri:bfc78fed76fb0cda1dc19ea85be43504,
+    entity(niiri:cfc19c68318aa2c092b0225c45df57a3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0010" %% xsd:string,
         nidm_coordinateVector: = "[-20,-10,48]" %% xsd:string])
-    wasDerivedFrom(niiri:04a53addf635f1622be8ce7e4b4fd46f, niiri:ac8f8138199a2f60489cb1fe2bc4c070, -, -, -)
-    entity(niiri:37fedcc605762daab25ba3d15823f4f6,
+    wasDerivedFrom(niiri:7535ee52d97e0bc1c5d6bbdca3559059, niiri:31f0c8a35e1f97bfc50658b184c91a4e, -, -, -)
+    entity(niiri:3b47a132eec8d65044e74c2e66e63878,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0011" %% xsd:string,
-        prov:location = 'niiri:97810d5af81d5e9362e02d4fd86a848e',
+        prov:location = 'niiri:d95a36ee990e793e5e1773d0c063ba39',
         prov:value = "4.24029636383057" %% xsd:float,
         nidm_equivalentZStatistic: = "3.30076820538094" %% xsd:float,
         nidm_pValueUncorrected: = "0.000482102531686568" %% xsd:float,
         nidm_pValueFWER: = "0.999999999415186" %% xsd:float,
         nidm_qValueFDR: = "0.015845468443456" %% xsd:float])
-    entity(niiri:97810d5af81d5e9362e02d4fd86a848e,
+    entity(niiri:d95a36ee990e793e5e1773d0c063ba39,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0011" %% xsd:string,
         nidm_coordinateVector: = "[-26,0,56]" %% xsd:string])
-    wasDerivedFrom(niiri:37fedcc605762daab25ba3d15823f4f6, niiri:ac8f8138199a2f60489cb1fe2bc4c070, -, -, -)
-    entity(niiri:4d986a80344be2abfcf5c339af16638a,
+    wasDerivedFrom(niiri:3b47a132eec8d65044e74c2e66e63878, niiri:31f0c8a35e1f97bfc50658b184c91a4e, -, -, -)
+    entity(niiri:c4a3a31ba4094216ac6f6faaf6eaa0a4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0012" %% xsd:string,
-        prov:location = 'niiri:2a40d83993773c6f1e5ebc1385fd442d',
+        prov:location = 'niiri:e6b1de5ca01719cb72bee5b149822da3',
         prov:value = "7.17061138153076" %% xsd:float,
         nidm_equivalentZStatistic: = "4.48608583316407" %% xsd:float,
         nidm_pValueUncorrected: = "3.62717632940157e-06" %% xsd:float,
         nidm_pValueFWER: = "0.521824836713063" %% xsd:float,
         nidm_qValueFDR: = "0.00145106406730833" %% xsd:float])
-    entity(niiri:2a40d83993773c6f1e5ebc1385fd442d,
+    entity(niiri:e6b1de5ca01719cb72bee5b149822da3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0012" %% xsd:string,
         nidm_coordinateVector: = "[46,6,28]" %% xsd:string])
-    wasDerivedFrom(niiri:4d986a80344be2abfcf5c339af16638a, niiri:3dfc00b52233c69b59012bb4e4590bd6, -, -, -)
-    entity(niiri:0fc5cc3b06805b359990af6af9b7de2c,
+    wasDerivedFrom(niiri:c4a3a31ba4094216ac6f6faaf6eaa0a4, niiri:b6d1a5338f79d387e625261c1a5fc9a7, -, -, -)
+    entity(niiri:ee43720d912cc9ffe41fe7963fb56ea9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0013" %% xsd:string,
-        prov:location = 'niiri:c348bcf295bbfcc12359afcb0fe8f75b',
+        prov:location = 'niiri:8730ab8dbcae3f1aec1aa08761219c41',
         prov:value = "5.89265918731689" %% xsd:float,
         nidm_equivalentZStatistic: = "4.04200617451887" %% xsd:float,
         nidm_pValueUncorrected: = "2.64979184040337e-05" %% xsd:float,
         nidm_pValueFWER: = "0.95205805171536" %% xsd:float,
         nidm_qValueFDR: = "0.00357309996201585" %% xsd:float])
-    entity(niiri:c348bcf295bbfcc12359afcb0fe8f75b,
+    entity(niiri:8730ab8dbcae3f1aec1aa08761219c41,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0013" %% xsd:string,
         nidm_coordinateVector: = "[52,12,26]" %% xsd:string])
-    wasDerivedFrom(niiri:0fc5cc3b06805b359990af6af9b7de2c, niiri:3dfc00b52233c69b59012bb4e4590bd6, -, -, -)
-    entity(niiri:53295d63fe3c3e2da20993fcb585d43a,
+    wasDerivedFrom(niiri:ee43720d912cc9ffe41fe7963fb56ea9, niiri:b6d1a5338f79d387e625261c1a5fc9a7, -, -, -)
+    entity(niiri:f582aebcb76bd1321b90c6c832a8868f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0014" %% xsd:string,
-        prov:location = 'niiri:7aa7d0132011ee94a14b377939be3510',
+        prov:location = 'niiri:96ce84fbd809926daf99d401d99c5f96',
         prov:value = "5.21978235244751" %% xsd:float,
         nidm_equivalentZStatistic: = "3.76688098065344" %% xsd:float,
         nidm_pValueUncorrected: = "8.26498774630924e-05" %% xsd:float,
         nidm_pValueFWER: = "0.998715750644301" %% xsd:float,
         nidm_qValueFDR: = "0.00632560594393137" %% xsd:float])
-    entity(niiri:7aa7d0132011ee94a14b377939be3510,
+    entity(niiri:96ce84fbd809926daf99d401d99c5f96,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0014" %% xsd:string,
         nidm_coordinateVector: = "[40,-2,30]" %% xsd:string])
-    wasDerivedFrom(niiri:53295d63fe3c3e2da20993fcb585d43a, niiri:3dfc00b52233c69b59012bb4e4590bd6, -, -, -)
-    entity(niiri:998b270ff5f29f350d50cfa5c76e8ad7,
+    wasDerivedFrom(niiri:f582aebcb76bd1321b90c6c832a8868f, niiri:b6d1a5338f79d387e625261c1a5fc9a7, -, -, -)
+    entity(niiri:90598d5de141bc929d45e79385d901f3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0015" %% xsd:string,
-        prov:location = 'niiri:87d8215adb89a7807d1b78b73a28d6f1',
+        prov:location = 'niiri:0aa584b0d2695f75a52c71a8a081fad8',
         prov:value = "6.82257699966431" %% xsd:float,
         nidm_equivalentZStatistic: = "4.3739930910033" %% xsd:float,
         nidm_pValueUncorrected: = "6.09971206799731e-06" %% xsd:float,
         nidm_pValueFWER: = "0.657888162568606" %% xsd:float,
         nidm_qValueFDR: = "0.00180198082091417" %% xsd:float])
-    entity(niiri:87d8215adb89a7807d1b78b73a28d6f1,
+    entity(niiri:0aa584b0d2695f75a52c71a8a081fad8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0015" %% xsd:string,
         nidm_coordinateVector: = "[-10,24,12]" %% xsd:string])
-    wasDerivedFrom(niiri:998b270ff5f29f350d50cfa5c76e8ad7, niiri:e17a558d17c93c4d23cebfdb241952ae, -, -, -)
-    entity(niiri:a209c7cd2db8d53b5b130f27b9322d0f,
+    wasDerivedFrom(niiri:90598d5de141bc929d45e79385d901f3, niiri:fdaeca1296f778d816f1b7c0961e6d62, -, -, -)
+    entity(niiri:420d0edfe7501f55a0716fc16168f372,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0016" %% xsd:string,
-        prov:location = 'niiri:21b4eea73e16e09c4881b4a5dc18afc5',
+        prov:location = 'niiri:784b5d1f4ee7488128af4e70def97978',
         prov:value = "4.99530935287476" %% xsd:float,
         nidm_equivalentZStatistic: = "3.66747111912266" %% xsd:float,
         nidm_pValueUncorrected: = "0.000122480604349273" %% xsd:float,
         nidm_pValueFWER: = "0.999830619862512" %% xsd:float,
         nidm_qValueFDR: = "0.00775152511109977" %% xsd:float])
-    entity(niiri:21b4eea73e16e09c4881b4a5dc18afc5,
+    entity(niiri:784b5d1f4ee7488128af4e70def97978,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0016" %% xsd:string,
         nidm_coordinateVector: = "[-24,28,4]" %% xsd:string])
-    wasDerivedFrom(niiri:a209c7cd2db8d53b5b130f27b9322d0f, niiri:e17a558d17c93c4d23cebfdb241952ae, -, -, -)
-    entity(niiri:693ea803be290552513560b1a7fef0bf,
+    wasDerivedFrom(niiri:420d0edfe7501f55a0716fc16168f372, niiri:fdaeca1296f778d816f1b7c0961e6d62, -, -, -)
+    entity(niiri:19f41654165c8ed7af25c33517d4ffac,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0017" %% xsd:string,
-        prov:location = 'niiri:aea6c3f2722e9910b54ddf00cebc5cee',
+        prov:location = 'niiri:502909021cc9967281dc282aee556905',
         prov:value = "6.34009504318237" %% xsd:float,
         nidm_equivalentZStatistic: = "4.20806884695295" %% xsd:float,
         nidm_pValueUncorrected: = "1.28781200698924e-05" %% xsd:float,
         nidm_pValueFWER: = "0.839224226046397" %% xsd:float,
         nidm_qValueFDR: = "0.00253613065643777" %% xsd:float])
-    entity(niiri:aea6c3f2722e9910b54ddf00cebc5cee,
+    entity(niiri:502909021cc9967281dc282aee556905,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0017" %% xsd:string,
         nidm_coordinateVector: = "[10,-74,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:693ea803be290552513560b1a7fef0bf, niiri:2ee06584880d716387a7002834742906, -, -, -)
-    entity(niiri:f536b5609348be9036fb10330e373e3f,
+    wasDerivedFrom(niiri:19f41654165c8ed7af25c33517d4ffac, niiri:6d0e6a1098242b9a42aa86b60dc1c165, -, -, -)
+    entity(niiri:427e843d221394aa733a0491568aa8a4,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0018" %% xsd:string,
-        prov:location = 'niiri:f90062339ac75c1a5a7bd5460360006e',
+        prov:location = 'niiri:285cfa83d44ae6b580e65ad2eca354ae',
         prov:value = "5.96963739395142" %% xsd:float,
         nidm_equivalentZStatistic: = "4.07147450951934" %% xsd:float,
         nidm_pValueUncorrected: = "2.3358237619564e-05" %% xsd:float,
         nidm_pValueFWER: = "0.938028702807278" %% xsd:float,
         nidm_qValueFDR: = "0.00332713529017219" %% xsd:float])
-    entity(niiri:f90062339ac75c1a5a7bd5460360006e,
+    entity(niiri:285cfa83d44ae6b580e65ad2eca354ae,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0018" %% xsd:string,
         nidm_coordinateVector: = "[-50,2,26]" %% xsd:string])
-    wasDerivedFrom(niiri:f536b5609348be9036fb10330e373e3f, niiri:0a170fb537c25a43d335a98102d35aeb, -, -, -)
-    entity(niiri:44a31bb2492c4d22b1d559091f48eefa,
+    wasDerivedFrom(niiri:427e843d221394aa733a0491568aa8a4, niiri:21e31a1448c8fbeee17661915c5bfa21, -, -, -)
+    entity(niiri:3b6e15c0a4729864df2fc07aec49a274,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0019" %% xsd:string,
-        prov:location = 'niiri:1da6912641096977dda7267c40fe4107',
+        prov:location = 'niiri:6da3f519aeeb66556b35684e9eb57dec',
         prov:value = "5.75492286682129" %% xsd:float,
         nidm_equivalentZStatistic: = "3.98829870240338" %% xsd:float,
         nidm_pValueUncorrected: = "3.32744188140666e-05" %% xsd:float,
         nidm_pValueFWER: = "0.971577838301208" %% xsd:float,
         nidm_qValueFDR: = "0.00400598087684945" %% xsd:float])
-    entity(niiri:1da6912641096977dda7267c40fe4107,
+    entity(niiri:6da3f519aeeb66556b35684e9eb57dec,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0019" %% xsd:string,
         nidm_coordinateVector: = "[-50,-4,50]" %% xsd:string])
-    wasDerivedFrom(niiri:44a31bb2492c4d22b1d559091f48eefa, niiri:0a170fb537c25a43d335a98102d35aeb, -, -, -)
-    entity(niiri:75cd1f4a8537e15fd6b96e3da0abf348,
+    wasDerivedFrom(niiri:3b6e15c0a4729864df2fc07aec49a274, niiri:21e31a1448c8fbeee17661915c5bfa21, -, -, -)
+    entity(niiri:32b46ebe456d694e1cf22d5d2e3dca74,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0020" %% xsd:string,
-        prov:location = 'niiri:e2d566acff4bd4ebe5d3246828cbfc6d',
+        prov:location = 'niiri:d617e777844256453a275dfa70e96389',
         prov:value = "5.52769041061401" %% xsd:float,
         nidm_equivalentZStatistic: = "3.89683707514784" %% xsd:float,
         nidm_pValueUncorrected: = "4.87285666391779e-05" %% xsd:float,
         nidm_pValueFWER: = "0.990314755199069" %% xsd:float,
         nidm_qValueFDR: = "0.00479616651502499" %% xsd:float])
-    entity(niiri:e2d566acff4bd4ebe5d3246828cbfc6d,
+    entity(niiri:d617e777844256453a275dfa70e96389,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0020" %% xsd:string,
         nidm_coordinateVector: = "[-52,0,40]" %% xsd:string])
-    wasDerivedFrom(niiri:75cd1f4a8537e15fd6b96e3da0abf348, niiri:0a170fb537c25a43d335a98102d35aeb, -, -, -)
-    entity(niiri:3575c3d4f244e7bf282358585a84906c,
+    wasDerivedFrom(niiri:32b46ebe456d694e1cf22d5d2e3dca74, niiri:21e31a1448c8fbeee17661915c5bfa21, -, -, -)
+    entity(niiri:43287007d57c4b33e7892b4d3b11ead3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0021" %% xsd:string,
-        prov:location = 'niiri:7b573b4dd63bc077dfe4dd6768191656',
+        prov:location = 'niiri:2a237b88945163b10865710700bc4d19',
         prov:value = "5.91596412658691" %% xsd:float,
         nidm_equivalentZStatistic: = "4.05096850425873" %% xsd:float,
         nidm_pValueUncorrected: = "2.55030367465325e-05" %% xsd:float,
         nidm_pValueFWER: = "0.948053549525439" %% xsd:float,
         nidm_qValueFDR: = "0.00348881065430462" %% xsd:float])
-    entity(niiri:7b573b4dd63bc077dfe4dd6768191656,
+    entity(niiri:2a237b88945163b10865710700bc4d19,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0021" %% xsd:string,
         nidm_coordinateVector: = "[6,18,6]" %% xsd:string])
-    wasDerivedFrom(niiri:3575c3d4f244e7bf282358585a84906c, niiri:0b191a1bce28484b4d509f123468cafc, -, -, -)
-    entity(niiri:4cc4b89c15af11852dd0fdf83661eab7,
+    wasDerivedFrom(niiri:43287007d57c4b33e7892b4d3b11ead3, niiri:432d988b9e7ab5b924110baf9a663199, -, -, -)
+    entity(niiri:78dc156d9677c8d1ef03dfd70d3cb5ff,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0022" %% xsd:string,
-        prov:location = 'niiri:12ad0a85c946e3ba0ee32ec6ca9d30df',
+        prov:location = 'niiri:65b0da4096001f7ef41395403f43cf4b',
         prov:value = "4.54182481765747" %% xsd:float,
         nidm_equivalentZStatistic: = "3.45355045258419" %% xsd:float,
         nidm_pValueUncorrected: = "0.000276629401356199" %% xsd:float,
         nidm_pValueFWER: = "0.999999655761857" %% xsd:float,
         nidm_qValueFDR: = "0.0116903072898716" %% xsd:float])
-    entity(niiri:12ad0a85c946e3ba0ee32ec6ca9d30df,
+    entity(niiri:65b0da4096001f7ef41395403f43cf4b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0022" %% xsd:string,
         nidm_coordinateVector: = "[14,24,4]" %% xsd:string])
-    wasDerivedFrom(niiri:4cc4b89c15af11852dd0fdf83661eab7, niiri:0b191a1bce28484b4d509f123468cafc, -, -, -)
-    entity(niiri:38d59cc816cec77fb882cd2fdd15a9bd,
+    wasDerivedFrom(niiri:78dc156d9677c8d1ef03dfd70d3cb5ff, niiri:432d988b9e7ab5b924110baf9a663199, -, -, -)
+    entity(niiri:c578c4d517a43cafd1400eb3eee95902,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0023" %% xsd:string,
-        prov:location = 'niiri:a2d5f7682067f7ac13c86ed08bac1fc2',
+        prov:location = 'niiri:1d6e51c565b598e29869232ed0ee207e',
         prov:value = "5.72671985626221" %% xsd:float,
         nidm_equivalentZStatistic: = "3.97714309813652" %% xsd:float,
         nidm_pValueUncorrected: = "3.48740977119677e-05" %% xsd:float,
         nidm_pValueFWER: = "0.974745203823651" %% xsd:float,
         nidm_qValueFDR: = "0.00410957672904248" %% xsd:float])
-    entity(niiri:a2d5f7682067f7ac13c86ed08bac1fc2,
+    entity(niiri:1d6e51c565b598e29869232ed0ee207e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0023" %% xsd:string,
         nidm_coordinateVector: = "[-6,0,58]" %% xsd:string])
-    wasDerivedFrom(niiri:38d59cc816cec77fb882cd2fdd15a9bd, niiri:03c0220efd2c203f65a22694082f5442, -, -, -)
-    entity(niiri:03b70a255fbe5aaeb503141abdf77e01,
+    wasDerivedFrom(niiri:c578c4d517a43cafd1400eb3eee95902, niiri:967f3e474d0f75f9f771a026048f7938, -, -, -)
+    entity(niiri:6e110d4362a02c7c1e67bcc603958b28,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0024" %% xsd:string,
-        prov:location = 'niiri:b2a905dcae5e518e954d4e5ca2afbf39',
+        prov:location = 'niiri:6f30c6a304af2833b29db55b0038b8ff',
         prov:value = "5.25150108337402" %% xsd:float,
         nidm_equivalentZStatistic: = "3.78060278170665" %% xsd:float,
         nidm_pValueUncorrected: = "7.82245573558438e-05" %% xsd:float,
         nidm_pValueFWER: = "0.998359989376909" %% xsd:float,
         nidm_qValueFDR: = "0.00612998059012206" %% xsd:float])
-    entity(niiri:b2a905dcae5e518e954d4e5ca2afbf39,
+    entity(niiri:6f30c6a304af2833b29db55b0038b8ff,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0024" %% xsd:string,
         nidm_coordinateVector: = "[0,6,56]" %% xsd:string])
-    wasDerivedFrom(niiri:03b70a255fbe5aaeb503141abdf77e01, niiri:03c0220efd2c203f65a22694082f5442, -, -, -)
-    entity(niiri:4157309e78d7ded58b0c0e0ead87a224,
+    wasDerivedFrom(niiri:6e110d4362a02c7c1e67bcc603958b28, niiri:967f3e474d0f75f9f771a026048f7938, -, -, -)
+    entity(niiri:7097efebbb7f449c17ed1b185ebc77cf,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0025" %% xsd:string,
-        prov:location = 'niiri:2bd2a2878ad3f221f0ec6abeed136ca3',
+        prov:location = 'niiri:00a0da67991b139c7177ecf470be7614',
         prov:value = "4.54090023040771" %% xsd:float,
         nidm_equivalentZStatistic: = "3.45309533835059" %% xsd:float,
         nidm_pValueUncorrected: = "0.00027709654919561" %% xsd:float,
         nidm_pValueFWER: = "0.99999966134203" %% xsd:float,
         nidm_qValueFDR: = "0.0116998384744116" %% xsd:float])
-    entity(niiri:2bd2a2878ad3f221f0ec6abeed136ca3,
+    entity(niiri:00a0da67991b139c7177ecf470be7614,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0025" %% xsd:string,
         nidm_coordinateVector: = "[-4,0,66]" %% xsd:string])
-    wasDerivedFrom(niiri:4157309e78d7ded58b0c0e0ead87a224, niiri:03c0220efd2c203f65a22694082f5442, -, -, -)
-    entity(niiri:f81e942c055a87ae23697653d0f9e931,
+    wasDerivedFrom(niiri:7097efebbb7f449c17ed1b185ebc77cf, niiri:967f3e474d0f75f9f771a026048f7938, -, -, -)
+    entity(niiri:6de3cb931aee0b120e8281a4cb64f791,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0026" %% xsd:string,
-        prov:location = 'niiri:01b426c0493efdc5de3e1ee498c74e3a',
+        prov:location = 'niiri:f50bbc2cc532f835ad13f64c1eb15677',
         prov:value = "5.37388372421265" %% xsd:float,
         nidm_equivalentZStatistic: = "3.83281667931374" %% xsd:float,
         nidm_pValueUncorrected: = "6.33421799035583e-05" %% xsd:float,
         nidm_pValueFWER: = "0.996123053382791" %% xsd:float,
         nidm_qValueFDR: = "0.00547832540919611" %% xsd:float])
-    entity(niiri:01b426c0493efdc5de3e1ee498c74e3a,
+    entity(niiri:f50bbc2cc532f835ad13f64c1eb15677,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0026" %% xsd:string,
         nidm_coordinateVector: = "[6,-12,14]" %% xsd:string])
-    wasDerivedFrom(niiri:f81e942c055a87ae23697653d0f9e931, niiri:847c108abc6d60c3422f305d80cbe544, -, -, -)
-    entity(niiri:558b717a6eaaf2aaa2613f2e2d87fd7e,
+    wasDerivedFrom(niiri:6de3cb931aee0b120e8281a4cb64f791, niiri:19214f2395b9d0fe87fea1042712b844, -, -, -)
+    entity(niiri:b7f6f27f1180315cf1515cb9f34bb7c3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0027" %% xsd:string,
-        prov:location = 'niiri:0be6fd36a7a88597550e5298744761b6',
+        prov:location = 'niiri:9035876a57a37d707c14e73993ae4007',
         prov:value = "5.16269016265869" %% xsd:float,
         nidm_equivalentZStatistic: = "3.74198250168727" %% xsd:float,
         nidm_pValueUncorrected: = "9.12871154093997e-05" %% xsd:float,
         nidm_pValueFWER: = "0.999192871962629" %% xsd:float,
         nidm_qValueFDR: = "0.00669851286267874" %% xsd:float])
-    entity(niiri:0be6fd36a7a88597550e5298744761b6,
+    entity(niiri:9035876a57a37d707c14e73993ae4007,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0027" %% xsd:string,
         nidm_coordinateVector: = "[36,20,4]" %% xsd:string])
-    wasDerivedFrom(niiri:558b717a6eaaf2aaa2613f2e2d87fd7e, niiri:89f5194a4b0e2d5f67db04f10c0882ac, -, -, -)
-    entity(niiri:3c7a990e35408ee2e2bc41f141132134,
+    wasDerivedFrom(niiri:b7f6f27f1180315cf1515cb9f34bb7c3, niiri:ea4fc41e78afb758775fdca881eec44e, -, -, -)
+    entity(niiri:8602b6cfc4b8e907f22eab95e94b5c29,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0028" %% xsd:string,
-        prov:location = 'niiri:efc8c79d2c3cdc3e0c280b1398a1831b',
+        prov:location = 'niiri:e240674ea9aaa4acc7e1af662cd84b63',
         prov:value = "4.8655366897583" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60809771461691" %% xsd:float,
         nidm_pValueUncorrected: = "0.000154225162826815" %% xsd:float,
         nidm_pValueFWER: = "0.9999601230968" %% xsd:float,
         nidm_qValueFDR: = "0.00861184257857328" %% xsd:float])
-    entity(niiri:efc8c79d2c3cdc3e0c280b1398a1831b,
+    entity(niiri:e240674ea9aaa4acc7e1af662cd84b63,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0028" %% xsd:string,
         nidm_coordinateVector: = "[30,24,0]" %% xsd:string])
-    wasDerivedFrom(niiri:3c7a990e35408ee2e2bc41f141132134, niiri:89f5194a4b0e2d5f67db04f10c0882ac, -, -, -)
-    entity(niiri:a4c025afba5ca5234ab79d7354c091c7,
+    wasDerivedFrom(niiri:8602b6cfc4b8e907f22eab95e94b5c29, niiri:ea4fc41e78afb758775fdca881eec44e, -, -, -)
+    entity(niiri:e7c7fa833df4549330d0ea6b302e5821,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0029" %% xsd:string,
-        prov:location = 'niiri:9c3802455fb925cb9f3bbd7949a49033',
+        prov:location = 'niiri:6cf6193795399b978fd68549664e7fc1',
         prov:value = "5.15075159072876" %% xsd:float,
         nidm_equivalentZStatistic: = "3.73674319192816" %% xsd:float,
         nidm_pValueUncorrected: = "9.3209572512909e-05" %% xsd:float,
         nidm_pValueFWER: = "0.999270580432391" %% xsd:float,
         nidm_qValueFDR: = "0.00676830985421939" %% xsd:float])
-    entity(niiri:9c3802455fb925cb9f3bbd7949a49033,
+    entity(niiri:6cf6193795399b978fd68549664e7fc1,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0029" %% xsd:string,
         nidm_coordinateVector: = "[0,-50,-28]" %% xsd:string])
-    wasDerivedFrom(niiri:a4c025afba5ca5234ab79d7354c091c7, niiri:d97dd5148291142c057785550af3eb2d, -, -, -)
-    entity(niiri:c132ce6a3b937fda0d16d0ee8cf1c129,
+    wasDerivedFrom(niiri:e7c7fa833df4549330d0ea6b302e5821, niiri:f07aa9c81d91e47a941582b5a886f55f, -, -, -)
+    entity(niiri:b5782e1864f16946f41675944cc33756,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0030" %% xsd:string,
-        prov:location = 'niiri:c291ec5fb390da072831c070b623bd2b',
+        prov:location = 'niiri:2f75ebaa83c262a7bfd682fab6e19b64',
         prov:value = "5.12083530426025" %% xsd:float,
         nidm_equivalentZStatistic: = "3.7235640261549" %% xsd:float,
         nidm_pValueUncorrected: = "9.82150082137201e-05" %% xsd:float,
         nidm_pValueFWER: = "0.999437677420886" %% xsd:float,
         nidm_qValueFDR: = "0.00690105743012952" %% xsd:float])
-    entity(niiri:c291ec5fb390da072831c070b623bd2b,
+    entity(niiri:2f75ebaa83c262a7bfd682fab6e19b64,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0030" %% xsd:string,
         nidm_coordinateVector: = "[52,10,40]" %% xsd:string])
-    wasDerivedFrom(niiri:c132ce6a3b937fda0d16d0ee8cf1c129, niiri:50d0f0b594a3407fd672472426d8a80a, -, -, -)
-    entity(niiri:66f1d389f91b7542af2830f2d003e0a0,
+    wasDerivedFrom(niiri:b5782e1864f16946f41675944cc33756, niiri:ddf14aef4dbd07683d036e006e3ca075, -, -, -)
+    entity(niiri:a0b0f2ed57e69ed5093be1c70090046a,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0031" %% xsd:string,
-        prov:location = 'niiri:0cffbb433a9a0d0427187a49d93a7e65',
+        prov:location = 'niiri:6f2bc36b4f3843b3aca8ab4d0651ef80',
         prov:value = "5.10948324203491" %% xsd:float,
         nidm_equivalentZStatistic: = "3.71854416501836" %% xsd:float,
         nidm_pValueUncorrected: = "0.000100187131384155" %% xsd:float,
         nidm_pValueFWER: = "0.999491804107717" %% xsd:float,
         nidm_qValueFDR: = "0.00699662698174139" %% xsd:float])
-    entity(niiri:0cffbb433a9a0d0427187a49d93a7e65,
+    entity(niiri:6f2bc36b4f3843b3aca8ab4d0651ef80,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0031" %% xsd:string,
         nidm_coordinateVector: = "[22,-14,12]" %% xsd:string])
-    wasDerivedFrom(niiri:66f1d389f91b7542af2830f2d003e0a0, niiri:5663af6390cbe1661580022d9cd1db76, -, -, -)
-    entity(niiri:97841d29b10ded1b99b8ce22449c5e38,
+    wasDerivedFrom(niiri:a0b0f2ed57e69ed5093be1c70090046a, niiri:fa453a18169e54396c5e1d3685158f71, -, -, -)
+    entity(niiri:99084e3c9f1a75a2d7316cff499e52e8,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0032" %% xsd:string,
-        prov:location = 'niiri:028379c32508bb74af9ecf4bf7c28dc2',
+        prov:location = 'niiri:5dbf5e840e66e3f67fe5ed96259a76db',
         prov:value = "4.99403047561646" %% xsd:float,
         nidm_equivalentZStatistic: = "3.66689294332376" %% xsd:float,
         nidm_pValueUncorrected: = "0.00012275776099846" %% xsd:float,
         nidm_pValueFWER: = "0.999832837977675" %% xsd:float,
         nidm_qValueFDR: = "0.00775559440349761" %% xsd:float])
-    entity(niiri:028379c32508bb74af9ecf4bf7c28dc2,
+    entity(niiri:5dbf5e840e66e3f67fe5ed96259a76db,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0032" %% xsd:string,
         nidm_coordinateVector: = "[-14,-2,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:97841d29b10ded1b99b8ce22449c5e38, niiri:936e9ee0499c3d068e7444f367b65d20, -, -, -)
-    entity(niiri:b6a3564f5f97cb6a6c26c428c3cf7fdd,
+    wasDerivedFrom(niiri:99084e3c9f1a75a2d7316cff499e52e8, niiri:cfc18ee1d82cfc55f82dba0b483526cf, -, -, -)
+    entity(niiri:7ce5a086f5f94a244bfc39c0ca8cc1ce,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0033" %% xsd:string,
-        prov:location = 'niiri:fb5948c52087fade7dc0a3c08e1c25b1',
+        prov:location = 'niiri:0d170b310ffb9d38b6f1e71fde5f3478',
         prov:value = "4.99324655532837" %% xsd:float,
         nidm_equivalentZStatistic: = "3.66653846830519" %% xsd:float,
         nidm_pValueUncorrected: = "0.000122927974348652" %% xsd:float,
         nidm_pValueFWER: = "0.99983418490596" %% xsd:float,
         nidm_qValueFDR: = "0.00775759422864875" %% xsd:float])
-    entity(niiri:fb5948c52087fade7dc0a3c08e1c25b1,
+    entity(niiri:0d170b310ffb9d38b6f1e71fde5f3478,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0033" %% xsd:string,
         nidm_coordinateVector: = "[8,-26,14]" %% xsd:string])
-    wasDerivedFrom(niiri:b6a3564f5f97cb6a6c26c428c3cf7fdd, niiri:37eed9b79d7a2993d16feb7189856a02, -, -, -)
-    entity(niiri:5323176e6096d153507b38ceb176512b,
+    wasDerivedFrom(niiri:7ce5a086f5f94a244bfc39c0ca8cc1ce, niiri:96e895ca671bf9512c361332af4e5112, -, -, -)
+    entity(niiri:6ac822ed2255aed59106eb0ac73f2419,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0034" %% xsd:string,
-        prov:location = 'niiri:e45c7da465b7b04138d0aa7007b2b615',
+        prov:location = 'niiri:a0f9bf4cfad7a1db7525f7bd3e4d24fc',
         prov:value = "4.89655494689941" %% xsd:float,
         nidm_equivalentZStatistic: = "3.62241950165507" %% xsd:float,
         nidm_pValueUncorrected: = "0.000145930150219908" %% xsd:float,
         nidm_pValueFWER: = "0.999942473649405" %% xsd:float,
         nidm_qValueFDR: = "0.0083498973939701" %% xsd:float])
-    entity(niiri:e45c7da465b7b04138d0aa7007b2b615,
+    entity(niiri:a0f9bf4cfad7a1db7525f7bd3e4d24fc,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0034" %% xsd:string,
         nidm_coordinateVector: = "[14,8,72]" %% xsd:string])
-    wasDerivedFrom(niiri:5323176e6096d153507b38ceb176512b, niiri:9d921e2cb3a8abbe97013ee4bc904c3e, -, -, -)
-    entity(niiri:a44a0f94f9fe2aaccb70c1503033e39b,
+    wasDerivedFrom(niiri:6ac822ed2255aed59106eb0ac73f2419, niiri:260c691d30c80806cf5f518fece69ec2, -, -, -)
+    entity(niiri:11147dafb82d8ded166d16fb1e1c03f5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0035" %% xsd:string,
-        prov:location = 'niiri:3303e5e553ccfb344b281bdf1fda0643',
+        prov:location = 'niiri:d6a02e5ea6fb5b5ca350b4e8a100e993',
         prov:value = "4.86036062240601" %% xsd:float,
         nidm_equivalentZStatistic: = "3.60569974829148" %% xsd:float,
         nidm_pValueUncorrected: = "0.000155656460372522" %% xsd:float,
         nidm_pValueFWER: = "0.999962538559828" %% xsd:float,
         nidm_qValueFDR: = "0.00864250020982424" %% xsd:float])
-    entity(niiri:3303e5e553ccfb344b281bdf1fda0643,
+    entity(niiri:d6a02e5ea6fb5b5ca350b4e8a100e993,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0035" %% xsd:string,
         nidm_coordinateVector: = "[-24,-42,-38]" %% xsd:string])
-    wasDerivedFrom(niiri:a44a0f94f9fe2aaccb70c1503033e39b, niiri:ba889b1413156c8c9b392f582f507018, -, -, -)
-    entity(niiri:5e9f9523049af6068781e26c745db894,
+    wasDerivedFrom(niiri:11147dafb82d8ded166d16fb1e1c03f5, niiri:e108cef37b66653f5877ad74ee875b20, -, -, -)
+    entity(niiri:c0b3b48b1a7be4b6942d241996feb925,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0036" %% xsd:string,
-        prov:location = 'niiri:af5219cdfc791f4e67e12be2e6c60fbe',
+        prov:location = 'niiri:acff28d3e5f7b086c6ed22d8345d08d6',
         prov:value = "4.81803417205811" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58600360944639" %% xsd:float,
         nidm_pValueUncorrected: = "0.00016789215592794" %% xsd:float,
         nidm_pValueFWER: = "0.999977855811547" %% xsd:float,
         nidm_qValueFDR: = "0.00900212220920404" %% xsd:float])
-    entity(niiri:af5219cdfc791f4e67e12be2e6c60fbe,
+    entity(niiri:acff28d3e5f7b086c6ed22d8345d08d6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0036" %% xsd:string,
         nidm_coordinateVector: = "[-54,30,14]" %% xsd:string])
-    wasDerivedFrom(niiri:5e9f9523049af6068781e26c745db894, niiri:51665d1fb0cfb8bda978b620ef449077, -, -, -)
-    entity(niiri:85a6db12151f29eba6c03ad052f455a9,
+    wasDerivedFrom(niiri:c0b3b48b1a7be4b6942d241996feb925, niiri:c4022d4c96fbeee42de7e3b591fc1985, -, -, -)
+    entity(niiri:9ed5119cb165ae1f056c8f3bb5d52c16,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0037" %% xsd:string,
-        prov:location = 'niiri:29cb11c342497725682c33295a8a3469',
+        prov:location = 'niiri:3f56edb451c34de8e9076463bfe94e1e',
         prov:value = "4.77066373825073" %% xsd:float,
         nidm_equivalentZStatistic: = "3.56377460375569" %% xsd:float,
         nidm_pValueUncorrected: = "0.000182779942677791" %% xsd:float,
         nidm_pValueFWER: = "0.999988096830174" %% xsd:float,
         nidm_qValueFDR: = "0.00940067644112613" %% xsd:float])
-    entity(niiri:29cb11c342497725682c33295a8a3469,
+    entity(niiri:3f56edb451c34de8e9076463bfe94e1e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0037" %% xsd:string,
         nidm_coordinateVector: = "[-46,30,16]" %% xsd:string])
-    wasDerivedFrom(niiri:85a6db12151f29eba6c03ad052f455a9, niiri:51665d1fb0cfb8bda978b620ef449077, -, -, -)
-    entity(niiri:a42893da4696ee8d301da513c039bb33,
+    wasDerivedFrom(niiri:9ed5119cb165ae1f056c8f3bb5d52c16, niiri:c4022d4c96fbeee42de7e3b591fc1985, -, -, -)
+    entity(niiri:7e58d61dd3ee319247815d3795d49725,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0038" %% xsd:string,
-        prov:location = 'niiri:0d6f26980a7c82addcff37e277d37f87',
+        prov:location = 'niiri:7f75855b293f102ea83c5c8deda1bc1b',
         prov:value = "4.8089394569397" %% xsd:float,
         nidm_equivalentZStatistic: = "3.58175111371795" %% xsd:float,
         nidm_pValueUncorrected: = "0.00017064943193823" %% xsd:float,
         nidm_pValueFWER: = "0.999980290560917" %% xsd:float,
         nidm_qValueFDR: = "0.00906568438361755" %% xsd:float])
-    entity(niiri:0d6f26980a7c82addcff37e277d37f87,
+    entity(niiri:7f75855b293f102ea83c5c8deda1bc1b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0038" %% xsd:string,
         nidm_coordinateVector: = "[0,-58,-38]" %% xsd:string])
-    wasDerivedFrom(niiri:a42893da4696ee8d301da513c039bb33, niiri:a24fb25342ea5df100b3c9f26c07ccf7, -, -, -)
-    entity(niiri:248a55c19c0892c52e726aa851cb8bdd,
+    wasDerivedFrom(niiri:7e58d61dd3ee319247815d3795d49725, niiri:0bf968a5bd587c050f6fd1233760911c, -, -, -)
+    entity(niiri:e2c98702e3550c85bd24de6a0931577e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0039" %% xsd:string,
-        prov:location = 'niiri:51a0bd12c442e02fba73ae2922f15a79',
+        prov:location = 'niiri:0d6119474d973ff061472cad4ca69a0d',
         prov:value = "4.80026483535767" %% xsd:float,
         nidm_equivalentZStatistic: = "3.57768829524451" %% xsd:float,
         nidm_pValueUncorrected: = "0.000173323244094692" %% xsd:float,
         nidm_pValueFWER: = "0.999982383849948" %% xsd:float,
         nidm_qValueFDR: = "0.00914672501351889" %% xsd:float])
-    entity(niiri:51a0bd12c442e02fba73ae2922f15a79,
+    entity(niiri:0d6119474d973ff061472cad4ca69a0d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0039" %% xsd:string,
         nidm_coordinateVector: = "[-54,12,0]" %% xsd:string])
-    wasDerivedFrom(niiri:248a55c19c0892c52e726aa851cb8bdd, niiri:6b3e2550575959313eec60bd44a6b445, -, -, -)
-    entity(niiri:759c0b26a71be25fa07292239859245d,
+    wasDerivedFrom(niiri:e2c98702e3550c85bd24de6a0931577e, niiri:c69936a9fe388c221c2512207fe7a647, -, -, -)
+    entity(niiri:06974af04f4a80e6b7c8276e41068362,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0040" %% xsd:string,
-        prov:location = 'niiri:b56fb9e5f57ce68403a9901ac11d45a4',
+        prov:location = 'niiri:565ec2a35b3d862759ba3061457fea7a',
         prov:value = "4.77761936187744" %% xsd:float,
         nidm_equivalentZStatistic: = "3.56705096724501" %% xsd:float,
         nidm_pValueUncorrected: = "0.000180510641497822" %% xsd:float,
         nidm_pValueFWER: = "0.999986932005675" %% xsd:float,
         nidm_qValueFDR: = "0.00934466092947769" %% xsd:float])
-    entity(niiri:b56fb9e5f57ce68403a9901ac11d45a4,
+    entity(niiri:565ec2a35b3d862759ba3061457fea7a,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0040" %% xsd:string,
         nidm_coordinateVector: = "[28,2,60]" %% xsd:string])
-    wasDerivedFrom(niiri:759c0b26a71be25fa07292239859245d, niiri:92cf9681c5af88815bed46d4f69484fe, -, -, -)
-    entity(niiri:31be7f0e3a63c3b71e9774b599f0525b,
+    wasDerivedFrom(niiri:06974af04f4a80e6b7c8276e41068362, niiri:6a73a70fccc4a55d2a2871c14348d86b, -, -, -)
+    entity(niiri:f414781bcc088d0804ea8e8a1ebf5333,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0041" %% xsd:string,
-        prov:location = 'niiri:942ddb276df261f58059a9ab77022724',
+        prov:location = 'niiri:c27f7b2ce793dd336a50d1abc82ca476',
         prov:value = "4.67176485061646" %% xsd:float,
         nidm_equivalentZStatistic: = "3.51672280482077" %% xsd:float,
         nidm_pValueUncorrected: = "0.000218454899154397" %% xsd:float,
         nidm_pValueFWER: = "0.999997106974601" %% xsd:float,
         nidm_qValueFDR: = "0.0103643846403155" %% xsd:float])
-    entity(niiri:942ddb276df261f58059a9ab77022724,
+    entity(niiri:c27f7b2ce793dd336a50d1abc82ca476,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0041" %% xsd:string,
         nidm_coordinateVector: = "[26,-4,54]" %% xsd:string])
-    wasDerivedFrom(niiri:31be7f0e3a63c3b71e9774b599f0525b, niiri:92cf9681c5af88815bed46d4f69484fe, -, -, -)
-    entity(niiri:be9f62ae29bc1bf6f51eea46b13a7a57,
+    wasDerivedFrom(niiri:f414781bcc088d0804ea8e8a1ebf5333, niiri:6a73a70fccc4a55d2a2871c14348d86b, -, -, -)
+    entity(niiri:73e466e9281c9f81b49a9540cafa36cb,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0042" %% xsd:string,
-        prov:location = 'niiri:9185d52c29fec95f3943cb1408fe38ac',
+        prov:location = 'niiri:b50695d1e0c5772605da1b10b6da79df',
         prov:value = "4.62480688095093" %% xsd:float,
         nidm_equivalentZStatistic: = "3.49407291194222" %% xsd:float,
         nidm_pValueUncorrected: = "0.000237855539300003" %% xsd:float,
         nidm_pValueFWER: = "0.999998608516906" %% xsd:float,
         nidm_qValueFDR: = "0.0108449863840995" %% xsd:float])
-    entity(niiri:9185d52c29fec95f3943cb1408fe38ac,
+    entity(niiri:b50695d1e0c5772605da1b10b6da79df,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0042" %% xsd:string,
         nidm_coordinateVector: = "[20,-4,60]" %% xsd:string])
-    wasDerivedFrom(niiri:be9f62ae29bc1bf6f51eea46b13a7a57, niiri:92cf9681c5af88815bed46d4f69484fe, -, -, -)
-    entity(niiri:5e5d7e7b87311887d80aece0fcc725f1,
+    wasDerivedFrom(niiri:73e466e9281c9f81b49a9540cafa36cb, niiri:6a73a70fccc4a55d2a2871c14348d86b, -, -, -)
+    entity(niiri:76c2415f534f669a3e125a6608ac44dd,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0043" %% xsd:string,
-        prov:location = 'niiri:a731413b420d2d57b872cb88cfeef28b',
+        prov:location = 'niiri:5092f9fdd12b84035bb1ddd240a68f96',
         prov:value = "4.67917585372925" %% xsd:float,
         nidm_equivalentZStatistic: = "3.5202791175394" %% xsd:float,
         nidm_pValueUncorrected: = "0.000215546442763337" %% xsd:float,
         nidm_pValueFWER: = "0.99999676461456" %% xsd:float,
         nidm_qValueFDR: = "0.0102906058805538" %% xsd:float])
-    entity(niiri:a731413b420d2d57b872cb88cfeef28b,
+    entity(niiri:5092f9fdd12b84035bb1ddd240a68f96,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0043" %% xsd:string,
         nidm_coordinateVector: = "[-34,-12,42]" %% xsd:string])
-    wasDerivedFrom(niiri:5e5d7e7b87311887d80aece0fcc725f1, niiri:c8b8db45e94c74708104298c433fecd6, -, -, -)
-    entity(niiri:eda03e9ad53b2d5ffc1d87c948b5c073,
+    wasDerivedFrom(niiri:76c2415f534f669a3e125a6608ac44dd, niiri:00d620a61a740b07661ceef12972b9ca, -, -, -)
+    entity(niiri:c9f2a2fdba523074d592d26285af44d6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0044" %% xsd:string,
-        prov:location = 'niiri:0a64737dfbc36713dca9405841ec7e26',
+        prov:location = 'niiri:998edb21001f9f73707daffe362a3400',
         prov:value = "4.5969614982605" %% xsd:float,
         nidm_equivalentZStatistic: = "3.48054638647577" %% xsd:float,
         nidm_pValueUncorrected: = "0.000250196083839915" %% xsd:float,
         nidm_pValueFWER: = "0.999999115925319" %% xsd:float,
         nidm_qValueFDR: = "0.0111238765457046" %% xsd:float])
-    entity(niiri:0a64737dfbc36713dca9405841ec7e26,
+    entity(niiri:998edb21001f9f73707daffe362a3400,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0044" %% xsd:string,
         nidm_coordinateVector: = "[36,-40,-10]" %% xsd:string])
-    wasDerivedFrom(niiri:eda03e9ad53b2d5ffc1d87c948b5c073, niiri:e9cca2166adb51f5ec340f78e542f76f, -, -, -)
-    entity(niiri:286d94947c4e1787b77f00b0b7114d06,
+    wasDerivedFrom(niiri:c9f2a2fdba523074d592d26285af44d6, niiri:5e8860ba68ee4852a37847e9d3243844, -, -, -)
+    entity(niiri:70f8d42ece9d45f4ccbb12de3d3820a5,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0045" %% xsd:string,
-        prov:location = 'niiri:f7eff259178a3f65efdc696ad7a247a6',
+        prov:location = 'niiri:6257ba2cc9673f277128f9b0eda09555',
         prov:value = "4.58732891082764" %% xsd:float,
         nidm_equivalentZStatistic: = "3.47585047258978" %% xsd:float,
         nidm_pValueUncorrected: = "0.000254618063707635" %% xsd:float,
         nidm_pValueFWER: = "0.999999246946643" %% xsd:float,
         nidm_qValueFDR: = "0.0112304749683021" %% xsd:float])
-    entity(niiri:f7eff259178a3f65efdc696ad7a247a6,
+    entity(niiri:6257ba2cc9673f277128f9b0eda09555,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0045" %% xsd:string,
         nidm_coordinateVector: = "[36,-10,48]" %% xsd:string])
-    wasDerivedFrom(niiri:286d94947c4e1787b77f00b0b7114d06, niiri:4ce2f04f5e11fd9609173ed79e458866, -, -, -)
-    entity(niiri:41f1a29b28047c513dad04890f92ea62,
+    wasDerivedFrom(niiri:70f8d42ece9d45f4ccbb12de3d3820a5, niiri:58aca5806af4df61d00fa77e5299f356, -, -, -)
+    entity(niiri:61fe029e5af44525b8626e9c9cea1a64,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0046" %% xsd:string,
-        prov:location = 'niiri:ca4d257e28c11e95eac69d8434cf5d21',
+        prov:location = 'niiri:2b9f9c31acb220cc877b9e45351fbff8',
         prov:value = "4.46814107894897" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41702777537423" %% xsd:float,
         nidm_pValueUncorrected: = "0.000316544101057636" %% xsd:float,
         nidm_pValueFWER: = "0.999999911601577" %% xsd:float,
         nidm_qValueFDR: = "0.0126051231599175" %% xsd:float])
-    entity(niiri:ca4d257e28c11e95eac69d8434cf5d21,
+    entity(niiri:2b9f9c31acb220cc877b9e45351fbff8,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0046" %% xsd:string,
         nidm_coordinateVector: = "[-20,-38,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:41f1a29b28047c513dad04890f92ea62, niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b, -, -, -)
-    entity(niiri:644473757bdf4f53de672927c317f640,
+    wasDerivedFrom(niiri:61fe029e5af44525b8626e9c9cea1a64, niiri:f964bc523e6702ec9bc3c985a3616110, -, -, -)
+    entity(niiri:6739b18096dd26074292cda4ff1306a3,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0047" %% xsd:string,
-        prov:location = 'niiri:91812858ace028392052bc61b2ec057f',
+        prov:location = 'niiri:c1b8f82e88512e697b9e6457112a5dd6',
         prov:value = "4.46168184280396" %% xsd:float,
         nidm_equivalentZStatistic: = "3.41380155002305" %% xsd:float,
         nidm_pValueUncorrected: = "0.000320316101733442" %% xsd:float,
         nidm_pValueFWER: = "0.999999921976257" %% xsd:float,
         nidm_qValueFDR: = "0.0126738773801948" %% xsd:float])
-    entity(niiri:91812858ace028392052bc61b2ec057f,
+    entity(niiri:c1b8f82e88512e697b9e6457112a5dd6,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0047" %% xsd:string,
         nidm_coordinateVector: = "[-12,-14,8]" %% xsd:string])
-    wasDerivedFrom(niiri:644473757bdf4f53de672927c317f640, niiri:18aa725ff182239ce52a92cec8c831fe, -, -, -)
-    entity(niiri:118e5465f1cdaee5740cf125155fe7b3,
+    wasDerivedFrom(niiri:6739b18096dd26074292cda4ff1306a3, niiri:f628a53c50b9d4110abc982b7e3ea4b8, -, -, -)
+    entity(niiri:a5ed81195ab4d690b09d57db1429c96d,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0048" %% xsd:string,
-        prov:location = 'niiri:3ff8424d596938b11ad96560eee5df78',
+        prov:location = 'niiri:60a2b827cb52843e392f7d0064a896ea',
         prov:value = "4.44263553619385" %% xsd:float,
         nidm_equivalentZStatistic: = "3.40426513461447" %% xsd:float,
         nidm_pValueUncorrected: = "0.000331711624065423" %% xsd:float,
         nidm_pValueFWER: = "0.999999946301375" %% xsd:float,
         nidm_qValueFDR: = "0.012902019341921" %% xsd:float])
-    entity(niiri:3ff8424d596938b11ad96560eee5df78,
+    entity(niiri:60a2b827cb52843e392f7d0064a896ea,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0048" %% xsd:string,
         nidm_coordinateVector: = "[-4,-28,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:118e5465f1cdaee5740cf125155fe7b3, niiri:7cf7dba6eb11ba3d163885cbe5c660cd, -, -, -)
-    entity(niiri:2aab067e93eed87166d2a6bcb0988f7f,
+    wasDerivedFrom(niiri:a5ed81195ab4d690b09d57db1429c96d, niiri:ce1ba8634c321921e4a4aaa4b9eb59d6, -, -, -)
+    entity(niiri:7cb44a0cd67d94500096125a646c7029,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0049" %% xsd:string,
-        prov:location = 'niiri:c035874bdf6e7d3a175e1e3e4dfd592f',
+        prov:location = 'niiri:6a127e18d64d404adebdb0a74db21ee4',
         prov:value = "4.4201717376709" %% xsd:float,
         nidm_equivalentZStatistic: = "3.39297275478629" %% xsd:float,
         nidm_pValueUncorrected: = "0.00034569257259931" %% xsd:float,
         nidm_pValueFWER: = "0.999999965808818" %% xsd:float,
         nidm_qValueFDR: = "0.01320481591718" %% xsd:float])
-    entity(niiri:c035874bdf6e7d3a175e1e3e4dfd592f,
+    entity(niiri:6a127e18d64d404adebdb0a74db21ee4,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0049" %% xsd:string,
         nidm_coordinateVector: = "[46,-42,54]" %% xsd:string])
-    wasDerivedFrom(niiri:2aab067e93eed87166d2a6bcb0988f7f, niiri:f2aa94f4ac2fd9ce977533852312353d, -, -, -)
-    entity(niiri:182e9fe46ed363f9769a906bff3f1e65,
+    wasDerivedFrom(niiri:7cb44a0cd67d94500096125a646c7029, niiri:49fb64dfbc518d7a1856ea507a08539e, -, -, -)
+    entity(niiri:a83e3cc3a91c735a04532e9ca21e92f2,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0050" %% xsd:string,
-        prov:location = 'niiri:5f08c4860ac9853a3ac9f667b9bea6f5',
+        prov:location = 'niiri:bceb9db36f207b97f69e84447649364e',
         prov:value = "4.41310739517212" %% xsd:float,
         nidm_equivalentZStatistic: = "3.38941149263013" %% xsd:float,
         nidm_pValueUncorrected: = "0.000350214079416045" %% xsd:float,
         nidm_pValueFWER: = "0.999999970406353" %% xsd:float,
         nidm_qValueFDR: = "0.0133062974642806" %% xsd:float])
-    entity(niiri:5f08c4860ac9853a3ac9f667b9bea6f5,
+    entity(niiri:bceb9db36f207b97f69e84447649364e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0050" %% xsd:string,
         nidm_coordinateVector: = "[-6,10,-2]" %% xsd:string])
-    wasDerivedFrom(niiri:182e9fe46ed363f9769a906bff3f1e65, niiri:b9d2c5e57e73184c133167c21e549e31, -, -, -)
-    entity(niiri:3963967f131dd75149db4432a7e47df4,
+    wasDerivedFrom(niiri:a83e3cc3a91c735a04532e9ca21e92f2, niiri:491b37db8347bcb337cac114d7c28332, -, -, -)
+    entity(niiri:9d26bd37ee6076edc804baf6dc4fe873,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0051" %% xsd:string,
-        prov:location = 'niiri:f6bec0e10961c94d25f2bde5fedfbbf8',
+        prov:location = 'niiri:cb188a1af7c32ebe8a3bbde2146b0e07',
         prov:value = "4.36529922485352" %% xsd:float,
         nidm_equivalentZStatistic: = "3.36518306130387" %% xsd:float,
         nidm_pValueUncorrected: = "0.000382464451876507" %% xsd:float,
         nidm_pValueFWER: = "0.999999989209637" %% xsd:float,
         nidm_qValueFDR: = "0.0139415542247477" %% xsd:float])
-    entity(niiri:f6bec0e10961c94d25f2bde5fedfbbf8,
+    entity(niiri:cb188a1af7c32ebe8a3bbde2146b0e07,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0051" %% xsd:string,
         nidm_coordinateVector: = "[42,42,30]" %% xsd:string])
-    wasDerivedFrom(niiri:3963967f131dd75149db4432a7e47df4, niiri:0fff44688bc869513d097e59a8311b54, -, -, -)
-    entity(niiri:90bcd9cecdebdfc1bc653e4a5ce6fdd4,
+    wasDerivedFrom(niiri:9d26bd37ee6076edc804baf6dc4fe873, niiri:2285d72bdbca74c3ffd05a878b326441, -, -, -)
+    entity(niiri:e2407cab140a2ab94b6aacc9f0ec9ee6,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0052" %% xsd:string,
-        prov:location = 'niiri:5dfa4e8409ebc190fafb2e54b42bf770',
+        prov:location = 'niiri:6e21dfb93f9812fc6de65b18af515278',
         prov:value = "4.33874082565308" %% xsd:float,
         nidm_equivalentZStatistic: = "3.35162706179118" %% xsd:float,
         nidm_pValueUncorrected: = "0.00040169081443242" %% xsd:float,
         nidm_pValueFWER: = "0.999999993988362" %% xsd:float,
         nidm_qValueFDR: = "0.014354585034373" %% xsd:float])
-    entity(niiri:5dfa4e8409ebc190fafb2e54b42bf770,
+    entity(niiri:6e21dfb93f9812fc6de65b18af515278,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0052" %% xsd:string,
         nidm_coordinateVector: = "[54,-38,50]" %% xsd:string])
-    wasDerivedFrom(niiri:90bcd9cecdebdfc1bc653e4a5ce6fdd4, niiri:6b373e69fdc37c9c1e68cb0b96d5160c, -, -, -)
-    entity(niiri:aef32c45bff8af696f74dfdd1d985ea3,
+    wasDerivedFrom(niiri:e2407cab140a2ab94b6aacc9f0ec9ee6, niiri:0caba67a7c80988ff6802b01d2bd2008, -, -, -)
+    entity(niiri:3ec22da54a5448d963b421dbc30bc678,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0053" %% xsd:string,
-        prov:location = 'niiri:5a1c6065723c47791b00a4157d8e72fb',
+        prov:location = 'niiri:5f567258b87e850df5be55555d7bd5e2',
         prov:value = "4.31020069122314" %% xsd:float,
         nidm_equivalentZStatistic: = "3.33698195919922" %% xsd:float,
         nidm_pValueUncorrected: = "0.000423467227465446" %% xsd:float,
         nidm_pValueFWER: = "0.999999996857889" %% xsd:float,
         nidm_qValueFDR: = "0.01478592692513" %% xsd:float])
-    entity(niiri:5a1c6065723c47791b00a4157d8e72fb,
+    entity(niiri:5f567258b87e850df5be55555d7bd5e2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0053" %% xsd:string,
         nidm_coordinateVector: = "[8,4,64]" %% xsd:string])
-    wasDerivedFrom(niiri:aef32c45bff8af696f74dfdd1d985ea3, niiri:739e3f4c274d5eac94fb06c09bd419a0, -, -, -)
-    entity(niiri:7c5846f0d310409dc36078590abc73fc,
+    wasDerivedFrom(niiri:3ec22da54a5448d963b421dbc30bc678, niiri:fa32ab50c48787013e9f7686116ae370, -, -, -)
+    entity(niiri:f52f7478d9ba81a1662cf940fd06553b,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0054" %% xsd:string,
-        prov:location = 'niiri:c6f8740e94fe4f1ac8fa83677062dddf',
+        prov:location = 'niiri:570bccdb1d0898c69d8eb32d6ad2fad0',
         prov:value = "4.30184555053711" %% xsd:float,
         nidm_equivalentZStatistic: = "3.33267930931343" %% xsd:float,
         nidm_pValueUncorrected: = "0.000430070120942982" %% xsd:float,
         nidm_pValueFWER: = "0.999999997411931" %% xsd:float,
         nidm_qValueFDR: = "0.0148953189902244" %% xsd:float])
-    entity(niiri:c6f8740e94fe4f1ac8fa83677062dddf,
+    entity(niiri:570bccdb1d0898c69d8eb32d6ad2fad0,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0054" %% xsd:string,
         nidm_coordinateVector: = "[-10,24,32]" %% xsd:string])
-    wasDerivedFrom(niiri:7c5846f0d310409dc36078590abc73fc, niiri:bf0f6f227a5f1dede37450defacf4ee4, -, -, -)
-    entity(niiri:cd504b882f3f5530c78f2f6fdf37a17a,
+    wasDerivedFrom(niiri:f52f7478d9ba81a1662cf940fd06553b, niiri:fd6e415702cd4c776cd6424ad207625b, -, -, -)
+    entity(niiri:3a6d5d6c8230dc370d28c6961f677a64,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0055" %% xsd:string,
-        prov:location = 'niiri:fbe560ba493337b0e163bb49250b595c',
+        prov:location = 'niiri:43d691d9acb35f3976b222e993f33996',
         prov:value = "4.27150821685791" %% xsd:float,
         nidm_equivalentZStatistic: = "3.31699794762384" %% xsd:float,
         nidm_pValueUncorrected: = "0.000454951424559202" %% xsd:float,
         nidm_pValueFWER: = "0.999999998740386" %% xsd:float,
         nidm_qValueFDR: = "0.0153518195589701" %% xsd:float])
-    entity(niiri:fbe560ba493337b0e163bb49250b595c,
+    entity(niiri:43d691d9acb35f3976b222e993f33996,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0055" %% xsd:string,
         nidm_coordinateVector: = "[-14,-2,72]" %% xsd:string])
-    wasDerivedFrom(niiri:cd504b882f3f5530c78f2f6fdf37a17a, niiri:27828afab99d35c7e234991a120cb219, -, -, -)
-    entity(niiri:2241ef49d05e5f1d71db21c706159ef1,
+    wasDerivedFrom(niiri:3a6d5d6c8230dc370d28c6961f677a64, niiri:1d0df51c88ee8bc083b5d2008437074e, -, -, -)
+    entity(niiri:c8c17b9e021b6e2c4eb63a800bcf3c08,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0056" %% xsd:string,
-        prov:location = 'niiri:2eedc6f2b2f210a352180ba9bf836bdb',
+        prov:location = 'niiri:7cc00805149f09da4bc9f9fd9c74a921',
         prov:value = "4.25738191604614" %% xsd:float,
         nidm_equivalentZStatistic: = "3.30966460961956" %% xsd:float,
         nidm_pValueUncorrected: = "0.000467039117525991" %% xsd:float,
         nidm_pValueFWER: = "0.999999999106929" %% xsd:float,
         nidm_qValueFDR: = "0.0155581475175598" %% xsd:float])
-    entity(niiri:2eedc6f2b2f210a352180ba9bf836bdb,
+    entity(niiri:7cc00805149f09da4bc9f9fd9c74a921,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0056" %% xsd:string,
         nidm_coordinateVector: = "[56,26,26]" %% xsd:string])
-    wasDerivedFrom(niiri:2241ef49d05e5f1d71db21c706159ef1, niiri:61fab5ab040124b4935fd160bc4c75c2, -, -, -)
-    entity(niiri:de1ef49da56b6d1ffb63fe6c57d93f44,
+    wasDerivedFrom(niiri:c8c17b9e021b6e2c4eb63a800bcf3c08, niiri:5c3fa5d9240ba93377acc27266386ab6, -, -, -)
+    entity(niiri:2decee0398327a85347c2993ac7e9b5f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0057" %% xsd:string,
-        prov:location = 'niiri:810f41807fafc1e5eaa827e6a868c17c',
+        prov:location = 'niiri:daff1324d950e105ac8dc95b7c19a0b7',
         prov:value = "4.23224687576294" %% xsd:float,
         nidm_equivalentZStatistic: = "3.29656664149817" %% xsd:float,
         nidm_pValueUncorrected: = "0.000489371958441343" %% xsd:float,
         nidm_pValueFWER: = "0.999999999522306" %% xsd:float,
         nidm_qValueFDR: = "0.0159527943368947" %% xsd:float])
-    entity(niiri:810f41807fafc1e5eaa827e6a868c17c,
+    entity(niiri:daff1324d950e105ac8dc95b7c19a0b7,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0057" %% xsd:string,
         nidm_coordinateVector: = "[14,-30,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:de1ef49da56b6d1ffb63fe6c57d93f44, niiri:3e195e76e0011bcbca16974bc51df875, -, -, -)
-    entity(niiri:c444ee8f429895614ebda9dbf5fbd1fb,
+    wasDerivedFrom(niiri:2decee0398327a85347c2993ac7e9b5f, niiri:3b1453b375b54b291f7345abbe23ea62, -, -, -)
+    entity(niiri:f2a8b2edad70831294a59c7ea307b926,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0058" %% xsd:string,
-        prov:location = 'niiri:5a6eb1a0f188a666a4aaaecea6d678fa',
+        prov:location = 'niiri:6c4e5f9ae054b7a8abef510227a976cf',
         prov:value = "4.21795654296875" %% xsd:float,
         nidm_equivalentZStatistic: = "3.28909139477101" %% xsd:float,
         nidm_pValueUncorrected: = "0.000502556899069861" %% xsd:float,
         nidm_pValueFWER: = "0.999999999667972" %% xsd:float,
         nidm_qValueFDR: = "0.0162089652787187" %% xsd:float])
-    entity(niiri:5a6eb1a0f188a666a4aaaecea6d678fa,
+    entity(niiri:6c4e5f9ae054b7a8abef510227a976cf,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0058" %% xsd:string,
         nidm_coordinateVector: = "[46,-54,-30]" %% xsd:string])
-    wasDerivedFrom(niiri:c444ee8f429895614ebda9dbf5fbd1fb, niiri:efb3b3e5edd63741aa95f90f1a73c855, -, -, -)
-    entity(niiri:5baaf3257c1f9338a03f1372087336aa,
+    wasDerivedFrom(niiri:f2a8b2edad70831294a59c7ea307b926, niiri:2ce833531fec9f54b7fd4cabb582abb4, -, -, -)
+    entity(niiri:a2b2fbe93d1634fef546cdbede36389f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0059" %% xsd:string,
-        prov:location = 'niiri:8288b9701fe4611f125b1363a4414e5a',
+        prov:location = 'niiri:8fd0fbdc8e1ef6d308bd57aa0f1f545f',
         prov:value = "4.19331645965576" %% xsd:float,
         nidm_equivalentZStatistic: = "3.27615344058961" %% xsd:float,
         nidm_pValueUncorrected: = "0.000526156861805016" %% xsd:float,
         nidm_pValueFWER: = "0.999999999825125" %% xsd:float,
         nidm_qValueFDR: = "0.0165459969587672" %% xsd:float])
-    entity(niiri:8288b9701fe4611f125b1363a4414e5a,
+    entity(niiri:8fd0fbdc8e1ef6d308bd57aa0f1f545f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0059" %% xsd:string,
         nidm_coordinateVector: = "[28,22,16]" %% xsd:string])
-    wasDerivedFrom(niiri:5baaf3257c1f9338a03f1372087336aa, niiri:e3b33814b86cd485564e0a0928f90e0f, -, -, -)
-    entity(niiri:280fd372fb559f3177b6e1256a306389,
+    wasDerivedFrom(niiri:a2b2fbe93d1634fef546cdbede36389f, niiri:4e8a04cb57e27c1354da0f9221cefad4, -, -, -)
+    entity(niiri:b6f88c6e0a0a91f0fdbc5e15f0467133,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0060" %% xsd:string,
-        prov:location = 'niiri:2335841ec513e02901317171950e6e7e',
+        prov:location = 'niiri:279e804c8cd6f4d982eac06678ec644d',
         prov:value = "4.164222240448" %% xsd:float,
         nidm_equivalentZStatistic: = "3.26079679766555" %% xsd:float,
         nidm_pValueUncorrected: = "0.000555498136877608" %% xsd:float,
         nidm_pValueFWER: = "0.999999999919858" %% xsd:float,
         nidm_qValueFDR: = "0.017023135244014" %% xsd:float])
-    entity(niiri:2335841ec513e02901317171950e6e7e,
+    entity(niiri:279e804c8cd6f4d982eac06678ec644d,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0060" %% xsd:string,
         nidm_coordinateVector: = "[32,-46,-8]" %% xsd:string])
-    wasDerivedFrom(niiri:280fd372fb559f3177b6e1256a306389, niiri:cfdf88b2a941aeba3fcc1f4b45b10448, -, -, -)
-    entity(niiri:68691392db8be62d02ad17ca0283c776,
+    wasDerivedFrom(niiri:b6f88c6e0a0a91f0fdbc5e15f0467133, niiri:a5bc72d93b1628741579fb91fca4ac04, -, -, -)
+    entity(niiri:770d5a9c1943768336a41dfed084d4e0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0061" %% xsd:string,
-        prov:location = 'niiri:007cea7d2370bfd078d23d8eba7e3a4d',
+        prov:location = 'niiri:560acb2ed13336590d0228d63f0eec04',
         prov:value = "4.1354022026062" %% xsd:float,
         nidm_equivalentZStatistic: = "3.24549898327499" %% xsd:float,
         nidm_pValueUncorrected: = "0.000586224915903544" %% xsd:float,
         nidm_pValueFWER: = "0.999999999963932" %% xsd:float,
         nidm_qValueFDR: = "0.0175104371158769" %% xsd:float])
-    entity(niiri:007cea7d2370bfd078d23d8eba7e3a4d,
+    entity(niiri:560acb2ed13336590d0228d63f0eec04,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0061" %% xsd:string,
         nidm_coordinateVector: = "[12,18,32]" %% xsd:string])
-    wasDerivedFrom(niiri:68691392db8be62d02ad17ca0283c776, niiri:8053ffdd2903523517c32abc5eed6805, -, -, -)
-    entity(niiri:e0dc036274a57f0fe2d89e9ced584377,
+    wasDerivedFrom(niiri:770d5a9c1943768336a41dfed084d4e0, niiri:67829b13c9a254ab8e5e036dfe81f295, -, -, -)
+    entity(niiri:6f5eab0276a97c20980194b57d0697d7,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0062" %% xsd:string,
-        prov:location = 'niiri:6964785c365b99534b9ed5d158738905',
+        prov:location = 'niiri:612e0339ecfceadf01e886fa7dee967f',
         prov:value = "4.09669637680054" %% xsd:float,
         nidm_equivalentZStatistic: = "3.22481821343066" %% xsd:float,
         nidm_pValueUncorrected: = "0.000630263410459797" %% xsd:float,
         nidm_pValueFWER: = "0.999999999988153" %% xsd:float,
         nidm_qValueFDR: = "0.0182494607837458" %% xsd:float])
-    entity(niiri:6964785c365b99534b9ed5d158738905,
+    entity(niiri:612e0339ecfceadf01e886fa7dee967f,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0062" %% xsd:string,
         nidm_coordinateVector: = "[6,-60,64]" %% xsd:string])
-    wasDerivedFrom(niiri:e0dc036274a57f0fe2d89e9ced584377, niiri:be2669b1217c5497ae7583e9f37e889f, -, -, -)
-    entity(niiri:171d6b4dfd03d1048a1523ac6ab16c51,
+    wasDerivedFrom(niiri:6f5eab0276a97c20980194b57d0697d7, niiri:c7ba4fe69a7060d041b8a1bd8e9abeb1, -, -, -)
+    entity(niiri:573ad2bca8ba5d7dc9c11840ae019222,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0063" %% xsd:string,
-        prov:location = 'niiri:0c042f9715d9ee75592c3572982a0982',
+        prov:location = 'niiri:9cbf0b11253a7d0b9281d19e6bfbd0ce',
         prov:value = "4.06586408615112" %% xsd:float,
         nidm_equivalentZStatistic: = "3.20823228054844" %% xsd:float,
         nidm_pValueUncorrected: = "0.000667767930319307" %% xsd:float,
         nidm_pValueFWER: = "0.999999999995287" %% xsd:float,
         nidm_qValueFDR: = "0.018874773548645" %% xsd:float])
-    entity(niiri:0c042f9715d9ee75592c3572982a0982,
+    entity(niiri:9cbf0b11253a7d0b9281d19e6bfbd0ce,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0063" %% xsd:string,
         nidm_coordinateVector: = "[-20,-66,-32]" %% xsd:string])
-    wasDerivedFrom(niiri:171d6b4dfd03d1048a1523ac6ab16c51, niiri:345d8154c25e6bc91b83c7a570393c32, -, -, -)
-    entity(niiri:a7098f4e7d792337d036f494fb50b3e4,
+    wasDerivedFrom(niiri:573ad2bca8ba5d7dc9c11840ae019222, niiri:d5ee6f1a9ca6bdd4f96fd93bea1b27d0, -, -, -)
+    entity(niiri:d2fe8bddf63332afaaa7841d1dd2d7aa,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0064" %% xsd:string,
-        prov:location = 'niiri:52a60ec1c4d123189f7f1133afcaa6c6',
+        prov:location = 'niiri:65660fd080de37355a27b90d9f3b6a41',
         prov:value = "4.05021715164185" %% xsd:float,
         nidm_equivalentZStatistic: = "3.19977690410182" %% xsd:float,
         nidm_pValueUncorrected: = "0.000687670008111763" %% xsd:float,
         nidm_pValueFWER: = "0.999999999997083" %% xsd:float,
         nidm_qValueFDR: = "0.0191721851735585" %% xsd:float])
-    entity(niiri:52a60ec1c4d123189f7f1133afcaa6c6,
+    entity(niiri:65660fd080de37355a27b90d9f3b6a41,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0064" %% xsd:string,
         nidm_coordinateVector: = "[-8,-72,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:a7098f4e7d792337d036f494fb50b3e4, niiri:0feb21dbaab7759d1a095b10570dbcbb, -, -, -)
-    entity(niiri:36b86426126175a8096c29f1919ba51d,
+    wasDerivedFrom(niiri:d2fe8bddf63332afaaa7841d1dd2d7aa, niiri:33b6b88c9f8662328644ad657a54d41f, -, -, -)
+    entity(niiri:871e4e5d0420aa5b61f92742d95e2f19,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0065" %% xsd:string,
-        prov:location = 'niiri:5490e18e279668b30172e0e8f638ec06',
+        prov:location = 'niiri:bdbeee804b8e36df65ced505b97d20d9',
         prov:value = "4.02814960479736" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18780790473987" %% xsd:float,
         nidm_pValueUncorrected: = "0.000716778694212938" %% xsd:float,
         nidm_pValueFWER: = "0.999999999998538" %% xsd:float,
         nidm_qValueFDR: = "0.0196630402446738" %% xsd:float])
-    entity(niiri:5490e18e279668b30172e0e8f638ec06,
+    entity(niiri:bdbeee804b8e36df65ced505b97d20d9,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0065" %% xsd:string,
         nidm_coordinateVector: = "[-26,-36,-24]" %% xsd:string])
-    wasDerivedFrom(niiri:36b86426126175a8096c29f1919ba51d, niiri:4867e698cc576f0b80c177fdf37912bc, -, -, -)
-    entity(niiri:68fbcfdade2d23e2a8f7038c87eb5cff,
+    wasDerivedFrom(niiri:871e4e5d0420aa5b61f92742d95e2f19, niiri:5f796a80c868cc4e07db3893075e2ab5, -, -, -)
+    entity(niiri:186d028736c894a4890184b7cf694827,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0066" %% xsd:string,
-        prov:location = 'niiri:77d8894d4ae1110ed28592a6314d05e6',
+        prov:location = 'niiri:b7b924c415f8fa0a7a0697aa72e7f6a5',
         prov:value = "4.0194239616394" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18306102742152" %% xsd:float,
         nidm_pValueUncorrected: = "0.000728634479518986" %% xsd:float,
         nidm_pValueFWER: = "0.999999999998893" %% xsd:float,
         nidm_qValueFDR: = "0.019829947388337" %% xsd:float])
-    entity(niiri:77d8894d4ae1110ed28592a6314d05e6,
+    entity(niiri:b7b924c415f8fa0a7a0697aa72e7f6a5,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0066" %% xsd:string,
         nidm_coordinateVector: = "[-26,6,66]" %% xsd:string])
-    wasDerivedFrom(niiri:68fbcfdade2d23e2a8f7038c87eb5cff, niiri:dbd7ff1039cc058a9180d3a6b19c0d65, -, -, -)
-    entity(niiri:00465a63053242b2dffac6ee659b2354,
+    wasDerivedFrom(niiri:186d028736c894a4890184b7cf694827, niiri:66c5c4f7aab02ec57f99c4903c0d0d24, -, -, -)
+    entity(niiri:a84f34e906ddfa583085ab412e782957,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0067" %% xsd:string,
-        prov:location = 'niiri:f450ec4d266f33c1b6d2eb7b93ec2c9b',
+        prov:location = 'niiri:2e1e2c6fde5e2e480843a37db05f8726',
         prov:value = "4.01476430892944" %% xsd:float,
         nidm_equivalentZStatistic: = "3.18052278869165" %% xsd:float,
         nidm_pValueUncorrected: = "0.000735047880785378" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999046" %% xsd:float,
         nidm_qValueFDR: = "0.0199399671265334" %% xsd:float])
-    entity(niiri:f450ec4d266f33c1b6d2eb7b93ec2c9b,
+    entity(niiri:2e1e2c6fde5e2e480843a37db05f8726,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0067" %% xsd:string,
         nidm_coordinateVector: = "[-32,-6,66]" %% xsd:string])
-    wasDerivedFrom(niiri:00465a63053242b2dffac6ee659b2354, niiri:9a04edbbfec2046f6e63a9808f7e31be, -, -, -)
-    entity(niiri:d1e53c6e21728e567ad7d5efc7526f76,
+    wasDerivedFrom(niiri:a84f34e906ddfa583085ab412e782957, niiri:dd22a79353aa6df10199cb87a8c73432, -, -, -)
+    entity(niiri:fa82f6ef2cafcb81390153f0dbc9d3b9,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0068" %% xsd:string,
-        prov:location = 'niiri:2f0f52f74919616dd5ecdc47bdf7662d',
+        prov:location = 'niiri:204dc7e2e23ff0ea824a15d83b604f5b',
         prov:value = "4.01372337341309" %% xsd:float,
         nidm_equivalentZStatistic: = "3.17995544681479" %% xsd:float,
         nidm_pValueUncorrected: = "0.000736488485902353" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999078" %% xsd:float,
         nidm_qValueFDR: = "0.0199550456355793" %% xsd:float])
-    entity(niiri:2f0f52f74919616dd5ecdc47bdf7662d,
+    entity(niiri:204dc7e2e23ff0ea824a15d83b604f5b,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0068" %% xsd:string,
         nidm_coordinateVector: = "[56,-4,46]" %% xsd:string])
-    wasDerivedFrom(niiri:d1e53c6e21728e567ad7d5efc7526f76, niiri:4802981400c706074d7089aa4f606c7a, -, -, -)
-    entity(niiri:590d2d1c331312707acd1dd13cad86a4,
+    wasDerivedFrom(niiri:fa82f6ef2cafcb81390153f0dbc9d3b9, niiri:620e2ba10d624da22f1d1ffc75882c40, -, -, -)
+    entity(niiri:a34303c6c2ad04b453d45e05467bb020,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0069" %% xsd:string,
-        prov:location = 'niiri:e13abed58503558f5419d66eb9a3daab',
+        prov:location = 'niiri:53ef23883ebbd94143fab90bcfe40272',
         prov:value = "3.99763154983521" %% xsd:float,
         nidm_equivalentZStatistic: = "3.17117019350021" %% xsd:float,
         nidm_pValueUncorrected: = "0.000759130810004449" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999453" %% xsd:float,
         nidm_qValueFDR: = "0.0202312537871442" %% xsd:float])
-    entity(niiri:e13abed58503558f5419d66eb9a3daab,
+    entity(niiri:53ef23883ebbd94143fab90bcfe40272,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0069" %% xsd:string,
         nidm_coordinateVector: = "[10,-20,-12]" %% xsd:string])
-    wasDerivedFrom(niiri:590d2d1c331312707acd1dd13cad86a4, niiri:0c9c1006b093a8cc91c759baf58575ee, -, -, -)
-    entity(niiri:d6a41ae2f605bfe0ffcfcdd41c571806,
+    wasDerivedFrom(niiri:a34303c6c2ad04b453d45e05467bb020, niiri:528d2a201077a9f036630cf90c25a2e4, -, -, -)
+    entity(niiri:fce0437e15464dfacfc60a07a75a3f05,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0070" %% xsd:string,
-        prov:location = 'niiri:b52aa1bb12ceb0dd758b5674ba71269e',
+        prov:location = 'niiri:40704d44d5a2d10993a11064245c7ca3',
         prov:value = "3.96427512168884" %% xsd:float,
         nidm_equivalentZStatistic: = "3.15287103994341" %% xsd:float,
         nidm_pValueUncorrected: = "0.000808366063659971" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999982" %% xsd:float,
         nidm_qValueFDR: = "0.0208863381686101" %% xsd:float])
-    entity(niiri:b52aa1bb12ceb0dd758b5674ba71269e,
+    entity(niiri:40704d44d5a2d10993a11064245c7ca3,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0070" %% xsd:string,
         nidm_coordinateVector: = "[-52,20,36]" %% xsd:string])
-    wasDerivedFrom(niiri:d6a41ae2f605bfe0ffcfcdd41c571806, niiri:9e9eebffba744c379bca54d713a85d3b, -, -, -)
-    entity(niiri:f48cec3f59920d1e0aef1e5edb72b3ae,
+    wasDerivedFrom(niiri:fce0437e15464dfacfc60a07a75a3f05, niiri:b6a501a185ba123c5d8ae0428a609570, -, -, -)
+    entity(niiri:61fa4fcddf7146388205e8f9f7e75c5f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0071" %% xsd:string,
-        prov:location = 'niiri:28e17599c65fb7c18cd3eb6c92fcdf63',
+        prov:location = 'niiri:f93b3f18b7ce2335eb4be32f6089aa8e',
         prov:value = "3.94705867767334" %% xsd:float,
         nidm_equivalentZStatistic: = "3.14337930633102" %% xsd:float,
         nidm_pValueUncorrected: = "0.000835046362340219" %% xsd:float,
         nidm_pValueFWER: = "0.9999999999999" %% xsd:float,
         nidm_qValueFDR: = "0.0212745029430363" %% xsd:float])
-    entity(niiri:28e17599c65fb7c18cd3eb6c92fcdf63,
+    entity(niiri:f93b3f18b7ce2335eb4be32f6089aa8e,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0071" %% xsd:string,
         nidm_coordinateVector: = "[10,-24,-14]" %% xsd:string])
-    wasDerivedFrom(niiri:f48cec3f59920d1e0aef1e5edb72b3ae, niiri:2ef2320c7a264cf13420c161d25ff5cc, -, -, -)
-    entity(niiri:0bf03c97edd7b117b1111cf0cfa73c96,
+    wasDerivedFrom(niiri:61fa4fcddf7146388205e8f9f7e75c5f, niiri:ac078cd746e0c0e589efde6d868f9503, -, -, -)
+    entity(niiri:9853e69b4f9f0cc9ab19c0da413e8b8f,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0072" %% xsd:string,
-        prov:location = 'niiri:05eb28fd11ef4f85b5b7fccadd23374f',
+        prov:location = 'niiri:20d1d862e5cafe0c2340f06b9ac43b97',
         prov:value = "3.93684697151184" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13773425766756" %% xsd:float,
         nidm_pValueUncorrected: = "0.00085129580940857" %% xsd:float,
         nidm_pValueFWER: = "0.99999999999993" %% xsd:float,
         nidm_qValueFDR: = "0.0215142897882816" %% xsd:float])
-    entity(niiri:05eb28fd11ef4f85b5b7fccadd23374f,
+    entity(niiri:20d1d862e5cafe0c2340f06b9ac43b97,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0072" %% xsd:string,
         nidm_coordinateVector: = "[-32,18,-6]" %% xsd:string])
-    wasDerivedFrom(niiri:0bf03c97edd7b117b1111cf0cfa73c96, niiri:53b5e166978251c052e00c9a4fe81fdc, -, -, -)
-    entity(niiri:bb138c83a7f0b859be01107344c7d312,
+    wasDerivedFrom(niiri:9853e69b4f9f0cc9ab19c0da413e8b8f, niiri:67a0a2929818d60014e2d343e4dd0e9f, -, -, -)
+    entity(niiri:d8d92593836f27ffec4700b588395eb0,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0073" %% xsd:string,
-        prov:location = 'niiri:e83ab329851a7f93c2f57864f4abe3b3',
+        prov:location = 'niiri:df48cc12c70ad9a5c5138ffd20279cc2',
         prov:value = "3.93397641181946" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13614537112983" %% xsd:float,
         nidm_pValueUncorrected: = "0.000855921637752388" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999937" %% xsd:float,
         nidm_qValueFDR: = "0.0215615444445258" %% xsd:float])
-    entity(niiri:e83ab329851a7f93c2f57864f4abe3b3,
+    entity(niiri:df48cc12c70ad9a5c5138ffd20279cc2,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0073" %% xsd:string,
         nidm_coordinateVector: = "[52,10,18]" %% xsd:string])
-    wasDerivedFrom(niiri:bb138c83a7f0b859be01107344c7d312, niiri:de88c64838ddf5de0155dcdce61cf6c0, -, -, -)
-    entity(niiri:86b5d287e5e443c1262f0ad80f006282,
+    wasDerivedFrom(niiri:d8d92593836f27ffec4700b588395eb0, niiri:48c77f140153e04f3768726af76bae9b, -, -, -)
+    entity(niiri:32987cca18a40d2d66d1f3113a5f9abc,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0074" %% xsd:string,
-        prov:location = 'niiri:9544cd35baa3055df29785d0cba7563e',
+        prov:location = 'niiri:517a7208250880bc2a041087570ae344',
         prov:value = "3.92871356010437" %% xsd:float,
         nidm_equivalentZStatistic: = "3.13323000033267" %% xsd:float,
         nidm_pValueUncorrected: = "0.000864469518982003" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999947" %% xsd:float,
         nidm_qValueFDR: = "0.0216822850176731" %% xsd:float])
-    entity(niiri:9544cd35baa3055df29785d0cba7563e,
+    entity(niiri:517a7208250880bc2a041087570ae344,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0074" %% xsd:string,
         nidm_coordinateVector: = "[34,-52,-4]" %% xsd:string])
-    wasDerivedFrom(niiri:86b5d287e5e443c1262f0ad80f006282, niiri:02344c7a7b0c9af7c25dbcd3cbd09300, -, -, -)
-    entity(niiri:a659cc920974b885b011950336fdb2e6,
+    wasDerivedFrom(niiri:32987cca18a40d2d66d1f3113a5f9abc, niiri:8d5fab1550256921e7e64a7712e48bae, -, -, -)
+    entity(niiri:dc4433638b5205f63b06c49e26770b5c,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0075" %% xsd:string,
-        prov:location = 'niiri:82c89a91afac0227805c920ac46780b4',
+        prov:location = 'niiri:1682a5cf8e3c9f83e8a3ffc904287034',
         prov:value = "3.91936802864075" %% xsd:float,
         nidm_equivalentZStatistic: = "3.12804559569402" %% xsd:float,
         nidm_pValueUncorrected: = "0.000879864400760821" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999962" %% xsd:float,
         nidm_qValueFDR: = "0.0218781120126672" %% xsd:float])
-    entity(niiri:82c89a91afac0227805c920ac46780b4,
+    entity(niiri:1682a5cf8e3c9f83e8a3ffc904287034,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0075" %% xsd:string,
         nidm_coordinateVector: = "[16,-32,-34]" %% xsd:string])
-    wasDerivedFrom(niiri:a659cc920974b885b011950336fdb2e6, niiri:22648332b0e4fb9a38556afd35646c42, -, -, -)
-    entity(niiri:8f404f298d64974fc27f83332fc6d68e,
+    wasDerivedFrom(niiri:dc4433638b5205f63b06c49e26770b5c, niiri:9302cebb2f2f594519eb7868350332d5, -, -, -)
+    entity(niiri:58e1b535c49f38e4a876570c300b830e,
         [prov:type = 'nidm_Peak:',
         prov:label = "Peak: 0076" %% xsd:string,
-        prov:location = 'niiri:6a1d3251cb160a559caa1932f4e6e20d',
+        prov:location = 'niiri:c639e8c70e4a07bb3fb69de3d3ffc484',
         prov:value = "3.8760769367218" %% xsd:float,
         nidm_equivalentZStatistic: = "3.1039055725094" %% xsd:float,
         nidm_pValueUncorrected: = "0.000954921373033768" %% xsd:float,
         nidm_pValueFWER: = "0.999999999999992" %% xsd:float,
         nidm_qValueFDR: = "0.0229044690727897" %% xsd:float])
-    entity(niiri:6a1d3251cb160a559caa1932f4e6e20d,
+    entity(niiri:c639e8c70e4a07bb3fb69de3d3ffc484,
         [prov:type = 'prov:Location',
         prov:type = 'nidm_Coordinate:',
         prov:label = "Coordinate: 0076" %% xsd:string,
         nidm_coordinateVector: = "[18,8,34]" %% xsd:string])
-    wasDerivedFrom(niiri:8f404f298d64974fc27f83332fc6d68e, niiri:3b46a57f86b33c173fe10a245389f4ff, -, -, -)
+    wasDerivedFrom(niiri:58e1b535c49f38e4a876570c300b830e, niiri:96084c5a0a8645a35c364d23198e7b84, -, -, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_t_test/nidm.provn
+++ b/spmexport/ex_spm_t_test/nidm.provn
@@ -1,0 +1,2105 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:1b00cc9eddb72e8298ae831abf8242a8,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:37ae388b351e24eff092878ed6c627e8,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:9fd2af475544e59d923f455813a60f9e,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:9fd2af475544e59d923f455813a60f9e, niiri:37ae388b351e24eff092878ed6c627e8, -)
+  wasGeneratedBy(niiri:1b00cc9eddb72e8298ae831abf8242a8, niiri:9fd2af475544e59d923f455813a60f9e, 2016-01-11T10:12:11)
+  bundle niiri:1b00cc9eddb72e8298ae831abf8242a8
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix nidm_IndependentError <http://purl.org/nidash/nidm#NIDM_0000048>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_OLS <http://purl.obolibrary.org/obo/STATO_0000370>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+    prefix nidm_SupraThresholdCluster <http://purl.org/nidash/nidm#NIDM_0000070>
+    prefix nidm_pValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000116>
+    prefix nidm_pValueFWER <http://purl.org/nidash/nidm#NIDM_0000115>
+    prefix nidm_qValueFDR <http://purl.org/nidash/nidm#NIDM_0000119>
+    prefix nidm_clusterLabelId <http://purl.org/nidash/nidm#NIDM_0000082>
+    prefix nidm_Peak <http://purl.org/nidash/nidm#NIDM_0000062>
+    prefix nidm_equivalentZStatistic <http://purl.org/nidash/nidm#NIDM_0000092>
+    prefix nidm_Coordinate <http://purl.org/nidash/nidm#NIDM_0000015>
+    prefix nidm_coordinateVector <http://purl.org/nidash/nidm#NIDM_0000086>
+
+    agent(niiri:a035080de4f5f70d7392a1a791404523,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:91c9c55e5f9fc572da5b4bf19a331220,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "false" %% xsd:boolean])
+    entity(niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:175b9210819e919a439d88ac4bc2ab57',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"mean\"]" %% xsd:string])
+    entity(niiri:175b9210819e919a439d88ac4bc2ab57,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:84b8dfaa3fa67fbd8f4c852110a04531,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'nidm_IndependentError:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean])
+    activity(niiri:b416890bf96d1dbb804f2efa4fda2d95,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_OLS:'])
+    wasAssociatedWith(niiri:b416890bf96d1dbb804f2efa4fda2d95, niiri:a035080de4f5f70d7392a1a791404523, -)
+    used(niiri:b416890bf96d1dbb804f2efa4fda2d95, niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0, -)
+    used(niiri:b416890bf96d1dbb804f2efa4fda2d95, niiri:91c9c55e5f9fc572da5b4bf19a331220, -)
+    used(niiri:b416890bf96d1dbb804f2efa4fda2d95, niiri:84b8dfaa3fa67fbd8f4c852110a04531, -)
+    entity(niiri:a99fcafea3bdd16053d3fbef6194f56c,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
+    entity(niiri:6079f21d5530fd7507553a99cd6bfac7,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e" %% xsd:string])
+    wasDerivedFrom(niiri:a99fcafea3bdd16053d3fbef6194f56c, niiri:6079f21d5530fd7507553a99cd6bfac7, -, -, -)
+    wasGeneratedBy(niiri:a99fcafea3bdd16053d3fbef6194f56c, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
+    entity(niiri:92fe3ceea82b9387c2e8a74870e1ff03,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "0.0584948938339949" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        crypto:sha512 = "504d2b5e17e73690caae29eafdc0448a1d5ac6d66af811a3fcbab8eec9f904820f0610d985a6f04e8808fcd8f77def3c063bfb11df56679b0b28261cdc2856f9" %% xsd:string])
+    wasGeneratedBy(niiri:92fe3ceea82b9387c2e8a74870e1ff03, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
+    entity(niiri:a5219921c3bcca062f97bd37da42f0f6,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd'])
+    entity(niiri:758caf4a74ea7c64784615391d3d8bb9,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "9a22064d78683e5b5375b6d3708584d2bb24dd434f40b311f06e185e10c9492d976c35967cc2545e3d7aefa2b83f7e433c957bd8dc87c22392e334027d0b438b" %% xsd:string])
+    wasDerivedFrom(niiri:a5219921c3bcca062f97bd37da42f0f6, niiri:758caf4a74ea7c64784615391d3d8bb9, -, -, -)
+    wasGeneratedBy(niiri:a5219921c3bcca062f97bd37da42f0f6, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
+    entity(niiri:42d6ab087f72abda2ef3d164d74b2af0,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        crypto:sha512 = "5796b765989869d8ad685aee159b41c06538552c8a91ed6cfa9dc7a334df02e91dd83703fd5d9be4a7fc8a27943157d2cf29f457aa1cf4a3d01ce813480ddaaa" %% xsd:string])
+    entity(niiri:794d510acaf63dceb059cc9ba8dab5d2,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "bd6687fb4b5d5af30fa322a8b6b6df29ead2c1e0ebe8e1962c3716c2c05a23365fe0428be1d420ef8b013c4c342c0d5efe704fec31b6e956c2b4d15a630b1c98" %% xsd:string])
+    wasDerivedFrom(niiri:42d6ab087f72abda2ef3d164d74b2af0, niiri:794d510acaf63dceb059cc9ba8dab5d2, -, -, -)
+    wasGeneratedBy(niiri:42d6ab087f72abda2ef3d164d74b2af0, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
+    entity(niiri:3aa3da07651e9afc3c6c5a49b7b97170,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        crypto:sha512 = "7090223b1a196dba349a102d5d369808fa90203f67c9021d2113b323996c67506be3e49d5e848a4f38a6ff78038478dee1401d2a7cd9ee5e6496f3d0313c6eb6" %% xsd:string])
+    entity(niiri:9b2bfe67b8475d87b43e4e93e350f76e,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "95b2ccdef4496cd3830f817f9d8893924091b302a09c66b1581f7ee4721c618a1d95d56e509e8f1537af7ea437bc5f3fbf7f69037f13203b6c98733647911d8d" %% xsd:string])
+    wasDerivedFrom(niiri:3aa3da07651e9afc3c6c5a49b7b97170, niiri:9b2bfe67b8475d87b43e4e93e350f76e, -, -, -)
+    wasGeneratedBy(niiri:3aa3da07651e9afc3c6c5a49b7b97170, niiri:b416890bf96d1dbb804f2efa4fda2d95, -)
+    entity(niiri:04b578701cf4564a0a334f46af3d16fa,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
+        prov:label = "Contrast: Con1: mr vs plain" %% xsd:string,
+        prov:value = "1" %% xsd:string])
+    activity(niiri:f8fa21d3adf52266399255440cb7dbde,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:a035080de4f5f70d7392a1a791404523, -)
+    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:a99fcafea3bdd16053d3fbef6194f56c, -)
+    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:42d6ab087f72abda2ef3d164d74b2af0, -)
+    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0, -)
+    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:04b578701cf4564a0a334f46af3d16fa, -)
+    used(niiri:f8fa21d3adf52266399255440cb7dbde, niiri:a5219921c3bcca062f97bd37da42f0f6, -)
+    entity(niiri:b925226ebcfaf81953c6c8d86b12edbe,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: Con1: mr vs plain" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "13" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        crypto:sha512 = "2eec11aca8e4898cb44b0e535e3abecde8d46ea6e5fe05bb26e2dee72769fcb985c90c0ed86b9dcaf260d502b34559700f7a3c0f944f020a4beb20042153d26f" %% xsd:string])
+    entity(niiri:c7968123d4a2445f2cc5efd45678f874,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "291b6fbfe377046689fa404484c99e68b419966665af4294ca5348faf3ee9e3e4ea972ccb9c17fc697c42c58d915fda6300a540027b872eccd1403215cd2e075" %% xsd:string])
+    wasDerivedFrom(niiri:b925226ebcfaf81953c6c8d86b12edbe, niiri:c7968123d4a2445f2cc5efd45678f874, -, -, -)
+    wasGeneratedBy(niiri:b925226ebcfaf81953c6c8d86b12edbe, niiri:f8fa21d3adf52266399255440cb7dbde, -)
+    entity(niiri:0d474a910bcd3d0f50d6a1c63d2c2081,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: Con1: mr vs plain" %% xsd:string,
+        nidm_contrastName: = "Con1: mr vs plain" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        crypto:sha512 = "d907fef7984f59a008b8963e5fb6d2386968ffcde54e31fabe7ed8b0e1a32e4410475271e4fa903e1aa6c01ef4903209fb61660bd47a5709a5c5c91bccc8b426" %% xsd:string])
+    entity(niiri:0f1eef5a71e2e8c320c07d47aaf5faa2,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "66e00621b81bef508ca685a72a398d532276891ec8b2abc489af8f6105099ca9a54f52697ea83360eed53387ba6bec3ae1fc7f882ca4f3c8f944ee9a15f099ba" %% xsd:string])
+    wasDerivedFrom(niiri:0d474a910bcd3d0f50d6a1c63d2c2081, niiri:0f1eef5a71e2e8c320c07d47aaf5faa2, -, -, -)
+    wasGeneratedBy(niiri:0d474a910bcd3d0f50d6a1c63d2c2081, niiri:f8fa21d3adf52266399255440cb7dbde, -)
+    entity(niiri:9ad91a55a933509c23c194d606e537a6,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        crypto:sha512 = "4fed4edb0da80cd11916dccc511db465d9a42101a08318ca494f751102dfed9e4ccf557dbb4eaef9d792f662864bfe3a77670a1c78dbbf144974e8866d9640f0" %% xsd:string])
+    wasGeneratedBy(niiri:9ad91a55a933509c23c194d606e537a6, niiri:f8fa21d3adf52266399255440cb7dbde, -)
+    entity(niiri:2b631fcf63e9820fbd2e40503305547d,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
+        prov:value = "0.000999500181305457" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:850496eee671baa44ef30a3c14bbc01f',
+        nidm_equivalentThreshold: = 'niiri:39e5898c4b517eee39c871cfc90544ea'])
+    entity(niiri:850496eee671baa44ef30a3c14bbc01f,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "3.85198238341593" %% xsd:float])
+    entity(niiri:39e5898c4b517eee39c871cfc90544ea,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.999999999999997" %% xsd:float])
+    entity(niiri:5f8ed8ba67e188085e5ae8dd56f0fd87,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:737e308a8a329df56e3800195e6a5520',
+        nidm_equivalentThreshold: = 'niiri:f3fad5b99b15cd5fa5fcf64d81b5c413'])
+    entity(niiri:737e308a8a329df56e3800195e6a5520,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:f3fad5b99b15cd5fa5fcf64d81b5c413,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:7a9d521a4e66bf249cf7ba064524933f,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:3f2044246932375109f3634cdd1b9da7,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:a035080de4f5f70d7392a1a791404523, -)
+    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:2b631fcf63e9820fbd2e40503305547d, -)
+    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:5f8ed8ba67e188085e5ae8dd56f0fd87, -)
+    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:b925226ebcfaf81953c6c8d86b12edbe, -)
+    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:3aa3da07651e9afc3c6c5a49b7b97170, -)
+    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:a99fcafea3bdd16053d3fbef6194f56c, -)
+    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:7a9d521a4e66bf249cf7ba064524933f, -)
+    used(niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, niiri:3f2044246932375109f3634cdd1b9da7, -)
+    entity(niiri:b8b1c6bd8a121e50549c32ca3ea169ca,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        nidm_searchVolumeInVoxels: = "167222" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1337776" %% xsd:float,
+        nidm_reselSizeInVoxels: = "83.1545653831017" %% xsd:float,
+        nidm_searchVolumeInResels: = "1850.56586239186" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[5, 52.6584563500118, 688.659482209668, 1850.56586239186]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.33608694259856, 4.31068523375487, 4.44878896221732]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.67217388519712, 8.62137046750973, 8.89757792443465]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "5.39987111748599" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "33.3985930251833" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "9.00548618010876" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "9.34592533111572" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "70" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "59" %% xsd:int,
+        crypto:sha512 = "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd" %% xsd:string])
+    wasGeneratedBy(niiri:b8b1c6bd8a121e50549c32ca3ea169ca, niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, -)
+    entity(niiri:04e3f1275db373d13cac82285a23f702,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "57" %% xsd:int,
+        nidm_pValue: = "0.000126072725041393" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:3651b3bac0c9746240cd1f49bb29caf5',
+        nidm_hasMaximumIntensityProjection: = 'niiri:8c55faf85816666e5ce4f7e8047a35de',
+        nidm_inCoordinateSpace: = 'niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd',
+        crypto:sha512 = "9bef1b01e85eeddf2e747ceba7ade799597c7837064cb2f65dd700a59f52a84d33bd06d9b28b57b0669461e4ff28c39b9df7e09752b27d653bc515d887e4927e" %% xsd:string])
+    entity(niiri:3651b3bac0c9746240cd1f49bb29caf5,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:8c55faf85816666e5ce4f7e8047a35de,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:04e3f1275db373d13cac82285a23f702, niiri:a7eb52ddc903ab04fcaa029f84ea6b4b, -)
+    entity(niiri:1cf06d93f4aed03ee50d587421161410,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0001" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3171" %% xsd:int,
+        nidm_clusterSizeInResels: = "38.1338052263381" %% xsd:float,
+        nidm_pValueUncorrected: = "1.51359313420427e-37" %% xsd:float,
+        nidm_pValueFWER: = "0" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "1" %% xsd:int])
+    wasDerivedFrom(niiri:1cf06d93f4aed03ee50d587421161410, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:1a7642317b9c235ad3c8606f26710b96,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0002" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1543" %% xsd:int,
+        nidm_clusterSizeInResels: = "18.555806201274" %% xsd:float,
+        nidm_pValueUncorrected: = "1.66432139866024e-23" %% xsd:float,
+        nidm_pValueFWER: = "0" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "2" %% xsd:int])
+    wasDerivedFrom(niiri:1a7642317b9c235ad3c8606f26710b96, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0003" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1032" %% xsd:int,
+        nidm_clusterSizeInResels: = "12.4106234606058" %% xsd:float,
+        nidm_pValueUncorrected: = "3.79330201851569e-18" %% xsd:float,
+        nidm_pValueFWER: = "1.11022302462516e-16" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "3" %% xsd:int])
+    wasDerivedFrom(niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:57b5c372ef2a2b5e726b538a4a5d80db,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0004" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "70" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.841805854886052" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00126629512703917" %% xsd:float,
+        nidm_pValueFWER: = "0.0414106244319472" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "4" %% xsd:int])
+    wasDerivedFrom(niiri:57b5c372ef2a2b5e726b538a4a5d80db, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:2260abfbc92b3918f8c4e115273811bc,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0005" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "250" %% xsd:int,
+        nidm_clusterSizeInResels: = "3.0064494817359" %% xsd:float,
+        nidm_pValueUncorrected: = "1.69880136830291e-07" %% xsd:float,
+        nidm_pValueFWER: = "5.6737414573238e-06" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "5" %% xsd:int])
+    wasDerivedFrom(niiri:2260abfbc92b3918f8c4e115273811bc, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:428e3b496b74c693be37a9557e535f44,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0006" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "96" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.15447660098659" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000265110996345557" %% xsd:float,
+        nidm_pValueFWER: = "0.00881525009559059" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "6" %% xsd:int])
+    wasDerivedFrom(niiri:428e3b496b74c693be37a9557e535f44, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:f2233fa4afd02fcceeb05d8f7c4801ff,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0007" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "16" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.192412766831098" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0825701010975274" %% xsd:float,
+        nidm_pValueFWER: = "0.936564091808241" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "7" %% xsd:int])
+    wasDerivedFrom(niiri:f2233fa4afd02fcceeb05d8f7c4801ff, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:b1ef2839e620d66c14bd83deb3aec390,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0008" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "320" %% xsd:int,
+        nidm_clusterSizeInResels: = "3.84825533662195" %% xsd:float,
+        nidm_pValueUncorrected: = "1.04491815175368e-08" %% xsd:float,
+        nidm_pValueFWER: = "3.48987900022912e-07" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "8" %% xsd:int])
+    wasDerivedFrom(niiri:b1ef2839e620d66c14bd83deb3aec390, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:6a1143e807a7221c10cbd94b8f352cb3,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0009" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "64" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.76965106732439" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00186450920193164" %% xsd:float,
+        nidm_pValueFWER: = "0.0603727115804786" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "9" %% xsd:int])
+    wasDerivedFrom(niiri:6a1143e807a7221c10cbd94b8f352cb3, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:17a361a6af9be1a09623d4875d9de272,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0010" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "161" %% xsd:int,
+        nidm_clusterSizeInResels: = "1.93615346623792" %% xsd:float,
+        nidm_pValueUncorrected: = "8.94149306858092e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.000298588701553082" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "10" %% xsd:int])
+    wasDerivedFrom(niiri:17a361a6af9be1a09623d4875d9de272, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:646a3e8aac6f4eee8e8562e0616d65ba,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0011" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "31" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.372799735735251" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0207288021023404" %% xsd:float,
+        nidm_pValueFWER: = "0.499582648292263" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "11" %% xsd:int])
+    wasDerivedFrom(niiri:646a3e8aac6f4eee8e8562e0616d65ba, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:8e53fdbcd507f29fa491c0ee30766820,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0012" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "71" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.853831652812995" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00118851678280378" %% xsd:float,
+        nidm_pValueFWER: = "0.0389172719454809" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "12" %% xsd:int])
+    wasDerivedFrom(niiri:8e53fdbcd507f29fa491c0ee30766820, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:caa24947392807e9fd656eb7e677bb90,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0013" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0962063834155488" %% xsd:float,
+        nidm_pValueUncorrected: = "0.207797889710554" %% xsd:float,
+        nidm_pValueFWER: = "0.999031882554387" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "13" %% xsd:int])
+    wasDerivedFrom(niiri:caa24947392807e9fd656eb7e677bb90, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:aa6f6ac422b272159fb670d4c6c75fe8,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0014" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "12" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.144309575123323" %% xsd:float,
+        nidm_pValueUncorrected: = "0.12760183958249" %% xsd:float,
+        nidm_pValueFWER: = "0.985901993992134" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "14" %% xsd:int])
+    wasDerivedFrom(niiri:aa6f6ac422b272159fb670d4c6c75fe8, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:62026e05a2a2355fc124787b15505315,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0015" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "8" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0962063834155488" %% xsd:float,
+        nidm_pValueUncorrected: = "0.207797889710554" %% xsd:float,
+        nidm_pValueFWER: = "0.999031882554387" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "15" %% xsd:int])
+    wasDerivedFrom(niiri:62026e05a2a2355fc124787b15505315, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:93450961f0d8d0f6a3b90a5894e1f87b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0016" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "24" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.288619150246646" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0380746884846506" %% xsd:float,
+        nidm_pValueFWER: = "0.719628852078667" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "16" %% xsd:int])
+    wasDerivedFrom(niiri:93450961f0d8d0f6a3b90a5894e1f87b, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:9b5ca13a3d263c59792e6e86be4a2e34,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0017" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "9" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.108232181342492" %% xsd:float,
+        nidm_pValueUncorrected: = "0.182768422209712" %% xsd:float,
+        nidm_pValueFWER: = "0.997766550775957" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "17" %% xsd:int])
+    wasDerivedFrom(niiri:9b5ca13a3d263c59792e6e86be4a2e34, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:bb0785359fefadd70b1adaaaac3b7884,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0018" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0240515958538872" %% xsd:float,
+        nidm_pValueUncorrected: = "0.536050498332642" %% xsd:float,
+        nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "18" %% xsd:int])
+    wasDerivedFrom(niiri:bb0785359fefadd70b1adaaaac3b7884, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:000e7e06128006bf16d2f8dd28c288f0,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0019" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "15" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.180386968904154" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0917146861027911" %% xsd:float,
+        nidm_pValueFWER: = "0.953259370207355" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "19" %% xsd:int])
+    wasDerivedFrom(niiri:000e7e06128006bf16d2f8dd28c288f0, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:fea4f2ec59548d5d8b403064bc42fcd3,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0020" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "22" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.264567554392759" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0457749346828495" %% xsd:float,
+        nidm_pValueFWER: = "0.78320832600297" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "20" %% xsd:int])
+    wasDerivedFrom(niiri:fea4f2ec59548d5d8b403064bc42fcd3, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:56aff3268c9efc59ac3dd1fccbb1e940,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0021" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "10" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.161507492809281" %% xsd:float,
+        nidm_pValueFWER: = "0.995456797062611" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "21" %% xsd:int])
+    wasDerivedFrom(niiri:56aff3268c9efc59ac3dd1fccbb1e940, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:30c41fd03e0e9666df9d194fbe412b52,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0022" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "16" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.192412766831098" %% xsd:float,
+        nidm_pValueUncorrected: = "0.0825701010975274" %% xsd:float,
+        nidm_pValueFWER: = "0.936564091808241" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "22" %% xsd:int])
+    wasDerivedFrom(niiri:30c41fd03e0e9666df9d194fbe412b52, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:195a3dcb7bf220b60a464a21245d4ee4,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0023" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "59" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.709522077689672" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00259801113118302" %% xsd:float,
+        nidm_pValueFWER: = "0.0831119677765624" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "23" %% xsd:int])
+    wasDerivedFrom(niiri:195a3dcb7bf220b60a464a21245d4ee4, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:d09f25e397a79ba3820081611e196ed7,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0024" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.060128989634718" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317097371523839" %% xsd:float,
+        nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "24" %% xsd:int])
+    wasDerivedFrom(niiri:d09f25e397a79ba3820081611e196ed7, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:2d07cb807cba69cb83d125ad8a6d9589,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0025" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0240515958538872" %% xsd:float,
+        nidm_pValueUncorrected: = "0.536050498332642" %% xsd:float,
+        nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "25" %% xsd:int])
+    wasDerivedFrom(niiri:2d07cb807cba69cb83d125ad8a6d9589, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:2d69939d531eb0168273379f7ce52907,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0026" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0240515958538872" %% xsd:float,
+        nidm_pValueUncorrected: = "0.536050498332642" %% xsd:float,
+        nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "26" %% xsd:int])
+    wasDerivedFrom(niiri:2d69939d531eb0168273379f7ce52907, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:1c2323d93891a0ddf5ac87752d859519,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0027" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0240515958538872" %% xsd:float,
+        nidm_pValueUncorrected: = "0.536050498332642" %% xsd:float,
+        nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "27" %% xsd:int])
+    wasDerivedFrom(niiri:1c2323d93891a0ddf5ac87752d859519, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:dc7f564798bbb1fc05334954d8385ba1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0028" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "11" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.13228377719638" %% xsd:float,
+        nidm_pValueUncorrected: = "0.143300710523383" %% xsd:float,
+        nidm_pValueFWER: = "0.991654577641533" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "28" %% xsd:int])
+    wasDerivedFrom(niiri:dc7f564798bbb1fc05334954d8385ba1, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:62a9cd07b50b07a1142d53889b87fd97,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0029" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "13" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.156335373050267" %% xsd:float,
+        nidm_pValueUncorrected: = "0.113985043745931" %% xsd:float,
+        nidm_pValueFWER: = "0.977783945749582" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "29" %% xsd:int])
+    wasDerivedFrom(niiri:62a9cd07b50b07a1142d53889b87fd97, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:12880301a0a653ca67efd232a37a486b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0030" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0481031917077744" %% xsd:float,
+        nidm_pValueUncorrected: = "0.371655744440408" %% xsd:float,
+        nidm_pValueFWER: = "0.99999593370769" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "30" %% xsd:int])
+    wasDerivedFrom(niiri:12880301a0a653ca67efd232a37a486b, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:7b940b3f554bfd8086ef06ec3a4c5e36,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0031" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.060128989634718" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317097371523839" %% xsd:float,
+        nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "31" %% xsd:int])
+    wasDerivedFrom(niiri:7b940b3f554bfd8086ef06ec3a4c5e36, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:4364ea14ae541a4b5530d0fc11478f4d,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0032" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "6" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0721547875616616" %% xsd:float,
+        nidm_pValueUncorrected: = "0.273353831547941" %% xsd:float,
+        nidm_pValueFWER: = "0.999891594677731" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "32" %% xsd:int])
+    wasDerivedFrom(niiri:4364ea14ae541a4b5530d0fc11478f4d, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:cad9672114cca77d75274be4de17ab9c,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0033" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0360773937808308" %% xsd:float,
+        nidm_pValueUncorrected: = "0.441732231987406" %% xsd:float,
+        nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "33" %% xsd:int])
+    wasDerivedFrom(niiri:cad9672114cca77d75274be4de17ab9c, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:9373fb96b8dcda6b9ae13dbf76afcaa6,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0034" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0360773937808308" %% xsd:float,
+        nidm_pValueUncorrected: = "0.441732231987406" %% xsd:float,
+        nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "34" %% xsd:int])
+    wasDerivedFrom(niiri:9373fb96b8dcda6b9ae13dbf76afcaa6, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:7737094062d61c5fc0d500987f11bda9,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0035" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.060128989634718" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317097371523839" %% xsd:float,
+        nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "35" %% xsd:int])
+    wasDerivedFrom(niiri:7737094062d61c5fc0d500987f11bda9, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:454d2ddee840a6eed8f9885efabde318,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0036" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.060128989634718" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317097371523839" %% xsd:float,
+        nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "36" %% xsd:int])
+    wasDerivedFrom(niiri:454d2ddee840a6eed8f9885efabde318, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:b2f3ddd032f5ca78054f0eca8d0c8769,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0037" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "37" %% xsd:int])
+    wasDerivedFrom(niiri:b2f3ddd032f5ca78054f0eca8d0c8769, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:cf4b88bff59c1a33cd867e9422f84011,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0038" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.060128989634718" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317097371523839" %% xsd:float,
+        nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "38" %% xsd:int])
+    wasDerivedFrom(niiri:cf4b88bff59c1a33cd867e9422f84011, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:3283422abdc309a208995369231fe32a,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0039" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "5" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.060128989634718" %% xsd:float,
+        nidm_pValueUncorrected: = "0.317097371523839" %% xsd:float,
+        nidm_pValueFWER: = "0.999974848827969" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "39" %% xsd:int])
+    wasDerivedFrom(niiri:3283422abdc309a208995369231fe32a, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:c9c180c62d3cd262bcb7bb862a2e2d3e,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0040" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "40" %% xsd:int])
+    wasDerivedFrom(niiri:c9c180c62d3cd262bcb7bb862a2e2d3e, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:f67691de01cdab9987a52d4efd6796df,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0041" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "41" %% xsd:int])
+    wasDerivedFrom(niiri:f67691de01cdab9987a52d4efd6796df, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:ef91e7140c5dbe4c9303f8f1e0cd8673,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0042" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0240515958538872" %% xsd:float,
+        nidm_pValueUncorrected: = "0.536050498332642" %% xsd:float,
+        nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "42" %% xsd:int])
+    wasDerivedFrom(niiri:ef91e7140c5dbe4c9303f8f1e0cd8673, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:dcd5d7321bb4d36d468ecf53edb77243,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0043" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "43" %% xsd:int])
+    wasDerivedFrom(niiri:dcd5d7321bb4d36d468ecf53edb77243, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:049381a7f67019f13a2b75b205f87af1,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0044" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0360773937808308" %% xsd:float,
+        nidm_pValueUncorrected: = "0.441732231987406" %% xsd:float,
+        nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "44" %% xsd:int])
+    wasDerivedFrom(niiri:049381a7f67019f13a2b75b205f87af1, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:6231cdc1c30543959e82f342e7f7c028,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0045" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "4" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0481031917077744" %% xsd:float,
+        nidm_pValueUncorrected: = "0.371655744440408" %% xsd:float,
+        nidm_pValueFWER: = "0.99999593370769" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "45" %% xsd:int])
+    wasDerivedFrom(niiri:6231cdc1c30543959e82f342e7f7c028, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:d078d2a64b3eee365a7318a424f3d55f,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0046" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "46" %% xsd:int])
+    wasDerivedFrom(niiri:d078d2a64b3eee365a7318a424f3d55f, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:b07d53658c12f0d165aec1cf959f1eb5,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0047" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "2" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0240515958538872" %% xsd:float,
+        nidm_pValueUncorrected: = "0.536050498332642" %% xsd:float,
+        nidm_pValueFWER: = "0.999999983224267" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "47" %% xsd:int])
+    wasDerivedFrom(niiri:b07d53658c12f0d165aec1cf959f1eb5, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:5e501329a485d9e81bca69bd136264fb,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0048" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "48" %% xsd:int])
+    wasDerivedFrom(niiri:5e501329a485d9e81bca69bd136264fb, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0049" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "49" %% xsd:int])
+    wasDerivedFrom(niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:f19fc244e1ad9fb88396e6dc5d62c29b,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0050" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "3" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0360773937808308" %% xsd:float,
+        nidm_pValueUncorrected: = "0.441732231987406" %% xsd:float,
+        nidm_pValueFWER: = "0.999999608482273" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "50" %% xsd:int])
+    wasDerivedFrom(niiri:f19fc244e1ad9fb88396e6dc5d62c29b, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:8a6f880f7b8eaf62148b54fef7844b09,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0051" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "51" %% xsd:int])
+    wasDerivedFrom(niiri:8a6f880f7b8eaf62148b54fef7844b09, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:de48b7494a3d45a8a57e155aeea2f132,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0052" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "52" %% xsd:int])
+    wasDerivedFrom(niiri:de48b7494a3d45a8a57e155aeea2f132, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:c60f3aab1eee7d78c6850a16c38162dc,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0053" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "53" %% xsd:int])
+    wasDerivedFrom(niiri:c60f3aab1eee7d78c6850a16c38162dc, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:859e657235309e3db15ccb1f14c1e7ba,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0054" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "54" %% xsd:int])
+    wasDerivedFrom(niiri:859e657235309e3db15ccb1f14c1e7ba, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:065fb1288e613aa1089a803ba4b13d87,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0055" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "55" %% xsd:int])
+    wasDerivedFrom(niiri:065fb1288e613aa1089a803ba4b13d87, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:021e14b3f5e58d6dd1904bdbad37b113,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0056" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "56" %% xsd:int])
+    wasDerivedFrom(niiri:021e14b3f5e58d6dd1904bdbad37b113, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:7fa11ca3554a75156c897f72b0a338ac,
+        [prov:type = 'nidm_SupraThresholdCluster:',
+        prov:label = "Supra-Threshold Cluster: 0057" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "1" %% xsd:int,
+        nidm_clusterSizeInResels: = "0.0120257979269436" %% xsd:float,
+        nidm_pValueUncorrected: = "0.675165563491534" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999838994" %% xsd:float,
+        nidm_qValueFDR: = "[]" %% xsd:float,
+        nidm_clusterLabelId: = "57" %% xsd:int])
+    wasDerivedFrom(niiri:7fa11ca3554a75156c897f72b0a338ac, niiri:04e3f1275db373d13cac82285a23f702, -, -, -)
+    entity(niiri:b3b769322ee6f2728df46b1d7e729a2c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0001" %% xsd:string,
+        prov:location = 'niiri:2cc8cbc51d2e2dd1d34f08891cbe366d',
+        prov:value = "13.6061105728149" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.86214047392852" %% xsd:float,
+        nidm_pValueUncorrected: = "2.28469099194939e-09" %% xsd:float,
+        nidm_pValueFWER: = "0.000382050559925018" %% xsd:float,
+        nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
+    entity(niiri:2cc8cbc51d2e2dd1d34f08891cbe366d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0001" %% xsd:string,
+        nidm_coordinateVector: = "[34,-86,0]" %% xsd:string])
+    wasDerivedFrom(niiri:b3b769322ee6f2728df46b1d7e729a2c, niiri:1cf06d93f4aed03ee50d587421161410, -, -, -)
+    entity(niiri:0962722c2fe8603177b631a54d2747fd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0002" %% xsd:string,
+        prov:location = 'niiri:12b4490a7a2a9265c0fb5c1cad432626',
+        prov:value = "11.9614944458008" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.59772141079875" %% xsd:float,
+        nidm_pValueUncorrected: = "1.08593692926817e-08" %% xsd:float,
+        nidm_pValueFWER: = "0.00181592543329545" %% xsd:float,
+        nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
+    entity(niiri:12b4490a7a2a9265c0fb5c1cad432626,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0002" %% xsd:string,
+        nidm_coordinateVector: = "[30,-78,36]" %% xsd:string])
+    wasDerivedFrom(niiri:0962722c2fe8603177b631a54d2747fd, niiri:1cf06d93f4aed03ee50d587421161410, -, -, -)
+    entity(niiri:56e9acaa44092839074f4fe2f1cbeb87,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0003" %% xsd:string,
+        prov:location = 'niiri:95c264e1e21bd313ad9649cc29570602',
+        prov:value = "10.5961866378784" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.34279531222125" %% xsd:float,
+        nidm_pValueUncorrected: = "4.5762046707587e-08" %% xsd:float,
+        nidm_pValueFWER: = "0.00765242110449371" %% xsd:float,
+        nidm_qValueFDR: = "0.000248881974141536" %% xsd:float])
+    entity(niiri:95c264e1e21bd313ad9649cc29570602,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0003" %% xsd:string,
+        nidm_coordinateVector: = "[34,-48,44]" %% xsd:string])
+    wasDerivedFrom(niiri:56e9acaa44092839074f4fe2f1cbeb87, niiri:1cf06d93f4aed03ee50d587421161410, -, -, -)
+    entity(niiri:5a1c78a3e12360263792a811b8b793e7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0004" %% xsd:string,
+        prov:location = 'niiri:fe2447910ca73bf4173a0bc09b5c82ef',
+        prov:value = "11.9789819717407" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.6007582829493" %% xsd:float,
+        nidm_pValueUncorrected: = "1.06708079039564e-08" %% xsd:float,
+        nidm_pValueFWER: = "0.00178439382075002" %% xsd:float,
+        nidm_qValueFDR: = "0.000186387780128805" %% xsd:float])
+    entity(niiri:fe2447910ca73bf4173a0bc09b5c82ef,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0004" %% xsd:string,
+        nidm_coordinateVector: = "[-46,-54,-12]" %% xsd:string])
+    wasDerivedFrom(niiri:5a1c78a3e12360263792a811b8b793e7, niiri:1a7642317b9c235ad3c8606f26710b96, -, -, -)
+    entity(niiri:579e3d2553a1f65ce2b443a85f7f7e78,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0005" %% xsd:string,
+        prov:location = 'niiri:38e45fd9e8f667e140bcb4cd465dff2a',
+        prov:value = "11.3053674697876" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.47978759981232" %% xsd:float,
+        nidm_pValueUncorrected: = "2.12918364050907e-08" %% xsd:float,
+        nidm_pValueFWER: = "0.00356046346733208" %% xsd:float,
+        nidm_qValueFDR: = "0.000225699919390338" %% xsd:float])
+    entity(niiri:38e45fd9e8f667e140bcb4cd465dff2a,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0005" %% xsd:string,
+        nidm_coordinateVector: = "[-48,-64,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:579e3d2553a1f65ce2b443a85f7f7e78, niiri:1a7642317b9c235ad3c8606f26710b96, -, -, -)
+    entity(niiri:8fde575882a0e0c286f85ce29ad62c58,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0006" %% xsd:string,
+        prov:location = 'niiri:ea247c88d42d40da9044ae0523463ac4',
+        prov:value = "9.59214210510254" %% xsd:float,
+        nidm_equivalentZStatistic: = "5.12915279008791" %% xsd:float,
+        nidm_pValueUncorrected: = "1.45524525096974e-07" %% xsd:float,
+        nidm_pValueFWER: = "0.0243349038623457" %% xsd:float,
+        nidm_qValueFDR: = "0.000374773184801466" %% xsd:float])
+    entity(niiri:ea247c88d42d40da9044ae0523463ac4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0006" %% xsd:string,
+        nidm_coordinateVector: = "[-46,-72,-6]" %% xsd:string])
+    wasDerivedFrom(niiri:8fde575882a0e0c286f85ce29ad62c58, niiri:1a7642317b9c235ad3c8606f26710b96, -, -, -)
+    entity(niiri:5620f2a9a83f08e4e4e2e452ed521bfb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0007" %% xsd:string,
+        prov:location = 'niiri:807ce33ed88a8e53dcb621151ae91a66',
+        prov:value = "8.26132202148438" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.8021068311854" %% xsd:float,
+        nidm_pValueUncorrected: = "7.85024427352177e-07" %% xsd:float,
+        nidm_pValueFWER: = "0.131273406272461" %% xsd:float,
+        nidm_qValueFDR: = "0.000714072820754613" %% xsd:float])
+    entity(niiri:807ce33ed88a8e53dcb621151ae91a66,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0007" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-76,32]" %% xsd:string])
+    wasDerivedFrom(niiri:5620f2a9a83f08e4e4e2e452ed521bfb, niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8, -, -, -)
+    entity(niiri:49d7d90f66e4da833c690cd5883a10e7,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0008" %% xsd:string,
+        prov:location = 'niiri:a9a21ab8f48ab130ada7bc6efcded96d',
+        prov:value = "7.54039764404297" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.59887376341391" %% xsd:float,
+        nidm_pValueUncorrected: = "2.12390533416151e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.355164074926112" %% xsd:float,
+        nidm_qValueFDR: = "0.00112750499976544" %% xsd:float])
+    entity(niiri:a9a21ab8f48ab130ada7bc6efcded96d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0008" %% xsd:string,
+        nidm_coordinateVector: = "[-38,-46,44]" %% xsd:string])
+    wasDerivedFrom(niiri:49d7d90f66e4da833c690cd5883a10e7, niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8, -, -, -)
+    entity(niiri:27fde605695ea87f488e331274bbffb0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0009" %% xsd:string,
+        prov:location = 'niiri:1f9cb7e030174f7f9631db464ceecffe',
+        prov:value = "7.09534215927124" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.46234965259847" %% xsd:float,
+        nidm_pValueUncorrected: = "4.05329024755208e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.550389997209789" %% xsd:float,
+        nidm_qValueFDR: = "0.00152026219003999" %% xsd:float])
+    entity(niiri:1f9cb7e030174f7f9631db464ceecffe,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0009" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-72,44]" %% xsd:string])
+    wasDerivedFrom(niiri:27fde605695ea87f488e331274bbffb0, niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8, -, -, -)
+    entity(niiri:9a3c595e0ddc14214f4c9c93eb68dd36,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0010" %% xsd:string,
+        prov:location = 'niiri:07d77ef1ba5bc8952fe942d5c9b7efd7',
+        prov:value = "7.53033494949341" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.59588573954922" %% xsd:float,
+        nidm_pValueUncorrected: = "2.15457400010166e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.36029256155409" %% xsd:float,
+        nidm_qValueFDR: = "0.00113656959480786" %% xsd:float])
+    entity(niiri:07d77ef1ba5bc8952fe942d5c9b7efd7,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0010" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-10,48]" %% xsd:string])
+    wasDerivedFrom(niiri:9a3c595e0ddc14214f4c9c93eb68dd36, niiri:57b5c372ef2a2b5e726b538a4a5d80db, -, -, -)
+    entity(niiri:b0acf117bc223f33dfefb698485fdbbc,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0011" %% xsd:string,
+        prov:location = 'niiri:45e55c7dc0c0ad9a7b5a0041cc5079ac',
+        prov:value = "4.24029636383057" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.30076820538094" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000482102531686568" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999415186" %% xsd:float,
+        nidm_qValueFDR: = "0.015845468443456" %% xsd:float])
+    entity(niiri:45e55c7dc0c0ad9a7b5a0041cc5079ac,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0011" %% xsd:string,
+        nidm_coordinateVector: = "[-26,0,56]" %% xsd:string])
+    wasDerivedFrom(niiri:b0acf117bc223f33dfefb698485fdbbc, niiri:57b5c372ef2a2b5e726b538a4a5d80db, -, -, -)
+    entity(niiri:7f38de5b18de7d50cf6bbab3de7ed61d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0012" %% xsd:string,
+        prov:location = 'niiri:549cbc20d7a3347bd507c93a62cb962d',
+        prov:value = "7.17061138153076" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.48608583316407" %% xsd:float,
+        nidm_pValueUncorrected: = "3.62717632940157e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.521824836713063" %% xsd:float,
+        nidm_qValueFDR: = "0.00145106406730833" %% xsd:float])
+    entity(niiri:549cbc20d7a3347bd507c93a62cb962d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0012" %% xsd:string,
+        nidm_coordinateVector: = "[46,6,28]" %% xsd:string])
+    wasDerivedFrom(niiri:7f38de5b18de7d50cf6bbab3de7ed61d, niiri:2260abfbc92b3918f8c4e115273811bc, -, -, -)
+    entity(niiri:737d6891167edd5697898729334b6f23,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0013" %% xsd:string,
+        prov:location = 'niiri:d13e6a0e17e641c4dd7a920619e27556',
+        prov:value = "5.89265918731689" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.04200617451887" %% xsd:float,
+        nidm_pValueUncorrected: = "2.64979184040337e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.95205805171536" %% xsd:float,
+        nidm_qValueFDR: = "0.00357309996201585" %% xsd:float])
+    entity(niiri:d13e6a0e17e641c4dd7a920619e27556,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0013" %% xsd:string,
+        nidm_coordinateVector: = "[52,12,26]" %% xsd:string])
+    wasDerivedFrom(niiri:737d6891167edd5697898729334b6f23, niiri:2260abfbc92b3918f8c4e115273811bc, -, -, -)
+    entity(niiri:7fb07c54f710b892820adb154f5437c2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0014" %% xsd:string,
+        prov:location = 'niiri:b15b1251bcf12c164abd2f8d5036175d',
+        prov:value = "5.21978235244751" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.76688098065344" %% xsd:float,
+        nidm_pValueUncorrected: = "8.26498774630924e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.998715750644301" %% xsd:float,
+        nidm_qValueFDR: = "0.00632560594393137" %% xsd:float])
+    entity(niiri:b15b1251bcf12c164abd2f8d5036175d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0014" %% xsd:string,
+        nidm_coordinateVector: = "[40,-2,30]" %% xsd:string])
+    wasDerivedFrom(niiri:7fb07c54f710b892820adb154f5437c2, niiri:2260abfbc92b3918f8c4e115273811bc, -, -, -)
+    entity(niiri:d196f3f4c50dd1d93b2bd4cae01fbd44,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0015" %% xsd:string,
+        prov:location = 'niiri:d867aea23af72afb3d824134fd7bb62e',
+        prov:value = "6.82257699966431" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.3739930910033" %% xsd:float,
+        nidm_pValueUncorrected: = "6.09971206799731e-06" %% xsd:float,
+        nidm_pValueFWER: = "0.657888162568606" %% xsd:float,
+        nidm_qValueFDR: = "0.00180198082091417" %% xsd:float])
+    entity(niiri:d867aea23af72afb3d824134fd7bb62e,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0015" %% xsd:string,
+        nidm_coordinateVector: = "[-10,24,12]" %% xsd:string])
+    wasDerivedFrom(niiri:d196f3f4c50dd1d93b2bd4cae01fbd44, niiri:428e3b496b74c693be37a9557e535f44, -, -, -)
+    entity(niiri:a87c684980a741cdd7c3d90c8cbe99df,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0016" %% xsd:string,
+        prov:location = 'niiri:497bf13cc6e31e241c2961c960131d00',
+        prov:value = "4.99530935287476" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.66747111912266" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000122480604349273" %% xsd:float,
+        nidm_pValueFWER: = "0.999830619862512" %% xsd:float,
+        nidm_qValueFDR: = "0.00775152511109977" %% xsd:float])
+    entity(niiri:497bf13cc6e31e241c2961c960131d00,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0016" %% xsd:string,
+        nidm_coordinateVector: = "[-24,28,4]" %% xsd:string])
+    wasDerivedFrom(niiri:a87c684980a741cdd7c3d90c8cbe99df, niiri:428e3b496b74c693be37a9557e535f44, -, -, -)
+    entity(niiri:f3bc13cbd3d6523a4cd20f41c8e6a115,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0017" %% xsd:string,
+        prov:location = 'niiri:3f00e702d729fe98e37d25e45791f4e9',
+        prov:value = "6.34009504318237" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.20806884695295" %% xsd:float,
+        nidm_pValueUncorrected: = "1.28781200698924e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.839224226046397" %% xsd:float,
+        nidm_qValueFDR: = "0.00253613065643777" %% xsd:float])
+    entity(niiri:3f00e702d729fe98e37d25e45791f4e9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0017" %% xsd:string,
+        nidm_coordinateVector: = "[10,-74,-34]" %% xsd:string])
+    wasDerivedFrom(niiri:f3bc13cbd3d6523a4cd20f41c8e6a115, niiri:f2233fa4afd02fcceeb05d8f7c4801ff, -, -, -)
+    entity(niiri:65f048f0e7c5732f5773ecc174b71f67,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0018" %% xsd:string,
+        prov:location = 'niiri:ca3f9e37a3e82369bdea4d8f85916a5d',
+        prov:value = "5.96963739395142" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.07147450951934" %% xsd:float,
+        nidm_pValueUncorrected: = "2.3358237619564e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.938028702807278" %% xsd:float,
+        nidm_qValueFDR: = "0.00332713529017219" %% xsd:float])
+    entity(niiri:ca3f9e37a3e82369bdea4d8f85916a5d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0018" %% xsd:string,
+        nidm_coordinateVector: = "[-50,2,26]" %% xsd:string])
+    wasDerivedFrom(niiri:65f048f0e7c5732f5773ecc174b71f67, niiri:b1ef2839e620d66c14bd83deb3aec390, -, -, -)
+    entity(niiri:9743d512bbbe9718ac3fa1edbe7c8695,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0019" %% xsd:string,
+        prov:location = 'niiri:fdded5d9c86faca9be4e46d670dd39dd',
+        prov:value = "5.75492286682129" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.98829870240338" %% xsd:float,
+        nidm_pValueUncorrected: = "3.32744188140666e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.971577838301208" %% xsd:float,
+        nidm_qValueFDR: = "0.00400598087684945" %% xsd:float])
+    entity(niiri:fdded5d9c86faca9be4e46d670dd39dd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0019" %% xsd:string,
+        nidm_coordinateVector: = "[-50,-4,50]" %% xsd:string])
+    wasDerivedFrom(niiri:9743d512bbbe9718ac3fa1edbe7c8695, niiri:b1ef2839e620d66c14bd83deb3aec390, -, -, -)
+    entity(niiri:ee644a0b74bfd447b2b2b3dbc440d5f2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0020" %% xsd:string,
+        prov:location = 'niiri:1249869c1dfb98c3e618a1f06d22a1ea',
+        prov:value = "5.52769041061401" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.89683707514784" %% xsd:float,
+        nidm_pValueUncorrected: = "4.87285666391779e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.990314755199069" %% xsd:float,
+        nidm_qValueFDR: = "0.00479616651502499" %% xsd:float])
+    entity(niiri:1249869c1dfb98c3e618a1f06d22a1ea,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0020" %% xsd:string,
+        nidm_coordinateVector: = "[-52,0,40]" %% xsd:string])
+    wasDerivedFrom(niiri:ee644a0b74bfd447b2b2b3dbc440d5f2, niiri:b1ef2839e620d66c14bd83deb3aec390, -, -, -)
+    entity(niiri:d870f02cb19a7c9c70e01dfea7cef689,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0021" %% xsd:string,
+        prov:location = 'niiri:cf09b331b6ecf92a4276fede122052dd',
+        prov:value = "5.91596412658691" %% xsd:float,
+        nidm_equivalentZStatistic: = "4.05096850425873" %% xsd:float,
+        nidm_pValueUncorrected: = "2.55030367465325e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.948053549525439" %% xsd:float,
+        nidm_qValueFDR: = "0.00348881065430462" %% xsd:float])
+    entity(niiri:cf09b331b6ecf92a4276fede122052dd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0021" %% xsd:string,
+        nidm_coordinateVector: = "[6,18,6]" %% xsd:string])
+    wasDerivedFrom(niiri:d870f02cb19a7c9c70e01dfea7cef689, niiri:6a1143e807a7221c10cbd94b8f352cb3, -, -, -)
+    entity(niiri:93eee431f407818d7a288b7a68d56d3b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0022" %% xsd:string,
+        prov:location = 'niiri:08dd0be6761b0981da82cbc6c136514c',
+        prov:value = "4.54182481765747" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.45355045258419" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000276629401356199" %% xsd:float,
+        nidm_pValueFWER: = "0.999999655761857" %% xsd:float,
+        nidm_qValueFDR: = "0.0116903072898716" %% xsd:float])
+    entity(niiri:08dd0be6761b0981da82cbc6c136514c,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0022" %% xsd:string,
+        nidm_coordinateVector: = "[14,24,4]" %% xsd:string])
+    wasDerivedFrom(niiri:93eee431f407818d7a288b7a68d56d3b, niiri:6a1143e807a7221c10cbd94b8f352cb3, -, -, -)
+    entity(niiri:d0dd419634f950cbbc6664604d2bfae1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0023" %% xsd:string,
+        prov:location = 'niiri:5073a8f82b87e9f0bec1f05cbf454d90',
+        prov:value = "5.72671985626221" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.97714309813652" %% xsd:float,
+        nidm_pValueUncorrected: = "3.48740977119677e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.974745203823651" %% xsd:float,
+        nidm_qValueFDR: = "0.00410957672904248" %% xsd:float])
+    entity(niiri:5073a8f82b87e9f0bec1f05cbf454d90,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0023" %% xsd:string,
+        nidm_coordinateVector: = "[-6,0,58]" %% xsd:string])
+    wasDerivedFrom(niiri:d0dd419634f950cbbc6664604d2bfae1, niiri:17a361a6af9be1a09623d4875d9de272, -, -, -)
+    entity(niiri:1595c393eed7051abc16cafee4ac6ae9,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0024" %% xsd:string,
+        prov:location = 'niiri:5f9783b56cea07afdad963e78526eb93',
+        prov:value = "5.25150108337402" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.78060278170665" %% xsd:float,
+        nidm_pValueUncorrected: = "7.82245573558438e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.998359989376909" %% xsd:float,
+        nidm_qValueFDR: = "0.00612998059012206" %% xsd:float])
+    entity(niiri:5f9783b56cea07afdad963e78526eb93,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0024" %% xsd:string,
+        nidm_coordinateVector: = "[0,6,56]" %% xsd:string])
+    wasDerivedFrom(niiri:1595c393eed7051abc16cafee4ac6ae9, niiri:17a361a6af9be1a09623d4875d9de272, -, -, -)
+    entity(niiri:cdf7c013da79b02373eb314d67b328ca,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0025" %% xsd:string,
+        prov:location = 'niiri:6e2c760a2125a3b04227107745989f35',
+        prov:value = "4.54090023040771" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.45309533835059" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00027709654919561" %% xsd:float,
+        nidm_pValueFWER: = "0.99999966134203" %% xsd:float,
+        nidm_qValueFDR: = "0.0116998384744116" %% xsd:float])
+    entity(niiri:6e2c760a2125a3b04227107745989f35,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0025" %% xsd:string,
+        nidm_coordinateVector: = "[-4,0,66]" %% xsd:string])
+    wasDerivedFrom(niiri:cdf7c013da79b02373eb314d67b328ca, niiri:17a361a6af9be1a09623d4875d9de272, -, -, -)
+    entity(niiri:1af924931744ebf87d5aa4d7b639a169,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0026" %% xsd:string,
+        prov:location = 'niiri:9be6eab29ca29ed5a1bda8a4751ab3e1',
+        prov:value = "5.37388372421265" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.83281667931374" %% xsd:float,
+        nidm_pValueUncorrected: = "6.33421799035583e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.996123053382791" %% xsd:float,
+        nidm_qValueFDR: = "0.00547832540919611" %% xsd:float])
+    entity(niiri:9be6eab29ca29ed5a1bda8a4751ab3e1,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0026" %% xsd:string,
+        nidm_coordinateVector: = "[6,-12,14]" %% xsd:string])
+    wasDerivedFrom(niiri:1af924931744ebf87d5aa4d7b639a169, niiri:646a3e8aac6f4eee8e8562e0616d65ba, -, -, -)
+    entity(niiri:063ac2e37579cf1830838723135ef892,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0027" %% xsd:string,
+        prov:location = 'niiri:17cc9a7d147c38df0908ed91f50ffed6',
+        prov:value = "5.16269016265869" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.74198250168727" %% xsd:float,
+        nidm_pValueUncorrected: = "9.12871154093997e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.999192871962629" %% xsd:float,
+        nidm_qValueFDR: = "0.00669851286267874" %% xsd:float])
+    entity(niiri:17cc9a7d147c38df0908ed91f50ffed6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0027" %% xsd:string,
+        nidm_coordinateVector: = "[36,20,4]" %% xsd:string])
+    wasDerivedFrom(niiri:063ac2e37579cf1830838723135ef892, niiri:8e53fdbcd507f29fa491c0ee30766820, -, -, -)
+    entity(niiri:0222a75a9a5232dac912eb7326478415,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0028" %% xsd:string,
+        prov:location = 'niiri:f59f2ef887c5f35ca37e79a29a172929',
+        prov:value = "4.8655366897583" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.60809771461691" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000154225162826815" %% xsd:float,
+        nidm_pValueFWER: = "0.9999601230968" %% xsd:float,
+        nidm_qValueFDR: = "0.00861184257857328" %% xsd:float])
+    entity(niiri:f59f2ef887c5f35ca37e79a29a172929,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0028" %% xsd:string,
+        nidm_coordinateVector: = "[30,24,0]" %% xsd:string])
+    wasDerivedFrom(niiri:0222a75a9a5232dac912eb7326478415, niiri:8e53fdbcd507f29fa491c0ee30766820, -, -, -)
+    entity(niiri:8453d293e50b367bb3a49f7533014a86,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0029" %% xsd:string,
+        prov:location = 'niiri:24146062d9114b1e61245629356d88ea',
+        prov:value = "5.15075159072876" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.73674319192816" %% xsd:float,
+        nidm_pValueUncorrected: = "9.3209572512909e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.999270580432391" %% xsd:float,
+        nidm_qValueFDR: = "0.00676830985421939" %% xsd:float])
+    entity(niiri:24146062d9114b1e61245629356d88ea,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0029" %% xsd:string,
+        nidm_coordinateVector: = "[0,-50,-28]" %% xsd:string])
+    wasDerivedFrom(niiri:8453d293e50b367bb3a49f7533014a86, niiri:caa24947392807e9fd656eb7e677bb90, -, -, -)
+    entity(niiri:2776c7b9e158c2ca4c466f45748a27ad,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0030" %% xsd:string,
+        prov:location = 'niiri:5d350af686c7181e6779f8105a3c4356',
+        prov:value = "5.12083530426025" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.7235640261549" %% xsd:float,
+        nidm_pValueUncorrected: = "9.82150082137201e-05" %% xsd:float,
+        nidm_pValueFWER: = "0.999437677420886" %% xsd:float,
+        nidm_qValueFDR: = "0.00690105743012952" %% xsd:float])
+    entity(niiri:5d350af686c7181e6779f8105a3c4356,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0030" %% xsd:string,
+        nidm_coordinateVector: = "[52,10,40]" %% xsd:string])
+    wasDerivedFrom(niiri:2776c7b9e158c2ca4c466f45748a27ad, niiri:aa6f6ac422b272159fb670d4c6c75fe8, -, -, -)
+    entity(niiri:36b9e15a4f579cb8b8c094d8019239d3,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0031" %% xsd:string,
+        prov:location = 'niiri:3cfe07192bdf278215f377f5cb477db4',
+        prov:value = "5.10948324203491" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.71854416501836" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000100187131384155" %% xsd:float,
+        nidm_pValueFWER: = "0.999491804107717" %% xsd:float,
+        nidm_qValueFDR: = "0.00699662698174139" %% xsd:float])
+    entity(niiri:3cfe07192bdf278215f377f5cb477db4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0031" %% xsd:string,
+        nidm_coordinateVector: = "[22,-14,12]" %% xsd:string])
+    wasDerivedFrom(niiri:36b9e15a4f579cb8b8c094d8019239d3, niiri:62026e05a2a2355fc124787b15505315, -, -, -)
+    entity(niiri:36d0607dbf3edae0ba7ee6f15811e9ec,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0032" %% xsd:string,
+        prov:location = 'niiri:43aa1b5aa2a65fcc758b9161fbb691f9',
+        prov:value = "4.99403047561646" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.66689294332376" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00012275776099846" %% xsd:float,
+        nidm_pValueFWER: = "0.999832837977675" %% xsd:float,
+        nidm_qValueFDR: = "0.00775559440349761" %% xsd:float])
+    entity(niiri:43aa1b5aa2a65fcc758b9161fbb691f9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0032" %% xsd:string,
+        nidm_coordinateVector: = "[-14,-2,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:36d0607dbf3edae0ba7ee6f15811e9ec, niiri:93450961f0d8d0f6a3b90a5894e1f87b, -, -, -)
+    entity(niiri:9244cd1d0c66ad9346c4da15cf625887,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0033" %% xsd:string,
+        prov:location = 'niiri:ba4f669757b7f20b7868b405af9297ec',
+        prov:value = "4.99324655532837" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.66653846830519" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000122927974348652" %% xsd:float,
+        nidm_pValueFWER: = "0.99983418490596" %% xsd:float,
+        nidm_qValueFDR: = "0.00775759422864875" %% xsd:float])
+    entity(niiri:ba4f669757b7f20b7868b405af9297ec,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0033" %% xsd:string,
+        nidm_coordinateVector: = "[8,-26,14]" %% xsd:string])
+    wasDerivedFrom(niiri:9244cd1d0c66ad9346c4da15cf625887, niiri:9b5ca13a3d263c59792e6e86be4a2e34, -, -, -)
+    entity(niiri:19366255ed63a36546b8f1ee872bddf0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0034" %% xsd:string,
+        prov:location = 'niiri:9082f78e97efa65c4dcb194c56ec70fd',
+        prov:value = "4.89655494689941" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.62241950165507" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000145930150219908" %% xsd:float,
+        nidm_pValueFWER: = "0.999942473649405" %% xsd:float,
+        nidm_qValueFDR: = "0.0083498973939701" %% xsd:float])
+    entity(niiri:9082f78e97efa65c4dcb194c56ec70fd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0034" %% xsd:string,
+        nidm_coordinateVector: = "[14,8,72]" %% xsd:string])
+    wasDerivedFrom(niiri:19366255ed63a36546b8f1ee872bddf0, niiri:bb0785359fefadd70b1adaaaac3b7884, -, -, -)
+    entity(niiri:7f57e213d8d5aad8818c2534a203dafb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0035" %% xsd:string,
+        prov:location = 'niiri:14712e03d1bd30c666abef48eaba5f35',
+        prov:value = "4.86036062240601" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.60569974829148" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000155656460372522" %% xsd:float,
+        nidm_pValueFWER: = "0.999962538559828" %% xsd:float,
+        nidm_qValueFDR: = "0.00864250020982424" %% xsd:float])
+    entity(niiri:14712e03d1bd30c666abef48eaba5f35,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0035" %% xsd:string,
+        nidm_coordinateVector: = "[-24,-42,-38]" %% xsd:string])
+    wasDerivedFrom(niiri:7f57e213d8d5aad8818c2534a203dafb, niiri:000e7e06128006bf16d2f8dd28c288f0, -, -, -)
+    entity(niiri:9b84b4a69aa3f9ede37b824a44d7ad2b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0036" %% xsd:string,
+        prov:location = 'niiri:abf6dcaaaa3aa218ffa6b3f8dd51d903',
+        prov:value = "4.81803417205811" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.58600360944639" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00016789215592794" %% xsd:float,
+        nidm_pValueFWER: = "0.999977855811547" %% xsd:float,
+        nidm_qValueFDR: = "0.00900212220920404" %% xsd:float])
+    entity(niiri:abf6dcaaaa3aa218ffa6b3f8dd51d903,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0036" %% xsd:string,
+        nidm_coordinateVector: = "[-54,30,14]" %% xsd:string])
+    wasDerivedFrom(niiri:9b84b4a69aa3f9ede37b824a44d7ad2b, niiri:fea4f2ec59548d5d8b403064bc42fcd3, -, -, -)
+    entity(niiri:7f9d189889ab743749e30fd6a45392f5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0037" %% xsd:string,
+        prov:location = 'niiri:a2eab965b389db1da335e25f6dbc3ef3',
+        prov:value = "4.77066373825073" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.56377460375569" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000182779942677791" %% xsd:float,
+        nidm_pValueFWER: = "0.999988096830174" %% xsd:float,
+        nidm_qValueFDR: = "0.00940067644112613" %% xsd:float])
+    entity(niiri:a2eab965b389db1da335e25f6dbc3ef3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0037" %% xsd:string,
+        nidm_coordinateVector: = "[-46,30,16]" %% xsd:string])
+    wasDerivedFrom(niiri:7f9d189889ab743749e30fd6a45392f5, niiri:fea4f2ec59548d5d8b403064bc42fcd3, -, -, -)
+    entity(niiri:6c13004b183580300b78177ee70c0f04,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0038" %% xsd:string,
+        prov:location = 'niiri:3cad6d43185f053748a6c03d25147aac',
+        prov:value = "4.8089394569397" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.58175111371795" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00017064943193823" %% xsd:float,
+        nidm_pValueFWER: = "0.999980290560917" %% xsd:float,
+        nidm_qValueFDR: = "0.00906568438361755" %% xsd:float])
+    entity(niiri:3cad6d43185f053748a6c03d25147aac,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0038" %% xsd:string,
+        nidm_coordinateVector: = "[0,-58,-38]" %% xsd:string])
+    wasDerivedFrom(niiri:6c13004b183580300b78177ee70c0f04, niiri:56aff3268c9efc59ac3dd1fccbb1e940, -, -, -)
+    entity(niiri:ca7f28f36d471bfff7d6cf2d7ec5bc5c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0039" %% xsd:string,
+        prov:location = 'niiri:5313dfeff4ad8a69948aefe317a1ff63',
+        prov:value = "4.80026483535767" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.57768829524451" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000173323244094692" %% xsd:float,
+        nidm_pValueFWER: = "0.999982383849948" %% xsd:float,
+        nidm_qValueFDR: = "0.00914672501351889" %% xsd:float])
+    entity(niiri:5313dfeff4ad8a69948aefe317a1ff63,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0039" %% xsd:string,
+        nidm_coordinateVector: = "[-54,12,0]" %% xsd:string])
+    wasDerivedFrom(niiri:ca7f28f36d471bfff7d6cf2d7ec5bc5c, niiri:30c41fd03e0e9666df9d194fbe412b52, -, -, -)
+    entity(niiri:49ab596dceb78a958aa318a733a8e5ff,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0040" %% xsd:string,
+        prov:location = 'niiri:a31fc51cce93b04af96388a0f734c45f',
+        prov:value = "4.77761936187744" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.56705096724501" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000180510641497822" %% xsd:float,
+        nidm_pValueFWER: = "0.999986932005675" %% xsd:float,
+        nidm_qValueFDR: = "0.00934466092947769" %% xsd:float])
+    entity(niiri:a31fc51cce93b04af96388a0f734c45f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0040" %% xsd:string,
+        nidm_coordinateVector: = "[28,2,60]" %% xsd:string])
+    wasDerivedFrom(niiri:49ab596dceb78a958aa318a733a8e5ff, niiri:195a3dcb7bf220b60a464a21245d4ee4, -, -, -)
+    entity(niiri:b1871e034d8d5ec7ff867d722b86b6bb,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0041" %% xsd:string,
+        prov:location = 'niiri:bb7833ec8cf5f8d5f4136884a1503263',
+        prov:value = "4.67176485061646" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.51672280482077" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000218454899154397" %% xsd:float,
+        nidm_pValueFWER: = "0.999997106974601" %% xsd:float,
+        nidm_qValueFDR: = "0.0103643846403155" %% xsd:float])
+    entity(niiri:bb7833ec8cf5f8d5f4136884a1503263,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0041" %% xsd:string,
+        nidm_coordinateVector: = "[26,-4,54]" %% xsd:string])
+    wasDerivedFrom(niiri:b1871e034d8d5ec7ff867d722b86b6bb, niiri:195a3dcb7bf220b60a464a21245d4ee4, -, -, -)
+    entity(niiri:c63bd3dd97f6db465634edf0fe3e6d7f,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0042" %% xsd:string,
+        prov:location = 'niiri:a7b543fd3444c95cdeddfd292b01c7d4',
+        prov:value = "4.62480688095093" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.49407291194222" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000237855539300003" %% xsd:float,
+        nidm_pValueFWER: = "0.999998608516906" %% xsd:float,
+        nidm_qValueFDR: = "0.0108449863840995" %% xsd:float])
+    entity(niiri:a7b543fd3444c95cdeddfd292b01c7d4,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0042" %% xsd:string,
+        nidm_coordinateVector: = "[20,-4,60]" %% xsd:string])
+    wasDerivedFrom(niiri:c63bd3dd97f6db465634edf0fe3e6d7f, niiri:195a3dcb7bf220b60a464a21245d4ee4, -, -, -)
+    entity(niiri:04edadfd4de6a98b1755ebbb982ffdc5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0043" %% xsd:string,
+        prov:location = 'niiri:3acb438e18302dca6ecfb8f09cc3b8c2',
+        prov:value = "4.67917585372925" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.5202791175394" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000215546442763337" %% xsd:float,
+        nidm_pValueFWER: = "0.99999676461456" %% xsd:float,
+        nidm_qValueFDR: = "0.0102906058805538" %% xsd:float])
+    entity(niiri:3acb438e18302dca6ecfb8f09cc3b8c2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0043" %% xsd:string,
+        nidm_coordinateVector: = "[-34,-12,42]" %% xsd:string])
+    wasDerivedFrom(niiri:04edadfd4de6a98b1755ebbb982ffdc5, niiri:d09f25e397a79ba3820081611e196ed7, -, -, -)
+    entity(niiri:738c518c78aeab009d62d16106762ec8,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0044" %% xsd:string,
+        prov:location = 'niiri:34e4d39ae426eddd8106a75fdb93df16',
+        prov:value = "4.5969614982605" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.48054638647577" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000250196083839915" %% xsd:float,
+        nidm_pValueFWER: = "0.999999115925319" %% xsd:float,
+        nidm_qValueFDR: = "0.0111238765457046" %% xsd:float])
+    entity(niiri:34e4d39ae426eddd8106a75fdb93df16,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0044" %% xsd:string,
+        nidm_coordinateVector: = "[36,-40,-10]" %% xsd:string])
+    wasDerivedFrom(niiri:738c518c78aeab009d62d16106762ec8, niiri:2d07cb807cba69cb83d125ad8a6d9589, -, -, -)
+    entity(niiri:b67b4596018aff50f75474b1bc7cec26,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0045" %% xsd:string,
+        prov:location = 'niiri:df63022294b12ffbb4ab2b6e51db3a61',
+        prov:value = "4.58732891082764" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.47585047258978" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000254618063707635" %% xsd:float,
+        nidm_pValueFWER: = "0.999999246946643" %% xsd:float,
+        nidm_qValueFDR: = "0.0112304749683021" %% xsd:float])
+    entity(niiri:df63022294b12ffbb4ab2b6e51db3a61,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0045" %% xsd:string,
+        nidm_coordinateVector: = "[36,-10,48]" %% xsd:string])
+    wasDerivedFrom(niiri:b67b4596018aff50f75474b1bc7cec26, niiri:2d69939d531eb0168273379f7ce52907, -, -, -)
+    entity(niiri:872525eb5016723dc3c4e0b0f2f2a5c5,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0046" %% xsd:string,
+        prov:location = 'niiri:5dffb2412c5920c035fa3d65f898aca6',
+        prov:value = "4.46814107894897" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.41702777537423" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000316544101057636" %% xsd:float,
+        nidm_pValueFWER: = "0.999999911601577" %% xsd:float,
+        nidm_qValueFDR: = "0.0126051231599175" %% xsd:float])
+    entity(niiri:5dffb2412c5920c035fa3d65f898aca6,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0046" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-38,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:872525eb5016723dc3c4e0b0f2f2a5c5, niiri:1c2323d93891a0ddf5ac87752d859519, -, -, -)
+    entity(niiri:27b211c70e2f7e9bd4a55df3443c4d04,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0047" %% xsd:string,
+        prov:location = 'niiri:f784d0452f15f23ba0c472ca2c2957c8',
+        prov:value = "4.46168184280396" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.41380155002305" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000320316101733442" %% xsd:float,
+        nidm_pValueFWER: = "0.999999921976257" %% xsd:float,
+        nidm_qValueFDR: = "0.0126738773801948" %% xsd:float])
+    entity(niiri:f784d0452f15f23ba0c472ca2c2957c8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0047" %% xsd:string,
+        nidm_coordinateVector: = "[-12,-14,8]" %% xsd:string])
+    wasDerivedFrom(niiri:27b211c70e2f7e9bd4a55df3443c4d04, niiri:dc7f564798bbb1fc05334954d8385ba1, -, -, -)
+    entity(niiri:8bf11b8dd19ff2763b1d679fcc567bdd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0048" %% xsd:string,
+        prov:location = 'niiri:69636daf4c95840e35d2278cb2ddf6a2',
+        prov:value = "4.44263553619385" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.40426513461447" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000331711624065423" %% xsd:float,
+        nidm_pValueFWER: = "0.999999946301375" %% xsd:float,
+        nidm_qValueFDR: = "0.012902019341921" %% xsd:float])
+    entity(niiri:69636daf4c95840e35d2278cb2ddf6a2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0048" %% xsd:string,
+        nidm_coordinateVector: = "[-4,-28,-34]" %% xsd:string])
+    wasDerivedFrom(niiri:8bf11b8dd19ff2763b1d679fcc567bdd, niiri:62a9cd07b50b07a1142d53889b87fd97, -, -, -)
+    entity(niiri:46c603d6044a9577f4f0e9b3938e4700,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0049" %% xsd:string,
+        prov:location = 'niiri:7f03bb810e2aa3de38abd130b42d0740',
+        prov:value = "4.4201717376709" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.39297275478629" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00034569257259931" %% xsd:float,
+        nidm_pValueFWER: = "0.999999965808818" %% xsd:float,
+        nidm_qValueFDR: = "0.01320481591718" %% xsd:float])
+    entity(niiri:7f03bb810e2aa3de38abd130b42d0740,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0049" %% xsd:string,
+        nidm_coordinateVector: = "[46,-42,54]" %% xsd:string])
+    wasDerivedFrom(niiri:46c603d6044a9577f4f0e9b3938e4700, niiri:12880301a0a653ca67efd232a37a486b, -, -, -)
+    entity(niiri:2fc0e632c6c67d632d879e25c94e0526,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0050" %% xsd:string,
+        prov:location = 'niiri:d1793ebb335efe18e8ce493107704c93',
+        prov:value = "4.41310739517212" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.38941149263013" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000350214079416045" %% xsd:float,
+        nidm_pValueFWER: = "0.999999970406353" %% xsd:float,
+        nidm_qValueFDR: = "0.0133062974642806" %% xsd:float])
+    entity(niiri:d1793ebb335efe18e8ce493107704c93,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0050" %% xsd:string,
+        nidm_coordinateVector: = "[-6,10,-2]" %% xsd:string])
+    wasDerivedFrom(niiri:2fc0e632c6c67d632d879e25c94e0526, niiri:7b940b3f554bfd8086ef06ec3a4c5e36, -, -, -)
+    entity(niiri:edea735fc405e897d60c9a150d58fdbd,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0051" %% xsd:string,
+        prov:location = 'niiri:ad6a5c6e9111ff2cd4961836c59aeee8',
+        prov:value = "4.36529922485352" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.36518306130387" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000382464451876507" %% xsd:float,
+        nidm_pValueFWER: = "0.999999989209637" %% xsd:float,
+        nidm_qValueFDR: = "0.0139415542247477" %% xsd:float])
+    entity(niiri:ad6a5c6e9111ff2cd4961836c59aeee8,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0051" %% xsd:string,
+        nidm_coordinateVector: = "[42,42,30]" %% xsd:string])
+    wasDerivedFrom(niiri:edea735fc405e897d60c9a150d58fdbd, niiri:4364ea14ae541a4b5530d0fc11478f4d, -, -, -)
+    entity(niiri:7b7f99b7f4133520004acf23cad3c6d2,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0052" %% xsd:string,
+        prov:location = 'niiri:6e740b892faab2ae5c18dda6b0263f44',
+        prov:value = "4.33874082565308" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.35162706179118" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00040169081443242" %% xsd:float,
+        nidm_pValueFWER: = "0.999999993988362" %% xsd:float,
+        nidm_qValueFDR: = "0.014354585034373" %% xsd:float])
+    entity(niiri:6e740b892faab2ae5c18dda6b0263f44,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0052" %% xsd:string,
+        nidm_coordinateVector: = "[54,-38,50]" %% xsd:string])
+    wasDerivedFrom(niiri:7b7f99b7f4133520004acf23cad3c6d2, niiri:cad9672114cca77d75274be4de17ab9c, -, -, -)
+    entity(niiri:6c1b3ff879fa04561531f81912615e99,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0053" %% xsd:string,
+        prov:location = 'niiri:376e1f563f89dca353cf7c8e7afe031d',
+        prov:value = "4.31020069122314" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.33698195919922" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000423467227465446" %% xsd:float,
+        nidm_pValueFWER: = "0.999999996857889" %% xsd:float,
+        nidm_qValueFDR: = "0.01478592692513" %% xsd:float])
+    entity(niiri:376e1f563f89dca353cf7c8e7afe031d,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0053" %% xsd:string,
+        nidm_coordinateVector: = "[8,4,64]" %% xsd:string])
+    wasDerivedFrom(niiri:6c1b3ff879fa04561531f81912615e99, niiri:9373fb96b8dcda6b9ae13dbf76afcaa6, -, -, -)
+    entity(niiri:d59e59cdaec7a9b385642f94b162a141,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0054" %% xsd:string,
+        prov:location = 'niiri:0faea80bec78d784e33b772fec951abe',
+        prov:value = "4.30184555053711" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.33267930931343" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000430070120942982" %% xsd:float,
+        nidm_pValueFWER: = "0.999999997411931" %% xsd:float,
+        nidm_qValueFDR: = "0.0148953189902244" %% xsd:float])
+    entity(niiri:0faea80bec78d784e33b772fec951abe,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0054" %% xsd:string,
+        nidm_coordinateVector: = "[-10,24,32]" %% xsd:string])
+    wasDerivedFrom(niiri:d59e59cdaec7a9b385642f94b162a141, niiri:7737094062d61c5fc0d500987f11bda9, -, -, -)
+    entity(niiri:14a69d6faff4a3b2af4d85d34b889f0b,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0055" %% xsd:string,
+        prov:location = 'niiri:e37bac689137c25c10888265d0e08602',
+        prov:value = "4.27150821685791" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.31699794762384" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000454951424559202" %% xsd:float,
+        nidm_pValueFWER: = "0.999999998740386" %% xsd:float,
+        nidm_qValueFDR: = "0.0153518195589701" %% xsd:float])
+    entity(niiri:e37bac689137c25c10888265d0e08602,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0055" %% xsd:string,
+        nidm_coordinateVector: = "[-14,-2,72]" %% xsd:string])
+    wasDerivedFrom(niiri:14a69d6faff4a3b2af4d85d34b889f0b, niiri:454d2ddee840a6eed8f9885efabde318, -, -, -)
+    entity(niiri:7031b6f01d04b3aa346e5d15b9d75e4d,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0056" %% xsd:string,
+        prov:location = 'niiri:f5b1c1485206e295c6ee4401f24e8fea',
+        prov:value = "4.25738191604614" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.30966460961956" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000467039117525991" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999106929" %% xsd:float,
+        nidm_qValueFDR: = "0.0155581475175598" %% xsd:float])
+    entity(niiri:f5b1c1485206e295c6ee4401f24e8fea,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0056" %% xsd:string,
+        nidm_coordinateVector: = "[56,26,26]" %% xsd:string])
+    wasDerivedFrom(niiri:7031b6f01d04b3aa346e5d15b9d75e4d, niiri:b2f3ddd032f5ca78054f0eca8d0c8769, -, -, -)
+    entity(niiri:9de3e3776111574cff8aedaff0068b73,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0057" %% xsd:string,
+        prov:location = 'niiri:35e6921502f4efac1ec19702a6773271',
+        prov:value = "4.23224687576294" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.29656664149817" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000489371958441343" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999522306" %% xsd:float,
+        nidm_qValueFDR: = "0.0159527943368947" %% xsd:float])
+    entity(niiri:35e6921502f4efac1ec19702a6773271,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0057" %% xsd:string,
+        nidm_coordinateVector: = "[14,-30,-32]" %% xsd:string])
+    wasDerivedFrom(niiri:9de3e3776111574cff8aedaff0068b73, niiri:cf4b88bff59c1a33cd867e9422f84011, -, -, -)
+    entity(niiri:bc149e6b113081f115e5a5ea364f34d0,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0058" %% xsd:string,
+        prov:location = 'niiri:1f636960ef3619fc8aec226fb7543fcf',
+        prov:value = "4.21795654296875" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.28909139477101" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000502556899069861" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999667972" %% xsd:float,
+        nidm_qValueFDR: = "0.0162089652787187" %% xsd:float])
+    entity(niiri:1f636960ef3619fc8aec226fb7543fcf,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0058" %% xsd:string,
+        nidm_coordinateVector: = "[46,-54,-30]" %% xsd:string])
+    wasDerivedFrom(niiri:bc149e6b113081f115e5a5ea364f34d0, niiri:3283422abdc309a208995369231fe32a, -, -, -)
+    entity(niiri:2bb4c41e8f9c06be5b3747cb28574b9a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0059" %% xsd:string,
+        prov:location = 'niiri:22ee550046229aa65e9420876ed6f5a0',
+        prov:value = "4.19331645965576" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.27615344058961" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000526156861805016" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999825125" %% xsd:float,
+        nidm_qValueFDR: = "0.0165459969587672" %% xsd:float])
+    entity(niiri:22ee550046229aa65e9420876ed6f5a0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0059" %% xsd:string,
+        nidm_coordinateVector: = "[28,22,16]" %% xsd:string])
+    wasDerivedFrom(niiri:2bb4c41e8f9c06be5b3747cb28574b9a, niiri:c9c180c62d3cd262bcb7bb862a2e2d3e, -, -, -)
+    entity(niiri:7c426e29ff0188e4df4277d19017ee63,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0060" %% xsd:string,
+        prov:location = 'niiri:20dcc56b68ae8b6b4c9741adb0b43549',
+        prov:value = "4.164222240448" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.26079679766555" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000555498136877608" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999919858" %% xsd:float,
+        nidm_qValueFDR: = "0.017023135244014" %% xsd:float])
+    entity(niiri:20dcc56b68ae8b6b4c9741adb0b43549,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0060" %% xsd:string,
+        nidm_coordinateVector: = "[32,-46,-8]" %% xsd:string])
+    wasDerivedFrom(niiri:7c426e29ff0188e4df4277d19017ee63, niiri:f67691de01cdab9987a52d4efd6796df, -, -, -)
+    entity(niiri:58b42fca78cd1d10deeed8bba2e7180a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0061" %% xsd:string,
+        prov:location = 'niiri:6f1505b8bbcfb75633a016754afd0dbb',
+        prov:value = "4.1354022026062" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.24549898327499" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000586224915903544" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999963932" %% xsd:float,
+        nidm_qValueFDR: = "0.0175104371158769" %% xsd:float])
+    entity(niiri:6f1505b8bbcfb75633a016754afd0dbb,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0061" %% xsd:string,
+        nidm_coordinateVector: = "[12,18,32]" %% xsd:string])
+    wasDerivedFrom(niiri:58b42fca78cd1d10deeed8bba2e7180a, niiri:ef91e7140c5dbe4c9303f8f1e0cd8673, -, -, -)
+    entity(niiri:360283f26ce5bb979d1d53571784870e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0062" %% xsd:string,
+        prov:location = 'niiri:e7f5f89929f3b52930ffb8fb16c0e839',
+        prov:value = "4.09669637680054" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.22481821343066" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000630263410459797" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999988153" %% xsd:float,
+        nidm_qValueFDR: = "0.0182494607837458" %% xsd:float])
+    entity(niiri:e7f5f89929f3b52930ffb8fb16c0e839,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0062" %% xsd:string,
+        nidm_coordinateVector: = "[6,-60,64]" %% xsd:string])
+    wasDerivedFrom(niiri:360283f26ce5bb979d1d53571784870e, niiri:dcd5d7321bb4d36d468ecf53edb77243, -, -, -)
+    entity(niiri:c8fd6993b937babaf1f8c2135d3b7f1e,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0063" %% xsd:string,
+        prov:location = 'niiri:836a956234439c9358b6ebe000e3dcc2',
+        prov:value = "4.06586408615112" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.20823228054844" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000667767930319307" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999995287" %% xsd:float,
+        nidm_qValueFDR: = "0.018874773548645" %% xsd:float])
+    entity(niiri:836a956234439c9358b6ebe000e3dcc2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0063" %% xsd:string,
+        nidm_coordinateVector: = "[-20,-66,-32]" %% xsd:string])
+    wasDerivedFrom(niiri:c8fd6993b937babaf1f8c2135d3b7f1e, niiri:049381a7f67019f13a2b75b205f87af1, -, -, -)
+    entity(niiri:ee630cfc618eede368be76300de9d971,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0064" %% xsd:string,
+        prov:location = 'niiri:b1b6a55493eae042a995758df3cd1afd',
+        prov:value = "4.05021715164185" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.19977690410182" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000687670008111763" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999997083" %% xsd:float,
+        nidm_qValueFDR: = "0.0191721851735585" %% xsd:float])
+    entity(niiri:b1b6a55493eae042a995758df3cd1afd,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0064" %% xsd:string,
+        nidm_coordinateVector: = "[-8,-72,-24]" %% xsd:string])
+    wasDerivedFrom(niiri:ee630cfc618eede368be76300de9d971, niiri:6231cdc1c30543959e82f342e7f7c028, -, -, -)
+    entity(niiri:aaf4f8141ee78e9a09556843acd95064,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0065" %% xsd:string,
+        prov:location = 'niiri:d17d2fa54d9211851a0ef3ebd18a78f0',
+        prov:value = "4.02814960479736" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.18780790473987" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000716778694212938" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999998538" %% xsd:float,
+        nidm_qValueFDR: = "0.0196630402446738" %% xsd:float])
+    entity(niiri:d17d2fa54d9211851a0ef3ebd18a78f0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0065" %% xsd:string,
+        nidm_coordinateVector: = "[-26,-36,-24]" %% xsd:string])
+    wasDerivedFrom(niiri:aaf4f8141ee78e9a09556843acd95064, niiri:d078d2a64b3eee365a7318a424f3d55f, -, -, -)
+    entity(niiri:122d4d1496fd61336c1b2e14c2eb7b08,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0066" %% xsd:string,
+        prov:location = 'niiri:e058fbd337495ddaef29dc0ea8a04073',
+        prov:value = "4.0194239616394" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.18306102742152" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000728634479518986" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999998893" %% xsd:float,
+        nidm_qValueFDR: = "0.019829947388337" %% xsd:float])
+    entity(niiri:e058fbd337495ddaef29dc0ea8a04073,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0066" %% xsd:string,
+        nidm_coordinateVector: = "[-26,6,66]" %% xsd:string])
+    wasDerivedFrom(niiri:122d4d1496fd61336c1b2e14c2eb7b08, niiri:b07d53658c12f0d165aec1cf959f1eb5, -, -, -)
+    entity(niiri:fdbadebbe5948d7060701cca85b9ec3c,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0067" %% xsd:string,
+        prov:location = 'niiri:bb35e3e75e4774ac32be8c7e9af072a0',
+        prov:value = "4.01476430892944" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.18052278869165" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000735047880785378" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999046" %% xsd:float,
+        nidm_qValueFDR: = "0.0199399671265334" %% xsd:float])
+    entity(niiri:bb35e3e75e4774ac32be8c7e9af072a0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0067" %% xsd:string,
+        nidm_coordinateVector: = "[-32,-6,66]" %% xsd:string])
+    wasDerivedFrom(niiri:fdbadebbe5948d7060701cca85b9ec3c, niiri:5e501329a485d9e81bca69bd136264fb, -, -, -)
+    entity(niiri:bac46c7751735f78e1059a5ed0f4d21a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0068" %% xsd:string,
+        prov:location = 'niiri:30f30dcc3a862edc1cc78ec4115bd0e9',
+        prov:value = "4.01372337341309" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.17995544681479" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000736488485902353" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999078" %% xsd:float,
+        nidm_qValueFDR: = "0.0199550456355793" %% xsd:float])
+    entity(niiri:30f30dcc3a862edc1cc78ec4115bd0e9,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0068" %% xsd:string,
+        nidm_coordinateVector: = "[56,-4,46]" %% xsd:string])
+    wasDerivedFrom(niiri:bac46c7751735f78e1059a5ed0f4d21a, niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097, -, -, -)
+    entity(niiri:2bfd75fa4bfe77aa205c149b2fec102a,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0069" %% xsd:string,
+        prov:location = 'niiri:6c5e7793c3c3b5878682a31efb3d04b2',
+        prov:value = "3.99763154983521" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.17117019350021" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000759130810004449" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999453" %% xsd:float,
+        nidm_qValueFDR: = "0.0202312537871442" %% xsd:float])
+    entity(niiri:6c5e7793c3c3b5878682a31efb3d04b2,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0069" %% xsd:string,
+        nidm_coordinateVector: = "[10,-20,-12]" %% xsd:string])
+    wasDerivedFrom(niiri:2bfd75fa4bfe77aa205c149b2fec102a, niiri:f19fc244e1ad9fb88396e6dc5d62c29b, -, -, -)
+    entity(niiri:089ac9f5b2b657c00a34b4ab8eaee4d1,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0070" %% xsd:string,
+        prov:location = 'niiri:af1872b1d428bd30ce24b10511479e0f',
+        prov:value = "3.96427512168884" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.15287103994341" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000808366063659971" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999999982" %% xsd:float,
+        nidm_qValueFDR: = "0.0208863381686101" %% xsd:float])
+    entity(niiri:af1872b1d428bd30ce24b10511479e0f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0070" %% xsd:string,
+        nidm_coordinateVector: = "[-52,20,36]" %% xsd:string])
+    wasDerivedFrom(niiri:089ac9f5b2b657c00a34b4ab8eaee4d1, niiri:8a6f880f7b8eaf62148b54fef7844b09, -, -, -)
+    entity(niiri:8cdecc19343e1178e26e45853c9023ed,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0071" %% xsd:string,
+        prov:location = 'niiri:77adc2dd71b080ae0c496d60454bd8e0',
+        prov:value = "3.94705867767334" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.14337930633102" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000835046362340219" %% xsd:float,
+        nidm_pValueFWER: = "0.9999999999999" %% xsd:float,
+        nidm_qValueFDR: = "0.0212745029430363" %% xsd:float])
+    entity(niiri:77adc2dd71b080ae0c496d60454bd8e0,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0071" %% xsd:string,
+        nidm_coordinateVector: = "[10,-24,-14]" %% xsd:string])
+    wasDerivedFrom(niiri:8cdecc19343e1178e26e45853c9023ed, niiri:de48b7494a3d45a8a57e155aeea2f132, -, -, -)
+    entity(niiri:be6866429745ec8fceee0123965bf9be,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0072" %% xsd:string,
+        prov:location = 'niiri:baa063c02b5a1e3acbac348c6e7f4f8f',
+        prov:value = "3.93684697151184" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.13773425766756" %% xsd:float,
+        nidm_pValueUncorrected: = "0.00085129580940857" %% xsd:float,
+        nidm_pValueFWER: = "0.99999999999993" %% xsd:float,
+        nidm_qValueFDR: = "0.0215142897882816" %% xsd:float])
+    entity(niiri:baa063c02b5a1e3acbac348c6e7f4f8f,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0072" %% xsd:string,
+        nidm_coordinateVector: = "[-32,18,-6]" %% xsd:string])
+    wasDerivedFrom(niiri:be6866429745ec8fceee0123965bf9be, niiri:c60f3aab1eee7d78c6850a16c38162dc, -, -, -)
+    entity(niiri:ad9707602adb5afb0acaa4237ca4f979,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0073" %% xsd:string,
+        prov:location = 'niiri:01154cd48f33a76a138d224c14ee2d42',
+        prov:value = "3.93397641181946" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.13614537112983" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000855921637752388" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999937" %% xsd:float,
+        nidm_qValueFDR: = "0.0215615444445258" %% xsd:float])
+    entity(niiri:01154cd48f33a76a138d224c14ee2d42,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0073" %% xsd:string,
+        nidm_coordinateVector: = "[52,10,18]" %% xsd:string])
+    wasDerivedFrom(niiri:ad9707602adb5afb0acaa4237ca4f979, niiri:859e657235309e3db15ccb1f14c1e7ba, -, -, -)
+    entity(niiri:11ba1d6f38fb1b63a2f74b7601766c83,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0074" %% xsd:string,
+        prov:location = 'niiri:6d498f6e4c82a7d741b60a62a8092e8b',
+        prov:value = "3.92871356010437" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.13323000033267" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000864469518982003" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999947" %% xsd:float,
+        nidm_qValueFDR: = "0.0216822850176731" %% xsd:float])
+    entity(niiri:6d498f6e4c82a7d741b60a62a8092e8b,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0074" %% xsd:string,
+        nidm_coordinateVector: = "[34,-52,-4]" %% xsd:string])
+    wasDerivedFrom(niiri:11ba1d6f38fb1b63a2f74b7601766c83, niiri:065fb1288e613aa1089a803ba4b13d87, -, -, -)
+    entity(niiri:ed629eddf9cc975359669c19b33ac397,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0075" %% xsd:string,
+        prov:location = 'niiri:58e5368187096a105a3cad65343f1be3',
+        prov:value = "3.91936802864075" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.12804559569402" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000879864400760821" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999962" %% xsd:float,
+        nidm_qValueFDR: = "0.0218781120126672" %% xsd:float])
+    entity(niiri:58e5368187096a105a3cad65343f1be3,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0075" %% xsd:string,
+        nidm_coordinateVector: = "[16,-32,-34]" %% xsd:string])
+    wasDerivedFrom(niiri:ed629eddf9cc975359669c19b33ac397, niiri:021e14b3f5e58d6dd1904bdbad37b113, -, -, -)
+    entity(niiri:15eec198bb6cca7b798e1e7a4e6de3b6,
+        [prov:type = 'nidm_Peak:',
+        prov:label = "Peak: 0076" %% xsd:string,
+        prov:location = 'niiri:63bfb114a4b23a3d0d57b8802a082634',
+        prov:value = "3.8760769367218" %% xsd:float,
+        nidm_equivalentZStatistic: = "3.1039055725094" %% xsd:float,
+        nidm_pValueUncorrected: = "0.000954921373033768" %% xsd:float,
+        nidm_pValueFWER: = "0.999999999999992" %% xsd:float,
+        nidm_qValueFDR: = "0.0229044690727897" %% xsd:float])
+    entity(niiri:63bfb114a4b23a3d0d57b8802a082634,
+        [prov:type = 'prov:Location',
+        prov:type = 'nidm_Coordinate:',
+        prov:label = "Coordinate: 0076" %% xsd:string,
+        nidm_coordinateVector: = "[18,8,34]" %% xsd:string])
+    wasDerivedFrom(niiri:15eec198bb6cca7b798e1e7a4e6de3b6, niiri:7fa11ca3554a75156c897f72b0a338ac, -, -, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_t_test/nidm.ttl
+++ b/spmexport/ex_spm_t_test/nidm.ttl
@@ -1,0 +1,2441 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:1b00cc9eddb72e8298ae831abf8242a8
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:37ae388b351e24eff092878ed6c627e8
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:9fd2af475544e59d923f455813a60f9e
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:9fd2af475544e59d923f455813a60f9e prov:wasAssociatedWith niiri:37ae388b351e24eff092878ed6c627e8 .
+
+_:blank5 a prov:Generation .
+
+niiri:1b00cc9eddb72e8298ae831abf8242a8 prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:12:11"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix nidm_IndependentError: <http://purl.org/nidash/nidm#NIDM_0000048> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_OLS: <http://purl.obolibrary.org/obo/STATO_0000370> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070> .
+@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
+@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .
+@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .
+@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082> .
+@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .
+@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092> .
+@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
+@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
+
+niiri:a035080de4f5f70d7392a1a791404523
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:91c9c55e5f9fc572da5b4bf19a331220
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "false"^^xsd:boolean .
+
+niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:175b9210819e919a439d88ac4bc2ab57 ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"mean\"]"^^xsd:string .
+
+niiri:175b9210819e919a439d88ac4bc2ab57
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:84b8dfaa3fa67fbd8f4c852110a04531
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: nidm_IndependentError: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean .
+
+niiri:b416890bf96d1dbb804f2efa4fda2d95
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_OLS: .
+
+niiri:b416890bf96d1dbb804f2efa4fda2d95 prov:wasAssociatedWith niiri:a035080de4f5f70d7392a1a791404523 .
+
+niiri:b416890bf96d1dbb804f2efa4fda2d95 prov:used niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0 .
+
+niiri:b416890bf96d1dbb804f2efa4fda2d95 prov:used niiri:91c9c55e5f9fc572da5b4bf19a331220 .
+
+niiri:b416890bf96d1dbb804f2efa4fda2d95 prov:used niiri:84b8dfaa3fa67fbd8f4c852110a04531 .
+
+niiri:a99fcafea3bdd16053d3fbef6194f56c
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
+
+niiri:6079f21d5530fd7507553a99cd6bfac7
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e"^^xsd:string .
+
+niiri:a99fcafea3bdd16053d3fbef6194f56c prov:wasDerivedFrom niiri:6079f21d5530fd7507553a99cd6bfac7 .
+
+niiri:a99fcafea3bdd16053d3fbef6194f56c prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+
+niiri:92fe3ceea82b9387c2e8a74870e1ff03
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "0.0584948938339949"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    crypto:sha512 "504d2b5e17e73690caae29eafdc0448a1d5ac6d66af811a3fcbab8eec9f904820f0610d985a6f04e8808fcd8f77def3c063bfb11df56679b0b28261cdc2856f9"^^xsd:string .
+
+niiri:92fe3ceea82b9387c2e8a74870e1ff03 prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+
+niiri:a5219921c3bcca062f97bd37da42f0f6
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd .
+
+niiri:758caf4a74ea7c64784615391d3d8bb9
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "9a22064d78683e5b5375b6d3708584d2bb24dd434f40b311f06e185e10c9492d976c35967cc2545e3d7aefa2b83f7e433c957bd8dc87c22392e334027d0b438b"^^xsd:string .
+
+niiri:a5219921c3bcca062f97bd37da42f0f6 prov:wasDerivedFrom niiri:758caf4a74ea7c64784615391d3d8bb9 .
+
+niiri:a5219921c3bcca062f97bd37da42f0f6 prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+
+niiri:42d6ab087f72abda2ef3d164d74b2af0
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    crypto:sha512 "5796b765989869d8ad685aee159b41c06538552c8a91ed6cfa9dc7a334df02e91dd83703fd5d9be4a7fc8a27943157d2cf29f457aa1cf4a3d01ce813480ddaaa"^^xsd:string .
+
+niiri:794d510acaf63dceb059cc9ba8dab5d2
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "bd6687fb4b5d5af30fa322a8b6b6df29ead2c1e0ebe8e1962c3716c2c05a23365fe0428be1d420ef8b013c4c342c0d5efe704fec31b6e956c2b4d15a630b1c98"^^xsd:string .
+
+niiri:42d6ab087f72abda2ef3d164d74b2af0 prov:wasDerivedFrom niiri:794d510acaf63dceb059cc9ba8dab5d2 .
+
+niiri:42d6ab087f72abda2ef3d164d74b2af0 prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+
+niiri:3aa3da07651e9afc3c6c5a49b7b97170
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    crypto:sha512 "7090223b1a196dba349a102d5d369808fa90203f67c9021d2113b323996c67506be3e49d5e848a4f38a6ff78038478dee1401d2a7cd9ee5e6496f3d0313c6eb6"^^xsd:string .
+
+niiri:9b2bfe67b8475d87b43e4e93e350f76e
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "95b2ccdef4496cd3830f817f9d8893924091b302a09c66b1581f7ee4721c618a1d95d56e509e8f1537af7ea437bc5f3fbf7f69037f13203b6c98733647911d8d"^^xsd:string .
+
+niiri:3aa3da07651e9afc3c6c5a49b7b97170 prov:wasDerivedFrom niiri:9b2bfe67b8475d87b43e4e93e350f76e .
+
+niiri:3aa3da07651e9afc3c6c5a49b7b97170 prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+
+niiri:04b578701cf4564a0a334f46af3d16fa
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
+    rdfs:label "Contrast: Con1: mr vs plain" ;
+    prov:value "1"^^xsd:string .
+
+niiri:f8fa21d3adf52266399255440cb7dbde
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:f8fa21d3adf52266399255440cb7dbde prov:wasAssociatedWith niiri:a035080de4f5f70d7392a1a791404523 .
+
+niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:a99fcafea3bdd16053d3fbef6194f56c .
+
+niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:42d6ab087f72abda2ef3d164d74b2af0 .
+
+niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0 .
+
+niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:04b578701cf4564a0a334f46af3d16fa .
+
+niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:a5219921c3bcca062f97bd37da42f0f6 .
+
+niiri:b925226ebcfaf81953c6c8d86b12edbe
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: Con1: mr vs plain" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "13"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    crypto:sha512 "2eec11aca8e4898cb44b0e535e3abecde8d46ea6e5fe05bb26e2dee72769fcb985c90c0ed86b9dcaf260d502b34559700f7a3c0f944f020a4beb20042153d26f"^^xsd:string .
+
+niiri:c7968123d4a2445f2cc5efd45678f874
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "291b6fbfe377046689fa404484c99e68b419966665af4294ca5348faf3ee9e3e4ea972ccb9c17fc697c42c58d915fda6300a540027b872eccd1403215cd2e075"^^xsd:string .
+
+niiri:b925226ebcfaf81953c6c8d86b12edbe prov:wasDerivedFrom niiri:c7968123d4a2445f2cc5efd45678f874 .
+
+niiri:b925226ebcfaf81953c6c8d86b12edbe prov:wasGeneratedBy niiri:f8fa21d3adf52266399255440cb7dbde .
+
+niiri:0d474a910bcd3d0f50d6a1c63d2c2081
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: Con1: mr vs plain" ;
+    nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    crypto:sha512 "d907fef7984f59a008b8963e5fb6d2386968ffcde54e31fabe7ed8b0e1a32e4410475271e4fa903e1aa6c01ef4903209fb61660bd47a5709a5c5c91bccc8b426"^^xsd:string .
+
+niiri:0f1eef5a71e2e8c320c07d47aaf5faa2
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "66e00621b81bef508ca685a72a398d532276891ec8b2abc489af8f6105099ca9a54f52697ea83360eed53387ba6bec3ae1fc7f882ca4f3c8f944ee9a15f099ba"^^xsd:string .
+
+niiri:0d474a910bcd3d0f50d6a1c63d2c2081 prov:wasDerivedFrom niiri:0f1eef5a71e2e8c320c07d47aaf5faa2 .
+
+niiri:0d474a910bcd3d0f50d6a1c63d2c2081 prov:wasGeneratedBy niiri:f8fa21d3adf52266399255440cb7dbde .
+
+niiri:9ad91a55a933509c23c194d606e537a6
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    crypto:sha512 "4fed4edb0da80cd11916dccc511db465d9a42101a08318ca494f751102dfed9e4ccf557dbb4eaef9d792f662864bfe3a77670a1c78dbbf144974e8866d9640f0"^^xsd:string .
+
+niiri:9ad91a55a933509c23c194d606e537a6 prov:wasGeneratedBy niiri:f8fa21d3adf52266399255440cb7dbde .
+
+niiri:2b631fcf63e9820fbd2e40503305547d
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    prov:value "0.000999500181305457"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:850496eee671baa44ef30a3c14bbc01f ;
+    nidm_equivalentThreshold: niiri:39e5898c4b517eee39c871cfc90544ea .
+
+niiri:850496eee671baa44ef30a3c14bbc01f
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "3.85198238341593"^^xsd:float .
+
+niiri:39e5898c4b517eee39c871cfc90544ea
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.999999999999997"^^xsd:float .
+
+niiri:5f8ed8ba67e188085e5ae8dd56f0fd87
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:737e308a8a329df56e3800195e6a5520 ;
+    nidm_equivalentThreshold: niiri:f3fad5b99b15cd5fa5fcf64d81b5c413 .
+
+niiri:737e308a8a329df56e3800195e6a5520
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:f3fad5b99b15cd5fa5fcf64d81b5c413
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:7a9d521a4e66bf249cf7ba064524933f
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:3f2044246932375109f3634cdd1b9da7
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:wasAssociatedWith niiri:a035080de4f5f70d7392a1a791404523 .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:2b631fcf63e9820fbd2e40503305547d .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:5f8ed8ba67e188085e5ae8dd56f0fd87 .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:b925226ebcfaf81953c6c8d86b12edbe .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:3aa3da07651e9afc3c6c5a49b7b97170 .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:a99fcafea3bdd16053d3fbef6194f56c .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:7a9d521a4e66bf249cf7ba064524933f .
+
+niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:3f2044246932375109f3634cdd1b9da7 .
+
+niiri:b8b1c6bd8a121e50549c32ca3ea169ca
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_searchVolumeInVoxels: "167222"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1337776"^^xsd:float ;
+    nidm_reselSizeInVoxels: "83.1545653831017"^^xsd:float ;
+    nidm_searchVolumeInResels: "1850.56586239186"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[5, 52.6584563500118, 688.659482209668, 1850.56586239186]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.33608694259856, 4.31068523375487, 4.44878896221732]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.67217388519712, 8.62137046750973, 8.89757792443465]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "5.39987111748599"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "33.3985930251833"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "9.00548618010876"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "9.34592533111572"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "70"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "59"^^xsd:int ;
+    crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
+
+niiri:b8b1c6bd8a121e50549c32ca3ea169ca prov:wasGeneratedBy niiri:a7eb52ddc903ab04fcaa029f84ea6b4b .
+
+niiri:04e3f1275db373d13cac82285a23f702
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "57"^^xsd:int ;
+    nidm_pValue: "0.000126072725041393"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:3651b3bac0c9746240cd1f49bb29caf5 ;
+    nidm_hasMaximumIntensityProjection: niiri:8c55faf85816666e5ce4f7e8047a35de ;
+    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    crypto:sha512 "9bef1b01e85eeddf2e747ceba7ade799597c7837064cb2f65dd700a59f52a84d33bd06d9b28b57b0669461e4ff28c39b9df7e09752b27d653bc515d887e4927e"^^xsd:string .
+
+niiri:3651b3bac0c9746240cd1f49bb29caf5
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:8c55faf85816666e5ce4f7e8047a35de
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:04e3f1275db373d13cac82285a23f702 prov:wasGeneratedBy niiri:a7eb52ddc903ab04fcaa029f84ea6b4b .
+
+niiri:1cf06d93f4aed03ee50d587421161410
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0001" ;
+    nidm_clusterSizeInVoxels: "3171"^^xsd:int ;
+    nidm_clusterSizeInResels: "38.1338052263381"^^xsd:float ;
+    nidm_pValueUncorrected: "1.51359313420427e-37"^^xsd:float ;
+    nidm_pValueFWER: "0"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "1"^^xsd:int .
+
+niiri:1cf06d93f4aed03ee50d587421161410 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:1a7642317b9c235ad3c8606f26710b96
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0002" ;
+    nidm_clusterSizeInVoxels: "1543"^^xsd:int ;
+    nidm_clusterSizeInResels: "18.555806201274"^^xsd:float ;
+    nidm_pValueUncorrected: "1.66432139866024e-23"^^xsd:float ;
+    nidm_pValueFWER: "0"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "2"^^xsd:int .
+
+niiri:1a7642317b9c235ad3c8606f26710b96 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0003" ;
+    nidm_clusterSizeInVoxels: "1032"^^xsd:int ;
+    nidm_clusterSizeInResels: "12.4106234606058"^^xsd:float ;
+    nidm_pValueUncorrected: "3.79330201851569e-18"^^xsd:float ;
+    nidm_pValueFWER: "1.11022302462516e-16"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "3"^^xsd:int .
+
+niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:57b5c372ef2a2b5e726b538a4a5d80db
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0004" ;
+    nidm_clusterSizeInVoxels: "70"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.841805854886052"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00126629512703917"^^xsd:float ;
+    nidm_pValueFWER: "0.0414106244319472"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "4"^^xsd:int .
+
+niiri:57b5c372ef2a2b5e726b538a4a5d80db prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:2260abfbc92b3918f8c4e115273811bc
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0005" ;
+    nidm_clusterSizeInVoxels: "250"^^xsd:int ;
+    nidm_clusterSizeInResels: "3.0064494817359"^^xsd:float ;
+    nidm_pValueUncorrected: "1.69880136830291e-07"^^xsd:float ;
+    nidm_pValueFWER: "5.6737414573238e-06"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "5"^^xsd:int .
+
+niiri:2260abfbc92b3918f8c4e115273811bc prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:428e3b496b74c693be37a9557e535f44
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0006" ;
+    nidm_clusterSizeInVoxels: "96"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.15447660098659"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000265110996345557"^^xsd:float ;
+    nidm_pValueFWER: "0.00881525009559059"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "6"^^xsd:int .
+
+niiri:428e3b496b74c693be37a9557e535f44 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:f2233fa4afd02fcceeb05d8f7c4801ff
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0007" ;
+    nidm_clusterSizeInVoxels: "16"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.192412766831098"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0825701010975274"^^xsd:float ;
+    nidm_pValueFWER: "0.936564091808241"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "7"^^xsd:int .
+
+niiri:f2233fa4afd02fcceeb05d8f7c4801ff prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:b1ef2839e620d66c14bd83deb3aec390
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0008" ;
+    nidm_clusterSizeInVoxels: "320"^^xsd:int ;
+    nidm_clusterSizeInResels: "3.84825533662195"^^xsd:float ;
+    nidm_pValueUncorrected: "1.04491815175368e-08"^^xsd:float ;
+    nidm_pValueFWER: "3.48987900022912e-07"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "8"^^xsd:int .
+
+niiri:b1ef2839e620d66c14bd83deb3aec390 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:6a1143e807a7221c10cbd94b8f352cb3
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0009" ;
+    nidm_clusterSizeInVoxels: "64"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.76965106732439"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00186450920193164"^^xsd:float ;
+    nidm_pValueFWER: "0.0603727115804786"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "9"^^xsd:int .
+
+niiri:6a1143e807a7221c10cbd94b8f352cb3 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:17a361a6af9be1a09623d4875d9de272
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0010" ;
+    nidm_clusterSizeInVoxels: "161"^^xsd:int ;
+    nidm_clusterSizeInResels: "1.93615346623792"^^xsd:float ;
+    nidm_pValueUncorrected: "8.94149306858092e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.000298588701553082"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "10"^^xsd:int .
+
+niiri:17a361a6af9be1a09623d4875d9de272 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:646a3e8aac6f4eee8e8562e0616d65ba
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0011" ;
+    nidm_clusterSizeInVoxels: "31"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.372799735735251"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0207288021023404"^^xsd:float ;
+    nidm_pValueFWER: "0.499582648292263"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "11"^^xsd:int .
+
+niiri:646a3e8aac6f4eee8e8562e0616d65ba prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:8e53fdbcd507f29fa491c0ee30766820
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0012" ;
+    nidm_clusterSizeInVoxels: "71"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.853831652812995"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00118851678280378"^^xsd:float ;
+    nidm_pValueFWER: "0.0389172719454809"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "12"^^xsd:int .
+
+niiri:8e53fdbcd507f29fa491c0ee30766820 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:caa24947392807e9fd656eb7e677bb90
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0013" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0962063834155488"^^xsd:float ;
+    nidm_pValueUncorrected: "0.207797889710554"^^xsd:float ;
+    nidm_pValueFWER: "0.999031882554387"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "13"^^xsd:int .
+
+niiri:caa24947392807e9fd656eb7e677bb90 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:aa6f6ac422b272159fb670d4c6c75fe8
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0014" ;
+    nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.144309575123323"^^xsd:float ;
+    nidm_pValueUncorrected: "0.12760183958249"^^xsd:float ;
+    nidm_pValueFWER: "0.985901993992134"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "14"^^xsd:int .
+
+niiri:aa6f6ac422b272159fb670d4c6c75fe8 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:62026e05a2a2355fc124787b15505315
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0015" ;
+    nidm_clusterSizeInVoxels: "8"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0962063834155488"^^xsd:float ;
+    nidm_pValueUncorrected: "0.207797889710554"^^xsd:float ;
+    nidm_pValueFWER: "0.999031882554387"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "15"^^xsd:int .
+
+niiri:62026e05a2a2355fc124787b15505315 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:93450961f0d8d0f6a3b90a5894e1f87b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0016" ;
+    nidm_clusterSizeInVoxels: "24"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.288619150246646"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0380746884846506"^^xsd:float ;
+    nidm_pValueFWER: "0.719628852078667"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "16"^^xsd:int .
+
+niiri:93450961f0d8d0f6a3b90a5894e1f87b prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:9b5ca13a3d263c59792e6e86be4a2e34
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0017" ;
+    nidm_clusterSizeInVoxels: "9"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.108232181342492"^^xsd:float ;
+    nidm_pValueUncorrected: "0.182768422209712"^^xsd:float ;
+    nidm_pValueFWER: "0.997766550775957"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "17"^^xsd:int .
+
+niiri:9b5ca13a3d263c59792e6e86be4a2e34 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:bb0785359fefadd70b1adaaaac3b7884
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0018" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0240515958538872"^^xsd:float ;
+    nidm_pValueUncorrected: "0.536050498332642"^^xsd:float ;
+    nidm_pValueFWER: "0.999999983224267"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "18"^^xsd:int .
+
+niiri:bb0785359fefadd70b1adaaaac3b7884 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:000e7e06128006bf16d2f8dd28c288f0
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0019" ;
+    nidm_clusterSizeInVoxels: "15"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.180386968904154"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0917146861027911"^^xsd:float ;
+    nidm_pValueFWER: "0.953259370207355"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "19"^^xsd:int .
+
+niiri:000e7e06128006bf16d2f8dd28c288f0 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:fea4f2ec59548d5d8b403064bc42fcd3
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0020" ;
+    nidm_clusterSizeInVoxels: "22"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.264567554392759"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0457749346828495"^^xsd:float ;
+    nidm_pValueFWER: "0.78320832600297"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "20"^^xsd:int .
+
+niiri:fea4f2ec59548d5d8b403064bc42fcd3 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:56aff3268c9efc59ac3dd1fccbb1e940
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0021" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.161507492809281"^^xsd:float ;
+    nidm_pValueFWER: "0.995456797062611"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "21"^^xsd:int .
+
+niiri:56aff3268c9efc59ac3dd1fccbb1e940 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:30c41fd03e0e9666df9d194fbe412b52
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0022" ;
+    nidm_clusterSizeInVoxels: "16"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.192412766831098"^^xsd:float ;
+    nidm_pValueUncorrected: "0.0825701010975274"^^xsd:float ;
+    nidm_pValueFWER: "0.936564091808241"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "22"^^xsd:int .
+
+niiri:30c41fd03e0e9666df9d194fbe412b52 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:195a3dcb7bf220b60a464a21245d4ee4
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0023" ;
+    nidm_clusterSizeInVoxels: "59"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.709522077689672"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00259801113118302"^^xsd:float ;
+    nidm_pValueFWER: "0.0831119677765624"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "23"^^xsd:int .
+
+niiri:195a3dcb7bf220b60a464a21245d4ee4 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:d09f25e397a79ba3820081611e196ed7
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0024" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.060128989634718"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317097371523839"^^xsd:float ;
+    nidm_pValueFWER: "0.999974848827969"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "24"^^xsd:int .
+
+niiri:d09f25e397a79ba3820081611e196ed7 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:2d07cb807cba69cb83d125ad8a6d9589
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0025" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0240515958538872"^^xsd:float ;
+    nidm_pValueUncorrected: "0.536050498332642"^^xsd:float ;
+    nidm_pValueFWER: "0.999999983224267"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "25"^^xsd:int .
+
+niiri:2d07cb807cba69cb83d125ad8a6d9589 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:2d69939d531eb0168273379f7ce52907
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0026" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0240515958538872"^^xsd:float ;
+    nidm_pValueUncorrected: "0.536050498332642"^^xsd:float ;
+    nidm_pValueFWER: "0.999999983224267"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "26"^^xsd:int .
+
+niiri:2d69939d531eb0168273379f7ce52907 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:1c2323d93891a0ddf5ac87752d859519
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0027" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0240515958538872"^^xsd:float ;
+    nidm_pValueUncorrected: "0.536050498332642"^^xsd:float ;
+    nidm_pValueFWER: "0.999999983224267"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "27"^^xsd:int .
+
+niiri:1c2323d93891a0ddf5ac87752d859519 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:dc7f564798bbb1fc05334954d8385ba1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0028" ;
+    nidm_clusterSizeInVoxels: "11"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.13228377719638"^^xsd:float ;
+    nidm_pValueUncorrected: "0.143300710523383"^^xsd:float ;
+    nidm_pValueFWER: "0.991654577641533"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "28"^^xsd:int .
+
+niiri:dc7f564798bbb1fc05334954d8385ba1 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:62a9cd07b50b07a1142d53889b87fd97
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0029" ;
+    nidm_clusterSizeInVoxels: "13"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.156335373050267"^^xsd:float ;
+    nidm_pValueUncorrected: "0.113985043745931"^^xsd:float ;
+    nidm_pValueFWER: "0.977783945749582"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "29"^^xsd:int .
+
+niiri:62a9cd07b50b07a1142d53889b87fd97 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:12880301a0a653ca67efd232a37a486b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0030" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0481031917077744"^^xsd:float ;
+    nidm_pValueUncorrected: "0.371655744440408"^^xsd:float ;
+    nidm_pValueFWER: "0.99999593370769"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "30"^^xsd:int .
+
+niiri:12880301a0a653ca67efd232a37a486b prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:7b940b3f554bfd8086ef06ec3a4c5e36
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0031" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.060128989634718"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317097371523839"^^xsd:float ;
+    nidm_pValueFWER: "0.999974848827969"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "31"^^xsd:int .
+
+niiri:7b940b3f554bfd8086ef06ec3a4c5e36 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:4364ea14ae541a4b5530d0fc11478f4d
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0032" ;
+    nidm_clusterSizeInVoxels: "6"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0721547875616616"^^xsd:float ;
+    nidm_pValueUncorrected: "0.273353831547941"^^xsd:float ;
+    nidm_pValueFWER: "0.999891594677731"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "32"^^xsd:int .
+
+niiri:4364ea14ae541a4b5530d0fc11478f4d prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:cad9672114cca77d75274be4de17ab9c
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0033" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0360773937808308"^^xsd:float ;
+    nidm_pValueUncorrected: "0.441732231987406"^^xsd:float ;
+    nidm_pValueFWER: "0.999999608482273"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "33"^^xsd:int .
+
+niiri:cad9672114cca77d75274be4de17ab9c prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:9373fb96b8dcda6b9ae13dbf76afcaa6
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0034" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0360773937808308"^^xsd:float ;
+    nidm_pValueUncorrected: "0.441732231987406"^^xsd:float ;
+    nidm_pValueFWER: "0.999999608482273"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "34"^^xsd:int .
+
+niiri:9373fb96b8dcda6b9ae13dbf76afcaa6 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:7737094062d61c5fc0d500987f11bda9
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0035" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.060128989634718"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317097371523839"^^xsd:float ;
+    nidm_pValueFWER: "0.999974848827969"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "35"^^xsd:int .
+
+niiri:7737094062d61c5fc0d500987f11bda9 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:454d2ddee840a6eed8f9885efabde318
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0036" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.060128989634718"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317097371523839"^^xsd:float ;
+    nidm_pValueFWER: "0.999974848827969"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "36"^^xsd:int .
+
+niiri:454d2ddee840a6eed8f9885efabde318 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:b2f3ddd032f5ca78054f0eca8d0c8769
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0037" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "37"^^xsd:int .
+
+niiri:b2f3ddd032f5ca78054f0eca8d0c8769 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:cf4b88bff59c1a33cd867e9422f84011
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0038" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.060128989634718"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317097371523839"^^xsd:float ;
+    nidm_pValueFWER: "0.999974848827969"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "38"^^xsd:int .
+
+niiri:cf4b88bff59c1a33cd867e9422f84011 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:3283422abdc309a208995369231fe32a
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0039" ;
+    nidm_clusterSizeInVoxels: "5"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.060128989634718"^^xsd:float ;
+    nidm_pValueUncorrected: "0.317097371523839"^^xsd:float ;
+    nidm_pValueFWER: "0.999974848827969"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "39"^^xsd:int .
+
+niiri:3283422abdc309a208995369231fe32a prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:c9c180c62d3cd262bcb7bb862a2e2d3e
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0040" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "40"^^xsd:int .
+
+niiri:c9c180c62d3cd262bcb7bb862a2e2d3e prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:f67691de01cdab9987a52d4efd6796df
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0041" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "41"^^xsd:int .
+
+niiri:f67691de01cdab9987a52d4efd6796df prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:ef91e7140c5dbe4c9303f8f1e0cd8673
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0042" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0240515958538872"^^xsd:float ;
+    nidm_pValueUncorrected: "0.536050498332642"^^xsd:float ;
+    nidm_pValueFWER: "0.999999983224267"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "42"^^xsd:int .
+
+niiri:ef91e7140c5dbe4c9303f8f1e0cd8673 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:dcd5d7321bb4d36d468ecf53edb77243
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0043" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "43"^^xsd:int .
+
+niiri:dcd5d7321bb4d36d468ecf53edb77243 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:049381a7f67019f13a2b75b205f87af1
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0044" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0360773937808308"^^xsd:float ;
+    nidm_pValueUncorrected: "0.441732231987406"^^xsd:float ;
+    nidm_pValueFWER: "0.999999608482273"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "44"^^xsd:int .
+
+niiri:049381a7f67019f13a2b75b205f87af1 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:6231cdc1c30543959e82f342e7f7c028
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0045" ;
+    nidm_clusterSizeInVoxels: "4"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0481031917077744"^^xsd:float ;
+    nidm_pValueUncorrected: "0.371655744440408"^^xsd:float ;
+    nidm_pValueFWER: "0.99999593370769"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "45"^^xsd:int .
+
+niiri:6231cdc1c30543959e82f342e7f7c028 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:d078d2a64b3eee365a7318a424f3d55f
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0046" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "46"^^xsd:int .
+
+niiri:d078d2a64b3eee365a7318a424f3d55f prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:b07d53658c12f0d165aec1cf959f1eb5
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0047" ;
+    nidm_clusterSizeInVoxels: "2"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0240515958538872"^^xsd:float ;
+    nidm_pValueUncorrected: "0.536050498332642"^^xsd:float ;
+    nidm_pValueFWER: "0.999999983224267"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "47"^^xsd:int .
+
+niiri:b07d53658c12f0d165aec1cf959f1eb5 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:5e501329a485d9e81bca69bd136264fb
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0048" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "48"^^xsd:int .
+
+niiri:5e501329a485d9e81bca69bd136264fb prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0049" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "49"^^xsd:int .
+
+niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:f19fc244e1ad9fb88396e6dc5d62c29b
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0050" ;
+    nidm_clusterSizeInVoxels: "3"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0360773937808308"^^xsd:float ;
+    nidm_pValueUncorrected: "0.441732231987406"^^xsd:float ;
+    nidm_pValueFWER: "0.999999608482273"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "50"^^xsd:int .
+
+niiri:f19fc244e1ad9fb88396e6dc5d62c29b prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:8a6f880f7b8eaf62148b54fef7844b09
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0051" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "51"^^xsd:int .
+
+niiri:8a6f880f7b8eaf62148b54fef7844b09 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:de48b7494a3d45a8a57e155aeea2f132
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0052" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "52"^^xsd:int .
+
+niiri:de48b7494a3d45a8a57e155aeea2f132 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:c60f3aab1eee7d78c6850a16c38162dc
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0053" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "53"^^xsd:int .
+
+niiri:c60f3aab1eee7d78c6850a16c38162dc prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:859e657235309e3db15ccb1f14c1e7ba
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0054" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "54"^^xsd:int .
+
+niiri:859e657235309e3db15ccb1f14c1e7ba prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:065fb1288e613aa1089a803ba4b13d87
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0055" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "55"^^xsd:int .
+
+niiri:065fb1288e613aa1089a803ba4b13d87 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:021e14b3f5e58d6dd1904bdbad37b113
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0056" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "56"^^xsd:int .
+
+niiri:021e14b3f5e58d6dd1904bdbad37b113 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:7fa11ca3554a75156c897f72b0a338ac
+    a prov:Entity, nidm_SupraThresholdCluster: ; 
+    rdfs:label "Supra-Threshold Cluster: 0057" ;
+    nidm_clusterSizeInVoxels: "1"^^xsd:int ;
+    nidm_clusterSizeInResels: "0.0120257979269436"^^xsd:float ;
+    nidm_pValueUncorrected: "0.675165563491534"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999838994"^^xsd:float ;
+    nidm_qValueFDR: "[]"^^xsd:float ;
+    nidm_clusterLabelId: "57"^^xsd:int .
+
+niiri:7fa11ca3554a75156c897f72b0a338ac prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+
+niiri:b3b769322ee6f2728df46b1d7e729a2c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0001" ;
+    prov:atLocation niiri:2cc8cbc51d2e2dd1d34f08891cbe366d ;
+    prov:value "13.6061105728149"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.86214047392852"^^xsd:float ;
+    nidm_pValueUncorrected: "2.28469099194939e-09"^^xsd:float ;
+    nidm_pValueFWER: "0.000382050559925018"^^xsd:float ;
+    nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
+
+niiri:2cc8cbc51d2e2dd1d34f08891cbe366d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0001" ;
+    nidm_coordinateVector: "[34,-86,0]"^^xsd:string .
+
+niiri:b3b769322ee6f2728df46b1d7e729a2c prov:wasDerivedFrom niiri:1cf06d93f4aed03ee50d587421161410 .
+
+niiri:0962722c2fe8603177b631a54d2747fd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0002" ;
+    prov:atLocation niiri:12b4490a7a2a9265c0fb5c1cad432626 ;
+    prov:value "11.9614944458008"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.59772141079875"^^xsd:float ;
+    nidm_pValueUncorrected: "1.08593692926817e-08"^^xsd:float ;
+    nidm_pValueFWER: "0.00181592543329545"^^xsd:float ;
+    nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
+
+niiri:12b4490a7a2a9265c0fb5c1cad432626
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0002" ;
+    nidm_coordinateVector: "[30,-78,36]"^^xsd:string .
+
+niiri:0962722c2fe8603177b631a54d2747fd prov:wasDerivedFrom niiri:1cf06d93f4aed03ee50d587421161410 .
+
+niiri:56e9acaa44092839074f4fe2f1cbeb87
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0003" ;
+    prov:atLocation niiri:95c264e1e21bd313ad9649cc29570602 ;
+    prov:value "10.5961866378784"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.34279531222125"^^xsd:float ;
+    nidm_pValueUncorrected: "4.5762046707587e-08"^^xsd:float ;
+    nidm_pValueFWER: "0.00765242110449371"^^xsd:float ;
+    nidm_qValueFDR: "0.000248881974141536"^^xsd:float .
+
+niiri:95c264e1e21bd313ad9649cc29570602
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0003" ;
+    nidm_coordinateVector: "[34,-48,44]"^^xsd:string .
+
+niiri:56e9acaa44092839074f4fe2f1cbeb87 prov:wasDerivedFrom niiri:1cf06d93f4aed03ee50d587421161410 .
+
+niiri:5a1c78a3e12360263792a811b8b793e7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0004" ;
+    prov:atLocation niiri:fe2447910ca73bf4173a0bc09b5c82ef ;
+    prov:value "11.9789819717407"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.6007582829493"^^xsd:float ;
+    nidm_pValueUncorrected: "1.06708079039564e-08"^^xsd:float ;
+    nidm_pValueFWER: "0.00178439382075002"^^xsd:float ;
+    nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
+
+niiri:fe2447910ca73bf4173a0bc09b5c82ef
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0004" ;
+    nidm_coordinateVector: "[-46,-54,-12]"^^xsd:string .
+
+niiri:5a1c78a3e12360263792a811b8b793e7 prov:wasDerivedFrom niiri:1a7642317b9c235ad3c8606f26710b96 .
+
+niiri:579e3d2553a1f65ce2b443a85f7f7e78
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0005" ;
+    prov:atLocation niiri:38e45fd9e8f667e140bcb4cd465dff2a ;
+    prov:value "11.3053674697876"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.47978759981232"^^xsd:float ;
+    nidm_pValueUncorrected: "2.12918364050907e-08"^^xsd:float ;
+    nidm_pValueFWER: "0.00356046346733208"^^xsd:float ;
+    nidm_qValueFDR: "0.000225699919390338"^^xsd:float .
+
+niiri:38e45fd9e8f667e140bcb4cd465dff2a
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0005" ;
+    nidm_coordinateVector: "[-48,-64,-8]"^^xsd:string .
+
+niiri:579e3d2553a1f65ce2b443a85f7f7e78 prov:wasDerivedFrom niiri:1a7642317b9c235ad3c8606f26710b96 .
+
+niiri:8fde575882a0e0c286f85ce29ad62c58
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0006" ;
+    prov:atLocation niiri:ea247c88d42d40da9044ae0523463ac4 ;
+    prov:value "9.59214210510254"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.12915279008791"^^xsd:float ;
+    nidm_pValueUncorrected: "1.45524525096974e-07"^^xsd:float ;
+    nidm_pValueFWER: "0.0243349038623457"^^xsd:float ;
+    nidm_qValueFDR: "0.000374773184801466"^^xsd:float .
+
+niiri:ea247c88d42d40da9044ae0523463ac4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0006" ;
+    nidm_coordinateVector: "[-46,-72,-6]"^^xsd:string .
+
+niiri:8fde575882a0e0c286f85ce29ad62c58 prov:wasDerivedFrom niiri:1a7642317b9c235ad3c8606f26710b96 .
+
+niiri:5620f2a9a83f08e4e4e2e452ed521bfb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0007" ;
+    prov:atLocation niiri:807ce33ed88a8e53dcb621151ae91a66 ;
+    prov:value "8.26132202148438"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.8021068311854"^^xsd:float ;
+    nidm_pValueUncorrected: "7.85024427352177e-07"^^xsd:float ;
+    nidm_pValueFWER: "0.131273406272461"^^xsd:float ;
+    nidm_qValueFDR: "0.000714072820754613"^^xsd:float .
+
+niiri:807ce33ed88a8e53dcb621151ae91a66
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0007" ;
+    nidm_coordinateVector: "[-26,-76,32]"^^xsd:string .
+
+niiri:5620f2a9a83f08e4e4e2e452ed521bfb prov:wasDerivedFrom niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8 .
+
+niiri:49d7d90f66e4da833c690cd5883a10e7
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0008" ;
+    prov:atLocation niiri:a9a21ab8f48ab130ada7bc6efcded96d ;
+    prov:value "7.54039764404297"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.59887376341391"^^xsd:float ;
+    nidm_pValueUncorrected: "2.12390533416151e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.355164074926112"^^xsd:float ;
+    nidm_qValueFDR: "0.00112750499976544"^^xsd:float .
+
+niiri:a9a21ab8f48ab130ada7bc6efcded96d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0008" ;
+    nidm_coordinateVector: "[-38,-46,44]"^^xsd:string .
+
+niiri:49d7d90f66e4da833c690cd5883a10e7 prov:wasDerivedFrom niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8 .
+
+niiri:27fde605695ea87f488e331274bbffb0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0009" ;
+    prov:atLocation niiri:1f9cb7e030174f7f9631db464ceecffe ;
+    prov:value "7.09534215927124"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.46234965259847"^^xsd:float ;
+    nidm_pValueUncorrected: "4.05329024755208e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.550389997209789"^^xsd:float ;
+    nidm_qValueFDR: "0.00152026219003999"^^xsd:float .
+
+niiri:1f9cb7e030174f7f9631db464ceecffe
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0009" ;
+    nidm_coordinateVector: "[-24,-72,44]"^^xsd:string .
+
+niiri:27fde605695ea87f488e331274bbffb0 prov:wasDerivedFrom niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8 .
+
+niiri:9a3c595e0ddc14214f4c9c93eb68dd36
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0010" ;
+    prov:atLocation niiri:07d77ef1ba5bc8952fe942d5c9b7efd7 ;
+    prov:value "7.53033494949341"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.59588573954922"^^xsd:float ;
+    nidm_pValueUncorrected: "2.15457400010166e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.36029256155409"^^xsd:float ;
+    nidm_qValueFDR: "0.00113656959480786"^^xsd:float .
+
+niiri:07d77ef1ba5bc8952fe942d5c9b7efd7
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0010" ;
+    nidm_coordinateVector: "[-20,-10,48]"^^xsd:string .
+
+niiri:9a3c595e0ddc14214f4c9c93eb68dd36 prov:wasDerivedFrom niiri:57b5c372ef2a2b5e726b538a4a5d80db .
+
+niiri:b0acf117bc223f33dfefb698485fdbbc
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0011" ;
+    prov:atLocation niiri:45e55c7dc0c0ad9a7b5a0041cc5079ac ;
+    prov:value "4.24029636383057"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.30076820538094"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000482102531686568"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999415186"^^xsd:float ;
+    nidm_qValueFDR: "0.015845468443456"^^xsd:float .
+
+niiri:45e55c7dc0c0ad9a7b5a0041cc5079ac
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0011" ;
+    nidm_coordinateVector: "[-26,0,56]"^^xsd:string .
+
+niiri:b0acf117bc223f33dfefb698485fdbbc prov:wasDerivedFrom niiri:57b5c372ef2a2b5e726b538a4a5d80db .
+
+niiri:7f38de5b18de7d50cf6bbab3de7ed61d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0012" ;
+    prov:atLocation niiri:549cbc20d7a3347bd507c93a62cb962d ;
+    prov:value "7.17061138153076"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.48608583316407"^^xsd:float ;
+    nidm_pValueUncorrected: "3.62717632940157e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.521824836713063"^^xsd:float ;
+    nidm_qValueFDR: "0.00145106406730833"^^xsd:float .
+
+niiri:549cbc20d7a3347bd507c93a62cb962d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0012" ;
+    nidm_coordinateVector: "[46,6,28]"^^xsd:string .
+
+niiri:7f38de5b18de7d50cf6bbab3de7ed61d prov:wasDerivedFrom niiri:2260abfbc92b3918f8c4e115273811bc .
+
+niiri:737d6891167edd5697898729334b6f23
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0013" ;
+    prov:atLocation niiri:d13e6a0e17e641c4dd7a920619e27556 ;
+    prov:value "5.89265918731689"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.04200617451887"^^xsd:float ;
+    nidm_pValueUncorrected: "2.64979184040337e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.95205805171536"^^xsd:float ;
+    nidm_qValueFDR: "0.00357309996201585"^^xsd:float .
+
+niiri:d13e6a0e17e641c4dd7a920619e27556
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0013" ;
+    nidm_coordinateVector: "[52,12,26]"^^xsd:string .
+
+niiri:737d6891167edd5697898729334b6f23 prov:wasDerivedFrom niiri:2260abfbc92b3918f8c4e115273811bc .
+
+niiri:7fb07c54f710b892820adb154f5437c2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0014" ;
+    prov:atLocation niiri:b15b1251bcf12c164abd2f8d5036175d ;
+    prov:value "5.21978235244751"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.76688098065344"^^xsd:float ;
+    nidm_pValueUncorrected: "8.26498774630924e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.998715750644301"^^xsd:float ;
+    nidm_qValueFDR: "0.00632560594393137"^^xsd:float .
+
+niiri:b15b1251bcf12c164abd2f8d5036175d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0014" ;
+    nidm_coordinateVector: "[40,-2,30]"^^xsd:string .
+
+niiri:7fb07c54f710b892820adb154f5437c2 prov:wasDerivedFrom niiri:2260abfbc92b3918f8c4e115273811bc .
+
+niiri:d196f3f4c50dd1d93b2bd4cae01fbd44
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0015" ;
+    prov:atLocation niiri:d867aea23af72afb3d824134fd7bb62e ;
+    prov:value "6.82257699966431"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.3739930910033"^^xsd:float ;
+    nidm_pValueUncorrected: "6.09971206799731e-06"^^xsd:float ;
+    nidm_pValueFWER: "0.657888162568606"^^xsd:float ;
+    nidm_qValueFDR: "0.00180198082091417"^^xsd:float .
+
+niiri:d867aea23af72afb3d824134fd7bb62e
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0015" ;
+    nidm_coordinateVector: "[-10,24,12]"^^xsd:string .
+
+niiri:d196f3f4c50dd1d93b2bd4cae01fbd44 prov:wasDerivedFrom niiri:428e3b496b74c693be37a9557e535f44 .
+
+niiri:a87c684980a741cdd7c3d90c8cbe99df
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0016" ;
+    prov:atLocation niiri:497bf13cc6e31e241c2961c960131d00 ;
+    prov:value "4.99530935287476"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.66747111912266"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000122480604349273"^^xsd:float ;
+    nidm_pValueFWER: "0.999830619862512"^^xsd:float ;
+    nidm_qValueFDR: "0.00775152511109977"^^xsd:float .
+
+niiri:497bf13cc6e31e241c2961c960131d00
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0016" ;
+    nidm_coordinateVector: "[-24,28,4]"^^xsd:string .
+
+niiri:a87c684980a741cdd7c3d90c8cbe99df prov:wasDerivedFrom niiri:428e3b496b74c693be37a9557e535f44 .
+
+niiri:f3bc13cbd3d6523a4cd20f41c8e6a115
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0017" ;
+    prov:atLocation niiri:3f00e702d729fe98e37d25e45791f4e9 ;
+    prov:value "6.34009504318237"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.20806884695295"^^xsd:float ;
+    nidm_pValueUncorrected: "1.28781200698924e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.839224226046397"^^xsd:float ;
+    nidm_qValueFDR: "0.00253613065643777"^^xsd:float .
+
+niiri:3f00e702d729fe98e37d25e45791f4e9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0017" ;
+    nidm_coordinateVector: "[10,-74,-34]"^^xsd:string .
+
+niiri:f3bc13cbd3d6523a4cd20f41c8e6a115 prov:wasDerivedFrom niiri:f2233fa4afd02fcceeb05d8f7c4801ff .
+
+niiri:65f048f0e7c5732f5773ecc174b71f67
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0018" ;
+    prov:atLocation niiri:ca3f9e37a3e82369bdea4d8f85916a5d ;
+    prov:value "5.96963739395142"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.07147450951934"^^xsd:float ;
+    nidm_pValueUncorrected: "2.3358237619564e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.938028702807278"^^xsd:float ;
+    nidm_qValueFDR: "0.00332713529017219"^^xsd:float .
+
+niiri:ca3f9e37a3e82369bdea4d8f85916a5d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0018" ;
+    nidm_coordinateVector: "[-50,2,26]"^^xsd:string .
+
+niiri:65f048f0e7c5732f5773ecc174b71f67 prov:wasDerivedFrom niiri:b1ef2839e620d66c14bd83deb3aec390 .
+
+niiri:9743d512bbbe9718ac3fa1edbe7c8695
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0019" ;
+    prov:atLocation niiri:fdded5d9c86faca9be4e46d670dd39dd ;
+    prov:value "5.75492286682129"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.98829870240338"^^xsd:float ;
+    nidm_pValueUncorrected: "3.32744188140666e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.971577838301208"^^xsd:float ;
+    nidm_qValueFDR: "0.00400598087684945"^^xsd:float .
+
+niiri:fdded5d9c86faca9be4e46d670dd39dd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0019" ;
+    nidm_coordinateVector: "[-50,-4,50]"^^xsd:string .
+
+niiri:9743d512bbbe9718ac3fa1edbe7c8695 prov:wasDerivedFrom niiri:b1ef2839e620d66c14bd83deb3aec390 .
+
+niiri:ee644a0b74bfd447b2b2b3dbc440d5f2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0020" ;
+    prov:atLocation niiri:1249869c1dfb98c3e618a1f06d22a1ea ;
+    prov:value "5.52769041061401"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.89683707514784"^^xsd:float ;
+    nidm_pValueUncorrected: "4.87285666391779e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.990314755199069"^^xsd:float ;
+    nidm_qValueFDR: "0.00479616651502499"^^xsd:float .
+
+niiri:1249869c1dfb98c3e618a1f06d22a1ea
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0020" ;
+    nidm_coordinateVector: "[-52,0,40]"^^xsd:string .
+
+niiri:ee644a0b74bfd447b2b2b3dbc440d5f2 prov:wasDerivedFrom niiri:b1ef2839e620d66c14bd83deb3aec390 .
+
+niiri:d870f02cb19a7c9c70e01dfea7cef689
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0021" ;
+    prov:atLocation niiri:cf09b331b6ecf92a4276fede122052dd ;
+    prov:value "5.91596412658691"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.05096850425873"^^xsd:float ;
+    nidm_pValueUncorrected: "2.55030367465325e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.948053549525439"^^xsd:float ;
+    nidm_qValueFDR: "0.00348881065430462"^^xsd:float .
+
+niiri:cf09b331b6ecf92a4276fede122052dd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0021" ;
+    nidm_coordinateVector: "[6,18,6]"^^xsd:string .
+
+niiri:d870f02cb19a7c9c70e01dfea7cef689 prov:wasDerivedFrom niiri:6a1143e807a7221c10cbd94b8f352cb3 .
+
+niiri:93eee431f407818d7a288b7a68d56d3b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0022" ;
+    prov:atLocation niiri:08dd0be6761b0981da82cbc6c136514c ;
+    prov:value "4.54182481765747"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.45355045258419"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000276629401356199"^^xsd:float ;
+    nidm_pValueFWER: "0.999999655761857"^^xsd:float ;
+    nidm_qValueFDR: "0.0116903072898716"^^xsd:float .
+
+niiri:08dd0be6761b0981da82cbc6c136514c
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0022" ;
+    nidm_coordinateVector: "[14,24,4]"^^xsd:string .
+
+niiri:93eee431f407818d7a288b7a68d56d3b prov:wasDerivedFrom niiri:6a1143e807a7221c10cbd94b8f352cb3 .
+
+niiri:d0dd419634f950cbbc6664604d2bfae1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0023" ;
+    prov:atLocation niiri:5073a8f82b87e9f0bec1f05cbf454d90 ;
+    prov:value "5.72671985626221"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.97714309813652"^^xsd:float ;
+    nidm_pValueUncorrected: "3.48740977119677e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.974745203823651"^^xsd:float ;
+    nidm_qValueFDR: "0.00410957672904248"^^xsd:float .
+
+niiri:5073a8f82b87e9f0bec1f05cbf454d90
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0023" ;
+    nidm_coordinateVector: "[-6,0,58]"^^xsd:string .
+
+niiri:d0dd419634f950cbbc6664604d2bfae1 prov:wasDerivedFrom niiri:17a361a6af9be1a09623d4875d9de272 .
+
+niiri:1595c393eed7051abc16cafee4ac6ae9
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0024" ;
+    prov:atLocation niiri:5f9783b56cea07afdad963e78526eb93 ;
+    prov:value "5.25150108337402"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.78060278170665"^^xsd:float ;
+    nidm_pValueUncorrected: "7.82245573558438e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.998359989376909"^^xsd:float ;
+    nidm_qValueFDR: "0.00612998059012206"^^xsd:float .
+
+niiri:5f9783b56cea07afdad963e78526eb93
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0024" ;
+    nidm_coordinateVector: "[0,6,56]"^^xsd:string .
+
+niiri:1595c393eed7051abc16cafee4ac6ae9 prov:wasDerivedFrom niiri:17a361a6af9be1a09623d4875d9de272 .
+
+niiri:cdf7c013da79b02373eb314d67b328ca
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0025" ;
+    prov:atLocation niiri:6e2c760a2125a3b04227107745989f35 ;
+    prov:value "4.54090023040771"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.45309533835059"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00027709654919561"^^xsd:float ;
+    nidm_pValueFWER: "0.99999966134203"^^xsd:float ;
+    nidm_qValueFDR: "0.0116998384744116"^^xsd:float .
+
+niiri:6e2c760a2125a3b04227107745989f35
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0025" ;
+    nidm_coordinateVector: "[-4,0,66]"^^xsd:string .
+
+niiri:cdf7c013da79b02373eb314d67b328ca prov:wasDerivedFrom niiri:17a361a6af9be1a09623d4875d9de272 .
+
+niiri:1af924931744ebf87d5aa4d7b639a169
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0026" ;
+    prov:atLocation niiri:9be6eab29ca29ed5a1bda8a4751ab3e1 ;
+    prov:value "5.37388372421265"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.83281667931374"^^xsd:float ;
+    nidm_pValueUncorrected: "6.33421799035583e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.996123053382791"^^xsd:float ;
+    nidm_qValueFDR: "0.00547832540919611"^^xsd:float .
+
+niiri:9be6eab29ca29ed5a1bda8a4751ab3e1
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0026" ;
+    nidm_coordinateVector: "[6,-12,14]"^^xsd:string .
+
+niiri:1af924931744ebf87d5aa4d7b639a169 prov:wasDerivedFrom niiri:646a3e8aac6f4eee8e8562e0616d65ba .
+
+niiri:063ac2e37579cf1830838723135ef892
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0027" ;
+    prov:atLocation niiri:17cc9a7d147c38df0908ed91f50ffed6 ;
+    prov:value "5.16269016265869"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.74198250168727"^^xsd:float ;
+    nidm_pValueUncorrected: "9.12871154093997e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.999192871962629"^^xsd:float ;
+    nidm_qValueFDR: "0.00669851286267874"^^xsd:float .
+
+niiri:17cc9a7d147c38df0908ed91f50ffed6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0027" ;
+    nidm_coordinateVector: "[36,20,4]"^^xsd:string .
+
+niiri:063ac2e37579cf1830838723135ef892 prov:wasDerivedFrom niiri:8e53fdbcd507f29fa491c0ee30766820 .
+
+niiri:0222a75a9a5232dac912eb7326478415
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0028" ;
+    prov:atLocation niiri:f59f2ef887c5f35ca37e79a29a172929 ;
+    prov:value "4.8655366897583"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.60809771461691"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000154225162826815"^^xsd:float ;
+    nidm_pValueFWER: "0.9999601230968"^^xsd:float ;
+    nidm_qValueFDR: "0.00861184257857328"^^xsd:float .
+
+niiri:f59f2ef887c5f35ca37e79a29a172929
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0028" ;
+    nidm_coordinateVector: "[30,24,0]"^^xsd:string .
+
+niiri:0222a75a9a5232dac912eb7326478415 prov:wasDerivedFrom niiri:8e53fdbcd507f29fa491c0ee30766820 .
+
+niiri:8453d293e50b367bb3a49f7533014a86
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0029" ;
+    prov:atLocation niiri:24146062d9114b1e61245629356d88ea ;
+    prov:value "5.15075159072876"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.73674319192816"^^xsd:float ;
+    nidm_pValueUncorrected: "9.3209572512909e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.999270580432391"^^xsd:float ;
+    nidm_qValueFDR: "0.00676830985421939"^^xsd:float .
+
+niiri:24146062d9114b1e61245629356d88ea
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0029" ;
+    nidm_coordinateVector: "[0,-50,-28]"^^xsd:string .
+
+niiri:8453d293e50b367bb3a49f7533014a86 prov:wasDerivedFrom niiri:caa24947392807e9fd656eb7e677bb90 .
+
+niiri:2776c7b9e158c2ca4c466f45748a27ad
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0030" ;
+    prov:atLocation niiri:5d350af686c7181e6779f8105a3c4356 ;
+    prov:value "5.12083530426025"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.7235640261549"^^xsd:float ;
+    nidm_pValueUncorrected: "9.82150082137201e-05"^^xsd:float ;
+    nidm_pValueFWER: "0.999437677420886"^^xsd:float ;
+    nidm_qValueFDR: "0.00690105743012952"^^xsd:float .
+
+niiri:5d350af686c7181e6779f8105a3c4356
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0030" ;
+    nidm_coordinateVector: "[52,10,40]"^^xsd:string .
+
+niiri:2776c7b9e158c2ca4c466f45748a27ad prov:wasDerivedFrom niiri:aa6f6ac422b272159fb670d4c6c75fe8 .
+
+niiri:36b9e15a4f579cb8b8c094d8019239d3
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0031" ;
+    prov:atLocation niiri:3cfe07192bdf278215f377f5cb477db4 ;
+    prov:value "5.10948324203491"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.71854416501836"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000100187131384155"^^xsd:float ;
+    nidm_pValueFWER: "0.999491804107717"^^xsd:float ;
+    nidm_qValueFDR: "0.00699662698174139"^^xsd:float .
+
+niiri:3cfe07192bdf278215f377f5cb477db4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0031" ;
+    nidm_coordinateVector: "[22,-14,12]"^^xsd:string .
+
+niiri:36b9e15a4f579cb8b8c094d8019239d3 prov:wasDerivedFrom niiri:62026e05a2a2355fc124787b15505315 .
+
+niiri:36d0607dbf3edae0ba7ee6f15811e9ec
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0032" ;
+    prov:atLocation niiri:43aa1b5aa2a65fcc758b9161fbb691f9 ;
+    prov:value "4.99403047561646"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.66689294332376"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00012275776099846"^^xsd:float ;
+    nidm_pValueFWER: "0.999832837977675"^^xsd:float ;
+    nidm_qValueFDR: "0.00775559440349761"^^xsd:float .
+
+niiri:43aa1b5aa2a65fcc758b9161fbb691f9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0032" ;
+    nidm_coordinateVector: "[-14,-2,-2]"^^xsd:string .
+
+niiri:36d0607dbf3edae0ba7ee6f15811e9ec prov:wasDerivedFrom niiri:93450961f0d8d0f6a3b90a5894e1f87b .
+
+niiri:9244cd1d0c66ad9346c4da15cf625887
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0033" ;
+    prov:atLocation niiri:ba4f669757b7f20b7868b405af9297ec ;
+    prov:value "4.99324655532837"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.66653846830519"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000122927974348652"^^xsd:float ;
+    nidm_pValueFWER: "0.99983418490596"^^xsd:float ;
+    nidm_qValueFDR: "0.00775759422864875"^^xsd:float .
+
+niiri:ba4f669757b7f20b7868b405af9297ec
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0033" ;
+    nidm_coordinateVector: "[8,-26,14]"^^xsd:string .
+
+niiri:9244cd1d0c66ad9346c4da15cf625887 prov:wasDerivedFrom niiri:9b5ca13a3d263c59792e6e86be4a2e34 .
+
+niiri:19366255ed63a36546b8f1ee872bddf0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0034" ;
+    prov:atLocation niiri:9082f78e97efa65c4dcb194c56ec70fd ;
+    prov:value "4.89655494689941"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.62241950165507"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000145930150219908"^^xsd:float ;
+    nidm_pValueFWER: "0.999942473649405"^^xsd:float ;
+    nidm_qValueFDR: "0.0083498973939701"^^xsd:float .
+
+niiri:9082f78e97efa65c4dcb194c56ec70fd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0034" ;
+    nidm_coordinateVector: "[14,8,72]"^^xsd:string .
+
+niiri:19366255ed63a36546b8f1ee872bddf0 prov:wasDerivedFrom niiri:bb0785359fefadd70b1adaaaac3b7884 .
+
+niiri:7f57e213d8d5aad8818c2534a203dafb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0035" ;
+    prov:atLocation niiri:14712e03d1bd30c666abef48eaba5f35 ;
+    prov:value "4.86036062240601"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.60569974829148"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000155656460372522"^^xsd:float ;
+    nidm_pValueFWER: "0.999962538559828"^^xsd:float ;
+    nidm_qValueFDR: "0.00864250020982424"^^xsd:float .
+
+niiri:14712e03d1bd30c666abef48eaba5f35
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0035" ;
+    nidm_coordinateVector: "[-24,-42,-38]"^^xsd:string .
+
+niiri:7f57e213d8d5aad8818c2534a203dafb prov:wasDerivedFrom niiri:000e7e06128006bf16d2f8dd28c288f0 .
+
+niiri:9b84b4a69aa3f9ede37b824a44d7ad2b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0036" ;
+    prov:atLocation niiri:abf6dcaaaa3aa218ffa6b3f8dd51d903 ;
+    prov:value "4.81803417205811"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.58600360944639"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00016789215592794"^^xsd:float ;
+    nidm_pValueFWER: "0.999977855811547"^^xsd:float ;
+    nidm_qValueFDR: "0.00900212220920404"^^xsd:float .
+
+niiri:abf6dcaaaa3aa218ffa6b3f8dd51d903
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0036" ;
+    nidm_coordinateVector: "[-54,30,14]"^^xsd:string .
+
+niiri:9b84b4a69aa3f9ede37b824a44d7ad2b prov:wasDerivedFrom niiri:fea4f2ec59548d5d8b403064bc42fcd3 .
+
+niiri:7f9d189889ab743749e30fd6a45392f5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0037" ;
+    prov:atLocation niiri:a2eab965b389db1da335e25f6dbc3ef3 ;
+    prov:value "4.77066373825073"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.56377460375569"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000182779942677791"^^xsd:float ;
+    nidm_pValueFWER: "0.999988096830174"^^xsd:float ;
+    nidm_qValueFDR: "0.00940067644112613"^^xsd:float .
+
+niiri:a2eab965b389db1da335e25f6dbc3ef3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0037" ;
+    nidm_coordinateVector: "[-46,30,16]"^^xsd:string .
+
+niiri:7f9d189889ab743749e30fd6a45392f5 prov:wasDerivedFrom niiri:fea4f2ec59548d5d8b403064bc42fcd3 .
+
+niiri:6c13004b183580300b78177ee70c0f04
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0038" ;
+    prov:atLocation niiri:3cad6d43185f053748a6c03d25147aac ;
+    prov:value "4.8089394569397"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.58175111371795"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00017064943193823"^^xsd:float ;
+    nidm_pValueFWER: "0.999980290560917"^^xsd:float ;
+    nidm_qValueFDR: "0.00906568438361755"^^xsd:float .
+
+niiri:3cad6d43185f053748a6c03d25147aac
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0038" ;
+    nidm_coordinateVector: "[0,-58,-38]"^^xsd:string .
+
+niiri:6c13004b183580300b78177ee70c0f04 prov:wasDerivedFrom niiri:56aff3268c9efc59ac3dd1fccbb1e940 .
+
+niiri:ca7f28f36d471bfff7d6cf2d7ec5bc5c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0039" ;
+    prov:atLocation niiri:5313dfeff4ad8a69948aefe317a1ff63 ;
+    prov:value "4.80026483535767"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.57768829524451"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000173323244094692"^^xsd:float ;
+    nidm_pValueFWER: "0.999982383849948"^^xsd:float ;
+    nidm_qValueFDR: "0.00914672501351889"^^xsd:float .
+
+niiri:5313dfeff4ad8a69948aefe317a1ff63
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0039" ;
+    nidm_coordinateVector: "[-54,12,0]"^^xsd:string .
+
+niiri:ca7f28f36d471bfff7d6cf2d7ec5bc5c prov:wasDerivedFrom niiri:30c41fd03e0e9666df9d194fbe412b52 .
+
+niiri:49ab596dceb78a958aa318a733a8e5ff
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0040" ;
+    prov:atLocation niiri:a31fc51cce93b04af96388a0f734c45f ;
+    prov:value "4.77761936187744"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.56705096724501"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000180510641497822"^^xsd:float ;
+    nidm_pValueFWER: "0.999986932005675"^^xsd:float ;
+    nidm_qValueFDR: "0.00934466092947769"^^xsd:float .
+
+niiri:a31fc51cce93b04af96388a0f734c45f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0040" ;
+    nidm_coordinateVector: "[28,2,60]"^^xsd:string .
+
+niiri:49ab596dceb78a958aa318a733a8e5ff prov:wasDerivedFrom niiri:195a3dcb7bf220b60a464a21245d4ee4 .
+
+niiri:b1871e034d8d5ec7ff867d722b86b6bb
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0041" ;
+    prov:atLocation niiri:bb7833ec8cf5f8d5f4136884a1503263 ;
+    prov:value "4.67176485061646"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.51672280482077"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000218454899154397"^^xsd:float ;
+    nidm_pValueFWER: "0.999997106974601"^^xsd:float ;
+    nidm_qValueFDR: "0.0103643846403155"^^xsd:float .
+
+niiri:bb7833ec8cf5f8d5f4136884a1503263
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0041" ;
+    nidm_coordinateVector: "[26,-4,54]"^^xsd:string .
+
+niiri:b1871e034d8d5ec7ff867d722b86b6bb prov:wasDerivedFrom niiri:195a3dcb7bf220b60a464a21245d4ee4 .
+
+niiri:c63bd3dd97f6db465634edf0fe3e6d7f
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0042" ;
+    prov:atLocation niiri:a7b543fd3444c95cdeddfd292b01c7d4 ;
+    prov:value "4.62480688095093"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.49407291194222"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000237855539300003"^^xsd:float ;
+    nidm_pValueFWER: "0.999998608516906"^^xsd:float ;
+    nidm_qValueFDR: "0.0108449863840995"^^xsd:float .
+
+niiri:a7b543fd3444c95cdeddfd292b01c7d4
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0042" ;
+    nidm_coordinateVector: "[20,-4,60]"^^xsd:string .
+
+niiri:c63bd3dd97f6db465634edf0fe3e6d7f prov:wasDerivedFrom niiri:195a3dcb7bf220b60a464a21245d4ee4 .
+
+niiri:04edadfd4de6a98b1755ebbb982ffdc5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0043" ;
+    prov:atLocation niiri:3acb438e18302dca6ecfb8f09cc3b8c2 ;
+    prov:value "4.67917585372925"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.5202791175394"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000215546442763337"^^xsd:float ;
+    nidm_pValueFWER: "0.99999676461456"^^xsd:float ;
+    nidm_qValueFDR: "0.0102906058805538"^^xsd:float .
+
+niiri:3acb438e18302dca6ecfb8f09cc3b8c2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0043" ;
+    nidm_coordinateVector: "[-34,-12,42]"^^xsd:string .
+
+niiri:04edadfd4de6a98b1755ebbb982ffdc5 prov:wasDerivedFrom niiri:d09f25e397a79ba3820081611e196ed7 .
+
+niiri:738c518c78aeab009d62d16106762ec8
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0044" ;
+    prov:atLocation niiri:34e4d39ae426eddd8106a75fdb93df16 ;
+    prov:value "4.5969614982605"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.48054638647577"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000250196083839915"^^xsd:float ;
+    nidm_pValueFWER: "0.999999115925319"^^xsd:float ;
+    nidm_qValueFDR: "0.0111238765457046"^^xsd:float .
+
+niiri:34e4d39ae426eddd8106a75fdb93df16
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0044" ;
+    nidm_coordinateVector: "[36,-40,-10]"^^xsd:string .
+
+niiri:738c518c78aeab009d62d16106762ec8 prov:wasDerivedFrom niiri:2d07cb807cba69cb83d125ad8a6d9589 .
+
+niiri:b67b4596018aff50f75474b1bc7cec26
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0045" ;
+    prov:atLocation niiri:df63022294b12ffbb4ab2b6e51db3a61 ;
+    prov:value "4.58732891082764"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.47585047258978"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000254618063707635"^^xsd:float ;
+    nidm_pValueFWER: "0.999999246946643"^^xsd:float ;
+    nidm_qValueFDR: "0.0112304749683021"^^xsd:float .
+
+niiri:df63022294b12ffbb4ab2b6e51db3a61
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0045" ;
+    nidm_coordinateVector: "[36,-10,48]"^^xsd:string .
+
+niiri:b67b4596018aff50f75474b1bc7cec26 prov:wasDerivedFrom niiri:2d69939d531eb0168273379f7ce52907 .
+
+niiri:872525eb5016723dc3c4e0b0f2f2a5c5
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0046" ;
+    prov:atLocation niiri:5dffb2412c5920c035fa3d65f898aca6 ;
+    prov:value "4.46814107894897"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.41702777537423"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000316544101057636"^^xsd:float ;
+    nidm_pValueFWER: "0.999999911601577"^^xsd:float ;
+    nidm_qValueFDR: "0.0126051231599175"^^xsd:float .
+
+niiri:5dffb2412c5920c035fa3d65f898aca6
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0046" ;
+    nidm_coordinateVector: "[-20,-38,-30]"^^xsd:string .
+
+niiri:872525eb5016723dc3c4e0b0f2f2a5c5 prov:wasDerivedFrom niiri:1c2323d93891a0ddf5ac87752d859519 .
+
+niiri:27b211c70e2f7e9bd4a55df3443c4d04
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0047" ;
+    prov:atLocation niiri:f784d0452f15f23ba0c472ca2c2957c8 ;
+    prov:value "4.46168184280396"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.41380155002305"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000320316101733442"^^xsd:float ;
+    nidm_pValueFWER: "0.999999921976257"^^xsd:float ;
+    nidm_qValueFDR: "0.0126738773801948"^^xsd:float .
+
+niiri:f784d0452f15f23ba0c472ca2c2957c8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0047" ;
+    nidm_coordinateVector: "[-12,-14,8]"^^xsd:string .
+
+niiri:27b211c70e2f7e9bd4a55df3443c4d04 prov:wasDerivedFrom niiri:dc7f564798bbb1fc05334954d8385ba1 .
+
+niiri:8bf11b8dd19ff2763b1d679fcc567bdd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0048" ;
+    prov:atLocation niiri:69636daf4c95840e35d2278cb2ddf6a2 ;
+    prov:value "4.44263553619385"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.40426513461447"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000331711624065423"^^xsd:float ;
+    nidm_pValueFWER: "0.999999946301375"^^xsd:float ;
+    nidm_qValueFDR: "0.012902019341921"^^xsd:float .
+
+niiri:69636daf4c95840e35d2278cb2ddf6a2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0048" ;
+    nidm_coordinateVector: "[-4,-28,-34]"^^xsd:string .
+
+niiri:8bf11b8dd19ff2763b1d679fcc567bdd prov:wasDerivedFrom niiri:62a9cd07b50b07a1142d53889b87fd97 .
+
+niiri:46c603d6044a9577f4f0e9b3938e4700
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0049" ;
+    prov:atLocation niiri:7f03bb810e2aa3de38abd130b42d0740 ;
+    prov:value "4.4201717376709"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.39297275478629"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00034569257259931"^^xsd:float ;
+    nidm_pValueFWER: "0.999999965808818"^^xsd:float ;
+    nidm_qValueFDR: "0.01320481591718"^^xsd:float .
+
+niiri:7f03bb810e2aa3de38abd130b42d0740
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0049" ;
+    nidm_coordinateVector: "[46,-42,54]"^^xsd:string .
+
+niiri:46c603d6044a9577f4f0e9b3938e4700 prov:wasDerivedFrom niiri:12880301a0a653ca67efd232a37a486b .
+
+niiri:2fc0e632c6c67d632d879e25c94e0526
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0050" ;
+    prov:atLocation niiri:d1793ebb335efe18e8ce493107704c93 ;
+    prov:value "4.41310739517212"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.38941149263013"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000350214079416045"^^xsd:float ;
+    nidm_pValueFWER: "0.999999970406353"^^xsd:float ;
+    nidm_qValueFDR: "0.0133062974642806"^^xsd:float .
+
+niiri:d1793ebb335efe18e8ce493107704c93
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0050" ;
+    nidm_coordinateVector: "[-6,10,-2]"^^xsd:string .
+
+niiri:2fc0e632c6c67d632d879e25c94e0526 prov:wasDerivedFrom niiri:7b940b3f554bfd8086ef06ec3a4c5e36 .
+
+niiri:edea735fc405e897d60c9a150d58fdbd
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0051" ;
+    prov:atLocation niiri:ad6a5c6e9111ff2cd4961836c59aeee8 ;
+    prov:value "4.36529922485352"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.36518306130387"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000382464451876507"^^xsd:float ;
+    nidm_pValueFWER: "0.999999989209637"^^xsd:float ;
+    nidm_qValueFDR: "0.0139415542247477"^^xsd:float .
+
+niiri:ad6a5c6e9111ff2cd4961836c59aeee8
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0051" ;
+    nidm_coordinateVector: "[42,42,30]"^^xsd:string .
+
+niiri:edea735fc405e897d60c9a150d58fdbd prov:wasDerivedFrom niiri:4364ea14ae541a4b5530d0fc11478f4d .
+
+niiri:7b7f99b7f4133520004acf23cad3c6d2
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0052" ;
+    prov:atLocation niiri:6e740b892faab2ae5c18dda6b0263f44 ;
+    prov:value "4.33874082565308"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.35162706179118"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00040169081443242"^^xsd:float ;
+    nidm_pValueFWER: "0.999999993988362"^^xsd:float ;
+    nidm_qValueFDR: "0.014354585034373"^^xsd:float .
+
+niiri:6e740b892faab2ae5c18dda6b0263f44
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0052" ;
+    nidm_coordinateVector: "[54,-38,50]"^^xsd:string .
+
+niiri:7b7f99b7f4133520004acf23cad3c6d2 prov:wasDerivedFrom niiri:cad9672114cca77d75274be4de17ab9c .
+
+niiri:6c1b3ff879fa04561531f81912615e99
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0053" ;
+    prov:atLocation niiri:376e1f563f89dca353cf7c8e7afe031d ;
+    prov:value "4.31020069122314"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.33698195919922"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000423467227465446"^^xsd:float ;
+    nidm_pValueFWER: "0.999999996857889"^^xsd:float ;
+    nidm_qValueFDR: "0.01478592692513"^^xsd:float .
+
+niiri:376e1f563f89dca353cf7c8e7afe031d
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0053" ;
+    nidm_coordinateVector: "[8,4,64]"^^xsd:string .
+
+niiri:6c1b3ff879fa04561531f81912615e99 prov:wasDerivedFrom niiri:9373fb96b8dcda6b9ae13dbf76afcaa6 .
+
+niiri:d59e59cdaec7a9b385642f94b162a141
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0054" ;
+    prov:atLocation niiri:0faea80bec78d784e33b772fec951abe ;
+    prov:value "4.30184555053711"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.33267930931343"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000430070120942982"^^xsd:float ;
+    nidm_pValueFWER: "0.999999997411931"^^xsd:float ;
+    nidm_qValueFDR: "0.0148953189902244"^^xsd:float .
+
+niiri:0faea80bec78d784e33b772fec951abe
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0054" ;
+    nidm_coordinateVector: "[-10,24,32]"^^xsd:string .
+
+niiri:d59e59cdaec7a9b385642f94b162a141 prov:wasDerivedFrom niiri:7737094062d61c5fc0d500987f11bda9 .
+
+niiri:14a69d6faff4a3b2af4d85d34b889f0b
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0055" ;
+    prov:atLocation niiri:e37bac689137c25c10888265d0e08602 ;
+    prov:value "4.27150821685791"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.31699794762384"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000454951424559202"^^xsd:float ;
+    nidm_pValueFWER: "0.999999998740386"^^xsd:float ;
+    nidm_qValueFDR: "0.0153518195589701"^^xsd:float .
+
+niiri:e37bac689137c25c10888265d0e08602
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0055" ;
+    nidm_coordinateVector: "[-14,-2,72]"^^xsd:string .
+
+niiri:14a69d6faff4a3b2af4d85d34b889f0b prov:wasDerivedFrom niiri:454d2ddee840a6eed8f9885efabde318 .
+
+niiri:7031b6f01d04b3aa346e5d15b9d75e4d
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0056" ;
+    prov:atLocation niiri:f5b1c1485206e295c6ee4401f24e8fea ;
+    prov:value "4.25738191604614"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.30966460961956"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000467039117525991"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999106929"^^xsd:float ;
+    nidm_qValueFDR: "0.0155581475175598"^^xsd:float .
+
+niiri:f5b1c1485206e295c6ee4401f24e8fea
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0056" ;
+    nidm_coordinateVector: "[56,26,26]"^^xsd:string .
+
+niiri:7031b6f01d04b3aa346e5d15b9d75e4d prov:wasDerivedFrom niiri:b2f3ddd032f5ca78054f0eca8d0c8769 .
+
+niiri:9de3e3776111574cff8aedaff0068b73
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0057" ;
+    prov:atLocation niiri:35e6921502f4efac1ec19702a6773271 ;
+    prov:value "4.23224687576294"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.29656664149817"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000489371958441343"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999522306"^^xsd:float ;
+    nidm_qValueFDR: "0.0159527943368947"^^xsd:float .
+
+niiri:35e6921502f4efac1ec19702a6773271
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0057" ;
+    nidm_coordinateVector: "[14,-30,-32]"^^xsd:string .
+
+niiri:9de3e3776111574cff8aedaff0068b73 prov:wasDerivedFrom niiri:cf4b88bff59c1a33cd867e9422f84011 .
+
+niiri:bc149e6b113081f115e5a5ea364f34d0
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0058" ;
+    prov:atLocation niiri:1f636960ef3619fc8aec226fb7543fcf ;
+    prov:value "4.21795654296875"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.28909139477101"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000502556899069861"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999667972"^^xsd:float ;
+    nidm_qValueFDR: "0.0162089652787187"^^xsd:float .
+
+niiri:1f636960ef3619fc8aec226fb7543fcf
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0058" ;
+    nidm_coordinateVector: "[46,-54,-30]"^^xsd:string .
+
+niiri:bc149e6b113081f115e5a5ea364f34d0 prov:wasDerivedFrom niiri:3283422abdc309a208995369231fe32a .
+
+niiri:2bb4c41e8f9c06be5b3747cb28574b9a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0059" ;
+    prov:atLocation niiri:22ee550046229aa65e9420876ed6f5a0 ;
+    prov:value "4.19331645965576"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.27615344058961"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000526156861805016"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999825125"^^xsd:float ;
+    nidm_qValueFDR: "0.0165459969587672"^^xsd:float .
+
+niiri:22ee550046229aa65e9420876ed6f5a0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0059" ;
+    nidm_coordinateVector: "[28,22,16]"^^xsd:string .
+
+niiri:2bb4c41e8f9c06be5b3747cb28574b9a prov:wasDerivedFrom niiri:c9c180c62d3cd262bcb7bb862a2e2d3e .
+
+niiri:7c426e29ff0188e4df4277d19017ee63
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0060" ;
+    prov:atLocation niiri:20dcc56b68ae8b6b4c9741adb0b43549 ;
+    prov:value "4.164222240448"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.26079679766555"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000555498136877608"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999919858"^^xsd:float ;
+    nidm_qValueFDR: "0.017023135244014"^^xsd:float .
+
+niiri:20dcc56b68ae8b6b4c9741adb0b43549
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0060" ;
+    nidm_coordinateVector: "[32,-46,-8]"^^xsd:string .
+
+niiri:7c426e29ff0188e4df4277d19017ee63 prov:wasDerivedFrom niiri:f67691de01cdab9987a52d4efd6796df .
+
+niiri:58b42fca78cd1d10deeed8bba2e7180a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0061" ;
+    prov:atLocation niiri:6f1505b8bbcfb75633a016754afd0dbb ;
+    prov:value "4.1354022026062"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.24549898327499"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000586224915903544"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999963932"^^xsd:float ;
+    nidm_qValueFDR: "0.0175104371158769"^^xsd:float .
+
+niiri:6f1505b8bbcfb75633a016754afd0dbb
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0061" ;
+    nidm_coordinateVector: "[12,18,32]"^^xsd:string .
+
+niiri:58b42fca78cd1d10deeed8bba2e7180a prov:wasDerivedFrom niiri:ef91e7140c5dbe4c9303f8f1e0cd8673 .
+
+niiri:360283f26ce5bb979d1d53571784870e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0062" ;
+    prov:atLocation niiri:e7f5f89929f3b52930ffb8fb16c0e839 ;
+    prov:value "4.09669637680054"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.22481821343066"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000630263410459797"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999988153"^^xsd:float ;
+    nidm_qValueFDR: "0.0182494607837458"^^xsd:float .
+
+niiri:e7f5f89929f3b52930ffb8fb16c0e839
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0062" ;
+    nidm_coordinateVector: "[6,-60,64]"^^xsd:string .
+
+niiri:360283f26ce5bb979d1d53571784870e prov:wasDerivedFrom niiri:dcd5d7321bb4d36d468ecf53edb77243 .
+
+niiri:c8fd6993b937babaf1f8c2135d3b7f1e
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0063" ;
+    prov:atLocation niiri:836a956234439c9358b6ebe000e3dcc2 ;
+    prov:value "4.06586408615112"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.20823228054844"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000667767930319307"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999995287"^^xsd:float ;
+    nidm_qValueFDR: "0.018874773548645"^^xsd:float .
+
+niiri:836a956234439c9358b6ebe000e3dcc2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0063" ;
+    nidm_coordinateVector: "[-20,-66,-32]"^^xsd:string .
+
+niiri:c8fd6993b937babaf1f8c2135d3b7f1e prov:wasDerivedFrom niiri:049381a7f67019f13a2b75b205f87af1 .
+
+niiri:ee630cfc618eede368be76300de9d971
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0064" ;
+    prov:atLocation niiri:b1b6a55493eae042a995758df3cd1afd ;
+    prov:value "4.05021715164185"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.19977690410182"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000687670008111763"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999997083"^^xsd:float ;
+    nidm_qValueFDR: "0.0191721851735585"^^xsd:float .
+
+niiri:b1b6a55493eae042a995758df3cd1afd
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0064" ;
+    nidm_coordinateVector: "[-8,-72,-24]"^^xsd:string .
+
+niiri:ee630cfc618eede368be76300de9d971 prov:wasDerivedFrom niiri:6231cdc1c30543959e82f342e7f7c028 .
+
+niiri:aaf4f8141ee78e9a09556843acd95064
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0065" ;
+    prov:atLocation niiri:d17d2fa54d9211851a0ef3ebd18a78f0 ;
+    prov:value "4.02814960479736"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.18780790473987"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000716778694212938"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999998538"^^xsd:float ;
+    nidm_qValueFDR: "0.0196630402446738"^^xsd:float .
+
+niiri:d17d2fa54d9211851a0ef3ebd18a78f0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0065" ;
+    nidm_coordinateVector: "[-26,-36,-24]"^^xsd:string .
+
+niiri:aaf4f8141ee78e9a09556843acd95064 prov:wasDerivedFrom niiri:d078d2a64b3eee365a7318a424f3d55f .
+
+niiri:122d4d1496fd61336c1b2e14c2eb7b08
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0066" ;
+    prov:atLocation niiri:e058fbd337495ddaef29dc0ea8a04073 ;
+    prov:value "4.0194239616394"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.18306102742152"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000728634479518986"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999998893"^^xsd:float ;
+    nidm_qValueFDR: "0.019829947388337"^^xsd:float .
+
+niiri:e058fbd337495ddaef29dc0ea8a04073
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0066" ;
+    nidm_coordinateVector: "[-26,6,66]"^^xsd:string .
+
+niiri:122d4d1496fd61336c1b2e14c2eb7b08 prov:wasDerivedFrom niiri:b07d53658c12f0d165aec1cf959f1eb5 .
+
+niiri:fdbadebbe5948d7060701cca85b9ec3c
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0067" ;
+    prov:atLocation niiri:bb35e3e75e4774ac32be8c7e9af072a0 ;
+    prov:value "4.01476430892944"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.18052278869165"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000735047880785378"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999046"^^xsd:float ;
+    nidm_qValueFDR: "0.0199399671265334"^^xsd:float .
+
+niiri:bb35e3e75e4774ac32be8c7e9af072a0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0067" ;
+    nidm_coordinateVector: "[-32,-6,66]"^^xsd:string .
+
+niiri:fdbadebbe5948d7060701cca85b9ec3c prov:wasDerivedFrom niiri:5e501329a485d9e81bca69bd136264fb .
+
+niiri:bac46c7751735f78e1059a5ed0f4d21a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0068" ;
+    prov:atLocation niiri:30f30dcc3a862edc1cc78ec4115bd0e9 ;
+    prov:value "4.01372337341309"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.17995544681479"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000736488485902353"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999078"^^xsd:float ;
+    nidm_qValueFDR: "0.0199550456355793"^^xsd:float .
+
+niiri:30f30dcc3a862edc1cc78ec4115bd0e9
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0068" ;
+    nidm_coordinateVector: "[56,-4,46]"^^xsd:string .
+
+niiri:bac46c7751735f78e1059a5ed0f4d21a prov:wasDerivedFrom niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097 .
+
+niiri:2bfd75fa4bfe77aa205c149b2fec102a
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0069" ;
+    prov:atLocation niiri:6c5e7793c3c3b5878682a31efb3d04b2 ;
+    prov:value "3.99763154983521"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.17117019350021"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000759130810004449"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999453"^^xsd:float ;
+    nidm_qValueFDR: "0.0202312537871442"^^xsd:float .
+
+niiri:6c5e7793c3c3b5878682a31efb3d04b2
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0069" ;
+    nidm_coordinateVector: "[10,-20,-12]"^^xsd:string .
+
+niiri:2bfd75fa4bfe77aa205c149b2fec102a prov:wasDerivedFrom niiri:f19fc244e1ad9fb88396e6dc5d62c29b .
+
+niiri:089ac9f5b2b657c00a34b4ab8eaee4d1
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0070" ;
+    prov:atLocation niiri:af1872b1d428bd30ce24b10511479e0f ;
+    prov:value "3.96427512168884"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.15287103994341"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000808366063659971"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999999982"^^xsd:float ;
+    nidm_qValueFDR: "0.0208863381686101"^^xsd:float .
+
+niiri:af1872b1d428bd30ce24b10511479e0f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0070" ;
+    nidm_coordinateVector: "[-52,20,36]"^^xsd:string .
+
+niiri:089ac9f5b2b657c00a34b4ab8eaee4d1 prov:wasDerivedFrom niiri:8a6f880f7b8eaf62148b54fef7844b09 .
+
+niiri:8cdecc19343e1178e26e45853c9023ed
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0071" ;
+    prov:atLocation niiri:77adc2dd71b080ae0c496d60454bd8e0 ;
+    prov:value "3.94705867767334"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.14337930633102"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000835046362340219"^^xsd:float ;
+    nidm_pValueFWER: "0.9999999999999"^^xsd:float ;
+    nidm_qValueFDR: "0.0212745029430363"^^xsd:float .
+
+niiri:77adc2dd71b080ae0c496d60454bd8e0
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0071" ;
+    nidm_coordinateVector: "[10,-24,-14]"^^xsd:string .
+
+niiri:8cdecc19343e1178e26e45853c9023ed prov:wasDerivedFrom niiri:de48b7494a3d45a8a57e155aeea2f132 .
+
+niiri:be6866429745ec8fceee0123965bf9be
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0072" ;
+    prov:atLocation niiri:baa063c02b5a1e3acbac348c6e7f4f8f ;
+    prov:value "3.93684697151184"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.13773425766756"^^xsd:float ;
+    nidm_pValueUncorrected: "0.00085129580940857"^^xsd:float ;
+    nidm_pValueFWER: "0.99999999999993"^^xsd:float ;
+    nidm_qValueFDR: "0.0215142897882816"^^xsd:float .
+
+niiri:baa063c02b5a1e3acbac348c6e7f4f8f
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0072" ;
+    nidm_coordinateVector: "[-32,18,-6]"^^xsd:string .
+
+niiri:be6866429745ec8fceee0123965bf9be prov:wasDerivedFrom niiri:c60f3aab1eee7d78c6850a16c38162dc .
+
+niiri:ad9707602adb5afb0acaa4237ca4f979
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0073" ;
+    prov:atLocation niiri:01154cd48f33a76a138d224c14ee2d42 ;
+    prov:value "3.93397641181946"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.13614537112983"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000855921637752388"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999937"^^xsd:float ;
+    nidm_qValueFDR: "0.0215615444445258"^^xsd:float .
+
+niiri:01154cd48f33a76a138d224c14ee2d42
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0073" ;
+    nidm_coordinateVector: "[52,10,18]"^^xsd:string .
+
+niiri:ad9707602adb5afb0acaa4237ca4f979 prov:wasDerivedFrom niiri:859e657235309e3db15ccb1f14c1e7ba .
+
+niiri:11ba1d6f38fb1b63a2f74b7601766c83
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0074" ;
+    prov:atLocation niiri:6d498f6e4c82a7d741b60a62a8092e8b ;
+    prov:value "3.92871356010437"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.13323000033267"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000864469518982003"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999947"^^xsd:float ;
+    nidm_qValueFDR: "0.0216822850176731"^^xsd:float .
+
+niiri:6d498f6e4c82a7d741b60a62a8092e8b
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0074" ;
+    nidm_coordinateVector: "[34,-52,-4]"^^xsd:string .
+
+niiri:11ba1d6f38fb1b63a2f74b7601766c83 prov:wasDerivedFrom niiri:065fb1288e613aa1089a803ba4b13d87 .
+
+niiri:ed629eddf9cc975359669c19b33ac397
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0075" ;
+    prov:atLocation niiri:58e5368187096a105a3cad65343f1be3 ;
+    prov:value "3.91936802864075"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.12804559569402"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000879864400760821"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999962"^^xsd:float ;
+    nidm_qValueFDR: "0.0218781120126672"^^xsd:float .
+
+niiri:58e5368187096a105a3cad65343f1be3
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0075" ;
+    nidm_coordinateVector: "[16,-32,-34]"^^xsd:string .
+
+niiri:ed629eddf9cc975359669c19b33ac397 prov:wasDerivedFrom niiri:021e14b3f5e58d6dd1904bdbad37b113 .
+
+niiri:15eec198bb6cca7b798e1e7a4e6de3b6
+    a prov:Entity, nidm_Peak: ; 
+    rdfs:label "Peak: 0076" ;
+    prov:atLocation niiri:63bfb114a4b23a3d0d57b8802a082634 ;
+    prov:value "3.8760769367218"^^xsd:float ;
+    nidm_equivalentZStatistic: "3.1039055725094"^^xsd:float ;
+    nidm_pValueUncorrected: "0.000954921373033768"^^xsd:float ;
+    nidm_pValueFWER: "0.999999999999992"^^xsd:float ;
+    nidm_qValueFDR: "0.0229044690727897"^^xsd:float .
+
+niiri:63bfb114a4b23a3d0d57b8802a082634
+    a prov:Entity, prov:Location, nidm_Coordinate: ; 
+    rdfs:label "Coordinate: 0076" ;
+    nidm_coordinateVector: "[18,8,34]"^^xsd:string .
+
+niiri:15eec198bb6cca7b798e1e7a4e6de3b6 prov:wasDerivedFrom niiri:7fa11ca3554a75156c897f72b0a338ac .
+

--- a/spmexport/ex_spm_t_test/nidm.ttl
+++ b/spmexport/ex_spm_t_test/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:0912ef5e7651a34c983f4ed45de3d308
+niiri:d3620d9b9dba21e55b8611d04687ee57
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:b18851d58fa1ff2313b6177c4f070859
+niiri:8bc0ef5e8cf743c84980e54ca732c862
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:f0b42854b0e7b708416cf70b7c8fedd1
+niiri:776fbf4cc67a6b80aadea0237f1fcc66
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:f0b42854b0e7b708416cf70b7c8fedd1 prov:wasAssociatedWith niiri:b18851d58fa1ff2313b6177c4f070859 .
+niiri:776fbf4cc67a6b80aadea0237f1fcc66 prov:wasAssociatedWith niiri:8bc0ef5e8cf743c84980e54ca732c862 .
 
 _:blank5 a prov:Generation .
 
-niiri:0912ef5e7651a34c983f4ed45de3d308 prov:qualifiedGeneration _:blank5 .
+niiri:d3620d9b9dba21e55b8611d04687ee57 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:34:29"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:45:12"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -128,12 +128,12 @@ _:blank5 prov:atTime "2016-01-11T10:34:29"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:c51db428dc8ee9bf707d42093e3d3377
+niiri:96198474ba98869050cdd078306a74e2
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:6db7cc02a5d65d98ca2f4e6e802b59cd
+niiri:04fbe324d49c159deb6e56f717129eed
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -143,154 +143,154 @@ niiri:6db7cc02a5d65d98ca2f4e6e802b59cd
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:a322de38d0ea077b76fbeb115a3d6f03
+niiri:4e487628f2f5dadc26c514f0fc01a044
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean .
 
-niiri:1e206e0f7ca8761333a5f8c2e84dda5b
+niiri:6198b51780af8d8f54862261a6e71c82
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:32e030b2b9eb8c5f3fc532b16c3a8fa0 ;
+    dc:description niiri:9cfa77b06d7c3e52c75bd1be4b4e5064 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"mean\"]"^^xsd:string .
 
-niiri:32e030b2b9eb8c5f3fc532b16c3a8fa0
+niiri:9cfa77b06d7c3e52c75bd1be4b4e5064
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:22cef4703417a75639fda532c16cf80d
+niiri:00a2d205839a2804eac5a33befd84f81
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean .
 
-niiri:a230dbc0ad05bf076dbd69b21f01dd10
+niiri:d1485b7f2748b3d29cb54551ff2cb41f
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_OLS: .
 
-niiri:a230dbc0ad05bf076dbd69b21f01dd10 prov:wasAssociatedWith niiri:c51db428dc8ee9bf707d42093e3d3377 .
+niiri:d1485b7f2748b3d29cb54551ff2cb41f prov:wasAssociatedWith niiri:96198474ba98869050cdd078306a74e2 .
 
-niiri:a230dbc0ad05bf076dbd69b21f01dd10 prov:used niiri:1e206e0f7ca8761333a5f8c2e84dda5b .
+niiri:d1485b7f2748b3d29cb54551ff2cb41f prov:used niiri:6198b51780af8d8f54862261a6e71c82 .
 
-niiri:a230dbc0ad05bf076dbd69b21f01dd10 prov:used niiri:a322de38d0ea077b76fbeb115a3d6f03 .
+niiri:d1485b7f2748b3d29cb54551ff2cb41f prov:used niiri:4e487628f2f5dadc26c514f0fc01a044 .
 
-niiri:a230dbc0ad05bf076dbd69b21f01dd10 prov:used niiri:22cef4703417a75639fda532c16cf80d .
+niiri:d1485b7f2748b3d29cb54551ff2cb41f prov:used niiri:00a2d205839a2804eac5a33befd84f81 .
 
-niiri:be07ca5d1a4babb35995fdf04899fb32
+niiri:7d4bc018981da17a2708e9aa1d5b9adf
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:7c74c0d0b2c4f48fa050e438562326f8
+niiri:f85f2b6d3a2b40d6fa37f164cd8461f5
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e"^^xsd:string .
 
-niiri:be07ca5d1a4babb35995fdf04899fb32 prov:wasDerivedFrom niiri:7c74c0d0b2c4f48fa050e438562326f8 .
+niiri:7d4bc018981da17a2708e9aa1d5b9adf prov:wasDerivedFrom niiri:f85f2b6d3a2b40d6fa37f164cd8461f5 .
 
-niiri:be07ca5d1a4babb35995fdf04899fb32 prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
+niiri:7d4bc018981da17a2708e9aa1d5b9adf prov:wasGeneratedBy niiri:d1485b7f2748b3d29cb54551ff2cb41f .
 
-niiri:d7f6f2a0365232d977b7db0afaf9a5fb
+niiri:74d4f7b4f324a17ecdd18d2ea997d1e0
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "0.0584948938339949"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     crypto:sha512 "504d2b5e17e73690caae29eafdc0448a1d5ac6d66af811a3fcbab8eec9f904820f0610d985a6f04e8808fcd8f77def3c063bfb11df56679b0b28261cdc2856f9"^^xsd:string .
 
-niiri:d7f6f2a0365232d977b7db0afaf9a5fb prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
+niiri:74d4f7b4f324a17ecdd18d2ea997d1e0 prov:wasGeneratedBy niiri:d1485b7f2748b3d29cb54551ff2cb41f .
 
-niiri:ef79850e03bdae0e1923acf92832ca93
+niiri:828d5d9fb555db8dd16ea37e38271b14
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd .
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed .
 
-niiri:a887854143325483e34db878814c8082
+niiri:627d8cb492bf8813020a3fdf5e0d2732
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "9a22064d78683e5b5375b6d3708584d2bb24dd434f40b311f06e185e10c9492d976c35967cc2545e3d7aefa2b83f7e433c957bd8dc87c22392e334027d0b438b"^^xsd:string .
 
-niiri:ef79850e03bdae0e1923acf92832ca93 prov:wasDerivedFrom niiri:a887854143325483e34db878814c8082 .
+niiri:828d5d9fb555db8dd16ea37e38271b14 prov:wasDerivedFrom niiri:627d8cb492bf8813020a3fdf5e0d2732 .
 
-niiri:ef79850e03bdae0e1923acf92832ca93 prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
+niiri:828d5d9fb555db8dd16ea37e38271b14 prov:wasGeneratedBy niiri:d1485b7f2748b3d29cb54551ff2cb41f .
 
-niiri:4df94669c28a6f6a636b1bbaa6a0d0f7
+niiri:61634d07c3a3f501827bc58fbbe9fda1
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     crypto:sha512 "5796b765989869d8ad685aee159b41c06538552c8a91ed6cfa9dc7a334df02e91dd83703fd5d9be4a7fc8a27943157d2cf29f457aa1cf4a3d01ce813480ddaaa"^^xsd:string .
 
-niiri:db622461201dc3fe743fb5d1e2b95c19
+niiri:93393dbc324f2290abe13206c556317a
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bd6687fb4b5d5af30fa322a8b6b6df29ead2c1e0ebe8e1962c3716c2c05a23365fe0428be1d420ef8b013c4c342c0d5efe704fec31b6e956c2b4d15a630b1c98"^^xsd:string .
 
-niiri:4df94669c28a6f6a636b1bbaa6a0d0f7 prov:wasDerivedFrom niiri:db622461201dc3fe743fb5d1e2b95c19 .
+niiri:61634d07c3a3f501827bc58fbbe9fda1 prov:wasDerivedFrom niiri:93393dbc324f2290abe13206c556317a .
 
-niiri:4df94669c28a6f6a636b1bbaa6a0d0f7 prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
+niiri:61634d07c3a3f501827bc58fbbe9fda1 prov:wasGeneratedBy niiri:d1485b7f2748b3d29cb54551ff2cb41f .
 
-niiri:de9f181e681892d8a4cecf00f081b937
+niiri:5826139507aacbfc3d4d420eae1b5252
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     crypto:sha512 "7090223b1a196dba349a102d5d369808fa90203f67c9021d2113b323996c67506be3e49d5e848a4f38a6ff78038478dee1401d2a7cd9ee5e6496f3d0313c6eb6"^^xsd:string .
 
-niiri:4bc17018182371ce2299d53dda370a88
+niiri:ff2e93be5a46fc6c0206e44008773a88
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "95b2ccdef4496cd3830f817f9d8893924091b302a09c66b1581f7ee4721c618a1d95d56e509e8f1537af7ea437bc5f3fbf7f69037f13203b6c98733647911d8d"^^xsd:string .
 
-niiri:de9f181e681892d8a4cecf00f081b937 prov:wasDerivedFrom niiri:4bc17018182371ce2299d53dda370a88 .
+niiri:5826139507aacbfc3d4d420eae1b5252 prov:wasDerivedFrom niiri:ff2e93be5a46fc6c0206e44008773a88 .
 
-niiri:de9f181e681892d8a4cecf00f081b937 prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
+niiri:5826139507aacbfc3d4d420eae1b5252 prov:wasGeneratedBy niiri:d1485b7f2748b3d29cb54551ff2cb41f .
 
-niiri:6bde2d077439c82e001fb48426475a91
+niiri:1112cf8b4737fbd5c27d443eb9e8637c
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
     rdfs:label "Contrast: Con1: mr vs plain" ;
     prov:value "1"^^xsd:string .
 
-niiri:130277e2f55ac12e05a80fbef35bd105
+niiri:8d0a21cc2e9836a5ff80b0438d25714a
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:130277e2f55ac12e05a80fbef35bd105 prov:wasAssociatedWith niiri:c51db428dc8ee9bf707d42093e3d3377 .
+niiri:8d0a21cc2e9836a5ff80b0438d25714a prov:wasAssociatedWith niiri:96198474ba98869050cdd078306a74e2 .
 
-niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:be07ca5d1a4babb35995fdf04899fb32 .
+niiri:8d0a21cc2e9836a5ff80b0438d25714a prov:used niiri:7d4bc018981da17a2708e9aa1d5b9adf .
 
-niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:4df94669c28a6f6a636b1bbaa6a0d0f7 .
+niiri:8d0a21cc2e9836a5ff80b0438d25714a prov:used niiri:61634d07c3a3f501827bc58fbbe9fda1 .
 
-niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:1e206e0f7ca8761333a5f8c2e84dda5b .
+niiri:8d0a21cc2e9836a5ff80b0438d25714a prov:used niiri:6198b51780af8d8f54862261a6e71c82 .
 
-niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:6bde2d077439c82e001fb48426475a91 .
+niiri:8d0a21cc2e9836a5ff80b0438d25714a prov:used niiri:1112cf8b4737fbd5c27d443eb9e8637c .
 
-niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:ef79850e03bdae0e1923acf92832ca93 .
+niiri:8d0a21cc2e9836a5ff80b0438d25714a prov:used niiri:828d5d9fb555db8dd16ea37e38271b14 .
 
-niiri:ad092c1420d338bff2feebb61bee6605
+niiri:75a864a5bb3a9315e23f3a7d3ce2f902
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -300,124 +300,124 @@ niiri:ad092c1420d338bff2feebb61bee6605
     nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "13"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     crypto:sha512 "2eec11aca8e4898cb44b0e535e3abecde8d46ea6e5fe05bb26e2dee72769fcb985c90c0ed86b9dcaf260d502b34559700f7a3c0f944f020a4beb20042153d26f"^^xsd:string .
 
-niiri:fe88d5b09130483c026b50e13977e412
+niiri:9f7b6f46b0180335525f9631e8c420f6
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "291b6fbfe377046689fa404484c99e68b419966665af4294ca5348faf3ee9e3e4ea972ccb9c17fc697c42c58d915fda6300a540027b872eccd1403215cd2e075"^^xsd:string .
 
-niiri:ad092c1420d338bff2feebb61bee6605 prov:wasDerivedFrom niiri:fe88d5b09130483c026b50e13977e412 .
+niiri:75a864a5bb3a9315e23f3a7d3ce2f902 prov:wasDerivedFrom niiri:9f7b6f46b0180335525f9631e8c420f6 .
 
-niiri:ad092c1420d338bff2feebb61bee6605 prov:wasGeneratedBy niiri:130277e2f55ac12e05a80fbef35bd105 .
+niiri:75a864a5bb3a9315e23f3a7d3ce2f902 prov:wasGeneratedBy niiri:8d0a21cc2e9836a5ff80b0438d25714a .
 
-niiri:b3dc79d8ad2eb32d47956780781c51d6
+niiri:3706554d9a0557214a89435bbaf15c65
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: Con1: mr vs plain" ;
     nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     crypto:sha512 "d907fef7984f59a008b8963e5fb6d2386968ffcde54e31fabe7ed8b0e1a32e4410475271e4fa903e1aa6c01ef4903209fb61660bd47a5709a5c5c91bccc8b426"^^xsd:string .
 
-niiri:6941db4ab0e9730a24b012b3310d0f8a
+niiri:c2816cbcca305cfd8a2ae01ee68dfbaa
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "66e00621b81bef508ca685a72a398d532276891ec8b2abc489af8f6105099ca9a54f52697ea83360eed53387ba6bec3ae1fc7f882ca4f3c8f944ee9a15f099ba"^^xsd:string .
 
-niiri:b3dc79d8ad2eb32d47956780781c51d6 prov:wasDerivedFrom niiri:6941db4ab0e9730a24b012b3310d0f8a .
+niiri:3706554d9a0557214a89435bbaf15c65 prov:wasDerivedFrom niiri:c2816cbcca305cfd8a2ae01ee68dfbaa .
 
-niiri:b3dc79d8ad2eb32d47956780781c51d6 prov:wasGeneratedBy niiri:130277e2f55ac12e05a80fbef35bd105 .
+niiri:3706554d9a0557214a89435bbaf15c65 prov:wasGeneratedBy niiri:8d0a21cc2e9836a5ff80b0438d25714a .
 
-niiri:1ef03434814308215299edd166a251be
+niiri:d0391616d3211341e5cef588713b179b
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     crypto:sha512 "4fed4edb0da80cd11916dccc511db465d9a42101a08318ca494f751102dfed9e4ccf557dbb4eaef9d792f662864bfe3a77670a1c78dbbf144974e8866d9640f0"^^xsd:string .
 
-niiri:1ef03434814308215299edd166a251be prov:wasGeneratedBy niiri:130277e2f55ac12e05a80fbef35bd105 .
+niiri:d0391616d3211341e5cef588713b179b prov:wasGeneratedBy niiri:8d0a21cc2e9836a5ff80b0438d25714a .
 
-niiri:aa34765c622ec88209dbca1ddf40b225
+niiri:2385d9825a21ef12f87f56c0390fcf54
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500181305457"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:66fda984913d6a14877915720b65e6ca ;
-    nidm_equivalentThreshold: niiri:802a4095edf055d7da2eb939ea257d85 .
+    nidm_equivalentThreshold: niiri:d241b46d63e6a3d40e6e9c5f3ce30109 ;
+    nidm_equivalentThreshold: niiri:e007aaa3cd10e5f5fb11901a850a522f .
 
-niiri:66fda984913d6a14877915720b65e6ca
+niiri:d241b46d63e6a3d40e6e9c5f3ce30109
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.85198238341593"^^xsd:float .
 
-niiri:802a4095edf055d7da2eb939ea257d85
+niiri:e007aaa3cd10e5f5fb11901a850a522f
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:2735f4f85b2c1346a8849aa3723fed30
+niiri:1bb19ad21632cfbd79ccb1eec4d22fc1
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:511e0e85d0615cf4311996169a6e8221 ;
-    nidm_equivalentThreshold: niiri:5a25669dc1de6e55ec1edcdeb918c132 .
+    nidm_equivalentThreshold: niiri:c972ecd11cbafdfd88b65d82f1f4fb7b ;
+    nidm_equivalentThreshold: niiri:b4215c470da5f16e85576273b7f9173c .
 
-niiri:511e0e85d0615cf4311996169a6e8221
+niiri:c972ecd11cbafdfd88b65d82f1f4fb7b
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:5a25669dc1de6e55ec1edcdeb918c132
+niiri:b4215c470da5f16e85576273b7f9173c
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:1ba31b971ce92f322556ea50dd1da5aa
+niiri:408e227b2049079df41fd4de56121bf8
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:59d671f65af3f2e501782f35d0cb64e3
+niiri:77b187d9f51e36eeff7db5a09c82ef24
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:292b1e1f2538029aed5f141c52538889
+niiri:82842b70a847c053a12e2c5786adc9d0
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:292b1e1f2538029aed5f141c52538889 prov:wasAssociatedWith niiri:c51db428dc8ee9bf707d42093e3d3377 .
+niiri:82842b70a847c053a12e2c5786adc9d0 prov:wasAssociatedWith niiri:96198474ba98869050cdd078306a74e2 .
 
-niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:aa34765c622ec88209dbca1ddf40b225 .
+niiri:82842b70a847c053a12e2c5786adc9d0 prov:used niiri:2385d9825a21ef12f87f56c0390fcf54 .
 
-niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:2735f4f85b2c1346a8849aa3723fed30 .
+niiri:82842b70a847c053a12e2c5786adc9d0 prov:used niiri:1bb19ad21632cfbd79ccb1eec4d22fc1 .
 
-niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:ad092c1420d338bff2feebb61bee6605 .
+niiri:82842b70a847c053a12e2c5786adc9d0 prov:used niiri:75a864a5bb3a9315e23f3a7d3ce2f902 .
 
-niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:de9f181e681892d8a4cecf00f081b937 .
+niiri:82842b70a847c053a12e2c5786adc9d0 prov:used niiri:5826139507aacbfc3d4d420eae1b5252 .
 
-niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:be07ca5d1a4babb35995fdf04899fb32 .
+niiri:82842b70a847c053a12e2c5786adc9d0 prov:used niiri:7d4bc018981da17a2708e9aa1d5b9adf .
 
-niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:1ba31b971ce92f322556ea50dd1da5aa .
+niiri:82842b70a847c053a12e2c5786adc9d0 prov:used niiri:408e227b2049079df41fd4de56121bf8 .
 
-niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:59d671f65af3f2e501782f35d0cb64e3 .
+niiri:82842b70a847c053a12e2c5786adc9d0 prov:used niiri:77b187d9f51e36eeff7db5a09c82ef24 .
 
-niiri:e45c455fef5d8cb108c1651352a3a733
+niiri:0b0948acd1b3bc01fc2d5c02d6c0a1b4
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     nidm_searchVolumeInVoxels: "167222"^^xsd:int ;
     nidm_searchVolumeInUnits: "1337776"^^xsd:float ;
     nidm_reselSizeInVoxels: "83.1545653831017"^^xsd:float ;
@@ -434,9 +434,9 @@ niiri:e45c455fef5d8cb108c1651352a3a733
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "59"^^xsd:int ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:e45c455fef5d8cb108c1651352a3a733 prov:wasGeneratedBy niiri:292b1e1f2538029aed5f141c52538889 .
+niiri:0b0948acd1b3bc01fc2d5c02d6c0a1b4 prov:wasGeneratedBy niiri:82842b70a847c053a12e2c5786adc9d0 .
 
-niiri:b92de8901b2a05ad20e537b7d45bcded
+niiri:e9ed0af535df635441b4855cd563907f
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -444,26 +444,26 @@ niiri:b92de8901b2a05ad20e537b7d45bcded
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "57"^^xsd:int ;
     nidm_pValue: "0.000126072725041393"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:d0125669d7f73a1dd58eac955bc608c1 ;
-    nidm_hasMaximumIntensityProjection: niiri:33e32bf5515a00f9b1224cdca9d36d84 ;
-    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
+    nidm_hasClusterLabelsMap: niiri:66d5b456d84920a48a31b01750d8a432 ;
+    nidm_hasMaximumIntensityProjection: niiri:6b2c7d129b65de53efdd562da4f554eb ;
+    nidm_inCoordinateSpace: niiri:04fbe324d49c159deb6e56f717129eed ;
     crypto:sha512 "9bef1b01e85eeddf2e747ceba7ade799597c7837064cb2f65dd700a59f52a84d33bd06d9b28b57b0669461e4ff28c39b9df7e09752b27d653bc515d887e4927e"^^xsd:string .
 
-niiri:d0125669d7f73a1dd58eac955bc608c1
+niiri:66d5b456d84920a48a31b01750d8a432
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:33e32bf5515a00f9b1224cdca9d36d84
+niiri:6b2c7d129b65de53efdd562da4f554eb
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:b92de8901b2a05ad20e537b7d45bcded prov:wasGeneratedBy niiri:292b1e1f2538029aed5f141c52538889 .
+niiri:e9ed0af535df635441b4855cd563907f prov:wasGeneratedBy niiri:82842b70a847c053a12e2c5786adc9d0 .
 
-niiri:46ce368f726925043d0fdf11d3ce812c
+niiri:215cf61bffa077f54837e2f6abb74357
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "3171"^^xsd:int ;
@@ -473,9 +473,9 @@ niiri:46ce368f726925043d0fdf11d3ce812c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:46ce368f726925043d0fdf11d3ce812c prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:215cf61bffa077f54837e2f6abb74357 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:a121a3d6c11f9c710a28e61253277933
+niiri:ffb620ba0971608a9222d31cc4937dc9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "1543"^^xsd:int ;
@@ -485,9 +485,9 @@ niiri:a121a3d6c11f9c710a28e61253277933
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:a121a3d6c11f9c710a28e61253277933 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:ffb620ba0971608a9222d31cc4937dc9 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:46ae5678b67f432a5739e26d30b8b9fc
+niiri:827f9e23c57be3072b3c3434a71afc3c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "1032"^^xsd:int ;
@@ -497,9 +497,9 @@ niiri:46ae5678b67f432a5739e26d30b8b9fc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:46ae5678b67f432a5739e26d30b8b9fc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:827f9e23c57be3072b3c3434a71afc3c prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:ac8f8138199a2f60489cb1fe2bc4c070
+niiri:31f0c8a35e1f97bfc50658b184c91a4e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "70"^^xsd:int ;
@@ -509,9 +509,9 @@ niiri:ac8f8138199a2f60489cb1fe2bc4c070
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:ac8f8138199a2f60489cb1fe2bc4c070 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:31f0c8a35e1f97bfc50658b184c91a4e prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:3dfc00b52233c69b59012bb4e4590bd6
+niiri:b6d1a5338f79d387e625261c1a5fc9a7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "250"^^xsd:int ;
@@ -521,9 +521,9 @@ niiri:3dfc00b52233c69b59012bb4e4590bd6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:3dfc00b52233c69b59012bb4e4590bd6 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:b6d1a5338f79d387e625261c1a5fc9a7 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:e17a558d17c93c4d23cebfdb241952ae
+niiri:fdaeca1296f778d816f1b7c0961e6d62
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "96"^^xsd:int ;
@@ -533,9 +533,9 @@ niiri:e17a558d17c93c4d23cebfdb241952ae
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:e17a558d17c93c4d23cebfdb241952ae prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:fdaeca1296f778d816f1b7c0961e6d62 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:2ee06584880d716387a7002834742906
+niiri:6d0e6a1098242b9a42aa86b60dc1c165
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -545,9 +545,9 @@ niiri:2ee06584880d716387a7002834742906
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:2ee06584880d716387a7002834742906 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:6d0e6a1098242b9a42aa86b60dc1c165 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:0a170fb537c25a43d335a98102d35aeb
+niiri:21e31a1448c8fbeee17661915c5bfa21
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "320"^^xsd:int ;
@@ -557,9 +557,9 @@ niiri:0a170fb537c25a43d335a98102d35aeb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:0a170fb537c25a43d335a98102d35aeb prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:21e31a1448c8fbeee17661915c5bfa21 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:0b191a1bce28484b4d509f123468cafc
+niiri:432d988b9e7ab5b924110baf9a663199
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "64"^^xsd:int ;
@@ -569,9 +569,9 @@ niiri:0b191a1bce28484b4d509f123468cafc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:0b191a1bce28484b4d509f123468cafc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:432d988b9e7ab5b924110baf9a663199 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:03c0220efd2c203f65a22694082f5442
+niiri:967f3e474d0f75f9f771a026048f7938
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "161"^^xsd:int ;
@@ -581,9 +581,9 @@ niiri:03c0220efd2c203f65a22694082f5442
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:03c0220efd2c203f65a22694082f5442 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:967f3e474d0f75f9f771a026048f7938 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:847c108abc6d60c3422f305d80cbe544
+niiri:19214f2395b9d0fe87fea1042712b844
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -593,9 +593,9 @@ niiri:847c108abc6d60c3422f305d80cbe544
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:847c108abc6d60c3422f305d80cbe544 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:19214f2395b9d0fe87fea1042712b844 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:89f5194a4b0e2d5f67db04f10c0882ac
+niiri:ea4fc41e78afb758775fdca881eec44e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "71"^^xsd:int ;
@@ -605,9 +605,9 @@ niiri:89f5194a4b0e2d5f67db04f10c0882ac
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:89f5194a4b0e2d5f67db04f10c0882ac prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:ea4fc41e78afb758775fdca881eec44e prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:d97dd5148291142c057785550af3eb2d
+niiri:f07aa9c81d91e47a941582b5a886f55f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -617,9 +617,9 @@ niiri:d97dd5148291142c057785550af3eb2d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:d97dd5148291142c057785550af3eb2d prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:f07aa9c81d91e47a941582b5a886f55f prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:50d0f0b594a3407fd672472426d8a80a
+niiri:ddf14aef4dbd07683d036e006e3ca075
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -629,9 +629,9 @@ niiri:50d0f0b594a3407fd672472426d8a80a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:50d0f0b594a3407fd672472426d8a80a prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:ddf14aef4dbd07683d036e006e3ca075 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:5663af6390cbe1661580022d9cd1db76
+niiri:fa453a18169e54396c5e1d3685158f71
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -641,9 +641,9 @@ niiri:5663af6390cbe1661580022d9cd1db76
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:5663af6390cbe1661580022d9cd1db76 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:fa453a18169e54396c5e1d3685158f71 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:936e9ee0499c3d068e7444f367b65d20
+niiri:cfc18ee1d82cfc55f82dba0b483526cf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -653,9 +653,9 @@ niiri:936e9ee0499c3d068e7444f367b65d20
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:936e9ee0499c3d068e7444f367b65d20 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:cfc18ee1d82cfc55f82dba0b483526cf prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:37eed9b79d7a2993d16feb7189856a02
+niiri:96e895ca671bf9512c361332af4e5112
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -665,9 +665,9 @@ niiri:37eed9b79d7a2993d16feb7189856a02
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:37eed9b79d7a2993d16feb7189856a02 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:96e895ca671bf9512c361332af4e5112 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:9d921e2cb3a8abbe97013ee4bc904c3e
+niiri:260c691d30c80806cf5f518fece69ec2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -677,9 +677,9 @@ niiri:9d921e2cb3a8abbe97013ee4bc904c3e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:9d921e2cb3a8abbe97013ee4bc904c3e prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:260c691d30c80806cf5f518fece69ec2 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:ba889b1413156c8c9b392f582f507018
+niiri:e108cef37b66653f5877ad74ee875b20
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -689,9 +689,9 @@ niiri:ba889b1413156c8c9b392f582f507018
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:ba889b1413156c8c9b392f582f507018 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:e108cef37b66653f5877ad74ee875b20 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:51665d1fb0cfb8bda978b620ef449077
+niiri:c4022d4c96fbeee42de7e3b591fc1985
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -701,9 +701,9 @@ niiri:51665d1fb0cfb8bda978b620ef449077
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:51665d1fb0cfb8bda978b620ef449077 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:c4022d4c96fbeee42de7e3b591fc1985 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:a24fb25342ea5df100b3c9f26c07ccf7
+niiri:0bf968a5bd587c050f6fd1233760911c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -713,9 +713,9 @@ niiri:a24fb25342ea5df100b3c9f26c07ccf7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:a24fb25342ea5df100b3c9f26c07ccf7 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:0bf968a5bd587c050f6fd1233760911c prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:6b3e2550575959313eec60bd44a6b445
+niiri:c69936a9fe388c221c2512207fe7a647
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -725,9 +725,9 @@ niiri:6b3e2550575959313eec60bd44a6b445
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:6b3e2550575959313eec60bd44a6b445 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:c69936a9fe388c221c2512207fe7a647 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:92cf9681c5af88815bed46d4f69484fe
+niiri:6a73a70fccc4a55d2a2871c14348d86b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "59"^^xsd:int ;
@@ -737,9 +737,9 @@ niiri:92cf9681c5af88815bed46d4f69484fe
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:92cf9681c5af88815bed46d4f69484fe prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:6a73a70fccc4a55d2a2871c14348d86b prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:c8b8db45e94c74708104298c433fecd6
+niiri:00d620a61a740b07661ceef12972b9ca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -749,9 +749,9 @@ niiri:c8b8db45e94c74708104298c433fecd6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:c8b8db45e94c74708104298c433fecd6 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:00d620a61a740b07661ceef12972b9ca prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:e9cca2166adb51f5ec340f78e542f76f
+niiri:5e8860ba68ee4852a37847e9d3243844
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -761,9 +761,9 @@ niiri:e9cca2166adb51f5ec340f78e542f76f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:e9cca2166adb51f5ec340f78e542f76f prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:5e8860ba68ee4852a37847e9d3243844 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:4ce2f04f5e11fd9609173ed79e458866
+niiri:58aca5806af4df61d00fa77e5299f356
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -773,9 +773,9 @@ niiri:4ce2f04f5e11fd9609173ed79e458866
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:4ce2f04f5e11fd9609173ed79e458866 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:58aca5806af4df61d00fa77e5299f356 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b
+niiri:f964bc523e6702ec9bc3c985a3616110
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -785,9 +785,9 @@ niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:f964bc523e6702ec9bc3c985a3616110 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:18aa725ff182239ce52a92cec8c831fe
+niiri:f628a53c50b9d4110abc982b7e3ea4b8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -797,9 +797,9 @@ niiri:18aa725ff182239ce52a92cec8c831fe
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:18aa725ff182239ce52a92cec8c831fe prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:f628a53c50b9d4110abc982b7e3ea4b8 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:7cf7dba6eb11ba3d163885cbe5c660cd
+niiri:ce1ba8634c321921e4a4aaa4b9eb59d6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -809,9 +809,9 @@ niiri:7cf7dba6eb11ba3d163885cbe5c660cd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:7cf7dba6eb11ba3d163885cbe5c660cd prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:ce1ba8634c321921e4a4aaa4b9eb59d6 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:f2aa94f4ac2fd9ce977533852312353d
+niiri:49fb64dfbc518d7a1856ea507a08539e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -821,9 +821,9 @@ niiri:f2aa94f4ac2fd9ce977533852312353d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:f2aa94f4ac2fd9ce977533852312353d prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:49fb64dfbc518d7a1856ea507a08539e prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:b9d2c5e57e73184c133167c21e549e31
+niiri:491b37db8347bcb337cac114d7c28332
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -833,9 +833,9 @@ niiri:b9d2c5e57e73184c133167c21e549e31
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:b9d2c5e57e73184c133167c21e549e31 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:491b37db8347bcb337cac114d7c28332 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:0fff44688bc869513d097e59a8311b54
+niiri:2285d72bdbca74c3ffd05a878b326441
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -845,9 +845,9 @@ niiri:0fff44688bc869513d097e59a8311b54
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:0fff44688bc869513d097e59a8311b54 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:2285d72bdbca74c3ffd05a878b326441 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:6b373e69fdc37c9c1e68cb0b96d5160c
+niiri:0caba67a7c80988ff6802b01d2bd2008
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -857,9 +857,9 @@ niiri:6b373e69fdc37c9c1e68cb0b96d5160c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:6b373e69fdc37c9c1e68cb0b96d5160c prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:0caba67a7c80988ff6802b01d2bd2008 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:739e3f4c274d5eac94fb06c09bd419a0
+niiri:fa32ab50c48787013e9f7686116ae370
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -869,9 +869,9 @@ niiri:739e3f4c274d5eac94fb06c09bd419a0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:739e3f4c274d5eac94fb06c09bd419a0 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:fa32ab50c48787013e9f7686116ae370 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:bf0f6f227a5f1dede37450defacf4ee4
+niiri:fd6e415702cd4c776cd6424ad207625b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -881,9 +881,9 @@ niiri:bf0f6f227a5f1dede37450defacf4ee4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:bf0f6f227a5f1dede37450defacf4ee4 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:fd6e415702cd4c776cd6424ad207625b prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:27828afab99d35c7e234991a120cb219
+niiri:1d0df51c88ee8bc083b5d2008437074e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -893,9 +893,9 @@ niiri:27828afab99d35c7e234991a120cb219
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:27828afab99d35c7e234991a120cb219 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:1d0df51c88ee8bc083b5d2008437074e prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:61fab5ab040124b4935fd160bc4c75c2
+niiri:5c3fa5d9240ba93377acc27266386ab6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -905,9 +905,9 @@ niiri:61fab5ab040124b4935fd160bc4c75c2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:61fab5ab040124b4935fd160bc4c75c2 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:5c3fa5d9240ba93377acc27266386ab6 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:3e195e76e0011bcbca16974bc51df875
+niiri:3b1453b375b54b291f7345abbe23ea62
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -917,9 +917,9 @@ niiri:3e195e76e0011bcbca16974bc51df875
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:3e195e76e0011bcbca16974bc51df875 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:3b1453b375b54b291f7345abbe23ea62 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:efb3b3e5edd63741aa95f90f1a73c855
+niiri:2ce833531fec9f54b7fd4cabb582abb4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -929,9 +929,9 @@ niiri:efb3b3e5edd63741aa95f90f1a73c855
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:efb3b3e5edd63741aa95f90f1a73c855 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:2ce833531fec9f54b7fd4cabb582abb4 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:e3b33814b86cd485564e0a0928f90e0f
+niiri:4e8a04cb57e27c1354da0f9221cefad4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -941,9 +941,9 @@ niiri:e3b33814b86cd485564e0a0928f90e0f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:e3b33814b86cd485564e0a0928f90e0f prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:4e8a04cb57e27c1354da0f9221cefad4 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:cfdf88b2a941aeba3fcc1f4b45b10448
+niiri:a5bc72d93b1628741579fb91fca4ac04
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -953,9 +953,9 @@ niiri:cfdf88b2a941aeba3fcc1f4b45b10448
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:cfdf88b2a941aeba3fcc1f4b45b10448 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:a5bc72d93b1628741579fb91fca4ac04 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:8053ffdd2903523517c32abc5eed6805
+niiri:67829b13c9a254ab8e5e036dfe81f295
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -965,9 +965,9 @@ niiri:8053ffdd2903523517c32abc5eed6805
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:8053ffdd2903523517c32abc5eed6805 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:67829b13c9a254ab8e5e036dfe81f295 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:be2669b1217c5497ae7583e9f37e889f
+niiri:c7ba4fe69a7060d041b8a1bd8e9abeb1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -977,9 +977,9 @@ niiri:be2669b1217c5497ae7583e9f37e889f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:be2669b1217c5497ae7583e9f37e889f prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:c7ba4fe69a7060d041b8a1bd8e9abeb1 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:345d8154c25e6bc91b83c7a570393c32
+niiri:d5ee6f1a9ca6bdd4f96fd93bea1b27d0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -989,9 +989,9 @@ niiri:345d8154c25e6bc91b83c7a570393c32
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:345d8154c25e6bc91b83c7a570393c32 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:d5ee6f1a9ca6bdd4f96fd93bea1b27d0 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:0feb21dbaab7759d1a095b10570dbcbb
+niiri:33b6b88c9f8662328644ad657a54d41f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1001,9 +1001,9 @@ niiri:0feb21dbaab7759d1a095b10570dbcbb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:0feb21dbaab7759d1a095b10570dbcbb prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:33b6b88c9f8662328644ad657a54d41f prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:4867e698cc576f0b80c177fdf37912bc
+niiri:5f796a80c868cc4e07db3893075e2ab5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1013,9 +1013,9 @@ niiri:4867e698cc576f0b80c177fdf37912bc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:4867e698cc576f0b80c177fdf37912bc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:5f796a80c868cc4e07db3893075e2ab5 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:dbd7ff1039cc058a9180d3a6b19c0d65
+niiri:66c5c4f7aab02ec57f99c4903c0d0d24
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1025,9 +1025,9 @@ niiri:dbd7ff1039cc058a9180d3a6b19c0d65
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:dbd7ff1039cc058a9180d3a6b19c0d65 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:66c5c4f7aab02ec57f99c4903c0d0d24 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:9a04edbbfec2046f6e63a9808f7e31be
+niiri:dd22a79353aa6df10199cb87a8c73432
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1037,9 +1037,9 @@ niiri:9a04edbbfec2046f6e63a9808f7e31be
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:9a04edbbfec2046f6e63a9808f7e31be prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:dd22a79353aa6df10199cb87a8c73432 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:4802981400c706074d7089aa4f606c7a
+niiri:620e2ba10d624da22f1d1ffc75882c40
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1049,9 +1049,9 @@ niiri:4802981400c706074d7089aa4f606c7a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:4802981400c706074d7089aa4f606c7a prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:620e2ba10d624da22f1d1ffc75882c40 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:0c9c1006b093a8cc91c759baf58575ee
+niiri:528d2a201077a9f036630cf90c25a2e4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1061,9 +1061,9 @@ niiri:0c9c1006b093a8cc91c759baf58575ee
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:0c9c1006b093a8cc91c759baf58575ee prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:528d2a201077a9f036630cf90c25a2e4 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:9e9eebffba744c379bca54d713a85d3b
+niiri:b6a501a185ba123c5d8ae0428a609570
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1073,9 +1073,9 @@ niiri:9e9eebffba744c379bca54d713a85d3b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:9e9eebffba744c379bca54d713a85d3b prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:b6a501a185ba123c5d8ae0428a609570 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:2ef2320c7a264cf13420c161d25ff5cc
+niiri:ac078cd746e0c0e589efde6d868f9503
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1085,9 +1085,9 @@ niiri:2ef2320c7a264cf13420c161d25ff5cc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:2ef2320c7a264cf13420c161d25ff5cc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:ac078cd746e0c0e589efde6d868f9503 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:53b5e166978251c052e00c9a4fe81fdc
+niiri:67a0a2929818d60014e2d343e4dd0e9f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1097,9 +1097,9 @@ niiri:53b5e166978251c052e00c9a4fe81fdc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:53b5e166978251c052e00c9a4fe81fdc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:67a0a2929818d60014e2d343e4dd0e9f prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:de88c64838ddf5de0155dcdce61cf6c0
+niiri:48c77f140153e04f3768726af76bae9b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1109,9 +1109,9 @@ niiri:de88c64838ddf5de0155dcdce61cf6c0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:de88c64838ddf5de0155dcdce61cf6c0 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:48c77f140153e04f3768726af76bae9b prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:02344c7a7b0c9af7c25dbcd3cbd09300
+niiri:8d5fab1550256921e7e64a7712e48bae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1121,9 +1121,9 @@ niiri:02344c7a7b0c9af7c25dbcd3cbd09300
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:02344c7a7b0c9af7c25dbcd3cbd09300 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:8d5fab1550256921e7e64a7712e48bae prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:22648332b0e4fb9a38556afd35646c42
+niiri:9302cebb2f2f594519eb7868350332d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1133,9 +1133,9 @@ niiri:22648332b0e4fb9a38556afd35646c42
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:22648332b0e4fb9a38556afd35646c42 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:9302cebb2f2f594519eb7868350332d5 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:3b46a57f86b33c173fe10a245389f4ff
+niiri:96084c5a0a8645a35c364d23198e7b84
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1145,1297 +1145,1297 @@ niiri:3b46a57f86b33c173fe10a245389f4ff
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:3b46a57f86b33c173fe10a245389f4ff prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
+niiri:96084c5a0a8645a35c364d23198e7b84 prov:wasDerivedFrom niiri:e9ed0af535df635441b4855cd563907f .
 
-niiri:bbac0b57ed4deddd70eb50803fb36999
+niiri:421f593cb8cdeb245041c97e2272fe53
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:253372e924e130c4a5343ebb6faf24b0 ;
+    prov:atLocation niiri:a345f9d98fa0a27293de7a6a7d8b9f1a ;
     prov:value "13.6061105728149"^^xsd:float ;
     nidm_equivalentZStatistic: "5.86214047392852"^^xsd:float ;
     nidm_pValueUncorrected: "2.28469099194939e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000382050559925018"^^xsd:float ;
     nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
 
-niiri:253372e924e130c4a5343ebb6faf24b0
+niiri:a345f9d98fa0a27293de7a6a7d8b9f1a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[34,-86,0]"^^xsd:string .
 
-niiri:bbac0b57ed4deddd70eb50803fb36999 prov:wasDerivedFrom niiri:46ce368f726925043d0fdf11d3ce812c .
+niiri:421f593cb8cdeb245041c97e2272fe53 prov:wasDerivedFrom niiri:215cf61bffa077f54837e2f6abb74357 .
 
-niiri:1c9824886d035515f910ce93f1becb24
+niiri:9b185bcb23e4c9275a21cfad622f9e0f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:6560dc3c0cedd518d2e9c8d22200d849 ;
+    prov:atLocation niiri:c4de60cedb7def5d2895d25b10d9bc09 ;
     prov:value "11.9614944458008"^^xsd:float ;
     nidm_equivalentZStatistic: "5.59772141079875"^^xsd:float ;
     nidm_pValueUncorrected: "1.08593692926817e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00181592543329545"^^xsd:float ;
     nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
 
-niiri:6560dc3c0cedd518d2e9c8d22200d849
+niiri:c4de60cedb7def5d2895d25b10d9bc09
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[30,-78,36]"^^xsd:string .
 
-niiri:1c9824886d035515f910ce93f1becb24 prov:wasDerivedFrom niiri:46ce368f726925043d0fdf11d3ce812c .
+niiri:9b185bcb23e4c9275a21cfad622f9e0f prov:wasDerivedFrom niiri:215cf61bffa077f54837e2f6abb74357 .
 
-niiri:64b80549819f8dfbe67bba4d26272007
+niiri:71bd49b63bf9414c7519bf64bd7f26f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:bf5b57a2467e79a41847b729706bb7f7 ;
+    prov:atLocation niiri:ce211af06478f3ae4508614668309311 ;
     prov:value "10.5961866378784"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34279531222125"^^xsd:float ;
     nidm_pValueUncorrected: "4.5762046707587e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00765242110449371"^^xsd:float ;
     nidm_qValueFDR: "0.000248881974141536"^^xsd:float .
 
-niiri:bf5b57a2467e79a41847b729706bb7f7
+niiri:ce211af06478f3ae4508614668309311
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[34,-48,44]"^^xsd:string .
 
-niiri:64b80549819f8dfbe67bba4d26272007 prov:wasDerivedFrom niiri:46ce368f726925043d0fdf11d3ce812c .
+niiri:71bd49b63bf9414c7519bf64bd7f26f7 prov:wasDerivedFrom niiri:215cf61bffa077f54837e2f6abb74357 .
 
-niiri:4d0e94437b61697668b47fdb1b75b33c
+niiri:840c8d55fde200dab5895ef707a336cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:53107adcc0ef1666a9861e881bf02340 ;
+    prov:atLocation niiri:06c6799120741194d5241c872733bb29 ;
     prov:value "11.9789819717407"^^xsd:float ;
     nidm_equivalentZStatistic: "5.6007582829493"^^xsd:float ;
     nidm_pValueUncorrected: "1.06708079039564e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00178439382075002"^^xsd:float ;
     nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
 
-niiri:53107adcc0ef1666a9861e881bf02340
+niiri:06c6799120741194d5241c872733bb29
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-46,-54,-12]"^^xsd:string .
 
-niiri:4d0e94437b61697668b47fdb1b75b33c prov:wasDerivedFrom niiri:a121a3d6c11f9c710a28e61253277933 .
+niiri:840c8d55fde200dab5895ef707a336cc prov:wasDerivedFrom niiri:ffb620ba0971608a9222d31cc4937dc9 .
 
-niiri:c72107be6be92b5977ee1b066d2ed2df
+niiri:e9a40a85d0b3e8c696a8e384fd583177
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:340954c4fec53251517830b22ef6060f ;
+    prov:atLocation niiri:ea494070725631aa09872881ecbc9a20 ;
     prov:value "11.3053674697876"^^xsd:float ;
     nidm_equivalentZStatistic: "5.47978759981232"^^xsd:float ;
     nidm_pValueUncorrected: "2.12918364050907e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00356046346733208"^^xsd:float ;
     nidm_qValueFDR: "0.000225699919390338"^^xsd:float .
 
-niiri:340954c4fec53251517830b22ef6060f
+niiri:ea494070725631aa09872881ecbc9a20
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[-48,-64,-8]"^^xsd:string .
 
-niiri:c72107be6be92b5977ee1b066d2ed2df prov:wasDerivedFrom niiri:a121a3d6c11f9c710a28e61253277933 .
+niiri:e9a40a85d0b3e8c696a8e384fd583177 prov:wasDerivedFrom niiri:ffb620ba0971608a9222d31cc4937dc9 .
 
-niiri:544ba6228591b8c8ffd1e693b78fb571
+niiri:08239743576aaf3a8a607b12797debe9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:beb47d7b86e9956408d6e84a62a2df4a ;
+    prov:atLocation niiri:30b02ec41b21c32c024c70c88eefa861 ;
     prov:value "9.59214210510254"^^xsd:float ;
     nidm_equivalentZStatistic: "5.12915279008791"^^xsd:float ;
     nidm_pValueUncorrected: "1.45524525096974e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0243349038623457"^^xsd:float ;
     nidm_qValueFDR: "0.000374773184801466"^^xsd:float .
 
-niiri:beb47d7b86e9956408d6e84a62a2df4a
+niiri:30b02ec41b21c32c024c70c88eefa861
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[-46,-72,-6]"^^xsd:string .
 
-niiri:544ba6228591b8c8ffd1e693b78fb571 prov:wasDerivedFrom niiri:a121a3d6c11f9c710a28e61253277933 .
+niiri:08239743576aaf3a8a607b12797debe9 prov:wasDerivedFrom niiri:ffb620ba0971608a9222d31cc4937dc9 .
 
-niiri:45d7b72f120c5a905c74b6ef035179d1
+niiri:d9c266a0a7d6f258146d0b2dbc92be88
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:fb524a7a97d8dc293563afed5235a273 ;
+    prov:atLocation niiri:072859c1bbe8323807123bd58f0339e5 ;
     prov:value "8.26132202148438"^^xsd:float ;
     nidm_equivalentZStatistic: "4.8021068311854"^^xsd:float ;
     nidm_pValueUncorrected: "7.85024427352177e-07"^^xsd:float ;
     nidm_pValueFWER: "0.131273406272461"^^xsd:float ;
     nidm_qValueFDR: "0.000714072820754613"^^xsd:float .
 
-niiri:fb524a7a97d8dc293563afed5235a273
+niiri:072859c1bbe8323807123bd58f0339e5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[-26,-76,32]"^^xsd:string .
 
-niiri:45d7b72f120c5a905c74b6ef035179d1 prov:wasDerivedFrom niiri:46ae5678b67f432a5739e26d30b8b9fc .
+niiri:d9c266a0a7d6f258146d0b2dbc92be88 prov:wasDerivedFrom niiri:827f9e23c57be3072b3c3434a71afc3c .
 
-niiri:750f947db3f44470b84b8a0b7262e50c
+niiri:9ff2cbaf49a1a6d0b379b7ac434e52ce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:8bc38c5d28a6e5a22576873242e357d3 ;
+    prov:atLocation niiri:f4eec5d9c1eb912c0b265c377493a799 ;
     prov:value "7.54039764404297"^^xsd:float ;
     nidm_equivalentZStatistic: "4.59887376341391"^^xsd:float ;
     nidm_pValueUncorrected: "2.12390533416151e-06"^^xsd:float ;
     nidm_pValueFWER: "0.355164074926112"^^xsd:float ;
     nidm_qValueFDR: "0.00112750499976544"^^xsd:float .
 
-niiri:8bc38c5d28a6e5a22576873242e357d3
+niiri:f4eec5d9c1eb912c0b265c377493a799
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-38,-46,44]"^^xsd:string .
 
-niiri:750f947db3f44470b84b8a0b7262e50c prov:wasDerivedFrom niiri:46ae5678b67f432a5739e26d30b8b9fc .
+niiri:9ff2cbaf49a1a6d0b379b7ac434e52ce prov:wasDerivedFrom niiri:827f9e23c57be3072b3c3434a71afc3c .
 
-niiri:89ab361e0947ad2cd7741823700a026b
+niiri:ad7761e7a8c3e26ebd7f73ba089dcb7b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:1e831d7963c01a6b5512e380dfc42b04 ;
+    prov:atLocation niiri:b3330dbc824e6962076fa07a7b039f98 ;
     prov:value "7.09534215927124"^^xsd:float ;
     nidm_equivalentZStatistic: "4.46234965259847"^^xsd:float ;
     nidm_pValueUncorrected: "4.05329024755208e-06"^^xsd:float ;
     nidm_pValueFWER: "0.550389997209789"^^xsd:float ;
     nidm_qValueFDR: "0.00152026219003999"^^xsd:float .
 
-niiri:1e831d7963c01a6b5512e380dfc42b04
+niiri:b3330dbc824e6962076fa07a7b039f98
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-24,-72,44]"^^xsd:string .
 
-niiri:89ab361e0947ad2cd7741823700a026b prov:wasDerivedFrom niiri:46ae5678b67f432a5739e26d30b8b9fc .
+niiri:ad7761e7a8c3e26ebd7f73ba089dcb7b prov:wasDerivedFrom niiri:827f9e23c57be3072b3c3434a71afc3c .
 
-niiri:04a53addf635f1622be8ce7e4b4fd46f
+niiri:7535ee52d97e0bc1c5d6bbdca3559059
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:bfc78fed76fb0cda1dc19ea85be43504 ;
+    prov:atLocation niiri:cfc19c68318aa2c092b0225c45df57a3 ;
     prov:value "7.53033494949341"^^xsd:float ;
     nidm_equivalentZStatistic: "4.59588573954922"^^xsd:float ;
     nidm_pValueUncorrected: "2.15457400010166e-06"^^xsd:float ;
     nidm_pValueFWER: "0.36029256155409"^^xsd:float ;
     nidm_qValueFDR: "0.00113656959480786"^^xsd:float .
 
-niiri:bfc78fed76fb0cda1dc19ea85be43504
+niiri:cfc19c68318aa2c092b0225c45df57a3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-20,-10,48]"^^xsd:string .
 
-niiri:04a53addf635f1622be8ce7e4b4fd46f prov:wasDerivedFrom niiri:ac8f8138199a2f60489cb1fe2bc4c070 .
+niiri:7535ee52d97e0bc1c5d6bbdca3559059 prov:wasDerivedFrom niiri:31f0c8a35e1f97bfc50658b184c91a4e .
 
-niiri:37fedcc605762daab25ba3d15823f4f6
+niiri:3b47a132eec8d65044e74c2e66e63878
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:97810d5af81d5e9362e02d4fd86a848e ;
+    prov:atLocation niiri:d95a36ee990e793e5e1773d0c063ba39 ;
     prov:value "4.24029636383057"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30076820538094"^^xsd:float ;
     nidm_pValueUncorrected: "0.000482102531686568"^^xsd:float ;
     nidm_pValueFWER: "0.999999999415186"^^xsd:float ;
     nidm_qValueFDR: "0.015845468443456"^^xsd:float .
 
-niiri:97810d5af81d5e9362e02d4fd86a848e
+niiri:d95a36ee990e793e5e1773d0c063ba39
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-26,0,56]"^^xsd:string .
 
-niiri:37fedcc605762daab25ba3d15823f4f6 prov:wasDerivedFrom niiri:ac8f8138199a2f60489cb1fe2bc4c070 .
+niiri:3b47a132eec8d65044e74c2e66e63878 prov:wasDerivedFrom niiri:31f0c8a35e1f97bfc50658b184c91a4e .
 
-niiri:4d986a80344be2abfcf5c339af16638a
+niiri:c4a3a31ba4094216ac6f6faaf6eaa0a4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:2a40d83993773c6f1e5ebc1385fd442d ;
+    prov:atLocation niiri:e6b1de5ca01719cb72bee5b149822da3 ;
     prov:value "7.17061138153076"^^xsd:float ;
     nidm_equivalentZStatistic: "4.48608583316407"^^xsd:float ;
     nidm_pValueUncorrected: "3.62717632940157e-06"^^xsd:float ;
     nidm_pValueFWER: "0.521824836713063"^^xsd:float ;
     nidm_qValueFDR: "0.00145106406730833"^^xsd:float .
 
-niiri:2a40d83993773c6f1e5ebc1385fd442d
+niiri:e6b1de5ca01719cb72bee5b149822da3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[46,6,28]"^^xsd:string .
 
-niiri:4d986a80344be2abfcf5c339af16638a prov:wasDerivedFrom niiri:3dfc00b52233c69b59012bb4e4590bd6 .
+niiri:c4a3a31ba4094216ac6f6faaf6eaa0a4 prov:wasDerivedFrom niiri:b6d1a5338f79d387e625261c1a5fc9a7 .
 
-niiri:0fc5cc3b06805b359990af6af9b7de2c
+niiri:ee43720d912cc9ffe41fe7963fb56ea9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:c348bcf295bbfcc12359afcb0fe8f75b ;
+    prov:atLocation niiri:8730ab8dbcae3f1aec1aa08761219c41 ;
     prov:value "5.89265918731689"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04200617451887"^^xsd:float ;
     nidm_pValueUncorrected: "2.64979184040337e-05"^^xsd:float ;
     nidm_pValueFWER: "0.95205805171536"^^xsd:float ;
     nidm_qValueFDR: "0.00357309996201585"^^xsd:float .
 
-niiri:c348bcf295bbfcc12359afcb0fe8f75b
+niiri:8730ab8dbcae3f1aec1aa08761219c41
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[52,12,26]"^^xsd:string .
 
-niiri:0fc5cc3b06805b359990af6af9b7de2c prov:wasDerivedFrom niiri:3dfc00b52233c69b59012bb4e4590bd6 .
+niiri:ee43720d912cc9ffe41fe7963fb56ea9 prov:wasDerivedFrom niiri:b6d1a5338f79d387e625261c1a5fc9a7 .
 
-niiri:53295d63fe3c3e2da20993fcb585d43a
+niiri:f582aebcb76bd1321b90c6c832a8868f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:7aa7d0132011ee94a14b377939be3510 ;
+    prov:atLocation niiri:96ce84fbd809926daf99d401d99c5f96 ;
     prov:value "5.21978235244751"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76688098065344"^^xsd:float ;
     nidm_pValueUncorrected: "8.26498774630924e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998715750644301"^^xsd:float ;
     nidm_qValueFDR: "0.00632560594393137"^^xsd:float .
 
-niiri:7aa7d0132011ee94a14b377939be3510
+niiri:96ce84fbd809926daf99d401d99c5f96
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[40,-2,30]"^^xsd:string .
 
-niiri:53295d63fe3c3e2da20993fcb585d43a prov:wasDerivedFrom niiri:3dfc00b52233c69b59012bb4e4590bd6 .
+niiri:f582aebcb76bd1321b90c6c832a8868f prov:wasDerivedFrom niiri:b6d1a5338f79d387e625261c1a5fc9a7 .
 
-niiri:998b270ff5f29f350d50cfa5c76e8ad7
+niiri:90598d5de141bc929d45e79385d901f3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:87d8215adb89a7807d1b78b73a28d6f1 ;
+    prov:atLocation niiri:0aa584b0d2695f75a52c71a8a081fad8 ;
     prov:value "6.82257699966431"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3739930910033"^^xsd:float ;
     nidm_pValueUncorrected: "6.09971206799731e-06"^^xsd:float ;
     nidm_pValueFWER: "0.657888162568606"^^xsd:float ;
     nidm_qValueFDR: "0.00180198082091417"^^xsd:float .
 
-niiri:87d8215adb89a7807d1b78b73a28d6f1
+niiri:0aa584b0d2695f75a52c71a8a081fad8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-10,24,12]"^^xsd:string .
 
-niiri:998b270ff5f29f350d50cfa5c76e8ad7 prov:wasDerivedFrom niiri:e17a558d17c93c4d23cebfdb241952ae .
+niiri:90598d5de141bc929d45e79385d901f3 prov:wasDerivedFrom niiri:fdaeca1296f778d816f1b7c0961e6d62 .
 
-niiri:a209c7cd2db8d53b5b130f27b9322d0f
+niiri:420d0edfe7501f55a0716fc16168f372
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:21b4eea73e16e09c4881b4a5dc18afc5 ;
+    prov:atLocation niiri:784b5d1f4ee7488128af4e70def97978 ;
     prov:value "4.99530935287476"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66747111912266"^^xsd:float ;
     nidm_pValueUncorrected: "0.000122480604349273"^^xsd:float ;
     nidm_pValueFWER: "0.999830619862512"^^xsd:float ;
     nidm_qValueFDR: "0.00775152511109977"^^xsd:float .
 
-niiri:21b4eea73e16e09c4881b4a5dc18afc5
+niiri:784b5d1f4ee7488128af4e70def97978
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-24,28,4]"^^xsd:string .
 
-niiri:a209c7cd2db8d53b5b130f27b9322d0f prov:wasDerivedFrom niiri:e17a558d17c93c4d23cebfdb241952ae .
+niiri:420d0edfe7501f55a0716fc16168f372 prov:wasDerivedFrom niiri:fdaeca1296f778d816f1b7c0961e6d62 .
 
-niiri:693ea803be290552513560b1a7fef0bf
+niiri:19f41654165c8ed7af25c33517d4ffac
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:aea6c3f2722e9910b54ddf00cebc5cee ;
+    prov:atLocation niiri:502909021cc9967281dc282aee556905 ;
     prov:value "6.34009504318237"^^xsd:float ;
     nidm_equivalentZStatistic: "4.20806884695295"^^xsd:float ;
     nidm_pValueUncorrected: "1.28781200698924e-05"^^xsd:float ;
     nidm_pValueFWER: "0.839224226046397"^^xsd:float ;
     nidm_qValueFDR: "0.00253613065643777"^^xsd:float .
 
-niiri:aea6c3f2722e9910b54ddf00cebc5cee
+niiri:502909021cc9967281dc282aee556905
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[10,-74,-34]"^^xsd:string .
 
-niiri:693ea803be290552513560b1a7fef0bf prov:wasDerivedFrom niiri:2ee06584880d716387a7002834742906 .
+niiri:19f41654165c8ed7af25c33517d4ffac prov:wasDerivedFrom niiri:6d0e6a1098242b9a42aa86b60dc1c165 .
 
-niiri:f536b5609348be9036fb10330e373e3f
+niiri:427e843d221394aa733a0491568aa8a4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:f90062339ac75c1a5a7bd5460360006e ;
+    prov:atLocation niiri:285cfa83d44ae6b580e65ad2eca354ae ;
     prov:value "5.96963739395142"^^xsd:float ;
     nidm_equivalentZStatistic: "4.07147450951934"^^xsd:float ;
     nidm_pValueUncorrected: "2.3358237619564e-05"^^xsd:float ;
     nidm_pValueFWER: "0.938028702807278"^^xsd:float ;
     nidm_qValueFDR: "0.00332713529017219"^^xsd:float .
 
-niiri:f90062339ac75c1a5a7bd5460360006e
+niiri:285cfa83d44ae6b580e65ad2eca354ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-50,2,26]"^^xsd:string .
 
-niiri:f536b5609348be9036fb10330e373e3f prov:wasDerivedFrom niiri:0a170fb537c25a43d335a98102d35aeb .
+niiri:427e843d221394aa733a0491568aa8a4 prov:wasDerivedFrom niiri:21e31a1448c8fbeee17661915c5bfa21 .
 
-niiri:44a31bb2492c4d22b1d559091f48eefa
+niiri:3b6e15c0a4729864df2fc07aec49a274
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:1da6912641096977dda7267c40fe4107 ;
+    prov:atLocation niiri:6da3f519aeeb66556b35684e9eb57dec ;
     prov:value "5.75492286682129"^^xsd:float ;
     nidm_equivalentZStatistic: "3.98829870240338"^^xsd:float ;
     nidm_pValueUncorrected: "3.32744188140666e-05"^^xsd:float ;
     nidm_pValueFWER: "0.971577838301208"^^xsd:float ;
     nidm_qValueFDR: "0.00400598087684945"^^xsd:float .
 
-niiri:1da6912641096977dda7267c40fe4107
+niiri:6da3f519aeeb66556b35684e9eb57dec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-50,-4,50]"^^xsd:string .
 
-niiri:44a31bb2492c4d22b1d559091f48eefa prov:wasDerivedFrom niiri:0a170fb537c25a43d335a98102d35aeb .
+niiri:3b6e15c0a4729864df2fc07aec49a274 prov:wasDerivedFrom niiri:21e31a1448c8fbeee17661915c5bfa21 .
 
-niiri:75cd1f4a8537e15fd6b96e3da0abf348
+niiri:32b46ebe456d694e1cf22d5d2e3dca74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:e2d566acff4bd4ebe5d3246828cbfc6d ;
+    prov:atLocation niiri:d617e777844256453a275dfa70e96389 ;
     prov:value "5.52769041061401"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89683707514784"^^xsd:float ;
     nidm_pValueUncorrected: "4.87285666391779e-05"^^xsd:float ;
     nidm_pValueFWER: "0.990314755199069"^^xsd:float ;
     nidm_qValueFDR: "0.00479616651502499"^^xsd:float .
 
-niiri:e2d566acff4bd4ebe5d3246828cbfc6d
+niiri:d617e777844256453a275dfa70e96389
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-52,0,40]"^^xsd:string .
 
-niiri:75cd1f4a8537e15fd6b96e3da0abf348 prov:wasDerivedFrom niiri:0a170fb537c25a43d335a98102d35aeb .
+niiri:32b46ebe456d694e1cf22d5d2e3dca74 prov:wasDerivedFrom niiri:21e31a1448c8fbeee17661915c5bfa21 .
 
-niiri:3575c3d4f244e7bf282358585a84906c
+niiri:43287007d57c4b33e7892b4d3b11ead3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:7b573b4dd63bc077dfe4dd6768191656 ;
+    prov:atLocation niiri:2a237b88945163b10865710700bc4d19 ;
     prov:value "5.91596412658691"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05096850425873"^^xsd:float ;
     nidm_pValueUncorrected: "2.55030367465325e-05"^^xsd:float ;
     nidm_pValueFWER: "0.948053549525439"^^xsd:float ;
     nidm_qValueFDR: "0.00348881065430462"^^xsd:float .
 
-niiri:7b573b4dd63bc077dfe4dd6768191656
+niiri:2a237b88945163b10865710700bc4d19
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[6,18,6]"^^xsd:string .
 
-niiri:3575c3d4f244e7bf282358585a84906c prov:wasDerivedFrom niiri:0b191a1bce28484b4d509f123468cafc .
+niiri:43287007d57c4b33e7892b4d3b11ead3 prov:wasDerivedFrom niiri:432d988b9e7ab5b924110baf9a663199 .
 
-niiri:4cc4b89c15af11852dd0fdf83661eab7
+niiri:78dc156d9677c8d1ef03dfd70d3cb5ff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:12ad0a85c946e3ba0ee32ec6ca9d30df ;
+    prov:atLocation niiri:65b0da4096001f7ef41395403f43cf4b ;
     prov:value "4.54182481765747"^^xsd:float ;
     nidm_equivalentZStatistic: "3.45355045258419"^^xsd:float ;
     nidm_pValueUncorrected: "0.000276629401356199"^^xsd:float ;
     nidm_pValueFWER: "0.999999655761857"^^xsd:float ;
     nidm_qValueFDR: "0.0116903072898716"^^xsd:float .
 
-niiri:12ad0a85c946e3ba0ee32ec6ca9d30df
+niiri:65b0da4096001f7ef41395403f43cf4b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[14,24,4]"^^xsd:string .
 
-niiri:4cc4b89c15af11852dd0fdf83661eab7 prov:wasDerivedFrom niiri:0b191a1bce28484b4d509f123468cafc .
+niiri:78dc156d9677c8d1ef03dfd70d3cb5ff prov:wasDerivedFrom niiri:432d988b9e7ab5b924110baf9a663199 .
 
-niiri:38d59cc816cec77fb882cd2fdd15a9bd
+niiri:c578c4d517a43cafd1400eb3eee95902
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:a2d5f7682067f7ac13c86ed08bac1fc2 ;
+    prov:atLocation niiri:1d6e51c565b598e29869232ed0ee207e ;
     prov:value "5.72671985626221"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97714309813652"^^xsd:float ;
     nidm_pValueUncorrected: "3.48740977119677e-05"^^xsd:float ;
     nidm_pValueFWER: "0.974745203823651"^^xsd:float ;
     nidm_qValueFDR: "0.00410957672904248"^^xsd:float .
 
-niiri:a2d5f7682067f7ac13c86ed08bac1fc2
+niiri:1d6e51c565b598e29869232ed0ee207e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-6,0,58]"^^xsd:string .
 
-niiri:38d59cc816cec77fb882cd2fdd15a9bd prov:wasDerivedFrom niiri:03c0220efd2c203f65a22694082f5442 .
+niiri:c578c4d517a43cafd1400eb3eee95902 prov:wasDerivedFrom niiri:967f3e474d0f75f9f771a026048f7938 .
 
-niiri:03b70a255fbe5aaeb503141abdf77e01
+niiri:6e110d4362a02c7c1e67bcc603958b28
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:b2a905dcae5e518e954d4e5ca2afbf39 ;
+    prov:atLocation niiri:6f30c6a304af2833b29db55b0038b8ff ;
     prov:value "5.25150108337402"^^xsd:float ;
     nidm_equivalentZStatistic: "3.78060278170665"^^xsd:float ;
     nidm_pValueUncorrected: "7.82245573558438e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998359989376909"^^xsd:float ;
     nidm_qValueFDR: "0.00612998059012206"^^xsd:float .
 
-niiri:b2a905dcae5e518e954d4e5ca2afbf39
+niiri:6f30c6a304af2833b29db55b0038b8ff
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[0,6,56]"^^xsd:string .
 
-niiri:03b70a255fbe5aaeb503141abdf77e01 prov:wasDerivedFrom niiri:03c0220efd2c203f65a22694082f5442 .
+niiri:6e110d4362a02c7c1e67bcc603958b28 prov:wasDerivedFrom niiri:967f3e474d0f75f9f771a026048f7938 .
 
-niiri:4157309e78d7ded58b0c0e0ead87a224
+niiri:7097efebbb7f449c17ed1b185ebc77cf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:2bd2a2878ad3f221f0ec6abeed136ca3 ;
+    prov:atLocation niiri:00a0da67991b139c7177ecf470be7614 ;
     prov:value "4.54090023040771"^^xsd:float ;
     nidm_equivalentZStatistic: "3.45309533835059"^^xsd:float ;
     nidm_pValueUncorrected: "0.00027709654919561"^^xsd:float ;
     nidm_pValueFWER: "0.99999966134203"^^xsd:float ;
     nidm_qValueFDR: "0.0116998384744116"^^xsd:float .
 
-niiri:2bd2a2878ad3f221f0ec6abeed136ca3
+niiri:00a0da67991b139c7177ecf470be7614
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[-4,0,66]"^^xsd:string .
 
-niiri:4157309e78d7ded58b0c0e0ead87a224 prov:wasDerivedFrom niiri:03c0220efd2c203f65a22694082f5442 .
+niiri:7097efebbb7f449c17ed1b185ebc77cf prov:wasDerivedFrom niiri:967f3e474d0f75f9f771a026048f7938 .
 
-niiri:f81e942c055a87ae23697653d0f9e931
+niiri:6de3cb931aee0b120e8281a4cb64f791
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:01b426c0493efdc5de3e1ee498c74e3a ;
+    prov:atLocation niiri:f50bbc2cc532f835ad13f64c1eb15677 ;
     prov:value "5.37388372421265"^^xsd:float ;
     nidm_equivalentZStatistic: "3.83281667931374"^^xsd:float ;
     nidm_pValueUncorrected: "6.33421799035583e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996123053382791"^^xsd:float ;
     nidm_qValueFDR: "0.00547832540919611"^^xsd:float .
 
-niiri:01b426c0493efdc5de3e1ee498c74e3a
+niiri:f50bbc2cc532f835ad13f64c1eb15677
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[6,-12,14]"^^xsd:string .
 
-niiri:f81e942c055a87ae23697653d0f9e931 prov:wasDerivedFrom niiri:847c108abc6d60c3422f305d80cbe544 .
+niiri:6de3cb931aee0b120e8281a4cb64f791 prov:wasDerivedFrom niiri:19214f2395b9d0fe87fea1042712b844 .
 
-niiri:558b717a6eaaf2aaa2613f2e2d87fd7e
+niiri:b7f6f27f1180315cf1515cb9f34bb7c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:0be6fd36a7a88597550e5298744761b6 ;
+    prov:atLocation niiri:9035876a57a37d707c14e73993ae4007 ;
     prov:value "5.16269016265869"^^xsd:float ;
     nidm_equivalentZStatistic: "3.74198250168727"^^xsd:float ;
     nidm_pValueUncorrected: "9.12871154093997e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999192871962629"^^xsd:float ;
     nidm_qValueFDR: "0.00669851286267874"^^xsd:float .
 
-niiri:0be6fd36a7a88597550e5298744761b6
+niiri:9035876a57a37d707c14e73993ae4007
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[36,20,4]"^^xsd:string .
 
-niiri:558b717a6eaaf2aaa2613f2e2d87fd7e prov:wasDerivedFrom niiri:89f5194a4b0e2d5f67db04f10c0882ac .
+niiri:b7f6f27f1180315cf1515cb9f34bb7c3 prov:wasDerivedFrom niiri:ea4fc41e78afb758775fdca881eec44e .
 
-niiri:3c7a990e35408ee2e2bc41f141132134
+niiri:8602b6cfc4b8e907f22eab95e94b5c29
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:efc8c79d2c3cdc3e0c280b1398a1831b ;
+    prov:atLocation niiri:e240674ea9aaa4acc7e1af662cd84b63 ;
     prov:value "4.8655366897583"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60809771461691"^^xsd:float ;
     nidm_pValueUncorrected: "0.000154225162826815"^^xsd:float ;
     nidm_pValueFWER: "0.9999601230968"^^xsd:float ;
     nidm_qValueFDR: "0.00861184257857328"^^xsd:float .
 
-niiri:efc8c79d2c3cdc3e0c280b1398a1831b
+niiri:e240674ea9aaa4acc7e1af662cd84b63
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[30,24,0]"^^xsd:string .
 
-niiri:3c7a990e35408ee2e2bc41f141132134 prov:wasDerivedFrom niiri:89f5194a4b0e2d5f67db04f10c0882ac .
+niiri:8602b6cfc4b8e907f22eab95e94b5c29 prov:wasDerivedFrom niiri:ea4fc41e78afb758775fdca881eec44e .
 
-niiri:a4c025afba5ca5234ab79d7354c091c7
+niiri:e7c7fa833df4549330d0ea6b302e5821
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:9c3802455fb925cb9f3bbd7949a49033 ;
+    prov:atLocation niiri:6cf6193795399b978fd68549664e7fc1 ;
     prov:value "5.15075159072876"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73674319192816"^^xsd:float ;
     nidm_pValueUncorrected: "9.3209572512909e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999270580432391"^^xsd:float ;
     nidm_qValueFDR: "0.00676830985421939"^^xsd:float .
 
-niiri:9c3802455fb925cb9f3bbd7949a49033
+niiri:6cf6193795399b978fd68549664e7fc1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[0,-50,-28]"^^xsd:string .
 
-niiri:a4c025afba5ca5234ab79d7354c091c7 prov:wasDerivedFrom niiri:d97dd5148291142c057785550af3eb2d .
+niiri:e7c7fa833df4549330d0ea6b302e5821 prov:wasDerivedFrom niiri:f07aa9c81d91e47a941582b5a886f55f .
 
-niiri:c132ce6a3b937fda0d16d0ee8cf1c129
+niiri:b5782e1864f16946f41675944cc33756
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:c291ec5fb390da072831c070b623bd2b ;
+    prov:atLocation niiri:2f75ebaa83c262a7bfd682fab6e19b64 ;
     prov:value "5.12083530426025"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7235640261549"^^xsd:float ;
     nidm_pValueUncorrected: "9.82150082137201e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999437677420886"^^xsd:float ;
     nidm_qValueFDR: "0.00690105743012952"^^xsd:float .
 
-niiri:c291ec5fb390da072831c070b623bd2b
+niiri:2f75ebaa83c262a7bfd682fab6e19b64
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[52,10,40]"^^xsd:string .
 
-niiri:c132ce6a3b937fda0d16d0ee8cf1c129 prov:wasDerivedFrom niiri:50d0f0b594a3407fd672472426d8a80a .
+niiri:b5782e1864f16946f41675944cc33756 prov:wasDerivedFrom niiri:ddf14aef4dbd07683d036e006e3ca075 .
 
-niiri:66f1d389f91b7542af2830f2d003e0a0
+niiri:a0b0f2ed57e69ed5093be1c70090046a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:0cffbb433a9a0d0427187a49d93a7e65 ;
+    prov:atLocation niiri:6f2bc36b4f3843b3aca8ab4d0651ef80 ;
     prov:value "5.10948324203491"^^xsd:float ;
     nidm_equivalentZStatistic: "3.71854416501836"^^xsd:float ;
     nidm_pValueUncorrected: "0.000100187131384155"^^xsd:float ;
     nidm_pValueFWER: "0.999491804107717"^^xsd:float ;
     nidm_qValueFDR: "0.00699662698174139"^^xsd:float .
 
-niiri:0cffbb433a9a0d0427187a49d93a7e65
+niiri:6f2bc36b4f3843b3aca8ab4d0651ef80
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[22,-14,12]"^^xsd:string .
 
-niiri:66f1d389f91b7542af2830f2d003e0a0 prov:wasDerivedFrom niiri:5663af6390cbe1661580022d9cd1db76 .
+niiri:a0b0f2ed57e69ed5093be1c70090046a prov:wasDerivedFrom niiri:fa453a18169e54396c5e1d3685158f71 .
 
-niiri:97841d29b10ded1b99b8ce22449c5e38
+niiri:99084e3c9f1a75a2d7316cff499e52e8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:028379c32508bb74af9ecf4bf7c28dc2 ;
+    prov:atLocation niiri:5dbf5e840e66e3f67fe5ed96259a76db ;
     prov:value "4.99403047561646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66689294332376"^^xsd:float ;
     nidm_pValueUncorrected: "0.00012275776099846"^^xsd:float ;
     nidm_pValueFWER: "0.999832837977675"^^xsd:float ;
     nidm_qValueFDR: "0.00775559440349761"^^xsd:float .
 
-niiri:028379c32508bb74af9ecf4bf7c28dc2
+niiri:5dbf5e840e66e3f67fe5ed96259a76db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-14,-2,-2]"^^xsd:string .
 
-niiri:97841d29b10ded1b99b8ce22449c5e38 prov:wasDerivedFrom niiri:936e9ee0499c3d068e7444f367b65d20 .
+niiri:99084e3c9f1a75a2d7316cff499e52e8 prov:wasDerivedFrom niiri:cfc18ee1d82cfc55f82dba0b483526cf .
 
-niiri:b6a3564f5f97cb6a6c26c428c3cf7fdd
+niiri:7ce5a086f5f94a244bfc39c0ca8cc1ce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:fb5948c52087fade7dc0a3c08e1c25b1 ;
+    prov:atLocation niiri:0d170b310ffb9d38b6f1e71fde5f3478 ;
     prov:value "4.99324655532837"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66653846830519"^^xsd:float ;
     nidm_pValueUncorrected: "0.000122927974348652"^^xsd:float ;
     nidm_pValueFWER: "0.99983418490596"^^xsd:float ;
     nidm_qValueFDR: "0.00775759422864875"^^xsd:float .
 
-niiri:fb5948c52087fade7dc0a3c08e1c25b1
+niiri:0d170b310ffb9d38b6f1e71fde5f3478
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[8,-26,14]"^^xsd:string .
 
-niiri:b6a3564f5f97cb6a6c26c428c3cf7fdd prov:wasDerivedFrom niiri:37eed9b79d7a2993d16feb7189856a02 .
+niiri:7ce5a086f5f94a244bfc39c0ca8cc1ce prov:wasDerivedFrom niiri:96e895ca671bf9512c361332af4e5112 .
 
-niiri:5323176e6096d153507b38ceb176512b
+niiri:6ac822ed2255aed59106eb0ac73f2419
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:e45c7da465b7b04138d0aa7007b2b615 ;
+    prov:atLocation niiri:a0f9bf4cfad7a1db7525f7bd3e4d24fc ;
     prov:value "4.89655494689941"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62241950165507"^^xsd:float ;
     nidm_pValueUncorrected: "0.000145930150219908"^^xsd:float ;
     nidm_pValueFWER: "0.999942473649405"^^xsd:float ;
     nidm_qValueFDR: "0.0083498973939701"^^xsd:float .
 
-niiri:e45c7da465b7b04138d0aa7007b2b615
+niiri:a0f9bf4cfad7a1db7525f7bd3e4d24fc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[14,8,72]"^^xsd:string .
 
-niiri:5323176e6096d153507b38ceb176512b prov:wasDerivedFrom niiri:9d921e2cb3a8abbe97013ee4bc904c3e .
+niiri:6ac822ed2255aed59106eb0ac73f2419 prov:wasDerivedFrom niiri:260c691d30c80806cf5f518fece69ec2 .
 
-niiri:a44a0f94f9fe2aaccb70c1503033e39b
+niiri:11147dafb82d8ded166d16fb1e1c03f5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:3303e5e553ccfb344b281bdf1fda0643 ;
+    prov:atLocation niiri:d6a02e5ea6fb5b5ca350b4e8a100e993 ;
     prov:value "4.86036062240601"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60569974829148"^^xsd:float ;
     nidm_pValueUncorrected: "0.000155656460372522"^^xsd:float ;
     nidm_pValueFWER: "0.999962538559828"^^xsd:float ;
     nidm_qValueFDR: "0.00864250020982424"^^xsd:float .
 
-niiri:3303e5e553ccfb344b281bdf1fda0643
+niiri:d6a02e5ea6fb5b5ca350b4e8a100e993
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-24,-42,-38]"^^xsd:string .
 
-niiri:a44a0f94f9fe2aaccb70c1503033e39b prov:wasDerivedFrom niiri:ba889b1413156c8c9b392f582f507018 .
+niiri:11147dafb82d8ded166d16fb1e1c03f5 prov:wasDerivedFrom niiri:e108cef37b66653f5877ad74ee875b20 .
 
-niiri:5e9f9523049af6068781e26c745db894
+niiri:c0b3b48b1a7be4b6942d241996feb925
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:af5219cdfc791f4e67e12be2e6c60fbe ;
+    prov:atLocation niiri:acff28d3e5f7b086c6ed22d8345d08d6 ;
     prov:value "4.81803417205811"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58600360944639"^^xsd:float ;
     nidm_pValueUncorrected: "0.00016789215592794"^^xsd:float ;
     nidm_pValueFWER: "0.999977855811547"^^xsd:float ;
     nidm_qValueFDR: "0.00900212220920404"^^xsd:float .
 
-niiri:af5219cdfc791f4e67e12be2e6c60fbe
+niiri:acff28d3e5f7b086c6ed22d8345d08d6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-54,30,14]"^^xsd:string .
 
-niiri:5e9f9523049af6068781e26c745db894 prov:wasDerivedFrom niiri:51665d1fb0cfb8bda978b620ef449077 .
+niiri:c0b3b48b1a7be4b6942d241996feb925 prov:wasDerivedFrom niiri:c4022d4c96fbeee42de7e3b591fc1985 .
 
-niiri:85a6db12151f29eba6c03ad052f455a9
+niiri:9ed5119cb165ae1f056c8f3bb5d52c16
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:29cb11c342497725682c33295a8a3469 ;
+    prov:atLocation niiri:3f56edb451c34de8e9076463bfe94e1e ;
     prov:value "4.77066373825073"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56377460375569"^^xsd:float ;
     nidm_pValueUncorrected: "0.000182779942677791"^^xsd:float ;
     nidm_pValueFWER: "0.999988096830174"^^xsd:float ;
     nidm_qValueFDR: "0.00940067644112613"^^xsd:float .
 
-niiri:29cb11c342497725682c33295a8a3469
+niiri:3f56edb451c34de8e9076463bfe94e1e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-46,30,16]"^^xsd:string .
 
-niiri:85a6db12151f29eba6c03ad052f455a9 prov:wasDerivedFrom niiri:51665d1fb0cfb8bda978b620ef449077 .
+niiri:9ed5119cb165ae1f056c8f3bb5d52c16 prov:wasDerivedFrom niiri:c4022d4c96fbeee42de7e3b591fc1985 .
 
-niiri:a42893da4696ee8d301da513c039bb33
+niiri:7e58d61dd3ee319247815d3795d49725
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:0d6f26980a7c82addcff37e277d37f87 ;
+    prov:atLocation niiri:7f75855b293f102ea83c5c8deda1bc1b ;
     prov:value "4.8089394569397"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58175111371795"^^xsd:float ;
     nidm_pValueUncorrected: "0.00017064943193823"^^xsd:float ;
     nidm_pValueFWER: "0.999980290560917"^^xsd:float ;
     nidm_qValueFDR: "0.00906568438361755"^^xsd:float .
 
-niiri:0d6f26980a7c82addcff37e277d37f87
+niiri:7f75855b293f102ea83c5c8deda1bc1b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[0,-58,-38]"^^xsd:string .
 
-niiri:a42893da4696ee8d301da513c039bb33 prov:wasDerivedFrom niiri:a24fb25342ea5df100b3c9f26c07ccf7 .
+niiri:7e58d61dd3ee319247815d3795d49725 prov:wasDerivedFrom niiri:0bf968a5bd587c050f6fd1233760911c .
 
-niiri:248a55c19c0892c52e726aa851cb8bdd
+niiri:e2c98702e3550c85bd24de6a0931577e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:51a0bd12c442e02fba73ae2922f15a79 ;
+    prov:atLocation niiri:0d6119474d973ff061472cad4ca69a0d ;
     prov:value "4.80026483535767"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57768829524451"^^xsd:float ;
     nidm_pValueUncorrected: "0.000173323244094692"^^xsd:float ;
     nidm_pValueFWER: "0.999982383849948"^^xsd:float ;
     nidm_qValueFDR: "0.00914672501351889"^^xsd:float .
 
-niiri:51a0bd12c442e02fba73ae2922f15a79
+niiri:0d6119474d973ff061472cad4ca69a0d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-54,12,0]"^^xsd:string .
 
-niiri:248a55c19c0892c52e726aa851cb8bdd prov:wasDerivedFrom niiri:6b3e2550575959313eec60bd44a6b445 .
+niiri:e2c98702e3550c85bd24de6a0931577e prov:wasDerivedFrom niiri:c69936a9fe388c221c2512207fe7a647 .
 
-niiri:759c0b26a71be25fa07292239859245d
+niiri:06974af04f4a80e6b7c8276e41068362
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:b56fb9e5f57ce68403a9901ac11d45a4 ;
+    prov:atLocation niiri:565ec2a35b3d862759ba3061457fea7a ;
     prov:value "4.77761936187744"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56705096724501"^^xsd:float ;
     nidm_pValueUncorrected: "0.000180510641497822"^^xsd:float ;
     nidm_pValueFWER: "0.999986932005675"^^xsd:float ;
     nidm_qValueFDR: "0.00934466092947769"^^xsd:float .
 
-niiri:b56fb9e5f57ce68403a9901ac11d45a4
+niiri:565ec2a35b3d862759ba3061457fea7a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[28,2,60]"^^xsd:string .
 
-niiri:759c0b26a71be25fa07292239859245d prov:wasDerivedFrom niiri:92cf9681c5af88815bed46d4f69484fe .
+niiri:06974af04f4a80e6b7c8276e41068362 prov:wasDerivedFrom niiri:6a73a70fccc4a55d2a2871c14348d86b .
 
-niiri:31be7f0e3a63c3b71e9774b599f0525b
+niiri:f414781bcc088d0804ea8e8a1ebf5333
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:942ddb276df261f58059a9ab77022724 ;
+    prov:atLocation niiri:c27f7b2ce793dd336a50d1abc82ca476 ;
     prov:value "4.67176485061646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51672280482077"^^xsd:float ;
     nidm_pValueUncorrected: "0.000218454899154397"^^xsd:float ;
     nidm_pValueFWER: "0.999997106974601"^^xsd:float ;
     nidm_qValueFDR: "0.0103643846403155"^^xsd:float .
 
-niiri:942ddb276df261f58059a9ab77022724
+niiri:c27f7b2ce793dd336a50d1abc82ca476
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[26,-4,54]"^^xsd:string .
 
-niiri:31be7f0e3a63c3b71e9774b599f0525b prov:wasDerivedFrom niiri:92cf9681c5af88815bed46d4f69484fe .
+niiri:f414781bcc088d0804ea8e8a1ebf5333 prov:wasDerivedFrom niiri:6a73a70fccc4a55d2a2871c14348d86b .
 
-niiri:be9f62ae29bc1bf6f51eea46b13a7a57
+niiri:73e466e9281c9f81b49a9540cafa36cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:9185d52c29fec95f3943cb1408fe38ac ;
+    prov:atLocation niiri:b50695d1e0c5772605da1b10b6da79df ;
     prov:value "4.62480688095093"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49407291194222"^^xsd:float ;
     nidm_pValueUncorrected: "0.000237855539300003"^^xsd:float ;
     nidm_pValueFWER: "0.999998608516906"^^xsd:float ;
     nidm_qValueFDR: "0.0108449863840995"^^xsd:float .
 
-niiri:9185d52c29fec95f3943cb1408fe38ac
+niiri:b50695d1e0c5772605da1b10b6da79df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[20,-4,60]"^^xsd:string .
 
-niiri:be9f62ae29bc1bf6f51eea46b13a7a57 prov:wasDerivedFrom niiri:92cf9681c5af88815bed46d4f69484fe .
+niiri:73e466e9281c9f81b49a9540cafa36cb prov:wasDerivedFrom niiri:6a73a70fccc4a55d2a2871c14348d86b .
 
-niiri:5e5d7e7b87311887d80aece0fcc725f1
+niiri:76c2415f534f669a3e125a6608ac44dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:a731413b420d2d57b872cb88cfeef28b ;
+    prov:atLocation niiri:5092f9fdd12b84035bb1ddd240a68f96 ;
     prov:value "4.67917585372925"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5202791175394"^^xsd:float ;
     nidm_pValueUncorrected: "0.000215546442763337"^^xsd:float ;
     nidm_pValueFWER: "0.99999676461456"^^xsd:float ;
     nidm_qValueFDR: "0.0102906058805538"^^xsd:float .
 
-niiri:a731413b420d2d57b872cb88cfeef28b
+niiri:5092f9fdd12b84035bb1ddd240a68f96
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-34,-12,42]"^^xsd:string .
 
-niiri:5e5d7e7b87311887d80aece0fcc725f1 prov:wasDerivedFrom niiri:c8b8db45e94c74708104298c433fecd6 .
+niiri:76c2415f534f669a3e125a6608ac44dd prov:wasDerivedFrom niiri:00d620a61a740b07661ceef12972b9ca .
 
-niiri:eda03e9ad53b2d5ffc1d87c948b5c073
+niiri:c9f2a2fdba523074d592d26285af44d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:0a64737dfbc36713dca9405841ec7e26 ;
+    prov:atLocation niiri:998edb21001f9f73707daffe362a3400 ;
     prov:value "4.5969614982605"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48054638647577"^^xsd:float ;
     nidm_pValueUncorrected: "0.000250196083839915"^^xsd:float ;
     nidm_pValueFWER: "0.999999115925319"^^xsd:float ;
     nidm_qValueFDR: "0.0111238765457046"^^xsd:float .
 
-niiri:0a64737dfbc36713dca9405841ec7e26
+niiri:998edb21001f9f73707daffe362a3400
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[36,-40,-10]"^^xsd:string .
 
-niiri:eda03e9ad53b2d5ffc1d87c948b5c073 prov:wasDerivedFrom niiri:e9cca2166adb51f5ec340f78e542f76f .
+niiri:c9f2a2fdba523074d592d26285af44d6 prov:wasDerivedFrom niiri:5e8860ba68ee4852a37847e9d3243844 .
 
-niiri:286d94947c4e1787b77f00b0b7114d06
+niiri:70f8d42ece9d45f4ccbb12de3d3820a5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:f7eff259178a3f65efdc696ad7a247a6 ;
+    prov:atLocation niiri:6257ba2cc9673f277128f9b0eda09555 ;
     prov:value "4.58732891082764"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47585047258978"^^xsd:float ;
     nidm_pValueUncorrected: "0.000254618063707635"^^xsd:float ;
     nidm_pValueFWER: "0.999999246946643"^^xsd:float ;
     nidm_qValueFDR: "0.0112304749683021"^^xsd:float .
 
-niiri:f7eff259178a3f65efdc696ad7a247a6
+niiri:6257ba2cc9673f277128f9b0eda09555
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[36,-10,48]"^^xsd:string .
 
-niiri:286d94947c4e1787b77f00b0b7114d06 prov:wasDerivedFrom niiri:4ce2f04f5e11fd9609173ed79e458866 .
+niiri:70f8d42ece9d45f4ccbb12de3d3820a5 prov:wasDerivedFrom niiri:58aca5806af4df61d00fa77e5299f356 .
 
-niiri:41f1a29b28047c513dad04890f92ea62
+niiri:61fe029e5af44525b8626e9c9cea1a64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:ca4d257e28c11e95eac69d8434cf5d21 ;
+    prov:atLocation niiri:2b9f9c31acb220cc877b9e45351fbff8 ;
     prov:value "4.46814107894897"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41702777537423"^^xsd:float ;
     nidm_pValueUncorrected: "0.000316544101057636"^^xsd:float ;
     nidm_pValueFWER: "0.999999911601577"^^xsd:float ;
     nidm_qValueFDR: "0.0126051231599175"^^xsd:float .
 
-niiri:ca4d257e28c11e95eac69d8434cf5d21
+niiri:2b9f9c31acb220cc877b9e45351fbff8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[-20,-38,-30]"^^xsd:string .
 
-niiri:41f1a29b28047c513dad04890f92ea62 prov:wasDerivedFrom niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b .
+niiri:61fe029e5af44525b8626e9c9cea1a64 prov:wasDerivedFrom niiri:f964bc523e6702ec9bc3c985a3616110 .
 
-niiri:644473757bdf4f53de672927c317f640
+niiri:6739b18096dd26074292cda4ff1306a3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:91812858ace028392052bc61b2ec057f ;
+    prov:atLocation niiri:c1b8f82e88512e697b9e6457112a5dd6 ;
     prov:value "4.46168184280396"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41380155002305"^^xsd:float ;
     nidm_pValueUncorrected: "0.000320316101733442"^^xsd:float ;
     nidm_pValueFWER: "0.999999921976257"^^xsd:float ;
     nidm_qValueFDR: "0.0126738773801948"^^xsd:float .
 
-niiri:91812858ace028392052bc61b2ec057f
+niiri:c1b8f82e88512e697b9e6457112a5dd6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-12,-14,8]"^^xsd:string .
 
-niiri:644473757bdf4f53de672927c317f640 prov:wasDerivedFrom niiri:18aa725ff182239ce52a92cec8c831fe .
+niiri:6739b18096dd26074292cda4ff1306a3 prov:wasDerivedFrom niiri:f628a53c50b9d4110abc982b7e3ea4b8 .
 
-niiri:118e5465f1cdaee5740cf125155fe7b3
+niiri:a5ed81195ab4d690b09d57db1429c96d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:3ff8424d596938b11ad96560eee5df78 ;
+    prov:atLocation niiri:60a2b827cb52843e392f7d0064a896ea ;
     prov:value "4.44263553619385"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40426513461447"^^xsd:float ;
     nidm_pValueUncorrected: "0.000331711624065423"^^xsd:float ;
     nidm_pValueFWER: "0.999999946301375"^^xsd:float ;
     nidm_qValueFDR: "0.012902019341921"^^xsd:float .
 
-niiri:3ff8424d596938b11ad96560eee5df78
+niiri:60a2b827cb52843e392f7d0064a896ea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-4,-28,-34]"^^xsd:string .
 
-niiri:118e5465f1cdaee5740cf125155fe7b3 prov:wasDerivedFrom niiri:7cf7dba6eb11ba3d163885cbe5c660cd .
+niiri:a5ed81195ab4d690b09d57db1429c96d prov:wasDerivedFrom niiri:ce1ba8634c321921e4a4aaa4b9eb59d6 .
 
-niiri:2aab067e93eed87166d2a6bcb0988f7f
+niiri:7cb44a0cd67d94500096125a646c7029
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:c035874bdf6e7d3a175e1e3e4dfd592f ;
+    prov:atLocation niiri:6a127e18d64d404adebdb0a74db21ee4 ;
     prov:value "4.4201717376709"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39297275478629"^^xsd:float ;
     nidm_pValueUncorrected: "0.00034569257259931"^^xsd:float ;
     nidm_pValueFWER: "0.999999965808818"^^xsd:float ;
     nidm_qValueFDR: "0.01320481591718"^^xsd:float .
 
-niiri:c035874bdf6e7d3a175e1e3e4dfd592f
+niiri:6a127e18d64d404adebdb0a74db21ee4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[46,-42,54]"^^xsd:string .
 
-niiri:2aab067e93eed87166d2a6bcb0988f7f prov:wasDerivedFrom niiri:f2aa94f4ac2fd9ce977533852312353d .
+niiri:7cb44a0cd67d94500096125a646c7029 prov:wasDerivedFrom niiri:49fb64dfbc518d7a1856ea507a08539e .
 
-niiri:182e9fe46ed363f9769a906bff3f1e65
+niiri:a83e3cc3a91c735a04532e9ca21e92f2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:5f08c4860ac9853a3ac9f667b9bea6f5 ;
+    prov:atLocation niiri:bceb9db36f207b97f69e84447649364e ;
     prov:value "4.41310739517212"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38941149263013"^^xsd:float ;
     nidm_pValueUncorrected: "0.000350214079416045"^^xsd:float ;
     nidm_pValueFWER: "0.999999970406353"^^xsd:float ;
     nidm_qValueFDR: "0.0133062974642806"^^xsd:float .
 
-niiri:5f08c4860ac9853a3ac9f667b9bea6f5
+niiri:bceb9db36f207b97f69e84447649364e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-6,10,-2]"^^xsd:string .
 
-niiri:182e9fe46ed363f9769a906bff3f1e65 prov:wasDerivedFrom niiri:b9d2c5e57e73184c133167c21e549e31 .
+niiri:a83e3cc3a91c735a04532e9ca21e92f2 prov:wasDerivedFrom niiri:491b37db8347bcb337cac114d7c28332 .
 
-niiri:3963967f131dd75149db4432a7e47df4
+niiri:9d26bd37ee6076edc804baf6dc4fe873
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:f6bec0e10961c94d25f2bde5fedfbbf8 ;
+    prov:atLocation niiri:cb188a1af7c32ebe8a3bbde2146b0e07 ;
     prov:value "4.36529922485352"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36518306130387"^^xsd:float ;
     nidm_pValueUncorrected: "0.000382464451876507"^^xsd:float ;
     nidm_pValueFWER: "0.999999989209637"^^xsd:float ;
     nidm_qValueFDR: "0.0139415542247477"^^xsd:float .
 
-niiri:f6bec0e10961c94d25f2bde5fedfbbf8
+niiri:cb188a1af7c32ebe8a3bbde2146b0e07
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[42,42,30]"^^xsd:string .
 
-niiri:3963967f131dd75149db4432a7e47df4 prov:wasDerivedFrom niiri:0fff44688bc869513d097e59a8311b54 .
+niiri:9d26bd37ee6076edc804baf6dc4fe873 prov:wasDerivedFrom niiri:2285d72bdbca74c3ffd05a878b326441 .
 
-niiri:90bcd9cecdebdfc1bc653e4a5ce6fdd4
+niiri:e2407cab140a2ab94b6aacc9f0ec9ee6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:5dfa4e8409ebc190fafb2e54b42bf770 ;
+    prov:atLocation niiri:6e21dfb93f9812fc6de65b18af515278 ;
     prov:value "4.33874082565308"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35162706179118"^^xsd:float ;
     nidm_pValueUncorrected: "0.00040169081443242"^^xsd:float ;
     nidm_pValueFWER: "0.999999993988362"^^xsd:float ;
     nidm_qValueFDR: "0.014354585034373"^^xsd:float .
 
-niiri:5dfa4e8409ebc190fafb2e54b42bf770
+niiri:6e21dfb93f9812fc6de65b18af515278
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[54,-38,50]"^^xsd:string .
 
-niiri:90bcd9cecdebdfc1bc653e4a5ce6fdd4 prov:wasDerivedFrom niiri:6b373e69fdc37c9c1e68cb0b96d5160c .
+niiri:e2407cab140a2ab94b6aacc9f0ec9ee6 prov:wasDerivedFrom niiri:0caba67a7c80988ff6802b01d2bd2008 .
 
-niiri:aef32c45bff8af696f74dfdd1d985ea3
+niiri:3ec22da54a5448d963b421dbc30bc678
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:5a1c6065723c47791b00a4157d8e72fb ;
+    prov:atLocation niiri:5f567258b87e850df5be55555d7bd5e2 ;
     prov:value "4.31020069122314"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33698195919922"^^xsd:float ;
     nidm_pValueUncorrected: "0.000423467227465446"^^xsd:float ;
     nidm_pValueFWER: "0.999999996857889"^^xsd:float ;
     nidm_qValueFDR: "0.01478592692513"^^xsd:float .
 
-niiri:5a1c6065723c47791b00a4157d8e72fb
+niiri:5f567258b87e850df5be55555d7bd5e2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[8,4,64]"^^xsd:string .
 
-niiri:aef32c45bff8af696f74dfdd1d985ea3 prov:wasDerivedFrom niiri:739e3f4c274d5eac94fb06c09bd419a0 .
+niiri:3ec22da54a5448d963b421dbc30bc678 prov:wasDerivedFrom niiri:fa32ab50c48787013e9f7686116ae370 .
 
-niiri:7c5846f0d310409dc36078590abc73fc
+niiri:f52f7478d9ba81a1662cf940fd06553b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:c6f8740e94fe4f1ac8fa83677062dddf ;
+    prov:atLocation niiri:570bccdb1d0898c69d8eb32d6ad2fad0 ;
     prov:value "4.30184555053711"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33267930931343"^^xsd:float ;
     nidm_pValueUncorrected: "0.000430070120942982"^^xsd:float ;
     nidm_pValueFWER: "0.999999997411931"^^xsd:float ;
     nidm_qValueFDR: "0.0148953189902244"^^xsd:float .
 
-niiri:c6f8740e94fe4f1ac8fa83677062dddf
+niiri:570bccdb1d0898c69d8eb32d6ad2fad0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-10,24,32]"^^xsd:string .
 
-niiri:7c5846f0d310409dc36078590abc73fc prov:wasDerivedFrom niiri:bf0f6f227a5f1dede37450defacf4ee4 .
+niiri:f52f7478d9ba81a1662cf940fd06553b prov:wasDerivedFrom niiri:fd6e415702cd4c776cd6424ad207625b .
 
-niiri:cd504b882f3f5530c78f2f6fdf37a17a
+niiri:3a6d5d6c8230dc370d28c6961f677a64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:fbe560ba493337b0e163bb49250b595c ;
+    prov:atLocation niiri:43d691d9acb35f3976b222e993f33996 ;
     prov:value "4.27150821685791"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31699794762384"^^xsd:float ;
     nidm_pValueUncorrected: "0.000454951424559202"^^xsd:float ;
     nidm_pValueFWER: "0.999999998740386"^^xsd:float ;
     nidm_qValueFDR: "0.0153518195589701"^^xsd:float .
 
-niiri:fbe560ba493337b0e163bb49250b595c
+niiri:43d691d9acb35f3976b222e993f33996
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-14,-2,72]"^^xsd:string .
 
-niiri:cd504b882f3f5530c78f2f6fdf37a17a prov:wasDerivedFrom niiri:27828afab99d35c7e234991a120cb219 .
+niiri:3a6d5d6c8230dc370d28c6961f677a64 prov:wasDerivedFrom niiri:1d0df51c88ee8bc083b5d2008437074e .
 
-niiri:2241ef49d05e5f1d71db21c706159ef1
+niiri:c8c17b9e021b6e2c4eb63a800bcf3c08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:2eedc6f2b2f210a352180ba9bf836bdb ;
+    prov:atLocation niiri:7cc00805149f09da4bc9f9fd9c74a921 ;
     prov:value "4.25738191604614"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30966460961956"^^xsd:float ;
     nidm_pValueUncorrected: "0.000467039117525991"^^xsd:float ;
     nidm_pValueFWER: "0.999999999106929"^^xsd:float ;
     nidm_qValueFDR: "0.0155581475175598"^^xsd:float .
 
-niiri:2eedc6f2b2f210a352180ba9bf836bdb
+niiri:7cc00805149f09da4bc9f9fd9c74a921
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[56,26,26]"^^xsd:string .
 
-niiri:2241ef49d05e5f1d71db21c706159ef1 prov:wasDerivedFrom niiri:61fab5ab040124b4935fd160bc4c75c2 .
+niiri:c8c17b9e021b6e2c4eb63a800bcf3c08 prov:wasDerivedFrom niiri:5c3fa5d9240ba93377acc27266386ab6 .
 
-niiri:de1ef49da56b6d1ffb63fe6c57d93f44
+niiri:2decee0398327a85347c2993ac7e9b5f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:810f41807fafc1e5eaa827e6a868c17c ;
+    prov:atLocation niiri:daff1324d950e105ac8dc95b7c19a0b7 ;
     prov:value "4.23224687576294"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29656664149817"^^xsd:float ;
     nidm_pValueUncorrected: "0.000489371958441343"^^xsd:float ;
     nidm_pValueFWER: "0.999999999522306"^^xsd:float ;
     nidm_qValueFDR: "0.0159527943368947"^^xsd:float .
 
-niiri:810f41807fafc1e5eaa827e6a868c17c
+niiri:daff1324d950e105ac8dc95b7c19a0b7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[14,-30,-32]"^^xsd:string .
 
-niiri:de1ef49da56b6d1ffb63fe6c57d93f44 prov:wasDerivedFrom niiri:3e195e76e0011bcbca16974bc51df875 .
+niiri:2decee0398327a85347c2993ac7e9b5f prov:wasDerivedFrom niiri:3b1453b375b54b291f7345abbe23ea62 .
 
-niiri:c444ee8f429895614ebda9dbf5fbd1fb
+niiri:f2a8b2edad70831294a59c7ea307b926
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:5a6eb1a0f188a666a4aaaecea6d678fa ;
+    prov:atLocation niiri:6c4e5f9ae054b7a8abef510227a976cf ;
     prov:value "4.21795654296875"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28909139477101"^^xsd:float ;
     nidm_pValueUncorrected: "0.000502556899069861"^^xsd:float ;
     nidm_pValueFWER: "0.999999999667972"^^xsd:float ;
     nidm_qValueFDR: "0.0162089652787187"^^xsd:float .
 
-niiri:5a6eb1a0f188a666a4aaaecea6d678fa
+niiri:6c4e5f9ae054b7a8abef510227a976cf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[46,-54,-30]"^^xsd:string .
 
-niiri:c444ee8f429895614ebda9dbf5fbd1fb prov:wasDerivedFrom niiri:efb3b3e5edd63741aa95f90f1a73c855 .
+niiri:f2a8b2edad70831294a59c7ea307b926 prov:wasDerivedFrom niiri:2ce833531fec9f54b7fd4cabb582abb4 .
 
-niiri:5baaf3257c1f9338a03f1372087336aa
+niiri:a2b2fbe93d1634fef546cdbede36389f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:8288b9701fe4611f125b1363a4414e5a ;
+    prov:atLocation niiri:8fd0fbdc8e1ef6d308bd57aa0f1f545f ;
     prov:value "4.19331645965576"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27615344058961"^^xsd:float ;
     nidm_pValueUncorrected: "0.000526156861805016"^^xsd:float ;
     nidm_pValueFWER: "0.999999999825125"^^xsd:float ;
     nidm_qValueFDR: "0.0165459969587672"^^xsd:float .
 
-niiri:8288b9701fe4611f125b1363a4414e5a
+niiri:8fd0fbdc8e1ef6d308bd57aa0f1f545f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[28,22,16]"^^xsd:string .
 
-niiri:5baaf3257c1f9338a03f1372087336aa prov:wasDerivedFrom niiri:e3b33814b86cd485564e0a0928f90e0f .
+niiri:a2b2fbe93d1634fef546cdbede36389f prov:wasDerivedFrom niiri:4e8a04cb57e27c1354da0f9221cefad4 .
 
-niiri:280fd372fb559f3177b6e1256a306389
+niiri:b6f88c6e0a0a91f0fdbc5e15f0467133
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:2335841ec513e02901317171950e6e7e ;
+    prov:atLocation niiri:279e804c8cd6f4d982eac06678ec644d ;
     prov:value "4.164222240448"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26079679766555"^^xsd:float ;
     nidm_pValueUncorrected: "0.000555498136877608"^^xsd:float ;
     nidm_pValueFWER: "0.999999999919858"^^xsd:float ;
     nidm_qValueFDR: "0.017023135244014"^^xsd:float .
 
-niiri:2335841ec513e02901317171950e6e7e
+niiri:279e804c8cd6f4d982eac06678ec644d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[32,-46,-8]"^^xsd:string .
 
-niiri:280fd372fb559f3177b6e1256a306389 prov:wasDerivedFrom niiri:cfdf88b2a941aeba3fcc1f4b45b10448 .
+niiri:b6f88c6e0a0a91f0fdbc5e15f0467133 prov:wasDerivedFrom niiri:a5bc72d93b1628741579fb91fca4ac04 .
 
-niiri:68691392db8be62d02ad17ca0283c776
+niiri:770d5a9c1943768336a41dfed084d4e0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:007cea7d2370bfd078d23d8eba7e3a4d ;
+    prov:atLocation niiri:560acb2ed13336590d0228d63f0eec04 ;
     prov:value "4.1354022026062"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24549898327499"^^xsd:float ;
     nidm_pValueUncorrected: "0.000586224915903544"^^xsd:float ;
     nidm_pValueFWER: "0.999999999963932"^^xsd:float ;
     nidm_qValueFDR: "0.0175104371158769"^^xsd:float .
 
-niiri:007cea7d2370bfd078d23d8eba7e3a4d
+niiri:560acb2ed13336590d0228d63f0eec04
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[12,18,32]"^^xsd:string .
 
-niiri:68691392db8be62d02ad17ca0283c776 prov:wasDerivedFrom niiri:8053ffdd2903523517c32abc5eed6805 .
+niiri:770d5a9c1943768336a41dfed084d4e0 prov:wasDerivedFrom niiri:67829b13c9a254ab8e5e036dfe81f295 .
 
-niiri:e0dc036274a57f0fe2d89e9ced584377
+niiri:6f5eab0276a97c20980194b57d0697d7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:6964785c365b99534b9ed5d158738905 ;
+    prov:atLocation niiri:612e0339ecfceadf01e886fa7dee967f ;
     prov:value "4.09669637680054"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22481821343066"^^xsd:float ;
     nidm_pValueUncorrected: "0.000630263410459797"^^xsd:float ;
     nidm_pValueFWER: "0.999999999988153"^^xsd:float ;
     nidm_qValueFDR: "0.0182494607837458"^^xsd:float .
 
-niiri:6964785c365b99534b9ed5d158738905
+niiri:612e0339ecfceadf01e886fa7dee967f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[6,-60,64]"^^xsd:string .
 
-niiri:e0dc036274a57f0fe2d89e9ced584377 prov:wasDerivedFrom niiri:be2669b1217c5497ae7583e9f37e889f .
+niiri:6f5eab0276a97c20980194b57d0697d7 prov:wasDerivedFrom niiri:c7ba4fe69a7060d041b8a1bd8e9abeb1 .
 
-niiri:171d6b4dfd03d1048a1523ac6ab16c51
+niiri:573ad2bca8ba5d7dc9c11840ae019222
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:0c042f9715d9ee75592c3572982a0982 ;
+    prov:atLocation niiri:9cbf0b11253a7d0b9281d19e6bfbd0ce ;
     prov:value "4.06586408615112"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20823228054844"^^xsd:float ;
     nidm_pValueUncorrected: "0.000667767930319307"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995287"^^xsd:float ;
     nidm_qValueFDR: "0.018874773548645"^^xsd:float .
 
-niiri:0c042f9715d9ee75592c3572982a0982
+niiri:9cbf0b11253a7d0b9281d19e6bfbd0ce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-20,-66,-32]"^^xsd:string .
 
-niiri:171d6b4dfd03d1048a1523ac6ab16c51 prov:wasDerivedFrom niiri:345d8154c25e6bc91b83c7a570393c32 .
+niiri:573ad2bca8ba5d7dc9c11840ae019222 prov:wasDerivedFrom niiri:d5ee6f1a9ca6bdd4f96fd93bea1b27d0 .
 
-niiri:a7098f4e7d792337d036f494fb50b3e4
+niiri:d2fe8bddf63332afaaa7841d1dd2d7aa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:52a60ec1c4d123189f7f1133afcaa6c6 ;
+    prov:atLocation niiri:65660fd080de37355a27b90d9f3b6a41 ;
     prov:value "4.05021715164185"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19977690410182"^^xsd:float ;
     nidm_pValueUncorrected: "0.000687670008111763"^^xsd:float ;
     nidm_pValueFWER: "0.999999999997083"^^xsd:float ;
     nidm_qValueFDR: "0.0191721851735585"^^xsd:float .
 
-niiri:52a60ec1c4d123189f7f1133afcaa6c6
+niiri:65660fd080de37355a27b90d9f3b6a41
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[-8,-72,-24]"^^xsd:string .
 
-niiri:a7098f4e7d792337d036f494fb50b3e4 prov:wasDerivedFrom niiri:0feb21dbaab7759d1a095b10570dbcbb .
+niiri:d2fe8bddf63332afaaa7841d1dd2d7aa prov:wasDerivedFrom niiri:33b6b88c9f8662328644ad657a54d41f .
 
-niiri:36b86426126175a8096c29f1919ba51d
+niiri:871e4e5d0420aa5b61f92742d95e2f19
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:5490e18e279668b30172e0e8f638ec06 ;
+    prov:atLocation niiri:bdbeee804b8e36df65ced505b97d20d9 ;
     prov:value "4.02814960479736"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18780790473987"^^xsd:float ;
     nidm_pValueUncorrected: "0.000716778694212938"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998538"^^xsd:float ;
     nidm_qValueFDR: "0.0196630402446738"^^xsd:float .
 
-niiri:5490e18e279668b30172e0e8f638ec06
+niiri:bdbeee804b8e36df65ced505b97d20d9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[-26,-36,-24]"^^xsd:string .
 
-niiri:36b86426126175a8096c29f1919ba51d prov:wasDerivedFrom niiri:4867e698cc576f0b80c177fdf37912bc .
+niiri:871e4e5d0420aa5b61f92742d95e2f19 prov:wasDerivedFrom niiri:5f796a80c868cc4e07db3893075e2ab5 .
 
-niiri:68fbcfdade2d23e2a8f7038c87eb5cff
+niiri:186d028736c894a4890184b7cf694827
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:77d8894d4ae1110ed28592a6314d05e6 ;
+    prov:atLocation niiri:b7b924c415f8fa0a7a0697aa72e7f6a5 ;
     prov:value "4.0194239616394"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18306102742152"^^xsd:float ;
     nidm_pValueUncorrected: "0.000728634479518986"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998893"^^xsd:float ;
     nidm_qValueFDR: "0.019829947388337"^^xsd:float .
 
-niiri:77d8894d4ae1110ed28592a6314d05e6
+niiri:b7b924c415f8fa0a7a0697aa72e7f6a5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-26,6,66]"^^xsd:string .
 
-niiri:68fbcfdade2d23e2a8f7038c87eb5cff prov:wasDerivedFrom niiri:dbd7ff1039cc058a9180d3a6b19c0d65 .
+niiri:186d028736c894a4890184b7cf694827 prov:wasDerivedFrom niiri:66c5c4f7aab02ec57f99c4903c0d0d24 .
 
-niiri:00465a63053242b2dffac6ee659b2354
+niiri:a84f34e906ddfa583085ab412e782957
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:f450ec4d266f33c1b6d2eb7b93ec2c9b ;
+    prov:atLocation niiri:2e1e2c6fde5e2e480843a37db05f8726 ;
     prov:value "4.01476430892944"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18052278869165"^^xsd:float ;
     nidm_pValueUncorrected: "0.000735047880785378"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999046"^^xsd:float ;
     nidm_qValueFDR: "0.0199399671265334"^^xsd:float .
 
-niiri:f450ec4d266f33c1b6d2eb7b93ec2c9b
+niiri:2e1e2c6fde5e2e480843a37db05f8726
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-32,-6,66]"^^xsd:string .
 
-niiri:00465a63053242b2dffac6ee659b2354 prov:wasDerivedFrom niiri:9a04edbbfec2046f6e63a9808f7e31be .
+niiri:a84f34e906ddfa583085ab412e782957 prov:wasDerivedFrom niiri:dd22a79353aa6df10199cb87a8c73432 .
 
-niiri:d1e53c6e21728e567ad7d5efc7526f76
+niiri:fa82f6ef2cafcb81390153f0dbc9d3b9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:2f0f52f74919616dd5ecdc47bdf7662d ;
+    prov:atLocation niiri:204dc7e2e23ff0ea824a15d83b604f5b ;
     prov:value "4.01372337341309"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17995544681479"^^xsd:float ;
     nidm_pValueUncorrected: "0.000736488485902353"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999078"^^xsd:float ;
     nidm_qValueFDR: "0.0199550456355793"^^xsd:float .
 
-niiri:2f0f52f74919616dd5ecdc47bdf7662d
+niiri:204dc7e2e23ff0ea824a15d83b604f5b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[56,-4,46]"^^xsd:string .
 
-niiri:d1e53c6e21728e567ad7d5efc7526f76 prov:wasDerivedFrom niiri:4802981400c706074d7089aa4f606c7a .
+niiri:fa82f6ef2cafcb81390153f0dbc9d3b9 prov:wasDerivedFrom niiri:620e2ba10d624da22f1d1ffc75882c40 .
 
-niiri:590d2d1c331312707acd1dd13cad86a4
+niiri:a34303c6c2ad04b453d45e05467bb020
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:e13abed58503558f5419d66eb9a3daab ;
+    prov:atLocation niiri:53ef23883ebbd94143fab90bcfe40272 ;
     prov:value "3.99763154983521"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17117019350021"^^xsd:float ;
     nidm_pValueUncorrected: "0.000759130810004449"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999453"^^xsd:float ;
     nidm_qValueFDR: "0.0202312537871442"^^xsd:float .
 
-niiri:e13abed58503558f5419d66eb9a3daab
+niiri:53ef23883ebbd94143fab90bcfe40272
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[10,-20,-12]"^^xsd:string .
 
-niiri:590d2d1c331312707acd1dd13cad86a4 prov:wasDerivedFrom niiri:0c9c1006b093a8cc91c759baf58575ee .
+niiri:a34303c6c2ad04b453d45e05467bb020 prov:wasDerivedFrom niiri:528d2a201077a9f036630cf90c25a2e4 .
 
-niiri:d6a41ae2f605bfe0ffcfcdd41c571806
+niiri:fce0437e15464dfacfc60a07a75a3f05
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:b52aa1bb12ceb0dd758b5674ba71269e ;
+    prov:atLocation niiri:40704d44d5a2d10993a11064245c7ca3 ;
     prov:value "3.96427512168884"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15287103994341"^^xsd:float ;
     nidm_pValueUncorrected: "0.000808366063659971"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999982"^^xsd:float ;
     nidm_qValueFDR: "0.0208863381686101"^^xsd:float .
 
-niiri:b52aa1bb12ceb0dd758b5674ba71269e
+niiri:40704d44d5a2d10993a11064245c7ca3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[-52,20,36]"^^xsd:string .
 
-niiri:d6a41ae2f605bfe0ffcfcdd41c571806 prov:wasDerivedFrom niiri:9e9eebffba744c379bca54d713a85d3b .
+niiri:fce0437e15464dfacfc60a07a75a3f05 prov:wasDerivedFrom niiri:b6a501a185ba123c5d8ae0428a609570 .
 
-niiri:f48cec3f59920d1e0aef1e5edb72b3ae
+niiri:61fa4fcddf7146388205e8f9f7e75c5f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:28e17599c65fb7c18cd3eb6c92fcdf63 ;
+    prov:atLocation niiri:f93b3f18b7ce2335eb4be32f6089aa8e ;
     prov:value "3.94705867767334"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14337930633102"^^xsd:float ;
     nidm_pValueUncorrected: "0.000835046362340219"^^xsd:float ;
     nidm_pValueFWER: "0.9999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.0212745029430363"^^xsd:float .
 
-niiri:28e17599c65fb7c18cd3eb6c92fcdf63
+niiri:f93b3f18b7ce2335eb4be32f6089aa8e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[10,-24,-14]"^^xsd:string .
 
-niiri:f48cec3f59920d1e0aef1e5edb72b3ae prov:wasDerivedFrom niiri:2ef2320c7a264cf13420c161d25ff5cc .
+niiri:61fa4fcddf7146388205e8f9f7e75c5f prov:wasDerivedFrom niiri:ac078cd746e0c0e589efde6d868f9503 .
 
-niiri:0bf03c97edd7b117b1111cf0cfa73c96
+niiri:9853e69b4f9f0cc9ab19c0da413e8b8f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:05eb28fd11ef4f85b5b7fccadd23374f ;
+    prov:atLocation niiri:20d1d862e5cafe0c2340f06b9ac43b97 ;
     prov:value "3.93684697151184"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13773425766756"^^xsd:float ;
     nidm_pValueUncorrected: "0.00085129580940857"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.0215142897882816"^^xsd:float .
 
-niiri:05eb28fd11ef4f85b5b7fccadd23374f
+niiri:20d1d862e5cafe0c2340f06b9ac43b97
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-32,18,-6]"^^xsd:string .
 
-niiri:0bf03c97edd7b117b1111cf0cfa73c96 prov:wasDerivedFrom niiri:53b5e166978251c052e00c9a4fe81fdc .
+niiri:9853e69b4f9f0cc9ab19c0da413e8b8f prov:wasDerivedFrom niiri:67a0a2929818d60014e2d343e4dd0e9f .
 
-niiri:bb138c83a7f0b859be01107344c7d312
+niiri:d8d92593836f27ffec4700b588395eb0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:e83ab329851a7f93c2f57864f4abe3b3 ;
+    prov:atLocation niiri:df48cc12c70ad9a5c5138ffd20279cc2 ;
     prov:value "3.93397641181946"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13614537112983"^^xsd:float ;
     nidm_pValueUncorrected: "0.000855921637752388"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999937"^^xsd:float ;
     nidm_qValueFDR: "0.0215615444445258"^^xsd:float .
 
-niiri:e83ab329851a7f93c2f57864f4abe3b3
+niiri:df48cc12c70ad9a5c5138ffd20279cc2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[52,10,18]"^^xsd:string .
 
-niiri:bb138c83a7f0b859be01107344c7d312 prov:wasDerivedFrom niiri:de88c64838ddf5de0155dcdce61cf6c0 .
+niiri:d8d92593836f27ffec4700b588395eb0 prov:wasDerivedFrom niiri:48c77f140153e04f3768726af76bae9b .
 
-niiri:86b5d287e5e443c1262f0ad80f006282
+niiri:32987cca18a40d2d66d1f3113a5f9abc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:9544cd35baa3055df29785d0cba7563e ;
+    prov:atLocation niiri:517a7208250880bc2a041087570ae344 ;
     prov:value "3.92871356010437"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13323000033267"^^xsd:float ;
     nidm_pValueUncorrected: "0.000864469518982003"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999947"^^xsd:float ;
     nidm_qValueFDR: "0.0216822850176731"^^xsd:float .
 
-niiri:9544cd35baa3055df29785d0cba7563e
+niiri:517a7208250880bc2a041087570ae344
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[34,-52,-4]"^^xsd:string .
 
-niiri:86b5d287e5e443c1262f0ad80f006282 prov:wasDerivedFrom niiri:02344c7a7b0c9af7c25dbcd3cbd09300 .
+niiri:32987cca18a40d2d66d1f3113a5f9abc prov:wasDerivedFrom niiri:8d5fab1550256921e7e64a7712e48bae .
 
-niiri:a659cc920974b885b011950336fdb2e6
+niiri:dc4433638b5205f63b06c49e26770b5c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:82c89a91afac0227805c920ac46780b4 ;
+    prov:atLocation niiri:1682a5cf8e3c9f83e8a3ffc904287034 ;
     prov:value "3.91936802864075"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12804559569402"^^xsd:float ;
     nidm_pValueUncorrected: "0.000879864400760821"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999962"^^xsd:float ;
     nidm_qValueFDR: "0.0218781120126672"^^xsd:float .
 
-niiri:82c89a91afac0227805c920ac46780b4
+niiri:1682a5cf8e3c9f83e8a3ffc904287034
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[16,-32,-34]"^^xsd:string .
 
-niiri:a659cc920974b885b011950336fdb2e6 prov:wasDerivedFrom niiri:22648332b0e4fb9a38556afd35646c42 .
+niiri:dc4433638b5205f63b06c49e26770b5c prov:wasDerivedFrom niiri:9302cebb2f2f594519eb7868350332d5 .
 
-niiri:8f404f298d64974fc27f83332fc6d68e
+niiri:58e1b535c49f38e4a876570c300b830e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:6a1d3251cb160a559caa1932f4e6e20d ;
+    prov:atLocation niiri:c639e8c70e4a07bb3fb69de3d3ffc484 ;
     prov:value "3.8760769367218"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1039055725094"^^xsd:float ;
     nidm_pValueUncorrected: "0.000954921373033768"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999992"^^xsd:float ;
     nidm_qValueFDR: "0.0229044690727897"^^xsd:float .
 
-niiri:6a1d3251cb160a559caa1932f4e6e20d
+niiri:c639e8c70e4a07bb3fb69de3d3ffc484
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[18,8,34]"^^xsd:string .
 
-niiri:8f404f298d64974fc27f83332fc6d68e prov:wasDerivedFrom niiri:3b46a57f86b33c173fe10a245389f4ff .
+niiri:58e1b535c49f38e4a876570c300b830e prov:wasDerivedFrom niiri:96084c5a0a8645a35c364d23198e7b84 .
 

--- a/spmexport/ex_spm_t_test/nidm.ttl
+++ b/spmexport/ex_spm_t_test/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:1b00cc9eddb72e8298ae831abf8242a8
+niiri:0912ef5e7651a34c983f4ed45de3d308
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:37ae388b351e24eff092878ed6c627e8
+niiri:b18851d58fa1ff2313b6177c4f070859
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:9fd2af475544e59d923f455813a60f9e
+niiri:f0b42854b0e7b708416cf70b7c8fedd1
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:9fd2af475544e59d923f455813a60f9e prov:wasAssociatedWith niiri:37ae388b351e24eff092878ed6c627e8 .
+niiri:f0b42854b0e7b708416cf70b7c8fedd1 prov:wasAssociatedWith niiri:b18851d58fa1ff2313b6177c4f070859 .
 
 _:blank5 a prov:Generation .
 
-niiri:1b00cc9eddb72e8298ae831abf8242a8 prov:qualifiedGeneration _:blank5 .
+niiri:0912ef5e7651a34c983f4ed45de3d308 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:12:11"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:34:29"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -128,12 +128,12 @@ _:blank5 prov:atTime "2016-01-11T10:12:11"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:a035080de4f5f70d7392a1a791404523
+niiri:c51db428dc8ee9bf707d42093e3d3377
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd
+niiri:6db7cc02a5d65d98ca2f4e6e802b59cd
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -143,154 +143,154 @@ niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:91c9c55e5f9fc572da5b4bf19a331220
+niiri:a322de38d0ea077b76fbeb115a3d6f03
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean .
 
-niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0
+niiri:1e206e0f7ca8761333a5f8c2e84dda5b
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:175b9210819e919a439d88ac4bc2ab57 ;
+    dc:description niiri:32e030b2b9eb8c5f3fc532b16c3a8fa0 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"mean\"]"^^xsd:string .
 
-niiri:175b9210819e919a439d88ac4bc2ab57
+niiri:32e030b2b9eb8c5f3fc532b16c3a8fa0
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:84b8dfaa3fa67fbd8f4c852110a04531
+niiri:22cef4703417a75639fda532c16cf80d
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean .
 
-niiri:b416890bf96d1dbb804f2efa4fda2d95
+niiri:a230dbc0ad05bf076dbd69b21f01dd10
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_OLS: .
 
-niiri:b416890bf96d1dbb804f2efa4fda2d95 prov:wasAssociatedWith niiri:a035080de4f5f70d7392a1a791404523 .
+niiri:a230dbc0ad05bf076dbd69b21f01dd10 prov:wasAssociatedWith niiri:c51db428dc8ee9bf707d42093e3d3377 .
 
-niiri:b416890bf96d1dbb804f2efa4fda2d95 prov:used niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0 .
+niiri:a230dbc0ad05bf076dbd69b21f01dd10 prov:used niiri:1e206e0f7ca8761333a5f8c2e84dda5b .
 
-niiri:b416890bf96d1dbb804f2efa4fda2d95 prov:used niiri:91c9c55e5f9fc572da5b4bf19a331220 .
+niiri:a230dbc0ad05bf076dbd69b21f01dd10 prov:used niiri:a322de38d0ea077b76fbeb115a3d6f03 .
 
-niiri:b416890bf96d1dbb804f2efa4fda2d95 prov:used niiri:84b8dfaa3fa67fbd8f4c852110a04531 .
+niiri:a230dbc0ad05bf076dbd69b21f01dd10 prov:used niiri:22cef4703417a75639fda532c16cf80d .
 
-niiri:a99fcafea3bdd16053d3fbef6194f56c
+niiri:be07ca5d1a4babb35995fdf04899fb32
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:6079f21d5530fd7507553a99cd6bfac7
+niiri:7c74c0d0b2c4f48fa050e438562326f8
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e"^^xsd:string .
 
-niiri:a99fcafea3bdd16053d3fbef6194f56c prov:wasDerivedFrom niiri:6079f21d5530fd7507553a99cd6bfac7 .
+niiri:be07ca5d1a4babb35995fdf04899fb32 prov:wasDerivedFrom niiri:7c74c0d0b2c4f48fa050e438562326f8 .
 
-niiri:a99fcafea3bdd16053d3fbef6194f56c prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+niiri:be07ca5d1a4babb35995fdf04899fb32 prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
 
-niiri:92fe3ceea82b9387c2e8a74870e1ff03
+niiri:d7f6f2a0365232d977b7db0afaf9a5fb
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "0.0584948938339949"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     crypto:sha512 "504d2b5e17e73690caae29eafdc0448a1d5ac6d66af811a3fcbab8eec9f904820f0610d985a6f04e8808fcd8f77def3c063bfb11df56679b0b28261cdc2856f9"^^xsd:string .
 
-niiri:92fe3ceea82b9387c2e8a74870e1ff03 prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+niiri:d7f6f2a0365232d977b7db0afaf9a5fb prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
 
-niiri:a5219921c3bcca062f97bd37da42f0f6
+niiri:ef79850e03bdae0e1923acf92832ca93
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd .
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd .
 
-niiri:758caf4a74ea7c64784615391d3d8bb9
+niiri:a887854143325483e34db878814c8082
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "9a22064d78683e5b5375b6d3708584d2bb24dd434f40b311f06e185e10c9492d976c35967cc2545e3d7aefa2b83f7e433c957bd8dc87c22392e334027d0b438b"^^xsd:string .
 
-niiri:a5219921c3bcca062f97bd37da42f0f6 prov:wasDerivedFrom niiri:758caf4a74ea7c64784615391d3d8bb9 .
+niiri:ef79850e03bdae0e1923acf92832ca93 prov:wasDerivedFrom niiri:a887854143325483e34db878814c8082 .
 
-niiri:a5219921c3bcca062f97bd37da42f0f6 prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+niiri:ef79850e03bdae0e1923acf92832ca93 prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
 
-niiri:42d6ab087f72abda2ef3d164d74b2af0
+niiri:4df94669c28a6f6a636b1bbaa6a0d0f7
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     crypto:sha512 "5796b765989869d8ad685aee159b41c06538552c8a91ed6cfa9dc7a334df02e91dd83703fd5d9be4a7fc8a27943157d2cf29f457aa1cf4a3d01ce813480ddaaa"^^xsd:string .
 
-niiri:794d510acaf63dceb059cc9ba8dab5d2
+niiri:db622461201dc3fe743fb5d1e2b95c19
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bd6687fb4b5d5af30fa322a8b6b6df29ead2c1e0ebe8e1962c3716c2c05a23365fe0428be1d420ef8b013c4c342c0d5efe704fec31b6e956c2b4d15a630b1c98"^^xsd:string .
 
-niiri:42d6ab087f72abda2ef3d164d74b2af0 prov:wasDerivedFrom niiri:794d510acaf63dceb059cc9ba8dab5d2 .
+niiri:4df94669c28a6f6a636b1bbaa6a0d0f7 prov:wasDerivedFrom niiri:db622461201dc3fe743fb5d1e2b95c19 .
 
-niiri:42d6ab087f72abda2ef3d164d74b2af0 prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+niiri:4df94669c28a6f6a636b1bbaa6a0d0f7 prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
 
-niiri:3aa3da07651e9afc3c6c5a49b7b97170
+niiri:de9f181e681892d8a4cecf00f081b937
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     crypto:sha512 "7090223b1a196dba349a102d5d369808fa90203f67c9021d2113b323996c67506be3e49d5e848a4f38a6ff78038478dee1401d2a7cd9ee5e6496f3d0313c6eb6"^^xsd:string .
 
-niiri:9b2bfe67b8475d87b43e4e93e350f76e
+niiri:4bc17018182371ce2299d53dda370a88
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "95b2ccdef4496cd3830f817f9d8893924091b302a09c66b1581f7ee4721c618a1d95d56e509e8f1537af7ea437bc5f3fbf7f69037f13203b6c98733647911d8d"^^xsd:string .
 
-niiri:3aa3da07651e9afc3c6c5a49b7b97170 prov:wasDerivedFrom niiri:9b2bfe67b8475d87b43e4e93e350f76e .
+niiri:de9f181e681892d8a4cecf00f081b937 prov:wasDerivedFrom niiri:4bc17018182371ce2299d53dda370a88 .
 
-niiri:3aa3da07651e9afc3c6c5a49b7b97170 prov:wasGeneratedBy niiri:b416890bf96d1dbb804f2efa4fda2d95 .
+niiri:de9f181e681892d8a4cecf00f081b937 prov:wasGeneratedBy niiri:a230dbc0ad05bf076dbd69b21f01dd10 .
 
-niiri:04b578701cf4564a0a334f46af3d16fa
+niiri:6bde2d077439c82e001fb48426475a91
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
     rdfs:label "Contrast: Con1: mr vs plain" ;
     prov:value "1"^^xsd:string .
 
-niiri:f8fa21d3adf52266399255440cb7dbde
+niiri:130277e2f55ac12e05a80fbef35bd105
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:f8fa21d3adf52266399255440cb7dbde prov:wasAssociatedWith niiri:a035080de4f5f70d7392a1a791404523 .
+niiri:130277e2f55ac12e05a80fbef35bd105 prov:wasAssociatedWith niiri:c51db428dc8ee9bf707d42093e3d3377 .
 
-niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:a99fcafea3bdd16053d3fbef6194f56c .
+niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:be07ca5d1a4babb35995fdf04899fb32 .
 
-niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:42d6ab087f72abda2ef3d164d74b2af0 .
+niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:4df94669c28a6f6a636b1bbaa6a0d0f7 .
 
-niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:dd0efc3abd4fbfed868a4fa7a14bd6a0 .
+niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:1e206e0f7ca8761333a5f8c2e84dda5b .
 
-niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:04b578701cf4564a0a334f46af3d16fa .
+niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:6bde2d077439c82e001fb48426475a91 .
 
-niiri:f8fa21d3adf52266399255440cb7dbde prov:used niiri:a5219921c3bcca062f97bd37da42f0f6 .
+niiri:130277e2f55ac12e05a80fbef35bd105 prov:used niiri:ef79850e03bdae0e1923acf92832ca93 .
 
-niiri:b925226ebcfaf81953c6c8d86b12edbe
+niiri:ad092c1420d338bff2feebb61bee6605
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -300,124 +300,124 @@ niiri:b925226ebcfaf81953c6c8d86b12edbe
     nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "13"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     crypto:sha512 "2eec11aca8e4898cb44b0e535e3abecde8d46ea6e5fe05bb26e2dee72769fcb985c90c0ed86b9dcaf260d502b34559700f7a3c0f944f020a4beb20042153d26f"^^xsd:string .
 
-niiri:c7968123d4a2445f2cc5efd45678f874
+niiri:fe88d5b09130483c026b50e13977e412
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "291b6fbfe377046689fa404484c99e68b419966665af4294ca5348faf3ee9e3e4ea972ccb9c17fc697c42c58d915fda6300a540027b872eccd1403215cd2e075"^^xsd:string .
 
-niiri:b925226ebcfaf81953c6c8d86b12edbe prov:wasDerivedFrom niiri:c7968123d4a2445f2cc5efd45678f874 .
+niiri:ad092c1420d338bff2feebb61bee6605 prov:wasDerivedFrom niiri:fe88d5b09130483c026b50e13977e412 .
 
-niiri:b925226ebcfaf81953c6c8d86b12edbe prov:wasGeneratedBy niiri:f8fa21d3adf52266399255440cb7dbde .
+niiri:ad092c1420d338bff2feebb61bee6605 prov:wasGeneratedBy niiri:130277e2f55ac12e05a80fbef35bd105 .
 
-niiri:0d474a910bcd3d0f50d6a1c63d2c2081
+niiri:b3dc79d8ad2eb32d47956780781c51d6
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: Con1: mr vs plain" ;
     nidm_contrastName: "Con1: mr vs plain"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     crypto:sha512 "d907fef7984f59a008b8963e5fb6d2386968ffcde54e31fabe7ed8b0e1a32e4410475271e4fa903e1aa6c01ef4903209fb61660bd47a5709a5c5c91bccc8b426"^^xsd:string .
 
-niiri:0f1eef5a71e2e8c320c07d47aaf5faa2
+niiri:6941db4ab0e9730a24b012b3310d0f8a
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "66e00621b81bef508ca685a72a398d532276891ec8b2abc489af8f6105099ca9a54f52697ea83360eed53387ba6bec3ae1fc7f882ca4f3c8f944ee9a15f099ba"^^xsd:string .
 
-niiri:0d474a910bcd3d0f50d6a1c63d2c2081 prov:wasDerivedFrom niiri:0f1eef5a71e2e8c320c07d47aaf5faa2 .
+niiri:b3dc79d8ad2eb32d47956780781c51d6 prov:wasDerivedFrom niiri:6941db4ab0e9730a24b012b3310d0f8a .
 
-niiri:0d474a910bcd3d0f50d6a1c63d2c2081 prov:wasGeneratedBy niiri:f8fa21d3adf52266399255440cb7dbde .
+niiri:b3dc79d8ad2eb32d47956780781c51d6 prov:wasGeneratedBy niiri:130277e2f55ac12e05a80fbef35bd105 .
 
-niiri:9ad91a55a933509c23c194d606e537a6
+niiri:1ef03434814308215299edd166a251be
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     crypto:sha512 "4fed4edb0da80cd11916dccc511db465d9a42101a08318ca494f751102dfed9e4ccf557dbb4eaef9d792f662864bfe3a77670a1c78dbbf144974e8866d9640f0"^^xsd:string .
 
-niiri:9ad91a55a933509c23c194d606e537a6 prov:wasGeneratedBy niiri:f8fa21d3adf52266399255440cb7dbde .
+niiri:1ef03434814308215299edd166a251be prov:wasGeneratedBy niiri:130277e2f55ac12e05a80fbef35bd105 .
 
-niiri:2b631fcf63e9820fbd2e40503305547d
+niiri:aa34765c622ec88209dbca1ddf40b225
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500181305457"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:850496eee671baa44ef30a3c14bbc01f ;
-    nidm_equivalentThreshold: niiri:39e5898c4b517eee39c871cfc90544ea .
+    nidm_equivalentThreshold: niiri:66fda984913d6a14877915720b65e6ca ;
+    nidm_equivalentThreshold: niiri:802a4095edf055d7da2eb939ea257d85 .
 
-niiri:850496eee671baa44ef30a3c14bbc01f
+niiri:66fda984913d6a14877915720b65e6ca
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.85198238341593"^^xsd:float .
 
-niiri:39e5898c4b517eee39c871cfc90544ea
+niiri:802a4095edf055d7da2eb939ea257d85
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:5f8ed8ba67e188085e5ae8dd56f0fd87
+niiri:2735f4f85b2c1346a8849aa3723fed30
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:737e308a8a329df56e3800195e6a5520 ;
-    nidm_equivalentThreshold: niiri:f3fad5b99b15cd5fa5fcf64d81b5c413 .
+    nidm_equivalentThreshold: niiri:511e0e85d0615cf4311996169a6e8221 ;
+    nidm_equivalentThreshold: niiri:5a25669dc1de6e55ec1edcdeb918c132 .
 
-niiri:737e308a8a329df56e3800195e6a5520
+niiri:511e0e85d0615cf4311996169a6e8221
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:f3fad5b99b15cd5fa5fcf64d81b5c413
+niiri:5a25669dc1de6e55ec1edcdeb918c132
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:7a9d521a4e66bf249cf7ba064524933f
+niiri:1ba31b971ce92f322556ea50dd1da5aa
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:3f2044246932375109f3634cdd1b9da7
+niiri:59d671f65af3f2e501782f35d0cb64e3
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b
+niiri:292b1e1f2538029aed5f141c52538889
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:wasAssociatedWith niiri:a035080de4f5f70d7392a1a791404523 .
+niiri:292b1e1f2538029aed5f141c52538889 prov:wasAssociatedWith niiri:c51db428dc8ee9bf707d42093e3d3377 .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:2b631fcf63e9820fbd2e40503305547d .
+niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:aa34765c622ec88209dbca1ddf40b225 .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:5f8ed8ba67e188085e5ae8dd56f0fd87 .
+niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:2735f4f85b2c1346a8849aa3723fed30 .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:b925226ebcfaf81953c6c8d86b12edbe .
+niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:ad092c1420d338bff2feebb61bee6605 .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:3aa3da07651e9afc3c6c5a49b7b97170 .
+niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:de9f181e681892d8a4cecf00f081b937 .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:a99fcafea3bdd16053d3fbef6194f56c .
+niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:be07ca5d1a4babb35995fdf04899fb32 .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:7a9d521a4e66bf249cf7ba064524933f .
+niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:1ba31b971ce92f322556ea50dd1da5aa .
 
-niiri:a7eb52ddc903ab04fcaa029f84ea6b4b prov:used niiri:3f2044246932375109f3634cdd1b9da7 .
+niiri:292b1e1f2538029aed5f141c52538889 prov:used niiri:59d671f65af3f2e501782f35d0cb64e3 .
 
-niiri:b8b1c6bd8a121e50549c32ca3ea169ca
+niiri:e45c455fef5d8cb108c1651352a3a733
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     nidm_searchVolumeInVoxels: "167222"^^xsd:int ;
     nidm_searchVolumeInUnits: "1337776"^^xsd:float ;
     nidm_reselSizeInVoxels: "83.1545653831017"^^xsd:float ;
@@ -434,9 +434,9 @@ niiri:b8b1c6bd8a121e50549c32ca3ea169ca
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "59"^^xsd:int ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:b8b1c6bd8a121e50549c32ca3ea169ca prov:wasGeneratedBy niiri:a7eb52ddc903ab04fcaa029f84ea6b4b .
+niiri:e45c455fef5d8cb108c1651352a3a733 prov:wasGeneratedBy niiri:292b1e1f2538029aed5f141c52538889 .
 
-niiri:04e3f1275db373d13cac82285a23f702
+niiri:b92de8901b2a05ad20e537b7d45bcded
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -444,26 +444,26 @@ niiri:04e3f1275db373d13cac82285a23f702
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "57"^^xsd:int ;
     nidm_pValue: "0.000126072725041393"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:3651b3bac0c9746240cd1f49bb29caf5 ;
-    nidm_hasMaximumIntensityProjection: niiri:8c55faf85816666e5ce4f7e8047a35de ;
-    nidm_inCoordinateSpace: niiri:aaa6d0f6b9bf8cd62fe12aaf1f49b6bd ;
+    nidm_hasClusterLabelsMap: niiri:d0125669d7f73a1dd58eac955bc608c1 ;
+    nidm_hasMaximumIntensityProjection: niiri:33e32bf5515a00f9b1224cdca9d36d84 ;
+    nidm_inCoordinateSpace: niiri:6db7cc02a5d65d98ca2f4e6e802b59cd ;
     crypto:sha512 "9bef1b01e85eeddf2e747ceba7ade799597c7837064cb2f65dd700a59f52a84d33bd06d9b28b57b0669461e4ff28c39b9df7e09752b27d653bc515d887e4927e"^^xsd:string .
 
-niiri:3651b3bac0c9746240cd1f49bb29caf5
+niiri:d0125669d7f73a1dd58eac955bc608c1
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:8c55faf85816666e5ce4f7e8047a35de
+niiri:33e32bf5515a00f9b1224cdca9d36d84
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:04e3f1275db373d13cac82285a23f702 prov:wasGeneratedBy niiri:a7eb52ddc903ab04fcaa029f84ea6b4b .
+niiri:b92de8901b2a05ad20e537b7d45bcded prov:wasGeneratedBy niiri:292b1e1f2538029aed5f141c52538889 .
 
-niiri:1cf06d93f4aed03ee50d587421161410
+niiri:46ce368f726925043d0fdf11d3ce812c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "3171"^^xsd:int ;
@@ -473,9 +473,9 @@ niiri:1cf06d93f4aed03ee50d587421161410
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:1cf06d93f4aed03ee50d587421161410 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:46ce368f726925043d0fdf11d3ce812c prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:1a7642317b9c235ad3c8606f26710b96
+niiri:a121a3d6c11f9c710a28e61253277933
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "1543"^^xsd:int ;
@@ -485,9 +485,9 @@ niiri:1a7642317b9c235ad3c8606f26710b96
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:1a7642317b9c235ad3c8606f26710b96 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:a121a3d6c11f9c710a28e61253277933 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8
+niiri:46ae5678b67f432a5739e26d30b8b9fc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "1032"^^xsd:int ;
@@ -497,9 +497,9 @@ niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:46ae5678b67f432a5739e26d30b8b9fc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:57b5c372ef2a2b5e726b538a4a5d80db
+niiri:ac8f8138199a2f60489cb1fe2bc4c070
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "70"^^xsd:int ;
@@ -509,9 +509,9 @@ niiri:57b5c372ef2a2b5e726b538a4a5d80db
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:57b5c372ef2a2b5e726b538a4a5d80db prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:ac8f8138199a2f60489cb1fe2bc4c070 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:2260abfbc92b3918f8c4e115273811bc
+niiri:3dfc00b52233c69b59012bb4e4590bd6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "250"^^xsd:int ;
@@ -521,9 +521,9 @@ niiri:2260abfbc92b3918f8c4e115273811bc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:2260abfbc92b3918f8c4e115273811bc prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:3dfc00b52233c69b59012bb4e4590bd6 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:428e3b496b74c693be37a9557e535f44
+niiri:e17a558d17c93c4d23cebfdb241952ae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "96"^^xsd:int ;
@@ -533,9 +533,9 @@ niiri:428e3b496b74c693be37a9557e535f44
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:428e3b496b74c693be37a9557e535f44 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:e17a558d17c93c4d23cebfdb241952ae prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:f2233fa4afd02fcceeb05d8f7c4801ff
+niiri:2ee06584880d716387a7002834742906
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -545,9 +545,9 @@ niiri:f2233fa4afd02fcceeb05d8f7c4801ff
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:f2233fa4afd02fcceeb05d8f7c4801ff prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:2ee06584880d716387a7002834742906 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:b1ef2839e620d66c14bd83deb3aec390
+niiri:0a170fb537c25a43d335a98102d35aeb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "320"^^xsd:int ;
@@ -557,9 +557,9 @@ niiri:b1ef2839e620d66c14bd83deb3aec390
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:b1ef2839e620d66c14bd83deb3aec390 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:0a170fb537c25a43d335a98102d35aeb prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:6a1143e807a7221c10cbd94b8f352cb3
+niiri:0b191a1bce28484b4d509f123468cafc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "64"^^xsd:int ;
@@ -569,9 +569,9 @@ niiri:6a1143e807a7221c10cbd94b8f352cb3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:6a1143e807a7221c10cbd94b8f352cb3 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:0b191a1bce28484b4d509f123468cafc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:17a361a6af9be1a09623d4875d9de272
+niiri:03c0220efd2c203f65a22694082f5442
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "161"^^xsd:int ;
@@ -581,9 +581,9 @@ niiri:17a361a6af9be1a09623d4875d9de272
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:17a361a6af9be1a09623d4875d9de272 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:03c0220efd2c203f65a22694082f5442 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:646a3e8aac6f4eee8e8562e0616d65ba
+niiri:847c108abc6d60c3422f305d80cbe544
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -593,9 +593,9 @@ niiri:646a3e8aac6f4eee8e8562e0616d65ba
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:646a3e8aac6f4eee8e8562e0616d65ba prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:847c108abc6d60c3422f305d80cbe544 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:8e53fdbcd507f29fa491c0ee30766820
+niiri:89f5194a4b0e2d5f67db04f10c0882ac
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "71"^^xsd:int ;
@@ -605,9 +605,9 @@ niiri:8e53fdbcd507f29fa491c0ee30766820
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:8e53fdbcd507f29fa491c0ee30766820 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:89f5194a4b0e2d5f67db04f10c0882ac prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:caa24947392807e9fd656eb7e677bb90
+niiri:d97dd5148291142c057785550af3eb2d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -617,9 +617,9 @@ niiri:caa24947392807e9fd656eb7e677bb90
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:caa24947392807e9fd656eb7e677bb90 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:d97dd5148291142c057785550af3eb2d prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:aa6f6ac422b272159fb670d4c6c75fe8
+niiri:50d0f0b594a3407fd672472426d8a80a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -629,9 +629,9 @@ niiri:aa6f6ac422b272159fb670d4c6c75fe8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:aa6f6ac422b272159fb670d4c6c75fe8 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:50d0f0b594a3407fd672472426d8a80a prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:62026e05a2a2355fc124787b15505315
+niiri:5663af6390cbe1661580022d9cd1db76
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -641,9 +641,9 @@ niiri:62026e05a2a2355fc124787b15505315
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:62026e05a2a2355fc124787b15505315 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:5663af6390cbe1661580022d9cd1db76 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:93450961f0d8d0f6a3b90a5894e1f87b
+niiri:936e9ee0499c3d068e7444f367b65d20
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -653,9 +653,9 @@ niiri:93450961f0d8d0f6a3b90a5894e1f87b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:93450961f0d8d0f6a3b90a5894e1f87b prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:936e9ee0499c3d068e7444f367b65d20 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:9b5ca13a3d263c59792e6e86be4a2e34
+niiri:37eed9b79d7a2993d16feb7189856a02
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -665,9 +665,9 @@ niiri:9b5ca13a3d263c59792e6e86be4a2e34
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:9b5ca13a3d263c59792e6e86be4a2e34 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:37eed9b79d7a2993d16feb7189856a02 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:bb0785359fefadd70b1adaaaac3b7884
+niiri:9d921e2cb3a8abbe97013ee4bc904c3e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -677,9 +677,9 @@ niiri:bb0785359fefadd70b1adaaaac3b7884
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:bb0785359fefadd70b1adaaaac3b7884 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:9d921e2cb3a8abbe97013ee4bc904c3e prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:000e7e06128006bf16d2f8dd28c288f0
+niiri:ba889b1413156c8c9b392f582f507018
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -689,9 +689,9 @@ niiri:000e7e06128006bf16d2f8dd28c288f0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:000e7e06128006bf16d2f8dd28c288f0 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:ba889b1413156c8c9b392f582f507018 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:fea4f2ec59548d5d8b403064bc42fcd3
+niiri:51665d1fb0cfb8bda978b620ef449077
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -701,9 +701,9 @@ niiri:fea4f2ec59548d5d8b403064bc42fcd3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:fea4f2ec59548d5d8b403064bc42fcd3 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:51665d1fb0cfb8bda978b620ef449077 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:56aff3268c9efc59ac3dd1fccbb1e940
+niiri:a24fb25342ea5df100b3c9f26c07ccf7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -713,9 +713,9 @@ niiri:56aff3268c9efc59ac3dd1fccbb1e940
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:56aff3268c9efc59ac3dd1fccbb1e940 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:a24fb25342ea5df100b3c9f26c07ccf7 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:30c41fd03e0e9666df9d194fbe412b52
+niiri:6b3e2550575959313eec60bd44a6b445
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -725,9 +725,9 @@ niiri:30c41fd03e0e9666df9d194fbe412b52
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:30c41fd03e0e9666df9d194fbe412b52 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:6b3e2550575959313eec60bd44a6b445 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:195a3dcb7bf220b60a464a21245d4ee4
+niiri:92cf9681c5af88815bed46d4f69484fe
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "59"^^xsd:int ;
@@ -737,9 +737,9 @@ niiri:195a3dcb7bf220b60a464a21245d4ee4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:195a3dcb7bf220b60a464a21245d4ee4 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:92cf9681c5af88815bed46d4f69484fe prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:d09f25e397a79ba3820081611e196ed7
+niiri:c8b8db45e94c74708104298c433fecd6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -749,9 +749,9 @@ niiri:d09f25e397a79ba3820081611e196ed7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:d09f25e397a79ba3820081611e196ed7 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:c8b8db45e94c74708104298c433fecd6 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:2d07cb807cba69cb83d125ad8a6d9589
+niiri:e9cca2166adb51f5ec340f78e542f76f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -761,9 +761,9 @@ niiri:2d07cb807cba69cb83d125ad8a6d9589
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:2d07cb807cba69cb83d125ad8a6d9589 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:e9cca2166adb51f5ec340f78e542f76f prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:2d69939d531eb0168273379f7ce52907
+niiri:4ce2f04f5e11fd9609173ed79e458866
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -773,9 +773,9 @@ niiri:2d69939d531eb0168273379f7ce52907
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:2d69939d531eb0168273379f7ce52907 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:4ce2f04f5e11fd9609173ed79e458866 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:1c2323d93891a0ddf5ac87752d859519
+niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -785,9 +785,9 @@ niiri:1c2323d93891a0ddf5ac87752d859519
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:1c2323d93891a0ddf5ac87752d859519 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:dc7f564798bbb1fc05334954d8385ba1
+niiri:18aa725ff182239ce52a92cec8c831fe
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -797,9 +797,9 @@ niiri:dc7f564798bbb1fc05334954d8385ba1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:dc7f564798bbb1fc05334954d8385ba1 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:18aa725ff182239ce52a92cec8c831fe prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:62a9cd07b50b07a1142d53889b87fd97
+niiri:7cf7dba6eb11ba3d163885cbe5c660cd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -809,9 +809,9 @@ niiri:62a9cd07b50b07a1142d53889b87fd97
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:62a9cd07b50b07a1142d53889b87fd97 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:7cf7dba6eb11ba3d163885cbe5c660cd prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:12880301a0a653ca67efd232a37a486b
+niiri:f2aa94f4ac2fd9ce977533852312353d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -821,9 +821,9 @@ niiri:12880301a0a653ca67efd232a37a486b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:12880301a0a653ca67efd232a37a486b prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:f2aa94f4ac2fd9ce977533852312353d prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:7b940b3f554bfd8086ef06ec3a4c5e36
+niiri:b9d2c5e57e73184c133167c21e549e31
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -833,9 +833,9 @@ niiri:7b940b3f554bfd8086ef06ec3a4c5e36
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:7b940b3f554bfd8086ef06ec3a4c5e36 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:b9d2c5e57e73184c133167c21e549e31 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:4364ea14ae541a4b5530d0fc11478f4d
+niiri:0fff44688bc869513d097e59a8311b54
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -845,9 +845,9 @@ niiri:4364ea14ae541a4b5530d0fc11478f4d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:4364ea14ae541a4b5530d0fc11478f4d prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:0fff44688bc869513d097e59a8311b54 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:cad9672114cca77d75274be4de17ab9c
+niiri:6b373e69fdc37c9c1e68cb0b96d5160c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -857,9 +857,9 @@ niiri:cad9672114cca77d75274be4de17ab9c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:cad9672114cca77d75274be4de17ab9c prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:6b373e69fdc37c9c1e68cb0b96d5160c prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:9373fb96b8dcda6b9ae13dbf76afcaa6
+niiri:739e3f4c274d5eac94fb06c09bd419a0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -869,9 +869,9 @@ niiri:9373fb96b8dcda6b9ae13dbf76afcaa6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:9373fb96b8dcda6b9ae13dbf76afcaa6 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:739e3f4c274d5eac94fb06c09bd419a0 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:7737094062d61c5fc0d500987f11bda9
+niiri:bf0f6f227a5f1dede37450defacf4ee4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -881,9 +881,9 @@ niiri:7737094062d61c5fc0d500987f11bda9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:7737094062d61c5fc0d500987f11bda9 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:bf0f6f227a5f1dede37450defacf4ee4 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:454d2ddee840a6eed8f9885efabde318
+niiri:27828afab99d35c7e234991a120cb219
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -893,9 +893,9 @@ niiri:454d2ddee840a6eed8f9885efabde318
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:454d2ddee840a6eed8f9885efabde318 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:27828afab99d35c7e234991a120cb219 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:b2f3ddd032f5ca78054f0eca8d0c8769
+niiri:61fab5ab040124b4935fd160bc4c75c2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -905,9 +905,9 @@ niiri:b2f3ddd032f5ca78054f0eca8d0c8769
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:b2f3ddd032f5ca78054f0eca8d0c8769 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:61fab5ab040124b4935fd160bc4c75c2 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:cf4b88bff59c1a33cd867e9422f84011
+niiri:3e195e76e0011bcbca16974bc51df875
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -917,9 +917,9 @@ niiri:cf4b88bff59c1a33cd867e9422f84011
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:cf4b88bff59c1a33cd867e9422f84011 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:3e195e76e0011bcbca16974bc51df875 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:3283422abdc309a208995369231fe32a
+niiri:efb3b3e5edd63741aa95f90f1a73c855
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -929,9 +929,9 @@ niiri:3283422abdc309a208995369231fe32a
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:3283422abdc309a208995369231fe32a prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:efb3b3e5edd63741aa95f90f1a73c855 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:c9c180c62d3cd262bcb7bb862a2e2d3e
+niiri:e3b33814b86cd485564e0a0928f90e0f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -941,9 +941,9 @@ niiri:c9c180c62d3cd262bcb7bb862a2e2d3e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:c9c180c62d3cd262bcb7bb862a2e2d3e prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:e3b33814b86cd485564e0a0928f90e0f prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:f67691de01cdab9987a52d4efd6796df
+niiri:cfdf88b2a941aeba3fcc1f4b45b10448
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -953,9 +953,9 @@ niiri:f67691de01cdab9987a52d4efd6796df
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:f67691de01cdab9987a52d4efd6796df prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:cfdf88b2a941aeba3fcc1f4b45b10448 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:ef91e7140c5dbe4c9303f8f1e0cd8673
+niiri:8053ffdd2903523517c32abc5eed6805
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -965,9 +965,9 @@ niiri:ef91e7140c5dbe4c9303f8f1e0cd8673
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:ef91e7140c5dbe4c9303f8f1e0cd8673 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:8053ffdd2903523517c32abc5eed6805 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:dcd5d7321bb4d36d468ecf53edb77243
+niiri:be2669b1217c5497ae7583e9f37e889f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -977,9 +977,9 @@ niiri:dcd5d7321bb4d36d468ecf53edb77243
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:dcd5d7321bb4d36d468ecf53edb77243 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:be2669b1217c5497ae7583e9f37e889f prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:049381a7f67019f13a2b75b205f87af1
+niiri:345d8154c25e6bc91b83c7a570393c32
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -989,9 +989,9 @@ niiri:049381a7f67019f13a2b75b205f87af1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:049381a7f67019f13a2b75b205f87af1 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:345d8154c25e6bc91b83c7a570393c32 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:6231cdc1c30543959e82f342e7f7c028
+niiri:0feb21dbaab7759d1a095b10570dbcbb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1001,9 +1001,9 @@ niiri:6231cdc1c30543959e82f342e7f7c028
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:6231cdc1c30543959e82f342e7f7c028 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:0feb21dbaab7759d1a095b10570dbcbb prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:d078d2a64b3eee365a7318a424f3d55f
+niiri:4867e698cc576f0b80c177fdf37912bc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1013,9 +1013,9 @@ niiri:d078d2a64b3eee365a7318a424f3d55f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:d078d2a64b3eee365a7318a424f3d55f prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:4867e698cc576f0b80c177fdf37912bc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:b07d53658c12f0d165aec1cf959f1eb5
+niiri:dbd7ff1039cc058a9180d3a6b19c0d65
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1025,9 +1025,9 @@ niiri:b07d53658c12f0d165aec1cf959f1eb5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:b07d53658c12f0d165aec1cf959f1eb5 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:dbd7ff1039cc058a9180d3a6b19c0d65 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:5e501329a485d9e81bca69bd136264fb
+niiri:9a04edbbfec2046f6e63a9808f7e31be
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1037,9 +1037,9 @@ niiri:5e501329a485d9e81bca69bd136264fb
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:5e501329a485d9e81bca69bd136264fb prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:9a04edbbfec2046f6e63a9808f7e31be prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097
+niiri:4802981400c706074d7089aa4f606c7a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1049,9 +1049,9 @@ niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:4802981400c706074d7089aa4f606c7a prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:f19fc244e1ad9fb88396e6dc5d62c29b
+niiri:0c9c1006b093a8cc91c759baf58575ee
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1061,9 +1061,9 @@ niiri:f19fc244e1ad9fb88396e6dc5d62c29b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:f19fc244e1ad9fb88396e6dc5d62c29b prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:0c9c1006b093a8cc91c759baf58575ee prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:8a6f880f7b8eaf62148b54fef7844b09
+niiri:9e9eebffba744c379bca54d713a85d3b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1073,9 +1073,9 @@ niiri:8a6f880f7b8eaf62148b54fef7844b09
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:8a6f880f7b8eaf62148b54fef7844b09 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:9e9eebffba744c379bca54d713a85d3b prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:de48b7494a3d45a8a57e155aeea2f132
+niiri:2ef2320c7a264cf13420c161d25ff5cc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1085,9 +1085,9 @@ niiri:de48b7494a3d45a8a57e155aeea2f132
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:de48b7494a3d45a8a57e155aeea2f132 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:2ef2320c7a264cf13420c161d25ff5cc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:c60f3aab1eee7d78c6850a16c38162dc
+niiri:53b5e166978251c052e00c9a4fe81fdc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1097,9 +1097,9 @@ niiri:c60f3aab1eee7d78c6850a16c38162dc
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:c60f3aab1eee7d78c6850a16c38162dc prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:53b5e166978251c052e00c9a4fe81fdc prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:859e657235309e3db15ccb1f14c1e7ba
+niiri:de88c64838ddf5de0155dcdce61cf6c0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1109,9 +1109,9 @@ niiri:859e657235309e3db15ccb1f14c1e7ba
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:859e657235309e3db15ccb1f14c1e7ba prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:de88c64838ddf5de0155dcdce61cf6c0 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:065fb1288e613aa1089a803ba4b13d87
+niiri:02344c7a7b0c9af7c25dbcd3cbd09300
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1121,9 +1121,9 @@ niiri:065fb1288e613aa1089a803ba4b13d87
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:065fb1288e613aa1089a803ba4b13d87 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:02344c7a7b0c9af7c25dbcd3cbd09300 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:021e14b3f5e58d6dd1904bdbad37b113
+niiri:22648332b0e4fb9a38556afd35646c42
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1133,9 +1133,9 @@ niiri:021e14b3f5e58d6dd1904bdbad37b113
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:021e14b3f5e58d6dd1904bdbad37b113 prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:22648332b0e4fb9a38556afd35646c42 prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:7fa11ca3554a75156c897f72b0a338ac
+niiri:3b46a57f86b33c173fe10a245389f4ff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1145,1297 +1145,1297 @@ niiri:7fa11ca3554a75156c897f72b0a338ac
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:7fa11ca3554a75156c897f72b0a338ac prov:wasDerivedFrom niiri:04e3f1275db373d13cac82285a23f702 .
+niiri:3b46a57f86b33c173fe10a245389f4ff prov:wasDerivedFrom niiri:b92de8901b2a05ad20e537b7d45bcded .
 
-niiri:b3b769322ee6f2728df46b1d7e729a2c
+niiri:bbac0b57ed4deddd70eb50803fb36999
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:2cc8cbc51d2e2dd1d34f08891cbe366d ;
+    prov:atLocation niiri:253372e924e130c4a5343ebb6faf24b0 ;
     prov:value "13.6061105728149"^^xsd:float ;
     nidm_equivalentZStatistic: "5.86214047392852"^^xsd:float ;
     nidm_pValueUncorrected: "2.28469099194939e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000382050559925018"^^xsd:float ;
     nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
 
-niiri:2cc8cbc51d2e2dd1d34f08891cbe366d
+niiri:253372e924e130c4a5343ebb6faf24b0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[34,-86,0]"^^xsd:string .
 
-niiri:b3b769322ee6f2728df46b1d7e729a2c prov:wasDerivedFrom niiri:1cf06d93f4aed03ee50d587421161410 .
+niiri:bbac0b57ed4deddd70eb50803fb36999 prov:wasDerivedFrom niiri:46ce368f726925043d0fdf11d3ce812c .
 
-niiri:0962722c2fe8603177b631a54d2747fd
+niiri:1c9824886d035515f910ce93f1becb24
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:12b4490a7a2a9265c0fb5c1cad432626 ;
+    prov:atLocation niiri:6560dc3c0cedd518d2e9c8d22200d849 ;
     prov:value "11.9614944458008"^^xsd:float ;
     nidm_equivalentZStatistic: "5.59772141079875"^^xsd:float ;
     nidm_pValueUncorrected: "1.08593692926817e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00181592543329545"^^xsd:float ;
     nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
 
-niiri:12b4490a7a2a9265c0fb5c1cad432626
+niiri:6560dc3c0cedd518d2e9c8d22200d849
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[30,-78,36]"^^xsd:string .
 
-niiri:0962722c2fe8603177b631a54d2747fd prov:wasDerivedFrom niiri:1cf06d93f4aed03ee50d587421161410 .
+niiri:1c9824886d035515f910ce93f1becb24 prov:wasDerivedFrom niiri:46ce368f726925043d0fdf11d3ce812c .
 
-niiri:56e9acaa44092839074f4fe2f1cbeb87
+niiri:64b80549819f8dfbe67bba4d26272007
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:95c264e1e21bd313ad9649cc29570602 ;
+    prov:atLocation niiri:bf5b57a2467e79a41847b729706bb7f7 ;
     prov:value "10.5961866378784"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34279531222125"^^xsd:float ;
     nidm_pValueUncorrected: "4.5762046707587e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00765242110449371"^^xsd:float ;
     nidm_qValueFDR: "0.000248881974141536"^^xsd:float .
 
-niiri:95c264e1e21bd313ad9649cc29570602
+niiri:bf5b57a2467e79a41847b729706bb7f7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[34,-48,44]"^^xsd:string .
 
-niiri:56e9acaa44092839074f4fe2f1cbeb87 prov:wasDerivedFrom niiri:1cf06d93f4aed03ee50d587421161410 .
+niiri:64b80549819f8dfbe67bba4d26272007 prov:wasDerivedFrom niiri:46ce368f726925043d0fdf11d3ce812c .
 
-niiri:5a1c78a3e12360263792a811b8b793e7
+niiri:4d0e94437b61697668b47fdb1b75b33c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:fe2447910ca73bf4173a0bc09b5c82ef ;
+    prov:atLocation niiri:53107adcc0ef1666a9861e881bf02340 ;
     prov:value "11.9789819717407"^^xsd:float ;
     nidm_equivalentZStatistic: "5.6007582829493"^^xsd:float ;
     nidm_pValueUncorrected: "1.06708079039564e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00178439382075002"^^xsd:float ;
     nidm_qValueFDR: "0.000186387780128805"^^xsd:float .
 
-niiri:fe2447910ca73bf4173a0bc09b5c82ef
+niiri:53107adcc0ef1666a9861e881bf02340
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-46,-54,-12]"^^xsd:string .
 
-niiri:5a1c78a3e12360263792a811b8b793e7 prov:wasDerivedFrom niiri:1a7642317b9c235ad3c8606f26710b96 .
+niiri:4d0e94437b61697668b47fdb1b75b33c prov:wasDerivedFrom niiri:a121a3d6c11f9c710a28e61253277933 .
 
-niiri:579e3d2553a1f65ce2b443a85f7f7e78
+niiri:c72107be6be92b5977ee1b066d2ed2df
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:38e45fd9e8f667e140bcb4cd465dff2a ;
+    prov:atLocation niiri:340954c4fec53251517830b22ef6060f ;
     prov:value "11.3053674697876"^^xsd:float ;
     nidm_equivalentZStatistic: "5.47978759981232"^^xsd:float ;
     nidm_pValueUncorrected: "2.12918364050907e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00356046346733208"^^xsd:float ;
     nidm_qValueFDR: "0.000225699919390338"^^xsd:float .
 
-niiri:38e45fd9e8f667e140bcb4cd465dff2a
+niiri:340954c4fec53251517830b22ef6060f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[-48,-64,-8]"^^xsd:string .
 
-niiri:579e3d2553a1f65ce2b443a85f7f7e78 prov:wasDerivedFrom niiri:1a7642317b9c235ad3c8606f26710b96 .
+niiri:c72107be6be92b5977ee1b066d2ed2df prov:wasDerivedFrom niiri:a121a3d6c11f9c710a28e61253277933 .
 
-niiri:8fde575882a0e0c286f85ce29ad62c58
+niiri:544ba6228591b8c8ffd1e693b78fb571
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:ea247c88d42d40da9044ae0523463ac4 ;
+    prov:atLocation niiri:beb47d7b86e9956408d6e84a62a2df4a ;
     prov:value "9.59214210510254"^^xsd:float ;
     nidm_equivalentZStatistic: "5.12915279008791"^^xsd:float ;
     nidm_pValueUncorrected: "1.45524525096974e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0243349038623457"^^xsd:float ;
     nidm_qValueFDR: "0.000374773184801466"^^xsd:float .
 
-niiri:ea247c88d42d40da9044ae0523463ac4
+niiri:beb47d7b86e9956408d6e84a62a2df4a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[-46,-72,-6]"^^xsd:string .
 
-niiri:8fde575882a0e0c286f85ce29ad62c58 prov:wasDerivedFrom niiri:1a7642317b9c235ad3c8606f26710b96 .
+niiri:544ba6228591b8c8ffd1e693b78fb571 prov:wasDerivedFrom niiri:a121a3d6c11f9c710a28e61253277933 .
 
-niiri:5620f2a9a83f08e4e4e2e452ed521bfb
+niiri:45d7b72f120c5a905c74b6ef035179d1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:807ce33ed88a8e53dcb621151ae91a66 ;
+    prov:atLocation niiri:fb524a7a97d8dc293563afed5235a273 ;
     prov:value "8.26132202148438"^^xsd:float ;
     nidm_equivalentZStatistic: "4.8021068311854"^^xsd:float ;
     nidm_pValueUncorrected: "7.85024427352177e-07"^^xsd:float ;
     nidm_pValueFWER: "0.131273406272461"^^xsd:float ;
     nidm_qValueFDR: "0.000714072820754613"^^xsd:float .
 
-niiri:807ce33ed88a8e53dcb621151ae91a66
+niiri:fb524a7a97d8dc293563afed5235a273
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[-26,-76,32]"^^xsd:string .
 
-niiri:5620f2a9a83f08e4e4e2e452ed521bfb prov:wasDerivedFrom niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8 .
+niiri:45d7b72f120c5a905c74b6ef035179d1 prov:wasDerivedFrom niiri:46ae5678b67f432a5739e26d30b8b9fc .
 
-niiri:49d7d90f66e4da833c690cd5883a10e7
+niiri:750f947db3f44470b84b8a0b7262e50c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:a9a21ab8f48ab130ada7bc6efcded96d ;
+    prov:atLocation niiri:8bc38c5d28a6e5a22576873242e357d3 ;
     prov:value "7.54039764404297"^^xsd:float ;
     nidm_equivalentZStatistic: "4.59887376341391"^^xsd:float ;
     nidm_pValueUncorrected: "2.12390533416151e-06"^^xsd:float ;
     nidm_pValueFWER: "0.355164074926112"^^xsd:float ;
     nidm_qValueFDR: "0.00112750499976544"^^xsd:float .
 
-niiri:a9a21ab8f48ab130ada7bc6efcded96d
+niiri:8bc38c5d28a6e5a22576873242e357d3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-38,-46,44]"^^xsd:string .
 
-niiri:49d7d90f66e4da833c690cd5883a10e7 prov:wasDerivedFrom niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8 .
+niiri:750f947db3f44470b84b8a0b7262e50c prov:wasDerivedFrom niiri:46ae5678b67f432a5739e26d30b8b9fc .
 
-niiri:27fde605695ea87f488e331274bbffb0
+niiri:89ab361e0947ad2cd7741823700a026b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:1f9cb7e030174f7f9631db464ceecffe ;
+    prov:atLocation niiri:1e831d7963c01a6b5512e380dfc42b04 ;
     prov:value "7.09534215927124"^^xsd:float ;
     nidm_equivalentZStatistic: "4.46234965259847"^^xsd:float ;
     nidm_pValueUncorrected: "4.05329024755208e-06"^^xsd:float ;
     nidm_pValueFWER: "0.550389997209789"^^xsd:float ;
     nidm_qValueFDR: "0.00152026219003999"^^xsd:float .
 
-niiri:1f9cb7e030174f7f9631db464ceecffe
+niiri:1e831d7963c01a6b5512e380dfc42b04
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-24,-72,44]"^^xsd:string .
 
-niiri:27fde605695ea87f488e331274bbffb0 prov:wasDerivedFrom niiri:a7c05d06d65ab3cc5a961d5c0c1a6ea8 .
+niiri:89ab361e0947ad2cd7741823700a026b prov:wasDerivedFrom niiri:46ae5678b67f432a5739e26d30b8b9fc .
 
-niiri:9a3c595e0ddc14214f4c9c93eb68dd36
+niiri:04a53addf635f1622be8ce7e4b4fd46f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:07d77ef1ba5bc8952fe942d5c9b7efd7 ;
+    prov:atLocation niiri:bfc78fed76fb0cda1dc19ea85be43504 ;
     prov:value "7.53033494949341"^^xsd:float ;
     nidm_equivalentZStatistic: "4.59588573954922"^^xsd:float ;
     nidm_pValueUncorrected: "2.15457400010166e-06"^^xsd:float ;
     nidm_pValueFWER: "0.36029256155409"^^xsd:float ;
     nidm_qValueFDR: "0.00113656959480786"^^xsd:float .
 
-niiri:07d77ef1ba5bc8952fe942d5c9b7efd7
+niiri:bfc78fed76fb0cda1dc19ea85be43504
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-20,-10,48]"^^xsd:string .
 
-niiri:9a3c595e0ddc14214f4c9c93eb68dd36 prov:wasDerivedFrom niiri:57b5c372ef2a2b5e726b538a4a5d80db .
+niiri:04a53addf635f1622be8ce7e4b4fd46f prov:wasDerivedFrom niiri:ac8f8138199a2f60489cb1fe2bc4c070 .
 
-niiri:b0acf117bc223f33dfefb698485fdbbc
+niiri:37fedcc605762daab25ba3d15823f4f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:45e55c7dc0c0ad9a7b5a0041cc5079ac ;
+    prov:atLocation niiri:97810d5af81d5e9362e02d4fd86a848e ;
     prov:value "4.24029636383057"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30076820538094"^^xsd:float ;
     nidm_pValueUncorrected: "0.000482102531686568"^^xsd:float ;
     nidm_pValueFWER: "0.999999999415186"^^xsd:float ;
     nidm_qValueFDR: "0.015845468443456"^^xsd:float .
 
-niiri:45e55c7dc0c0ad9a7b5a0041cc5079ac
+niiri:97810d5af81d5e9362e02d4fd86a848e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-26,0,56]"^^xsd:string .
 
-niiri:b0acf117bc223f33dfefb698485fdbbc prov:wasDerivedFrom niiri:57b5c372ef2a2b5e726b538a4a5d80db .
+niiri:37fedcc605762daab25ba3d15823f4f6 prov:wasDerivedFrom niiri:ac8f8138199a2f60489cb1fe2bc4c070 .
 
-niiri:7f38de5b18de7d50cf6bbab3de7ed61d
+niiri:4d986a80344be2abfcf5c339af16638a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:549cbc20d7a3347bd507c93a62cb962d ;
+    prov:atLocation niiri:2a40d83993773c6f1e5ebc1385fd442d ;
     prov:value "7.17061138153076"^^xsd:float ;
     nidm_equivalentZStatistic: "4.48608583316407"^^xsd:float ;
     nidm_pValueUncorrected: "3.62717632940157e-06"^^xsd:float ;
     nidm_pValueFWER: "0.521824836713063"^^xsd:float ;
     nidm_qValueFDR: "0.00145106406730833"^^xsd:float .
 
-niiri:549cbc20d7a3347bd507c93a62cb962d
+niiri:2a40d83993773c6f1e5ebc1385fd442d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[46,6,28]"^^xsd:string .
 
-niiri:7f38de5b18de7d50cf6bbab3de7ed61d prov:wasDerivedFrom niiri:2260abfbc92b3918f8c4e115273811bc .
+niiri:4d986a80344be2abfcf5c339af16638a prov:wasDerivedFrom niiri:3dfc00b52233c69b59012bb4e4590bd6 .
 
-niiri:737d6891167edd5697898729334b6f23
+niiri:0fc5cc3b06805b359990af6af9b7de2c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:d13e6a0e17e641c4dd7a920619e27556 ;
+    prov:atLocation niiri:c348bcf295bbfcc12359afcb0fe8f75b ;
     prov:value "5.89265918731689"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04200617451887"^^xsd:float ;
     nidm_pValueUncorrected: "2.64979184040337e-05"^^xsd:float ;
     nidm_pValueFWER: "0.95205805171536"^^xsd:float ;
     nidm_qValueFDR: "0.00357309996201585"^^xsd:float .
 
-niiri:d13e6a0e17e641c4dd7a920619e27556
+niiri:c348bcf295bbfcc12359afcb0fe8f75b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[52,12,26]"^^xsd:string .
 
-niiri:737d6891167edd5697898729334b6f23 prov:wasDerivedFrom niiri:2260abfbc92b3918f8c4e115273811bc .
+niiri:0fc5cc3b06805b359990af6af9b7de2c prov:wasDerivedFrom niiri:3dfc00b52233c69b59012bb4e4590bd6 .
 
-niiri:7fb07c54f710b892820adb154f5437c2
+niiri:53295d63fe3c3e2da20993fcb585d43a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:b15b1251bcf12c164abd2f8d5036175d ;
+    prov:atLocation niiri:7aa7d0132011ee94a14b377939be3510 ;
     prov:value "5.21978235244751"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76688098065344"^^xsd:float ;
     nidm_pValueUncorrected: "8.26498774630924e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998715750644301"^^xsd:float ;
     nidm_qValueFDR: "0.00632560594393137"^^xsd:float .
 
-niiri:b15b1251bcf12c164abd2f8d5036175d
+niiri:7aa7d0132011ee94a14b377939be3510
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[40,-2,30]"^^xsd:string .
 
-niiri:7fb07c54f710b892820adb154f5437c2 prov:wasDerivedFrom niiri:2260abfbc92b3918f8c4e115273811bc .
+niiri:53295d63fe3c3e2da20993fcb585d43a prov:wasDerivedFrom niiri:3dfc00b52233c69b59012bb4e4590bd6 .
 
-niiri:d196f3f4c50dd1d93b2bd4cae01fbd44
+niiri:998b270ff5f29f350d50cfa5c76e8ad7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:d867aea23af72afb3d824134fd7bb62e ;
+    prov:atLocation niiri:87d8215adb89a7807d1b78b73a28d6f1 ;
     prov:value "6.82257699966431"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3739930910033"^^xsd:float ;
     nidm_pValueUncorrected: "6.09971206799731e-06"^^xsd:float ;
     nidm_pValueFWER: "0.657888162568606"^^xsd:float ;
     nidm_qValueFDR: "0.00180198082091417"^^xsd:float .
 
-niiri:d867aea23af72afb3d824134fd7bb62e
+niiri:87d8215adb89a7807d1b78b73a28d6f1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-10,24,12]"^^xsd:string .
 
-niiri:d196f3f4c50dd1d93b2bd4cae01fbd44 prov:wasDerivedFrom niiri:428e3b496b74c693be37a9557e535f44 .
+niiri:998b270ff5f29f350d50cfa5c76e8ad7 prov:wasDerivedFrom niiri:e17a558d17c93c4d23cebfdb241952ae .
 
-niiri:a87c684980a741cdd7c3d90c8cbe99df
+niiri:a209c7cd2db8d53b5b130f27b9322d0f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:497bf13cc6e31e241c2961c960131d00 ;
+    prov:atLocation niiri:21b4eea73e16e09c4881b4a5dc18afc5 ;
     prov:value "4.99530935287476"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66747111912266"^^xsd:float ;
     nidm_pValueUncorrected: "0.000122480604349273"^^xsd:float ;
     nidm_pValueFWER: "0.999830619862512"^^xsd:float ;
     nidm_qValueFDR: "0.00775152511109977"^^xsd:float .
 
-niiri:497bf13cc6e31e241c2961c960131d00
+niiri:21b4eea73e16e09c4881b4a5dc18afc5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-24,28,4]"^^xsd:string .
 
-niiri:a87c684980a741cdd7c3d90c8cbe99df prov:wasDerivedFrom niiri:428e3b496b74c693be37a9557e535f44 .
+niiri:a209c7cd2db8d53b5b130f27b9322d0f prov:wasDerivedFrom niiri:e17a558d17c93c4d23cebfdb241952ae .
 
-niiri:f3bc13cbd3d6523a4cd20f41c8e6a115
+niiri:693ea803be290552513560b1a7fef0bf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:3f00e702d729fe98e37d25e45791f4e9 ;
+    prov:atLocation niiri:aea6c3f2722e9910b54ddf00cebc5cee ;
     prov:value "6.34009504318237"^^xsd:float ;
     nidm_equivalentZStatistic: "4.20806884695295"^^xsd:float ;
     nidm_pValueUncorrected: "1.28781200698924e-05"^^xsd:float ;
     nidm_pValueFWER: "0.839224226046397"^^xsd:float ;
     nidm_qValueFDR: "0.00253613065643777"^^xsd:float .
 
-niiri:3f00e702d729fe98e37d25e45791f4e9
+niiri:aea6c3f2722e9910b54ddf00cebc5cee
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[10,-74,-34]"^^xsd:string .
 
-niiri:f3bc13cbd3d6523a4cd20f41c8e6a115 prov:wasDerivedFrom niiri:f2233fa4afd02fcceeb05d8f7c4801ff .
+niiri:693ea803be290552513560b1a7fef0bf prov:wasDerivedFrom niiri:2ee06584880d716387a7002834742906 .
 
-niiri:65f048f0e7c5732f5773ecc174b71f67
+niiri:f536b5609348be9036fb10330e373e3f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:ca3f9e37a3e82369bdea4d8f85916a5d ;
+    prov:atLocation niiri:f90062339ac75c1a5a7bd5460360006e ;
     prov:value "5.96963739395142"^^xsd:float ;
     nidm_equivalentZStatistic: "4.07147450951934"^^xsd:float ;
     nidm_pValueUncorrected: "2.3358237619564e-05"^^xsd:float ;
     nidm_pValueFWER: "0.938028702807278"^^xsd:float ;
     nidm_qValueFDR: "0.00332713529017219"^^xsd:float .
 
-niiri:ca3f9e37a3e82369bdea4d8f85916a5d
+niiri:f90062339ac75c1a5a7bd5460360006e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-50,2,26]"^^xsd:string .
 
-niiri:65f048f0e7c5732f5773ecc174b71f67 prov:wasDerivedFrom niiri:b1ef2839e620d66c14bd83deb3aec390 .
+niiri:f536b5609348be9036fb10330e373e3f prov:wasDerivedFrom niiri:0a170fb537c25a43d335a98102d35aeb .
 
-niiri:9743d512bbbe9718ac3fa1edbe7c8695
+niiri:44a31bb2492c4d22b1d559091f48eefa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:fdded5d9c86faca9be4e46d670dd39dd ;
+    prov:atLocation niiri:1da6912641096977dda7267c40fe4107 ;
     prov:value "5.75492286682129"^^xsd:float ;
     nidm_equivalentZStatistic: "3.98829870240338"^^xsd:float ;
     nidm_pValueUncorrected: "3.32744188140666e-05"^^xsd:float ;
     nidm_pValueFWER: "0.971577838301208"^^xsd:float ;
     nidm_qValueFDR: "0.00400598087684945"^^xsd:float .
 
-niiri:fdded5d9c86faca9be4e46d670dd39dd
+niiri:1da6912641096977dda7267c40fe4107
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-50,-4,50]"^^xsd:string .
 
-niiri:9743d512bbbe9718ac3fa1edbe7c8695 prov:wasDerivedFrom niiri:b1ef2839e620d66c14bd83deb3aec390 .
+niiri:44a31bb2492c4d22b1d559091f48eefa prov:wasDerivedFrom niiri:0a170fb537c25a43d335a98102d35aeb .
 
-niiri:ee644a0b74bfd447b2b2b3dbc440d5f2
+niiri:75cd1f4a8537e15fd6b96e3da0abf348
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:1249869c1dfb98c3e618a1f06d22a1ea ;
+    prov:atLocation niiri:e2d566acff4bd4ebe5d3246828cbfc6d ;
     prov:value "5.52769041061401"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89683707514784"^^xsd:float ;
     nidm_pValueUncorrected: "4.87285666391779e-05"^^xsd:float ;
     nidm_pValueFWER: "0.990314755199069"^^xsd:float ;
     nidm_qValueFDR: "0.00479616651502499"^^xsd:float .
 
-niiri:1249869c1dfb98c3e618a1f06d22a1ea
+niiri:e2d566acff4bd4ebe5d3246828cbfc6d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-52,0,40]"^^xsd:string .
 
-niiri:ee644a0b74bfd447b2b2b3dbc440d5f2 prov:wasDerivedFrom niiri:b1ef2839e620d66c14bd83deb3aec390 .
+niiri:75cd1f4a8537e15fd6b96e3da0abf348 prov:wasDerivedFrom niiri:0a170fb537c25a43d335a98102d35aeb .
 
-niiri:d870f02cb19a7c9c70e01dfea7cef689
+niiri:3575c3d4f244e7bf282358585a84906c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:cf09b331b6ecf92a4276fede122052dd ;
+    prov:atLocation niiri:7b573b4dd63bc077dfe4dd6768191656 ;
     prov:value "5.91596412658691"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05096850425873"^^xsd:float ;
     nidm_pValueUncorrected: "2.55030367465325e-05"^^xsd:float ;
     nidm_pValueFWER: "0.948053549525439"^^xsd:float ;
     nidm_qValueFDR: "0.00348881065430462"^^xsd:float .
 
-niiri:cf09b331b6ecf92a4276fede122052dd
+niiri:7b573b4dd63bc077dfe4dd6768191656
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[6,18,6]"^^xsd:string .
 
-niiri:d870f02cb19a7c9c70e01dfea7cef689 prov:wasDerivedFrom niiri:6a1143e807a7221c10cbd94b8f352cb3 .
+niiri:3575c3d4f244e7bf282358585a84906c prov:wasDerivedFrom niiri:0b191a1bce28484b4d509f123468cafc .
 
-niiri:93eee431f407818d7a288b7a68d56d3b
+niiri:4cc4b89c15af11852dd0fdf83661eab7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:08dd0be6761b0981da82cbc6c136514c ;
+    prov:atLocation niiri:12ad0a85c946e3ba0ee32ec6ca9d30df ;
     prov:value "4.54182481765747"^^xsd:float ;
     nidm_equivalentZStatistic: "3.45355045258419"^^xsd:float ;
     nidm_pValueUncorrected: "0.000276629401356199"^^xsd:float ;
     nidm_pValueFWER: "0.999999655761857"^^xsd:float ;
     nidm_qValueFDR: "0.0116903072898716"^^xsd:float .
 
-niiri:08dd0be6761b0981da82cbc6c136514c
+niiri:12ad0a85c946e3ba0ee32ec6ca9d30df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[14,24,4]"^^xsd:string .
 
-niiri:93eee431f407818d7a288b7a68d56d3b prov:wasDerivedFrom niiri:6a1143e807a7221c10cbd94b8f352cb3 .
+niiri:4cc4b89c15af11852dd0fdf83661eab7 prov:wasDerivedFrom niiri:0b191a1bce28484b4d509f123468cafc .
 
-niiri:d0dd419634f950cbbc6664604d2bfae1
+niiri:38d59cc816cec77fb882cd2fdd15a9bd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:5073a8f82b87e9f0bec1f05cbf454d90 ;
+    prov:atLocation niiri:a2d5f7682067f7ac13c86ed08bac1fc2 ;
     prov:value "5.72671985626221"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97714309813652"^^xsd:float ;
     nidm_pValueUncorrected: "3.48740977119677e-05"^^xsd:float ;
     nidm_pValueFWER: "0.974745203823651"^^xsd:float ;
     nidm_qValueFDR: "0.00410957672904248"^^xsd:float .
 
-niiri:5073a8f82b87e9f0bec1f05cbf454d90
+niiri:a2d5f7682067f7ac13c86ed08bac1fc2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-6,0,58]"^^xsd:string .
 
-niiri:d0dd419634f950cbbc6664604d2bfae1 prov:wasDerivedFrom niiri:17a361a6af9be1a09623d4875d9de272 .
+niiri:38d59cc816cec77fb882cd2fdd15a9bd prov:wasDerivedFrom niiri:03c0220efd2c203f65a22694082f5442 .
 
-niiri:1595c393eed7051abc16cafee4ac6ae9
+niiri:03b70a255fbe5aaeb503141abdf77e01
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:5f9783b56cea07afdad963e78526eb93 ;
+    prov:atLocation niiri:b2a905dcae5e518e954d4e5ca2afbf39 ;
     prov:value "5.25150108337402"^^xsd:float ;
     nidm_equivalentZStatistic: "3.78060278170665"^^xsd:float ;
     nidm_pValueUncorrected: "7.82245573558438e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998359989376909"^^xsd:float ;
     nidm_qValueFDR: "0.00612998059012206"^^xsd:float .
 
-niiri:5f9783b56cea07afdad963e78526eb93
+niiri:b2a905dcae5e518e954d4e5ca2afbf39
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[0,6,56]"^^xsd:string .
 
-niiri:1595c393eed7051abc16cafee4ac6ae9 prov:wasDerivedFrom niiri:17a361a6af9be1a09623d4875d9de272 .
+niiri:03b70a255fbe5aaeb503141abdf77e01 prov:wasDerivedFrom niiri:03c0220efd2c203f65a22694082f5442 .
 
-niiri:cdf7c013da79b02373eb314d67b328ca
+niiri:4157309e78d7ded58b0c0e0ead87a224
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:6e2c760a2125a3b04227107745989f35 ;
+    prov:atLocation niiri:2bd2a2878ad3f221f0ec6abeed136ca3 ;
     prov:value "4.54090023040771"^^xsd:float ;
     nidm_equivalentZStatistic: "3.45309533835059"^^xsd:float ;
     nidm_pValueUncorrected: "0.00027709654919561"^^xsd:float ;
     nidm_pValueFWER: "0.99999966134203"^^xsd:float ;
     nidm_qValueFDR: "0.0116998384744116"^^xsd:float .
 
-niiri:6e2c760a2125a3b04227107745989f35
+niiri:2bd2a2878ad3f221f0ec6abeed136ca3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[-4,0,66]"^^xsd:string .
 
-niiri:cdf7c013da79b02373eb314d67b328ca prov:wasDerivedFrom niiri:17a361a6af9be1a09623d4875d9de272 .
+niiri:4157309e78d7ded58b0c0e0ead87a224 prov:wasDerivedFrom niiri:03c0220efd2c203f65a22694082f5442 .
 
-niiri:1af924931744ebf87d5aa4d7b639a169
+niiri:f81e942c055a87ae23697653d0f9e931
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:9be6eab29ca29ed5a1bda8a4751ab3e1 ;
+    prov:atLocation niiri:01b426c0493efdc5de3e1ee498c74e3a ;
     prov:value "5.37388372421265"^^xsd:float ;
     nidm_equivalentZStatistic: "3.83281667931374"^^xsd:float ;
     nidm_pValueUncorrected: "6.33421799035583e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996123053382791"^^xsd:float ;
     nidm_qValueFDR: "0.00547832540919611"^^xsd:float .
 
-niiri:9be6eab29ca29ed5a1bda8a4751ab3e1
+niiri:01b426c0493efdc5de3e1ee498c74e3a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[6,-12,14]"^^xsd:string .
 
-niiri:1af924931744ebf87d5aa4d7b639a169 prov:wasDerivedFrom niiri:646a3e8aac6f4eee8e8562e0616d65ba .
+niiri:f81e942c055a87ae23697653d0f9e931 prov:wasDerivedFrom niiri:847c108abc6d60c3422f305d80cbe544 .
 
-niiri:063ac2e37579cf1830838723135ef892
+niiri:558b717a6eaaf2aaa2613f2e2d87fd7e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:17cc9a7d147c38df0908ed91f50ffed6 ;
+    prov:atLocation niiri:0be6fd36a7a88597550e5298744761b6 ;
     prov:value "5.16269016265869"^^xsd:float ;
     nidm_equivalentZStatistic: "3.74198250168727"^^xsd:float ;
     nidm_pValueUncorrected: "9.12871154093997e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999192871962629"^^xsd:float ;
     nidm_qValueFDR: "0.00669851286267874"^^xsd:float .
 
-niiri:17cc9a7d147c38df0908ed91f50ffed6
+niiri:0be6fd36a7a88597550e5298744761b6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[36,20,4]"^^xsd:string .
 
-niiri:063ac2e37579cf1830838723135ef892 prov:wasDerivedFrom niiri:8e53fdbcd507f29fa491c0ee30766820 .
+niiri:558b717a6eaaf2aaa2613f2e2d87fd7e prov:wasDerivedFrom niiri:89f5194a4b0e2d5f67db04f10c0882ac .
 
-niiri:0222a75a9a5232dac912eb7326478415
+niiri:3c7a990e35408ee2e2bc41f141132134
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:f59f2ef887c5f35ca37e79a29a172929 ;
+    prov:atLocation niiri:efc8c79d2c3cdc3e0c280b1398a1831b ;
     prov:value "4.8655366897583"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60809771461691"^^xsd:float ;
     nidm_pValueUncorrected: "0.000154225162826815"^^xsd:float ;
     nidm_pValueFWER: "0.9999601230968"^^xsd:float ;
     nidm_qValueFDR: "0.00861184257857328"^^xsd:float .
 
-niiri:f59f2ef887c5f35ca37e79a29a172929
+niiri:efc8c79d2c3cdc3e0c280b1398a1831b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[30,24,0]"^^xsd:string .
 
-niiri:0222a75a9a5232dac912eb7326478415 prov:wasDerivedFrom niiri:8e53fdbcd507f29fa491c0ee30766820 .
+niiri:3c7a990e35408ee2e2bc41f141132134 prov:wasDerivedFrom niiri:89f5194a4b0e2d5f67db04f10c0882ac .
 
-niiri:8453d293e50b367bb3a49f7533014a86
+niiri:a4c025afba5ca5234ab79d7354c091c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:24146062d9114b1e61245629356d88ea ;
+    prov:atLocation niiri:9c3802455fb925cb9f3bbd7949a49033 ;
     prov:value "5.15075159072876"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73674319192816"^^xsd:float ;
     nidm_pValueUncorrected: "9.3209572512909e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999270580432391"^^xsd:float ;
     nidm_qValueFDR: "0.00676830985421939"^^xsd:float .
 
-niiri:24146062d9114b1e61245629356d88ea
+niiri:9c3802455fb925cb9f3bbd7949a49033
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[0,-50,-28]"^^xsd:string .
 
-niiri:8453d293e50b367bb3a49f7533014a86 prov:wasDerivedFrom niiri:caa24947392807e9fd656eb7e677bb90 .
+niiri:a4c025afba5ca5234ab79d7354c091c7 prov:wasDerivedFrom niiri:d97dd5148291142c057785550af3eb2d .
 
-niiri:2776c7b9e158c2ca4c466f45748a27ad
+niiri:c132ce6a3b937fda0d16d0ee8cf1c129
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:5d350af686c7181e6779f8105a3c4356 ;
+    prov:atLocation niiri:c291ec5fb390da072831c070b623bd2b ;
     prov:value "5.12083530426025"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7235640261549"^^xsd:float ;
     nidm_pValueUncorrected: "9.82150082137201e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999437677420886"^^xsd:float ;
     nidm_qValueFDR: "0.00690105743012952"^^xsd:float .
 
-niiri:5d350af686c7181e6779f8105a3c4356
+niiri:c291ec5fb390da072831c070b623bd2b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[52,10,40]"^^xsd:string .
 
-niiri:2776c7b9e158c2ca4c466f45748a27ad prov:wasDerivedFrom niiri:aa6f6ac422b272159fb670d4c6c75fe8 .
+niiri:c132ce6a3b937fda0d16d0ee8cf1c129 prov:wasDerivedFrom niiri:50d0f0b594a3407fd672472426d8a80a .
 
-niiri:36b9e15a4f579cb8b8c094d8019239d3
+niiri:66f1d389f91b7542af2830f2d003e0a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:3cfe07192bdf278215f377f5cb477db4 ;
+    prov:atLocation niiri:0cffbb433a9a0d0427187a49d93a7e65 ;
     prov:value "5.10948324203491"^^xsd:float ;
     nidm_equivalentZStatistic: "3.71854416501836"^^xsd:float ;
     nidm_pValueUncorrected: "0.000100187131384155"^^xsd:float ;
     nidm_pValueFWER: "0.999491804107717"^^xsd:float ;
     nidm_qValueFDR: "0.00699662698174139"^^xsd:float .
 
-niiri:3cfe07192bdf278215f377f5cb477db4
+niiri:0cffbb433a9a0d0427187a49d93a7e65
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[22,-14,12]"^^xsd:string .
 
-niiri:36b9e15a4f579cb8b8c094d8019239d3 prov:wasDerivedFrom niiri:62026e05a2a2355fc124787b15505315 .
+niiri:66f1d389f91b7542af2830f2d003e0a0 prov:wasDerivedFrom niiri:5663af6390cbe1661580022d9cd1db76 .
 
-niiri:36d0607dbf3edae0ba7ee6f15811e9ec
+niiri:97841d29b10ded1b99b8ce22449c5e38
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:43aa1b5aa2a65fcc758b9161fbb691f9 ;
+    prov:atLocation niiri:028379c32508bb74af9ecf4bf7c28dc2 ;
     prov:value "4.99403047561646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66689294332376"^^xsd:float ;
     nidm_pValueUncorrected: "0.00012275776099846"^^xsd:float ;
     nidm_pValueFWER: "0.999832837977675"^^xsd:float ;
     nidm_qValueFDR: "0.00775559440349761"^^xsd:float .
 
-niiri:43aa1b5aa2a65fcc758b9161fbb691f9
+niiri:028379c32508bb74af9ecf4bf7c28dc2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-14,-2,-2]"^^xsd:string .
 
-niiri:36d0607dbf3edae0ba7ee6f15811e9ec prov:wasDerivedFrom niiri:93450961f0d8d0f6a3b90a5894e1f87b .
+niiri:97841d29b10ded1b99b8ce22449c5e38 prov:wasDerivedFrom niiri:936e9ee0499c3d068e7444f367b65d20 .
 
-niiri:9244cd1d0c66ad9346c4da15cf625887
+niiri:b6a3564f5f97cb6a6c26c428c3cf7fdd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:ba4f669757b7f20b7868b405af9297ec ;
+    prov:atLocation niiri:fb5948c52087fade7dc0a3c08e1c25b1 ;
     prov:value "4.99324655532837"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66653846830519"^^xsd:float ;
     nidm_pValueUncorrected: "0.000122927974348652"^^xsd:float ;
     nidm_pValueFWER: "0.99983418490596"^^xsd:float ;
     nidm_qValueFDR: "0.00775759422864875"^^xsd:float .
 
-niiri:ba4f669757b7f20b7868b405af9297ec
+niiri:fb5948c52087fade7dc0a3c08e1c25b1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[8,-26,14]"^^xsd:string .
 
-niiri:9244cd1d0c66ad9346c4da15cf625887 prov:wasDerivedFrom niiri:9b5ca13a3d263c59792e6e86be4a2e34 .
+niiri:b6a3564f5f97cb6a6c26c428c3cf7fdd prov:wasDerivedFrom niiri:37eed9b79d7a2993d16feb7189856a02 .
 
-niiri:19366255ed63a36546b8f1ee872bddf0
+niiri:5323176e6096d153507b38ceb176512b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:9082f78e97efa65c4dcb194c56ec70fd ;
+    prov:atLocation niiri:e45c7da465b7b04138d0aa7007b2b615 ;
     prov:value "4.89655494689941"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62241950165507"^^xsd:float ;
     nidm_pValueUncorrected: "0.000145930150219908"^^xsd:float ;
     nidm_pValueFWER: "0.999942473649405"^^xsd:float ;
     nidm_qValueFDR: "0.0083498973939701"^^xsd:float .
 
-niiri:9082f78e97efa65c4dcb194c56ec70fd
+niiri:e45c7da465b7b04138d0aa7007b2b615
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[14,8,72]"^^xsd:string .
 
-niiri:19366255ed63a36546b8f1ee872bddf0 prov:wasDerivedFrom niiri:bb0785359fefadd70b1adaaaac3b7884 .
+niiri:5323176e6096d153507b38ceb176512b prov:wasDerivedFrom niiri:9d921e2cb3a8abbe97013ee4bc904c3e .
 
-niiri:7f57e213d8d5aad8818c2534a203dafb
+niiri:a44a0f94f9fe2aaccb70c1503033e39b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:14712e03d1bd30c666abef48eaba5f35 ;
+    prov:atLocation niiri:3303e5e553ccfb344b281bdf1fda0643 ;
     prov:value "4.86036062240601"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60569974829148"^^xsd:float ;
     nidm_pValueUncorrected: "0.000155656460372522"^^xsd:float ;
     nidm_pValueFWER: "0.999962538559828"^^xsd:float ;
     nidm_qValueFDR: "0.00864250020982424"^^xsd:float .
 
-niiri:14712e03d1bd30c666abef48eaba5f35
+niiri:3303e5e553ccfb344b281bdf1fda0643
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-24,-42,-38]"^^xsd:string .
 
-niiri:7f57e213d8d5aad8818c2534a203dafb prov:wasDerivedFrom niiri:000e7e06128006bf16d2f8dd28c288f0 .
+niiri:a44a0f94f9fe2aaccb70c1503033e39b prov:wasDerivedFrom niiri:ba889b1413156c8c9b392f582f507018 .
 
-niiri:9b84b4a69aa3f9ede37b824a44d7ad2b
+niiri:5e9f9523049af6068781e26c745db894
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:abf6dcaaaa3aa218ffa6b3f8dd51d903 ;
+    prov:atLocation niiri:af5219cdfc791f4e67e12be2e6c60fbe ;
     prov:value "4.81803417205811"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58600360944639"^^xsd:float ;
     nidm_pValueUncorrected: "0.00016789215592794"^^xsd:float ;
     nidm_pValueFWER: "0.999977855811547"^^xsd:float ;
     nidm_qValueFDR: "0.00900212220920404"^^xsd:float .
 
-niiri:abf6dcaaaa3aa218ffa6b3f8dd51d903
+niiri:af5219cdfc791f4e67e12be2e6c60fbe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-54,30,14]"^^xsd:string .
 
-niiri:9b84b4a69aa3f9ede37b824a44d7ad2b prov:wasDerivedFrom niiri:fea4f2ec59548d5d8b403064bc42fcd3 .
+niiri:5e9f9523049af6068781e26c745db894 prov:wasDerivedFrom niiri:51665d1fb0cfb8bda978b620ef449077 .
 
-niiri:7f9d189889ab743749e30fd6a45392f5
+niiri:85a6db12151f29eba6c03ad052f455a9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:a2eab965b389db1da335e25f6dbc3ef3 ;
+    prov:atLocation niiri:29cb11c342497725682c33295a8a3469 ;
     prov:value "4.77066373825073"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56377460375569"^^xsd:float ;
     nidm_pValueUncorrected: "0.000182779942677791"^^xsd:float ;
     nidm_pValueFWER: "0.999988096830174"^^xsd:float ;
     nidm_qValueFDR: "0.00940067644112613"^^xsd:float .
 
-niiri:a2eab965b389db1da335e25f6dbc3ef3
+niiri:29cb11c342497725682c33295a8a3469
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-46,30,16]"^^xsd:string .
 
-niiri:7f9d189889ab743749e30fd6a45392f5 prov:wasDerivedFrom niiri:fea4f2ec59548d5d8b403064bc42fcd3 .
+niiri:85a6db12151f29eba6c03ad052f455a9 prov:wasDerivedFrom niiri:51665d1fb0cfb8bda978b620ef449077 .
 
-niiri:6c13004b183580300b78177ee70c0f04
+niiri:a42893da4696ee8d301da513c039bb33
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:3cad6d43185f053748a6c03d25147aac ;
+    prov:atLocation niiri:0d6f26980a7c82addcff37e277d37f87 ;
     prov:value "4.8089394569397"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58175111371795"^^xsd:float ;
     nidm_pValueUncorrected: "0.00017064943193823"^^xsd:float ;
     nidm_pValueFWER: "0.999980290560917"^^xsd:float ;
     nidm_qValueFDR: "0.00906568438361755"^^xsd:float .
 
-niiri:3cad6d43185f053748a6c03d25147aac
+niiri:0d6f26980a7c82addcff37e277d37f87
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[0,-58,-38]"^^xsd:string .
 
-niiri:6c13004b183580300b78177ee70c0f04 prov:wasDerivedFrom niiri:56aff3268c9efc59ac3dd1fccbb1e940 .
+niiri:a42893da4696ee8d301da513c039bb33 prov:wasDerivedFrom niiri:a24fb25342ea5df100b3c9f26c07ccf7 .
 
-niiri:ca7f28f36d471bfff7d6cf2d7ec5bc5c
+niiri:248a55c19c0892c52e726aa851cb8bdd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:5313dfeff4ad8a69948aefe317a1ff63 ;
+    prov:atLocation niiri:51a0bd12c442e02fba73ae2922f15a79 ;
     prov:value "4.80026483535767"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57768829524451"^^xsd:float ;
     nidm_pValueUncorrected: "0.000173323244094692"^^xsd:float ;
     nidm_pValueFWER: "0.999982383849948"^^xsd:float ;
     nidm_qValueFDR: "0.00914672501351889"^^xsd:float .
 
-niiri:5313dfeff4ad8a69948aefe317a1ff63
+niiri:51a0bd12c442e02fba73ae2922f15a79
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-54,12,0]"^^xsd:string .
 
-niiri:ca7f28f36d471bfff7d6cf2d7ec5bc5c prov:wasDerivedFrom niiri:30c41fd03e0e9666df9d194fbe412b52 .
+niiri:248a55c19c0892c52e726aa851cb8bdd prov:wasDerivedFrom niiri:6b3e2550575959313eec60bd44a6b445 .
 
-niiri:49ab596dceb78a958aa318a733a8e5ff
+niiri:759c0b26a71be25fa07292239859245d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:a31fc51cce93b04af96388a0f734c45f ;
+    prov:atLocation niiri:b56fb9e5f57ce68403a9901ac11d45a4 ;
     prov:value "4.77761936187744"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56705096724501"^^xsd:float ;
     nidm_pValueUncorrected: "0.000180510641497822"^^xsd:float ;
     nidm_pValueFWER: "0.999986932005675"^^xsd:float ;
     nidm_qValueFDR: "0.00934466092947769"^^xsd:float .
 
-niiri:a31fc51cce93b04af96388a0f734c45f
+niiri:b56fb9e5f57ce68403a9901ac11d45a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[28,2,60]"^^xsd:string .
 
-niiri:49ab596dceb78a958aa318a733a8e5ff prov:wasDerivedFrom niiri:195a3dcb7bf220b60a464a21245d4ee4 .
+niiri:759c0b26a71be25fa07292239859245d prov:wasDerivedFrom niiri:92cf9681c5af88815bed46d4f69484fe .
 
-niiri:b1871e034d8d5ec7ff867d722b86b6bb
+niiri:31be7f0e3a63c3b71e9774b599f0525b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:bb7833ec8cf5f8d5f4136884a1503263 ;
+    prov:atLocation niiri:942ddb276df261f58059a9ab77022724 ;
     prov:value "4.67176485061646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51672280482077"^^xsd:float ;
     nidm_pValueUncorrected: "0.000218454899154397"^^xsd:float ;
     nidm_pValueFWER: "0.999997106974601"^^xsd:float ;
     nidm_qValueFDR: "0.0103643846403155"^^xsd:float .
 
-niiri:bb7833ec8cf5f8d5f4136884a1503263
+niiri:942ddb276df261f58059a9ab77022724
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[26,-4,54]"^^xsd:string .
 
-niiri:b1871e034d8d5ec7ff867d722b86b6bb prov:wasDerivedFrom niiri:195a3dcb7bf220b60a464a21245d4ee4 .
+niiri:31be7f0e3a63c3b71e9774b599f0525b prov:wasDerivedFrom niiri:92cf9681c5af88815bed46d4f69484fe .
 
-niiri:c63bd3dd97f6db465634edf0fe3e6d7f
+niiri:be9f62ae29bc1bf6f51eea46b13a7a57
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:a7b543fd3444c95cdeddfd292b01c7d4 ;
+    prov:atLocation niiri:9185d52c29fec95f3943cb1408fe38ac ;
     prov:value "4.62480688095093"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49407291194222"^^xsd:float ;
     nidm_pValueUncorrected: "0.000237855539300003"^^xsd:float ;
     nidm_pValueFWER: "0.999998608516906"^^xsd:float ;
     nidm_qValueFDR: "0.0108449863840995"^^xsd:float .
 
-niiri:a7b543fd3444c95cdeddfd292b01c7d4
+niiri:9185d52c29fec95f3943cb1408fe38ac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[20,-4,60]"^^xsd:string .
 
-niiri:c63bd3dd97f6db465634edf0fe3e6d7f prov:wasDerivedFrom niiri:195a3dcb7bf220b60a464a21245d4ee4 .
+niiri:be9f62ae29bc1bf6f51eea46b13a7a57 prov:wasDerivedFrom niiri:92cf9681c5af88815bed46d4f69484fe .
 
-niiri:04edadfd4de6a98b1755ebbb982ffdc5
+niiri:5e5d7e7b87311887d80aece0fcc725f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:3acb438e18302dca6ecfb8f09cc3b8c2 ;
+    prov:atLocation niiri:a731413b420d2d57b872cb88cfeef28b ;
     prov:value "4.67917585372925"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5202791175394"^^xsd:float ;
     nidm_pValueUncorrected: "0.000215546442763337"^^xsd:float ;
     nidm_pValueFWER: "0.99999676461456"^^xsd:float ;
     nidm_qValueFDR: "0.0102906058805538"^^xsd:float .
 
-niiri:3acb438e18302dca6ecfb8f09cc3b8c2
+niiri:a731413b420d2d57b872cb88cfeef28b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-34,-12,42]"^^xsd:string .
 
-niiri:04edadfd4de6a98b1755ebbb982ffdc5 prov:wasDerivedFrom niiri:d09f25e397a79ba3820081611e196ed7 .
+niiri:5e5d7e7b87311887d80aece0fcc725f1 prov:wasDerivedFrom niiri:c8b8db45e94c74708104298c433fecd6 .
 
-niiri:738c518c78aeab009d62d16106762ec8
+niiri:eda03e9ad53b2d5ffc1d87c948b5c073
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:34e4d39ae426eddd8106a75fdb93df16 ;
+    prov:atLocation niiri:0a64737dfbc36713dca9405841ec7e26 ;
     prov:value "4.5969614982605"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48054638647577"^^xsd:float ;
     nidm_pValueUncorrected: "0.000250196083839915"^^xsd:float ;
     nidm_pValueFWER: "0.999999115925319"^^xsd:float ;
     nidm_qValueFDR: "0.0111238765457046"^^xsd:float .
 
-niiri:34e4d39ae426eddd8106a75fdb93df16
+niiri:0a64737dfbc36713dca9405841ec7e26
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[36,-40,-10]"^^xsd:string .
 
-niiri:738c518c78aeab009d62d16106762ec8 prov:wasDerivedFrom niiri:2d07cb807cba69cb83d125ad8a6d9589 .
+niiri:eda03e9ad53b2d5ffc1d87c948b5c073 prov:wasDerivedFrom niiri:e9cca2166adb51f5ec340f78e542f76f .
 
-niiri:b67b4596018aff50f75474b1bc7cec26
+niiri:286d94947c4e1787b77f00b0b7114d06
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:df63022294b12ffbb4ab2b6e51db3a61 ;
+    prov:atLocation niiri:f7eff259178a3f65efdc696ad7a247a6 ;
     prov:value "4.58732891082764"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47585047258978"^^xsd:float ;
     nidm_pValueUncorrected: "0.000254618063707635"^^xsd:float ;
     nidm_pValueFWER: "0.999999246946643"^^xsd:float ;
     nidm_qValueFDR: "0.0112304749683021"^^xsd:float .
 
-niiri:df63022294b12ffbb4ab2b6e51db3a61
+niiri:f7eff259178a3f65efdc696ad7a247a6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[36,-10,48]"^^xsd:string .
 
-niiri:b67b4596018aff50f75474b1bc7cec26 prov:wasDerivedFrom niiri:2d69939d531eb0168273379f7ce52907 .
+niiri:286d94947c4e1787b77f00b0b7114d06 prov:wasDerivedFrom niiri:4ce2f04f5e11fd9609173ed79e458866 .
 
-niiri:872525eb5016723dc3c4e0b0f2f2a5c5
+niiri:41f1a29b28047c513dad04890f92ea62
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:5dffb2412c5920c035fa3d65f898aca6 ;
+    prov:atLocation niiri:ca4d257e28c11e95eac69d8434cf5d21 ;
     prov:value "4.46814107894897"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41702777537423"^^xsd:float ;
     nidm_pValueUncorrected: "0.000316544101057636"^^xsd:float ;
     nidm_pValueFWER: "0.999999911601577"^^xsd:float ;
     nidm_qValueFDR: "0.0126051231599175"^^xsd:float .
 
-niiri:5dffb2412c5920c035fa3d65f898aca6
+niiri:ca4d257e28c11e95eac69d8434cf5d21
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[-20,-38,-30]"^^xsd:string .
 
-niiri:872525eb5016723dc3c4e0b0f2f2a5c5 prov:wasDerivedFrom niiri:1c2323d93891a0ddf5ac87752d859519 .
+niiri:41f1a29b28047c513dad04890f92ea62 prov:wasDerivedFrom niiri:b48687fcbc3b1f0f9ee5b14ce9ed924b .
 
-niiri:27b211c70e2f7e9bd4a55df3443c4d04
+niiri:644473757bdf4f53de672927c317f640
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:f784d0452f15f23ba0c472ca2c2957c8 ;
+    prov:atLocation niiri:91812858ace028392052bc61b2ec057f ;
     prov:value "4.46168184280396"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41380155002305"^^xsd:float ;
     nidm_pValueUncorrected: "0.000320316101733442"^^xsd:float ;
     nidm_pValueFWER: "0.999999921976257"^^xsd:float ;
     nidm_qValueFDR: "0.0126738773801948"^^xsd:float .
 
-niiri:f784d0452f15f23ba0c472ca2c2957c8
+niiri:91812858ace028392052bc61b2ec057f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-12,-14,8]"^^xsd:string .
 
-niiri:27b211c70e2f7e9bd4a55df3443c4d04 prov:wasDerivedFrom niiri:dc7f564798bbb1fc05334954d8385ba1 .
+niiri:644473757bdf4f53de672927c317f640 prov:wasDerivedFrom niiri:18aa725ff182239ce52a92cec8c831fe .
 
-niiri:8bf11b8dd19ff2763b1d679fcc567bdd
+niiri:118e5465f1cdaee5740cf125155fe7b3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:69636daf4c95840e35d2278cb2ddf6a2 ;
+    prov:atLocation niiri:3ff8424d596938b11ad96560eee5df78 ;
     prov:value "4.44263553619385"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40426513461447"^^xsd:float ;
     nidm_pValueUncorrected: "0.000331711624065423"^^xsd:float ;
     nidm_pValueFWER: "0.999999946301375"^^xsd:float ;
     nidm_qValueFDR: "0.012902019341921"^^xsd:float .
 
-niiri:69636daf4c95840e35d2278cb2ddf6a2
+niiri:3ff8424d596938b11ad96560eee5df78
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-4,-28,-34]"^^xsd:string .
 
-niiri:8bf11b8dd19ff2763b1d679fcc567bdd prov:wasDerivedFrom niiri:62a9cd07b50b07a1142d53889b87fd97 .
+niiri:118e5465f1cdaee5740cf125155fe7b3 prov:wasDerivedFrom niiri:7cf7dba6eb11ba3d163885cbe5c660cd .
 
-niiri:46c603d6044a9577f4f0e9b3938e4700
+niiri:2aab067e93eed87166d2a6bcb0988f7f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:7f03bb810e2aa3de38abd130b42d0740 ;
+    prov:atLocation niiri:c035874bdf6e7d3a175e1e3e4dfd592f ;
     prov:value "4.4201717376709"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39297275478629"^^xsd:float ;
     nidm_pValueUncorrected: "0.00034569257259931"^^xsd:float ;
     nidm_pValueFWER: "0.999999965808818"^^xsd:float ;
     nidm_qValueFDR: "0.01320481591718"^^xsd:float .
 
-niiri:7f03bb810e2aa3de38abd130b42d0740
+niiri:c035874bdf6e7d3a175e1e3e4dfd592f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[46,-42,54]"^^xsd:string .
 
-niiri:46c603d6044a9577f4f0e9b3938e4700 prov:wasDerivedFrom niiri:12880301a0a653ca67efd232a37a486b .
+niiri:2aab067e93eed87166d2a6bcb0988f7f prov:wasDerivedFrom niiri:f2aa94f4ac2fd9ce977533852312353d .
 
-niiri:2fc0e632c6c67d632d879e25c94e0526
+niiri:182e9fe46ed363f9769a906bff3f1e65
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:d1793ebb335efe18e8ce493107704c93 ;
+    prov:atLocation niiri:5f08c4860ac9853a3ac9f667b9bea6f5 ;
     prov:value "4.41310739517212"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38941149263013"^^xsd:float ;
     nidm_pValueUncorrected: "0.000350214079416045"^^xsd:float ;
     nidm_pValueFWER: "0.999999970406353"^^xsd:float ;
     nidm_qValueFDR: "0.0133062974642806"^^xsd:float .
 
-niiri:d1793ebb335efe18e8ce493107704c93
+niiri:5f08c4860ac9853a3ac9f667b9bea6f5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-6,10,-2]"^^xsd:string .
 
-niiri:2fc0e632c6c67d632d879e25c94e0526 prov:wasDerivedFrom niiri:7b940b3f554bfd8086ef06ec3a4c5e36 .
+niiri:182e9fe46ed363f9769a906bff3f1e65 prov:wasDerivedFrom niiri:b9d2c5e57e73184c133167c21e549e31 .
 
-niiri:edea735fc405e897d60c9a150d58fdbd
+niiri:3963967f131dd75149db4432a7e47df4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:ad6a5c6e9111ff2cd4961836c59aeee8 ;
+    prov:atLocation niiri:f6bec0e10961c94d25f2bde5fedfbbf8 ;
     prov:value "4.36529922485352"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36518306130387"^^xsd:float ;
     nidm_pValueUncorrected: "0.000382464451876507"^^xsd:float ;
     nidm_pValueFWER: "0.999999989209637"^^xsd:float ;
     nidm_qValueFDR: "0.0139415542247477"^^xsd:float .
 
-niiri:ad6a5c6e9111ff2cd4961836c59aeee8
+niiri:f6bec0e10961c94d25f2bde5fedfbbf8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[42,42,30]"^^xsd:string .
 
-niiri:edea735fc405e897d60c9a150d58fdbd prov:wasDerivedFrom niiri:4364ea14ae541a4b5530d0fc11478f4d .
+niiri:3963967f131dd75149db4432a7e47df4 prov:wasDerivedFrom niiri:0fff44688bc869513d097e59a8311b54 .
 
-niiri:7b7f99b7f4133520004acf23cad3c6d2
+niiri:90bcd9cecdebdfc1bc653e4a5ce6fdd4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:6e740b892faab2ae5c18dda6b0263f44 ;
+    prov:atLocation niiri:5dfa4e8409ebc190fafb2e54b42bf770 ;
     prov:value "4.33874082565308"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35162706179118"^^xsd:float ;
     nidm_pValueUncorrected: "0.00040169081443242"^^xsd:float ;
     nidm_pValueFWER: "0.999999993988362"^^xsd:float ;
     nidm_qValueFDR: "0.014354585034373"^^xsd:float .
 
-niiri:6e740b892faab2ae5c18dda6b0263f44
+niiri:5dfa4e8409ebc190fafb2e54b42bf770
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[54,-38,50]"^^xsd:string .
 
-niiri:7b7f99b7f4133520004acf23cad3c6d2 prov:wasDerivedFrom niiri:cad9672114cca77d75274be4de17ab9c .
+niiri:90bcd9cecdebdfc1bc653e4a5ce6fdd4 prov:wasDerivedFrom niiri:6b373e69fdc37c9c1e68cb0b96d5160c .
 
-niiri:6c1b3ff879fa04561531f81912615e99
+niiri:aef32c45bff8af696f74dfdd1d985ea3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:376e1f563f89dca353cf7c8e7afe031d ;
+    prov:atLocation niiri:5a1c6065723c47791b00a4157d8e72fb ;
     prov:value "4.31020069122314"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33698195919922"^^xsd:float ;
     nidm_pValueUncorrected: "0.000423467227465446"^^xsd:float ;
     nidm_pValueFWER: "0.999999996857889"^^xsd:float ;
     nidm_qValueFDR: "0.01478592692513"^^xsd:float .
 
-niiri:376e1f563f89dca353cf7c8e7afe031d
+niiri:5a1c6065723c47791b00a4157d8e72fb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[8,4,64]"^^xsd:string .
 
-niiri:6c1b3ff879fa04561531f81912615e99 prov:wasDerivedFrom niiri:9373fb96b8dcda6b9ae13dbf76afcaa6 .
+niiri:aef32c45bff8af696f74dfdd1d985ea3 prov:wasDerivedFrom niiri:739e3f4c274d5eac94fb06c09bd419a0 .
 
-niiri:d59e59cdaec7a9b385642f94b162a141
+niiri:7c5846f0d310409dc36078590abc73fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:0faea80bec78d784e33b772fec951abe ;
+    prov:atLocation niiri:c6f8740e94fe4f1ac8fa83677062dddf ;
     prov:value "4.30184555053711"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33267930931343"^^xsd:float ;
     nidm_pValueUncorrected: "0.000430070120942982"^^xsd:float ;
     nidm_pValueFWER: "0.999999997411931"^^xsd:float ;
     nidm_qValueFDR: "0.0148953189902244"^^xsd:float .
 
-niiri:0faea80bec78d784e33b772fec951abe
+niiri:c6f8740e94fe4f1ac8fa83677062dddf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-10,24,32]"^^xsd:string .
 
-niiri:d59e59cdaec7a9b385642f94b162a141 prov:wasDerivedFrom niiri:7737094062d61c5fc0d500987f11bda9 .
+niiri:7c5846f0d310409dc36078590abc73fc prov:wasDerivedFrom niiri:bf0f6f227a5f1dede37450defacf4ee4 .
 
-niiri:14a69d6faff4a3b2af4d85d34b889f0b
+niiri:cd504b882f3f5530c78f2f6fdf37a17a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:e37bac689137c25c10888265d0e08602 ;
+    prov:atLocation niiri:fbe560ba493337b0e163bb49250b595c ;
     prov:value "4.27150821685791"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31699794762384"^^xsd:float ;
     nidm_pValueUncorrected: "0.000454951424559202"^^xsd:float ;
     nidm_pValueFWER: "0.999999998740386"^^xsd:float ;
     nidm_qValueFDR: "0.0153518195589701"^^xsd:float .
 
-niiri:e37bac689137c25c10888265d0e08602
+niiri:fbe560ba493337b0e163bb49250b595c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-14,-2,72]"^^xsd:string .
 
-niiri:14a69d6faff4a3b2af4d85d34b889f0b prov:wasDerivedFrom niiri:454d2ddee840a6eed8f9885efabde318 .
+niiri:cd504b882f3f5530c78f2f6fdf37a17a prov:wasDerivedFrom niiri:27828afab99d35c7e234991a120cb219 .
 
-niiri:7031b6f01d04b3aa346e5d15b9d75e4d
+niiri:2241ef49d05e5f1d71db21c706159ef1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:f5b1c1485206e295c6ee4401f24e8fea ;
+    prov:atLocation niiri:2eedc6f2b2f210a352180ba9bf836bdb ;
     prov:value "4.25738191604614"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30966460961956"^^xsd:float ;
     nidm_pValueUncorrected: "0.000467039117525991"^^xsd:float ;
     nidm_pValueFWER: "0.999999999106929"^^xsd:float ;
     nidm_qValueFDR: "0.0155581475175598"^^xsd:float .
 
-niiri:f5b1c1485206e295c6ee4401f24e8fea
+niiri:2eedc6f2b2f210a352180ba9bf836bdb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[56,26,26]"^^xsd:string .
 
-niiri:7031b6f01d04b3aa346e5d15b9d75e4d prov:wasDerivedFrom niiri:b2f3ddd032f5ca78054f0eca8d0c8769 .
+niiri:2241ef49d05e5f1d71db21c706159ef1 prov:wasDerivedFrom niiri:61fab5ab040124b4935fd160bc4c75c2 .
 
-niiri:9de3e3776111574cff8aedaff0068b73
+niiri:de1ef49da56b6d1ffb63fe6c57d93f44
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:35e6921502f4efac1ec19702a6773271 ;
+    prov:atLocation niiri:810f41807fafc1e5eaa827e6a868c17c ;
     prov:value "4.23224687576294"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29656664149817"^^xsd:float ;
     nidm_pValueUncorrected: "0.000489371958441343"^^xsd:float ;
     nidm_pValueFWER: "0.999999999522306"^^xsd:float ;
     nidm_qValueFDR: "0.0159527943368947"^^xsd:float .
 
-niiri:35e6921502f4efac1ec19702a6773271
+niiri:810f41807fafc1e5eaa827e6a868c17c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[14,-30,-32]"^^xsd:string .
 
-niiri:9de3e3776111574cff8aedaff0068b73 prov:wasDerivedFrom niiri:cf4b88bff59c1a33cd867e9422f84011 .
+niiri:de1ef49da56b6d1ffb63fe6c57d93f44 prov:wasDerivedFrom niiri:3e195e76e0011bcbca16974bc51df875 .
 
-niiri:bc149e6b113081f115e5a5ea364f34d0
+niiri:c444ee8f429895614ebda9dbf5fbd1fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:1f636960ef3619fc8aec226fb7543fcf ;
+    prov:atLocation niiri:5a6eb1a0f188a666a4aaaecea6d678fa ;
     prov:value "4.21795654296875"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28909139477101"^^xsd:float ;
     nidm_pValueUncorrected: "0.000502556899069861"^^xsd:float ;
     nidm_pValueFWER: "0.999999999667972"^^xsd:float ;
     nidm_qValueFDR: "0.0162089652787187"^^xsd:float .
 
-niiri:1f636960ef3619fc8aec226fb7543fcf
+niiri:5a6eb1a0f188a666a4aaaecea6d678fa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[46,-54,-30]"^^xsd:string .
 
-niiri:bc149e6b113081f115e5a5ea364f34d0 prov:wasDerivedFrom niiri:3283422abdc309a208995369231fe32a .
+niiri:c444ee8f429895614ebda9dbf5fbd1fb prov:wasDerivedFrom niiri:efb3b3e5edd63741aa95f90f1a73c855 .
 
-niiri:2bb4c41e8f9c06be5b3747cb28574b9a
+niiri:5baaf3257c1f9338a03f1372087336aa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:22ee550046229aa65e9420876ed6f5a0 ;
+    prov:atLocation niiri:8288b9701fe4611f125b1363a4414e5a ;
     prov:value "4.19331645965576"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27615344058961"^^xsd:float ;
     nidm_pValueUncorrected: "0.000526156861805016"^^xsd:float ;
     nidm_pValueFWER: "0.999999999825125"^^xsd:float ;
     nidm_qValueFDR: "0.0165459969587672"^^xsd:float .
 
-niiri:22ee550046229aa65e9420876ed6f5a0
+niiri:8288b9701fe4611f125b1363a4414e5a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[28,22,16]"^^xsd:string .
 
-niiri:2bb4c41e8f9c06be5b3747cb28574b9a prov:wasDerivedFrom niiri:c9c180c62d3cd262bcb7bb862a2e2d3e .
+niiri:5baaf3257c1f9338a03f1372087336aa prov:wasDerivedFrom niiri:e3b33814b86cd485564e0a0928f90e0f .
 
-niiri:7c426e29ff0188e4df4277d19017ee63
+niiri:280fd372fb559f3177b6e1256a306389
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:20dcc56b68ae8b6b4c9741adb0b43549 ;
+    prov:atLocation niiri:2335841ec513e02901317171950e6e7e ;
     prov:value "4.164222240448"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26079679766555"^^xsd:float ;
     nidm_pValueUncorrected: "0.000555498136877608"^^xsd:float ;
     nidm_pValueFWER: "0.999999999919858"^^xsd:float ;
     nidm_qValueFDR: "0.017023135244014"^^xsd:float .
 
-niiri:20dcc56b68ae8b6b4c9741adb0b43549
+niiri:2335841ec513e02901317171950e6e7e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[32,-46,-8]"^^xsd:string .
 
-niiri:7c426e29ff0188e4df4277d19017ee63 prov:wasDerivedFrom niiri:f67691de01cdab9987a52d4efd6796df .
+niiri:280fd372fb559f3177b6e1256a306389 prov:wasDerivedFrom niiri:cfdf88b2a941aeba3fcc1f4b45b10448 .
 
-niiri:58b42fca78cd1d10deeed8bba2e7180a
+niiri:68691392db8be62d02ad17ca0283c776
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:6f1505b8bbcfb75633a016754afd0dbb ;
+    prov:atLocation niiri:007cea7d2370bfd078d23d8eba7e3a4d ;
     prov:value "4.1354022026062"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24549898327499"^^xsd:float ;
     nidm_pValueUncorrected: "0.000586224915903544"^^xsd:float ;
     nidm_pValueFWER: "0.999999999963932"^^xsd:float ;
     nidm_qValueFDR: "0.0175104371158769"^^xsd:float .
 
-niiri:6f1505b8bbcfb75633a016754afd0dbb
+niiri:007cea7d2370bfd078d23d8eba7e3a4d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[12,18,32]"^^xsd:string .
 
-niiri:58b42fca78cd1d10deeed8bba2e7180a prov:wasDerivedFrom niiri:ef91e7140c5dbe4c9303f8f1e0cd8673 .
+niiri:68691392db8be62d02ad17ca0283c776 prov:wasDerivedFrom niiri:8053ffdd2903523517c32abc5eed6805 .
 
-niiri:360283f26ce5bb979d1d53571784870e
+niiri:e0dc036274a57f0fe2d89e9ced584377
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:e7f5f89929f3b52930ffb8fb16c0e839 ;
+    prov:atLocation niiri:6964785c365b99534b9ed5d158738905 ;
     prov:value "4.09669637680054"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22481821343066"^^xsd:float ;
     nidm_pValueUncorrected: "0.000630263410459797"^^xsd:float ;
     nidm_pValueFWER: "0.999999999988153"^^xsd:float ;
     nidm_qValueFDR: "0.0182494607837458"^^xsd:float .
 
-niiri:e7f5f89929f3b52930ffb8fb16c0e839
+niiri:6964785c365b99534b9ed5d158738905
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[6,-60,64]"^^xsd:string .
 
-niiri:360283f26ce5bb979d1d53571784870e prov:wasDerivedFrom niiri:dcd5d7321bb4d36d468ecf53edb77243 .
+niiri:e0dc036274a57f0fe2d89e9ced584377 prov:wasDerivedFrom niiri:be2669b1217c5497ae7583e9f37e889f .
 
-niiri:c8fd6993b937babaf1f8c2135d3b7f1e
+niiri:171d6b4dfd03d1048a1523ac6ab16c51
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:836a956234439c9358b6ebe000e3dcc2 ;
+    prov:atLocation niiri:0c042f9715d9ee75592c3572982a0982 ;
     prov:value "4.06586408615112"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20823228054844"^^xsd:float ;
     nidm_pValueUncorrected: "0.000667767930319307"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995287"^^xsd:float ;
     nidm_qValueFDR: "0.018874773548645"^^xsd:float .
 
-niiri:836a956234439c9358b6ebe000e3dcc2
+niiri:0c042f9715d9ee75592c3572982a0982
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-20,-66,-32]"^^xsd:string .
 
-niiri:c8fd6993b937babaf1f8c2135d3b7f1e prov:wasDerivedFrom niiri:049381a7f67019f13a2b75b205f87af1 .
+niiri:171d6b4dfd03d1048a1523ac6ab16c51 prov:wasDerivedFrom niiri:345d8154c25e6bc91b83c7a570393c32 .
 
-niiri:ee630cfc618eede368be76300de9d971
+niiri:a7098f4e7d792337d036f494fb50b3e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:b1b6a55493eae042a995758df3cd1afd ;
+    prov:atLocation niiri:52a60ec1c4d123189f7f1133afcaa6c6 ;
     prov:value "4.05021715164185"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19977690410182"^^xsd:float ;
     nidm_pValueUncorrected: "0.000687670008111763"^^xsd:float ;
     nidm_pValueFWER: "0.999999999997083"^^xsd:float ;
     nidm_qValueFDR: "0.0191721851735585"^^xsd:float .
 
-niiri:b1b6a55493eae042a995758df3cd1afd
+niiri:52a60ec1c4d123189f7f1133afcaa6c6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[-8,-72,-24]"^^xsd:string .
 
-niiri:ee630cfc618eede368be76300de9d971 prov:wasDerivedFrom niiri:6231cdc1c30543959e82f342e7f7c028 .
+niiri:a7098f4e7d792337d036f494fb50b3e4 prov:wasDerivedFrom niiri:0feb21dbaab7759d1a095b10570dbcbb .
 
-niiri:aaf4f8141ee78e9a09556843acd95064
+niiri:36b86426126175a8096c29f1919ba51d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:d17d2fa54d9211851a0ef3ebd18a78f0 ;
+    prov:atLocation niiri:5490e18e279668b30172e0e8f638ec06 ;
     prov:value "4.02814960479736"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18780790473987"^^xsd:float ;
     nidm_pValueUncorrected: "0.000716778694212938"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998538"^^xsd:float ;
     nidm_qValueFDR: "0.0196630402446738"^^xsd:float .
 
-niiri:d17d2fa54d9211851a0ef3ebd18a78f0
+niiri:5490e18e279668b30172e0e8f638ec06
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[-26,-36,-24]"^^xsd:string .
 
-niiri:aaf4f8141ee78e9a09556843acd95064 prov:wasDerivedFrom niiri:d078d2a64b3eee365a7318a424f3d55f .
+niiri:36b86426126175a8096c29f1919ba51d prov:wasDerivedFrom niiri:4867e698cc576f0b80c177fdf37912bc .
 
-niiri:122d4d1496fd61336c1b2e14c2eb7b08
+niiri:68fbcfdade2d23e2a8f7038c87eb5cff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:e058fbd337495ddaef29dc0ea8a04073 ;
+    prov:atLocation niiri:77d8894d4ae1110ed28592a6314d05e6 ;
     prov:value "4.0194239616394"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18306102742152"^^xsd:float ;
     nidm_pValueUncorrected: "0.000728634479518986"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998893"^^xsd:float ;
     nidm_qValueFDR: "0.019829947388337"^^xsd:float .
 
-niiri:e058fbd337495ddaef29dc0ea8a04073
+niiri:77d8894d4ae1110ed28592a6314d05e6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-26,6,66]"^^xsd:string .
 
-niiri:122d4d1496fd61336c1b2e14c2eb7b08 prov:wasDerivedFrom niiri:b07d53658c12f0d165aec1cf959f1eb5 .
+niiri:68fbcfdade2d23e2a8f7038c87eb5cff prov:wasDerivedFrom niiri:dbd7ff1039cc058a9180d3a6b19c0d65 .
 
-niiri:fdbadebbe5948d7060701cca85b9ec3c
+niiri:00465a63053242b2dffac6ee659b2354
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:bb35e3e75e4774ac32be8c7e9af072a0 ;
+    prov:atLocation niiri:f450ec4d266f33c1b6d2eb7b93ec2c9b ;
     prov:value "4.01476430892944"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18052278869165"^^xsd:float ;
     nidm_pValueUncorrected: "0.000735047880785378"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999046"^^xsd:float ;
     nidm_qValueFDR: "0.0199399671265334"^^xsd:float .
 
-niiri:bb35e3e75e4774ac32be8c7e9af072a0
+niiri:f450ec4d266f33c1b6d2eb7b93ec2c9b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-32,-6,66]"^^xsd:string .
 
-niiri:fdbadebbe5948d7060701cca85b9ec3c prov:wasDerivedFrom niiri:5e501329a485d9e81bca69bd136264fb .
+niiri:00465a63053242b2dffac6ee659b2354 prov:wasDerivedFrom niiri:9a04edbbfec2046f6e63a9808f7e31be .
 
-niiri:bac46c7751735f78e1059a5ed0f4d21a
+niiri:d1e53c6e21728e567ad7d5efc7526f76
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:30f30dcc3a862edc1cc78ec4115bd0e9 ;
+    prov:atLocation niiri:2f0f52f74919616dd5ecdc47bdf7662d ;
     prov:value "4.01372337341309"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17995544681479"^^xsd:float ;
     nidm_pValueUncorrected: "0.000736488485902353"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999078"^^xsd:float ;
     nidm_qValueFDR: "0.0199550456355793"^^xsd:float .
 
-niiri:30f30dcc3a862edc1cc78ec4115bd0e9
+niiri:2f0f52f74919616dd5ecdc47bdf7662d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[56,-4,46]"^^xsd:string .
 
-niiri:bac46c7751735f78e1059a5ed0f4d21a prov:wasDerivedFrom niiri:c67e04b4ffbe3c4b8ad3c704ed5fd097 .
+niiri:d1e53c6e21728e567ad7d5efc7526f76 prov:wasDerivedFrom niiri:4802981400c706074d7089aa4f606c7a .
 
-niiri:2bfd75fa4bfe77aa205c149b2fec102a
+niiri:590d2d1c331312707acd1dd13cad86a4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:6c5e7793c3c3b5878682a31efb3d04b2 ;
+    prov:atLocation niiri:e13abed58503558f5419d66eb9a3daab ;
     prov:value "3.99763154983521"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17117019350021"^^xsd:float ;
     nidm_pValueUncorrected: "0.000759130810004449"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999453"^^xsd:float ;
     nidm_qValueFDR: "0.0202312537871442"^^xsd:float .
 
-niiri:6c5e7793c3c3b5878682a31efb3d04b2
+niiri:e13abed58503558f5419d66eb9a3daab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[10,-20,-12]"^^xsd:string .
 
-niiri:2bfd75fa4bfe77aa205c149b2fec102a prov:wasDerivedFrom niiri:f19fc244e1ad9fb88396e6dc5d62c29b .
+niiri:590d2d1c331312707acd1dd13cad86a4 prov:wasDerivedFrom niiri:0c9c1006b093a8cc91c759baf58575ee .
 
-niiri:089ac9f5b2b657c00a34b4ab8eaee4d1
+niiri:d6a41ae2f605bfe0ffcfcdd41c571806
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:af1872b1d428bd30ce24b10511479e0f ;
+    prov:atLocation niiri:b52aa1bb12ceb0dd758b5674ba71269e ;
     prov:value "3.96427512168884"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15287103994341"^^xsd:float ;
     nidm_pValueUncorrected: "0.000808366063659971"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999982"^^xsd:float ;
     nidm_qValueFDR: "0.0208863381686101"^^xsd:float .
 
-niiri:af1872b1d428bd30ce24b10511479e0f
+niiri:b52aa1bb12ceb0dd758b5674ba71269e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[-52,20,36]"^^xsd:string .
 
-niiri:089ac9f5b2b657c00a34b4ab8eaee4d1 prov:wasDerivedFrom niiri:8a6f880f7b8eaf62148b54fef7844b09 .
+niiri:d6a41ae2f605bfe0ffcfcdd41c571806 prov:wasDerivedFrom niiri:9e9eebffba744c379bca54d713a85d3b .
 
-niiri:8cdecc19343e1178e26e45853c9023ed
+niiri:f48cec3f59920d1e0aef1e5edb72b3ae
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:77adc2dd71b080ae0c496d60454bd8e0 ;
+    prov:atLocation niiri:28e17599c65fb7c18cd3eb6c92fcdf63 ;
     prov:value "3.94705867767334"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14337930633102"^^xsd:float ;
     nidm_pValueUncorrected: "0.000835046362340219"^^xsd:float ;
     nidm_pValueFWER: "0.9999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.0212745029430363"^^xsd:float .
 
-niiri:77adc2dd71b080ae0c496d60454bd8e0
+niiri:28e17599c65fb7c18cd3eb6c92fcdf63
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[10,-24,-14]"^^xsd:string .
 
-niiri:8cdecc19343e1178e26e45853c9023ed prov:wasDerivedFrom niiri:de48b7494a3d45a8a57e155aeea2f132 .
+niiri:f48cec3f59920d1e0aef1e5edb72b3ae prov:wasDerivedFrom niiri:2ef2320c7a264cf13420c161d25ff5cc .
 
-niiri:be6866429745ec8fceee0123965bf9be
+niiri:0bf03c97edd7b117b1111cf0cfa73c96
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:baa063c02b5a1e3acbac348c6e7f4f8f ;
+    prov:atLocation niiri:05eb28fd11ef4f85b5b7fccadd23374f ;
     prov:value "3.93684697151184"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13773425766756"^^xsd:float ;
     nidm_pValueUncorrected: "0.00085129580940857"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.0215142897882816"^^xsd:float .
 
-niiri:baa063c02b5a1e3acbac348c6e7f4f8f
+niiri:05eb28fd11ef4f85b5b7fccadd23374f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-32,18,-6]"^^xsd:string .
 
-niiri:be6866429745ec8fceee0123965bf9be prov:wasDerivedFrom niiri:c60f3aab1eee7d78c6850a16c38162dc .
+niiri:0bf03c97edd7b117b1111cf0cfa73c96 prov:wasDerivedFrom niiri:53b5e166978251c052e00c9a4fe81fdc .
 
-niiri:ad9707602adb5afb0acaa4237ca4f979
+niiri:bb138c83a7f0b859be01107344c7d312
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:01154cd48f33a76a138d224c14ee2d42 ;
+    prov:atLocation niiri:e83ab329851a7f93c2f57864f4abe3b3 ;
     prov:value "3.93397641181946"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13614537112983"^^xsd:float ;
     nidm_pValueUncorrected: "0.000855921637752388"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999937"^^xsd:float ;
     nidm_qValueFDR: "0.0215615444445258"^^xsd:float .
 
-niiri:01154cd48f33a76a138d224c14ee2d42
+niiri:e83ab329851a7f93c2f57864f4abe3b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[52,10,18]"^^xsd:string .
 
-niiri:ad9707602adb5afb0acaa4237ca4f979 prov:wasDerivedFrom niiri:859e657235309e3db15ccb1f14c1e7ba .
+niiri:bb138c83a7f0b859be01107344c7d312 prov:wasDerivedFrom niiri:de88c64838ddf5de0155dcdce61cf6c0 .
 
-niiri:11ba1d6f38fb1b63a2f74b7601766c83
+niiri:86b5d287e5e443c1262f0ad80f006282
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:6d498f6e4c82a7d741b60a62a8092e8b ;
+    prov:atLocation niiri:9544cd35baa3055df29785d0cba7563e ;
     prov:value "3.92871356010437"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13323000033267"^^xsd:float ;
     nidm_pValueUncorrected: "0.000864469518982003"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999947"^^xsd:float ;
     nidm_qValueFDR: "0.0216822850176731"^^xsd:float .
 
-niiri:6d498f6e4c82a7d741b60a62a8092e8b
+niiri:9544cd35baa3055df29785d0cba7563e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[34,-52,-4]"^^xsd:string .
 
-niiri:11ba1d6f38fb1b63a2f74b7601766c83 prov:wasDerivedFrom niiri:065fb1288e613aa1089a803ba4b13d87 .
+niiri:86b5d287e5e443c1262f0ad80f006282 prov:wasDerivedFrom niiri:02344c7a7b0c9af7c25dbcd3cbd09300 .
 
-niiri:ed629eddf9cc975359669c19b33ac397
+niiri:a659cc920974b885b011950336fdb2e6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:58e5368187096a105a3cad65343f1be3 ;
+    prov:atLocation niiri:82c89a91afac0227805c920ac46780b4 ;
     prov:value "3.91936802864075"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12804559569402"^^xsd:float ;
     nidm_pValueUncorrected: "0.000879864400760821"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999962"^^xsd:float ;
     nidm_qValueFDR: "0.0218781120126672"^^xsd:float .
 
-niiri:58e5368187096a105a3cad65343f1be3
+niiri:82c89a91afac0227805c920ac46780b4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[16,-32,-34]"^^xsd:string .
 
-niiri:ed629eddf9cc975359669c19b33ac397 prov:wasDerivedFrom niiri:021e14b3f5e58d6dd1904bdbad37b113 .
+niiri:a659cc920974b885b011950336fdb2e6 prov:wasDerivedFrom niiri:22648332b0e4fb9a38556afd35646c42 .
 
-niiri:15eec198bb6cca7b798e1e7a4e6de3b6
+niiri:8f404f298d64974fc27f83332fc6d68e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:63bfb114a4b23a3d0d57b8802a082634 ;
+    prov:atLocation niiri:6a1d3251cb160a559caa1932f4e6e20d ;
     prov:value "3.8760769367218"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1039055725094"^^xsd:float ;
     nidm_pValueUncorrected: "0.000954921373033768"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999992"^^xsd:float ;
     nidm_qValueFDR: "0.0229044690727897"^^xsd:float .
 
-niiri:63bfb114a4b23a3d0d57b8802a082634
+niiri:6a1d3251cb160a559caa1932f4e6e20d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[18,8,34]"^^xsd:string .
 
-niiri:15eec198bb6cca7b798e1e7a4e6de3b6 prov:wasDerivedFrom niiri:7fa11ca3554a75156c897f72b0a338ac .
+niiri:8f404f298d64974fc27f83332fc6d68e prov:wasDerivedFrom niiri:3b46a57f86b33c173fe10a245389f4ff .
 

--- a/spmexport/ex_spm_temporal_derivative/config.json
+++ b/spmexport/ex_spm_temporal_derivative/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["temporal_derivative/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_temporal_derivative/nidm.provn
+++ b/spmexport/ex_spm_temporal_derivative/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:3c6dc086c76678be7063859e84986baf,
+  entity(niiri:e64702adc0e35cc1bd2b3e358bf7a7f8,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:f60eebb85e75a51b2f784027bd6c65f0,
+  agent(niiri:0d47f7667162b705032684d55436c4fe,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:5208480176f629a6812b18fda01fd47b,
+  activity(niiri:9d126fde60b32d6488e156ea10c53065,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:5208480176f629a6812b18fda01fd47b, niiri:f60eebb85e75a51b2f784027bd6c65f0, -)
-  wasGeneratedBy(niiri:3c6dc086c76678be7063859e84986baf, niiri:5208480176f629a6812b18fda01fd47b, 2016-01-11T10:34:35)
-  bundle niiri:3c6dc086c76678be7063859e84986baf
+  wasAssociatedWith(niiri:9d126fde60b32d6488e156ea10c53065, niiri:0d47f7667162b705032684d55436c4fe, -)
+  wasGeneratedBy(niiri:e64702adc0e35cc1bd2b3e358bf7a7f8, niiri:9d126fde60b32d6488e156ea10c53065, 2016-01-11T10:45:18)
+  bundle niiri:e64702adc0e35cc1bd2b3e358bf7a7f8
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -120,12 +120,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:305f6d612e80d0ac7f38f2c4707cfa10,
+    agent(niiri:3a62fb6ad2d39c5660be6897ee3c3e73,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:e58601fa87a65231a7d5f04d9abeb8ab,
+    entity(niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -134,178 +134,178 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:0587895d96cc3d928268ee75cb0fb2d7,
+    entity(niiri:5a3c12bc7a1267841d000c61cf0343d3,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:eac3ba341a653c3f2f431a2f2191daeb,
+    entity(niiri:c637c184fba84571528b3f45c6dc7f97,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:09fc15666b65ec5e0b51db428e596afc,
+    entity(niiri:1b2d6f3c3e049fd1e78bc7a80520f259,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:db6ec6e7212de8a96f98952b255e71ab',
+        dc:description = 'niiri:784be6c513a5f5195c0010a862afe583',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:eac3ba341a653c3f2f431a2f2191daeb',
+        nidm_hasDriftModel: = 'niiri:c637c184fba84571528b3f45c6dc7f97',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:',
         nidm_hasHRFBasis: = 'spm_SPMsTemporalDerivative:'])
-    entity(niiri:db6ec6e7212de8a96f98952b255e71ab,
+    entity(niiri:784be6c513a5f5195c0010a862afe583,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:aa63ccf32993ab6946641662c0b826f9,
+    entity(niiri:2f2815f79f719eb33f62c88fe52f9bb8,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:0563a0d470bf09dae2ab32ec6e4e53b8,
+    activity(niiri:abcb1bebeb3a219b4710129779851f27,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:0563a0d470bf09dae2ab32ec6e4e53b8, niiri:305f6d612e80d0ac7f38f2c4707cfa10, -)
-    used(niiri:0563a0d470bf09dae2ab32ec6e4e53b8, niiri:09fc15666b65ec5e0b51db428e596afc, -)
-    used(niiri:0563a0d470bf09dae2ab32ec6e4e53b8, niiri:0587895d96cc3d928268ee75cb0fb2d7, -)
-    used(niiri:0563a0d470bf09dae2ab32ec6e4e53b8, niiri:aa63ccf32993ab6946641662c0b826f9, -)
-    entity(niiri:60b72a68a7d90c7546bd6a8c0159ab36,
+    wasAssociatedWith(niiri:abcb1bebeb3a219b4710129779851f27, niiri:3a62fb6ad2d39c5660be6897ee3c3e73, -)
+    used(niiri:abcb1bebeb3a219b4710129779851f27, niiri:1b2d6f3c3e049fd1e78bc7a80520f259, -)
+    used(niiri:abcb1bebeb3a219b4710129779851f27, niiri:5a3c12bc7a1267841d000c61cf0343d3, -)
+    used(niiri:abcb1bebeb3a219b4710129779851f27, niiri:2f2815f79f719eb33f62c88fe52f9bb8, -)
+    entity(niiri:c0dd0e9c97451986d441709660e35e73,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:df4480035b6ca748071681a72c956d53,
+    entity(niiri:25afb4a1bf7b03778e3914d4b622aed9,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:60b72a68a7d90c7546bd6a8c0159ab36, niiri:df4480035b6ca748071681a72c956d53, -, -, -)
-    wasGeneratedBy(niiri:60b72a68a7d90c7546bd6a8c0159ab36, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:ecbcc5aff9d93b04dd5bed528c105a0c,
+    wasDerivedFrom(niiri:c0dd0e9c97451986d441709660e35e73, niiri:25afb4a1bf7b03778e3914d4b622aed9, -, -, -)
+    wasGeneratedBy(niiri:c0dd0e9c97451986d441709660e35e73, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:f288f760f9c5a20b9ef5ee46a8e8d86c,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.554069519043" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         crypto:sha512 = "cd9a68897ec41212e51351c42135ef25ca8e0f20a78efeb7384fd90bd31b87de1dacd27c2320e59d3be730da14aa9139e74401a7942414518089ea8dcd808f5d" %% xsd:string])
-    wasGeneratedBy(niiri:ecbcc5aff9d93b04dd5bed528c105a0c, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:a5ff1a49bd0d02d12709d779ec463354,
+    wasGeneratedBy(niiri:f288f760f9c5a20b9ef5ee46a8e8d86c, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:ec293a0de477afbef9957e9f47a1c702,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
-    entity(niiri:4c397e405accc6b80e5533a92a239e51,
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f'])
+    entity(niiri:3011bc0d1771062a2ffdf3e49be8b11f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d14d038ad88a006ca6afd74c35b91715787ace3677a2c9a2fea05d43dc02fde023379242720516252ba79f85717d4d4bf943a4ab0b5deac4415d3d3cd33ff4dd" %% xsd:string])
-    wasDerivedFrom(niiri:a5ff1a49bd0d02d12709d779ec463354, niiri:4c397e405accc6b80e5533a92a239e51, -, -, -)
-    wasGeneratedBy(niiri:a5ff1a49bd0d02d12709d779ec463354, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:e418795fad65d93f647c66b4cafc44d3,
+    wasDerivedFrom(niiri:ec293a0de477afbef9957e9f47a1c702, niiri:3011bc0d1771062a2ffdf3e49be8b11f, -, -, -)
+    wasGeneratedBy(niiri:ec293a0de477afbef9957e9f47a1c702, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:f11b9ce477b25eb9c64a9090ee72bab8,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
-    entity(niiri:b329517cdd0324fd17bc197ac363d942,
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f'])
+    entity(niiri:2696d8cec23d6b95ff92f685420ee58b,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3d641f2628f4d10f4a105aec937f2a8715ac785644f23cecd51c0ef60598851826f703e6681c3a94c067adcd1832b2718dbd91f398bb2c79fc2cedd5b93c67ff" %% xsd:string])
-    wasDerivedFrom(niiri:e418795fad65d93f647c66b4cafc44d3, niiri:b329517cdd0324fd17bc197ac363d942, -, -, -)
-    wasGeneratedBy(niiri:e418795fad65d93f647c66b4cafc44d3, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:0120da9e3c4c2f68a90e4e07859e01a5,
+    wasDerivedFrom(niiri:f11b9ce477b25eb9c64a9090ee72bab8, niiri:2696d8cec23d6b95ff92f685420ee58b, -, -, -)
+    wasGeneratedBy(niiri:f11b9ce477b25eb9c64a9090ee72bab8, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:0362da72912ae3440c96a8e8e17265b6,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
-    entity(niiri:804259da565a8f875a2f6ae188ae3106,
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f'])
+    entity(niiri:1abd490970d36138556f36a5da162c30,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "16f85e5e7f11ff93aafcd55124d9fcfe76b60f083ebb65d3354e3a31e4460318d91d4f6d546148ca6392dec705340612f7899445d9eaf64cf52ecb9a8d9d6a49" %% xsd:string])
-    wasDerivedFrom(niiri:0120da9e3c4c2f68a90e4e07859e01a5, niiri:804259da565a8f875a2f6ae188ae3106, -, -, -)
-    wasGeneratedBy(niiri:0120da9e3c4c2f68a90e4e07859e01a5, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:37b1f61f5f383179a1108cbeb18a7fc8,
+    wasDerivedFrom(niiri:0362da72912ae3440c96a8e8e17265b6, niiri:1abd490970d36138556f36a5da162c30, -, -, -)
+    wasGeneratedBy(niiri:0362da72912ae3440c96a8e8e17265b6, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:70d10fe634f06ac32e487717a068ad91,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
-    entity(niiri:e37c798696d7e40fb64bd0b6c2d3e17f,
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f'])
+    entity(niiri:ccc7dc519c07c56740aae8333cc486aa,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5a91e7e2139a66cb1402e4f1132476f384c5c02f402f73063b295ce5c365a7887e41e14bcc0324461f9d6cabae02318068185081d6b20466fb4f93829c4a8947" %% xsd:string])
-    wasDerivedFrom(niiri:37b1f61f5f383179a1108cbeb18a7fc8, niiri:e37c798696d7e40fb64bd0b6c2d3e17f, -, -, -)
-    wasGeneratedBy(niiri:37b1f61f5f383179a1108cbeb18a7fc8, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:7f8e3b395832ae03175831efa814e15d,
+    wasDerivedFrom(niiri:70d10fe634f06ac32e487717a068ad91, niiri:ccc7dc519c07c56740aae8333cc486aa, -, -, -)
+    wasGeneratedBy(niiri:70d10fe634f06ac32e487717a068ad91, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:3664093d905bb224f173ac25c7b0b09c,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
-    entity(niiri:523a5a385bac09773d12da89f2d1c547,
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f'])
+    entity(niiri:c1d441e1161da8bcb56ede99f8f76082,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "1df2fce8ae0e72a428af31f2198e42ceefcc04f482480c5700513d29e6fd413327bb5579b9d7558281ce6036b22ca352cf17523adce6c574d3ef9dd8a0821b9b" %% xsd:string])
-    wasDerivedFrom(niiri:7f8e3b395832ae03175831efa814e15d, niiri:523a5a385bac09773d12da89f2d1c547, -, -, -)
-    wasGeneratedBy(niiri:7f8e3b395832ae03175831efa814e15d, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:86f2c8c5518e16774d9bd82a5c1b451c,
+    wasDerivedFrom(niiri:3664093d905bb224f173ac25c7b0b09c, niiri:c1d441e1161da8bcb56ede99f8f76082, -, -, -)
+    wasGeneratedBy(niiri:3664093d905bb224f173ac25c7b0b09c, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:03ab2c2b25290bfbb92b205d06f30309,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         crypto:sha512 = "4e2e030b949c1b60b3560f5525cd528b84fd6a54e692647c9f002f96a46b06f1cfeef976d7ff3c63264582e55b8716d5cf57885aade6b1a5153ca8e3b2d79fde" %% xsd:string])
-    entity(niiri:eb2335b9a2a16ccbea2f07c7b833cf55,
+    entity(niiri:4a967fd750c7aa187bd625e049fe2ab2,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "a9c63ba9a666166bb13156094cc2620daea103b764e8386540bd52bd4b42c7f6f61009d65275411044b63a513ff257dddcb1882f36a4c633be14275f847005f2" %% xsd:string])
-    wasDerivedFrom(niiri:86f2c8c5518e16774d9bd82a5c1b451c, niiri:eb2335b9a2a16ccbea2f07c7b833cf55, -, -, -)
-    wasGeneratedBy(niiri:86f2c8c5518e16774d9bd82a5c1b451c, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:dfdd94c4bf399011a3075afb77f548c9,
+    wasDerivedFrom(niiri:03ab2c2b25290bfbb92b205d06f30309, niiri:4a967fd750c7aa187bd625e049fe2ab2, -, -, -)
+    wasGeneratedBy(niiri:03ab2c2b25290bfbb92b205d06f30309, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:1c02618dddbb4d92e807a09c4813dff9,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         crypto:sha512 = "ef1340dc691e63767d8ee59ddd92b94aa8108415ecb57ae4d00aa2a2b3088a647cc031364ccfbe7c8bd246a0f64a5147eb9590975dd41e1eb2510559ccb1b121" %% xsd:string])
-    entity(niiri:232af3b69fab7e03bf7daa3f28d65d79,
+    entity(niiri:85c571232916f46e46796be93b6448a3,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "38c048c905cbdc241bf470117e0f919457d92c8e7836b99e3eb9b70356b5b87f2733701a749b2e49af678bef88d6bddb7628d483702befc624a9933a5bcb5c85" %% xsd:string])
-    wasDerivedFrom(niiri:dfdd94c4bf399011a3075afb77f548c9, niiri:232af3b69fab7e03bf7daa3f28d65d79, -, -, -)
-    wasGeneratedBy(niiri:dfdd94c4bf399011a3075afb77f548c9, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
-    entity(niiri:59f5a82e85ac6cc9b45ceb6e9896b7db,
+    wasDerivedFrom(niiri:1c02618dddbb4d92e807a09c4813dff9, niiri:85c571232916f46e46796be93b6448a3, -, -, -)
+    wasGeneratedBy(niiri:1c02618dddbb4d92e807a09c4813dff9, niiri:abcb1bebeb3a219b4710129779851f27, -)
+    entity(niiri:3a2ce7e48305fa577a002108c633bff0,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, 0, -1, 0, 0]" %% xsd:string])
-    activity(niiri:24047e30c15c9d7c34e301287b91b981,
+    activity(niiri:8df5ae68cdbcac646e75a717043d3718,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:24047e30c15c9d7c34e301287b91b981, niiri:305f6d612e80d0ac7f38f2c4707cfa10, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:60b72a68a7d90c7546bd6a8c0159ab36, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:86f2c8c5518e16774d9bd82a5c1b451c, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:09fc15666b65ec5e0b51db428e596afc, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:59f5a82e85ac6cc9b45ceb6e9896b7db, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:a5ff1a49bd0d02d12709d779ec463354, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:e418795fad65d93f647c66b4cafc44d3, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:0120da9e3c4c2f68a90e4e07859e01a5, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:37b1f61f5f383179a1108cbeb18a7fc8, -)
-    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:7f8e3b395832ae03175831efa814e15d, -)
-    entity(niiri:e6857ee15115bf5982f48cfda7a54ae1,
+    wasAssociatedWith(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:3a62fb6ad2d39c5660be6897ee3c3e73, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:c0dd0e9c97451986d441709660e35e73, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:03ab2c2b25290bfbb92b205d06f30309, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:1b2d6f3c3e049fd1e78bc7a80520f259, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:3a2ce7e48305fa577a002108c633bff0, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:ec293a0de477afbef9957e9f47a1c702, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:f11b9ce477b25eb9c64a9090ee72bab8, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:0362da72912ae3440c96a8e8e17265b6, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:70d10fe634f06ac32e487717a068ad91, -)
+    used(niiri:8df5ae68cdbcac646e75a717043d3718, niiri:3664093d905bb224f173ac25c7b0b09c, -)
+    entity(niiri:4aceeb9a2a8ce680a59e8635f0d3047f,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -315,103 +315,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "212.999999999914" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         crypto:sha512 = "4f4148b82d622f62a0b9842cc107d4d805da1fd2a2b7dd81c8077c78385094a5cf257e58be485665ae71549f14bbd5b373500b019912c16b148bf6139f2c9fab" %% xsd:string])
-    entity(niiri:cccbadac1a5f632236cdbc06acb912cf,
+    entity(niiri:e0e04cb6635c9e16b86da8eeca18e0a7,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "caed758baa658ea340614ee572505b07bb99c6b7522e49d910fcf107be3e222bfee02e569e70a12d6c977666a85015146e4b03a43813e4cbada9ff111a42bdad" %% xsd:string])
-    wasDerivedFrom(niiri:e6857ee15115bf5982f48cfda7a54ae1, niiri:cccbadac1a5f632236cdbc06acb912cf, -, -, -)
-    wasGeneratedBy(niiri:e6857ee15115bf5982f48cfda7a54ae1, niiri:24047e30c15c9d7c34e301287b91b981, -)
-    entity(niiri:acaaa17be1f71e29539bda1ed50c9aa2,
+    wasDerivedFrom(niiri:4aceeb9a2a8ce680a59e8635f0d3047f, niiri:e0e04cb6635c9e16b86da8eeca18e0a7, -, -, -)
+    wasGeneratedBy(niiri:4aceeb9a2a8ce680a59e8635f0d3047f, niiri:8df5ae68cdbcac646e75a717043d3718, -)
+    entity(niiri:692d28943246a664b9e7e7e9206df663,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         crypto:sha512 = "6258b3318e234dbcbfa4da6f3bd4b0cd6cbfd514b715dd7259452d0405cdaf92749fcffa37c20ce6cb758156f68ef45029c6718d0a58ad979174c1a2d5110d93" %% xsd:string])
-    entity(niiri:4a8442f7e40f06f7fd28381d52f1cfab,
+    entity(niiri:b9303f1155f08e72e0dbd25761423b21,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "e5b55cefb29fd399e8e8ee884704774197d2d239935a0c8fc9eb014e6a975180003e867dac7a60e4ad79bfd7f8349eccf6e4811020881055b7995d0b6f3e0db1" %% xsd:string])
-    wasDerivedFrom(niiri:acaaa17be1f71e29539bda1ed50c9aa2, niiri:4a8442f7e40f06f7fd28381d52f1cfab, -, -, -)
-    wasGeneratedBy(niiri:acaaa17be1f71e29539bda1ed50c9aa2, niiri:24047e30c15c9d7c34e301287b91b981, -)
-    entity(niiri:23831cb16298fefad15200a03cc85773,
+    wasDerivedFrom(niiri:692d28943246a664b9e7e7e9206df663, niiri:b9303f1155f08e72e0dbd25761423b21, -, -, -)
+    wasGeneratedBy(niiri:692d28943246a664b9e7e7e9206df663, niiri:8df5ae68cdbcac646e75a717043d3718, -)
+    entity(niiri:8daeaf56bc70c0f5bf1a81764af0b2ca,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         crypto:sha512 = "5b685962b23bfa2ff341c7dc697adf20554dc001471f9971776835a5444cfd08e90f7e84528fe2ea2697ee30518711d41b43cf0f6a5fb629c6bf80ff3c682ce2" %% xsd:string])
-    wasGeneratedBy(niiri:23831cb16298fefad15200a03cc85773, niiri:24047e30c15c9d7c34e301287b91b981, -)
-    entity(niiri:4685875d4c37edd35c7616b7984ac314,
+    wasGeneratedBy(niiri:8daeaf56bc70c0f5bf1a81764af0b2ca, niiri:8df5ae68cdbcac646e75a717043d3718, -)
+    entity(niiri:dcb306a40fa1effcc0e24151e72d9a00,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500527674169" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:9439581215c093989e2cb9b9b2cfef2b',
-        nidm_equivalentThreshold: = 'niiri:2e586d635af17f2cac288422770f898f'])
-    entity(niiri:9439581215c093989e2cb9b9b2cfef2b,
+        nidm_equivalentThreshold: = 'niiri:16f8f2d187ac448f0820206896f8d974',
+        nidm_equivalentThreshold: = 'niiri:2d9a21c41805947505308d4381ed1646'])
+    entity(niiri:16f8f2d187ac448f0820206896f8d974,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12893352901528" %% xsd:float])
-    entity(niiri:2e586d635af17f2cac288422770f898f,
+    entity(niiri:2d9a21c41805947505308d4381ed1646,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999998805" %% xsd:float])
-    entity(niiri:6d104331bd48210744660822994327f2,
+    entity(niiri:405a3e3b2d43c2b49fe2845cee377f20,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:1b9f15d700e97915229a543ba32bd8a8',
-        nidm_equivalentThreshold: = 'niiri:3134a36023d8c49d230c67515678719c'])
-    entity(niiri:1b9f15d700e97915229a543ba32bd8a8,
+        nidm_equivalentThreshold: = 'niiri:b16ffc8a4586ea9d2a92c621c6dbc2b7',
+        nidm_equivalentThreshold: = 'niiri:9c1b8d55c87073d44c156d77d64cebc8'])
+    entity(niiri:b16ffc8a4586ea9d2a92c621c6dbc2b7,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:3134a36023d8c49d230c67515678719c,
+    entity(niiri:9c1b8d55c87073d44c156d77d64cebc8,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:c4ba6790d5172238d71004c657c82986,
+    entity(niiri:c13f56c81e56b4bf430e9ad8c59ed9c9,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:6fbfbeb641d64d9bcff32d7e452d85e8,
+    entity(niiri:d245e44445df3c547ce27e85b2b279e3,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:4ce4c366179aebb1e0b39602e0016a6f,
+    activity(niiri:67a3a091ab8d2be44d931d38ab79b7e5,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:305f6d612e80d0ac7f38f2c4707cfa10, -)
-    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:4685875d4c37edd35c7616b7984ac314, -)
-    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:6d104331bd48210744660822994327f2, -)
-    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:e6857ee15115bf5982f48cfda7a54ae1, -)
-    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:dfdd94c4bf399011a3075afb77f548c9, -)
-    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:60b72a68a7d90c7546bd6a8c0159ab36, -)
-    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:c4ba6790d5172238d71004c657c82986, -)
-    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:6fbfbeb641d64d9bcff32d7e452d85e8, -)
-    entity(niiri:6edd5609affac25edaef6d72ee3e16c5,
+    wasAssociatedWith(niiri:67a3a091ab8d2be44d931d38ab79b7e5, niiri:3a62fb6ad2d39c5660be6897ee3c3e73, -)
+    used(niiri:67a3a091ab8d2be44d931d38ab79b7e5, niiri:dcb306a40fa1effcc0e24151e72d9a00, -)
+    used(niiri:67a3a091ab8d2be44d931d38ab79b7e5, niiri:405a3e3b2d43c2b49fe2845cee377f20, -)
+    used(niiri:67a3a091ab8d2be44d931d38ab79b7e5, niiri:4aceeb9a2a8ce680a59e8635f0d3047f, -)
+    used(niiri:67a3a091ab8d2be44d931d38ab79b7e5, niiri:1c02618dddbb4d92e807a09c4813dff9, -)
+    used(niiri:67a3a091ab8d2be44d931d38ab79b7e5, niiri:c0dd0e9c97451986d441709660e35e73, -)
+    used(niiri:67a3a091ab8d2be44d931d38ab79b7e5, niiri:c13f56c81e56b4bf430e9ad8c59ed9c9, -)
+    used(niiri:67a3a091ab8d2be44d931d38ab79b7e5, niiri:d245e44445df3c547ce27e85b2b279e3, -)
+    entity(niiri:484a553efa3623dde693658e447c2636,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.3737898804348" %% xsd:float,
@@ -427,8 +427,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:6edd5609affac25edaef6d72ee3e16c5, niiri:4ce4c366179aebb1e0b39602e0016a6f, -)
-    entity(niiri:814dac7697f054e96b414c81e163b5c9,
+    wasGeneratedBy(niiri:484a553efa3623dde693658e447c2636, niiri:67a3a091ab8d2be44d931d38ab79b7e5, -)
+    entity(niiri:04474cbbc5a7e57a5b71f4b30c61a2a5,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -436,20 +436,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:e790a6ab78f56df2937e78ef7a0da9c2',
-        nidm_hasMaximumIntensityProjection: = 'niiri:c977725ffc765ddf73f18a35c8f64c04',
-        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
+        nidm_hasClusterLabelsMap: = 'niiri:357689e63ba5127bf2e86eaa3173c9d7',
+        nidm_hasMaximumIntensityProjection: = 'niiri:121c8fb35d94f7d4b9f4bfbed0262915',
+        nidm_inCoordinateSpace: = 'niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:e790a6ab78f56df2937e78ef7a0da9c2,
+    entity(niiri:357689e63ba5127bf2e86eaa3173c9d7,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:c977725ffc765ddf73f18a35c8f64c04,
+    entity(niiri:121c8fb35d94f7d4b9f4bfbed0262915,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:814dac7697f054e96b414c81e163b5c9, niiri:4ce4c366179aebb1e0b39602e0016a6f, -)
+    wasGeneratedBy(niiri:04474cbbc5a7e57a5b71f4b30c61a2a5, niiri:67a3a091ab8d2be44d931d38ab79b7e5, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_temporal_derivative/nidm.provn
+++ b/spmexport/ex_spm_temporal_derivative/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:475a4f7f9c3392031b97984b42a5bd4b,
+  entity(niiri:3c6dc086c76678be7063859e84986baf,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:6d61c24dd3145fc5efad404e8bc6d4fc,
+  agent(niiri:f60eebb85e75a51b2f784027bd6c65f0,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:5c74fef440631f9ccb7fe34d279272fc,
+  activity(niiri:5208480176f629a6812b18fda01fd47b,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:5c74fef440631f9ccb7fe34d279272fc, niiri:6d61c24dd3145fc5efad404e8bc6d4fc, -)
-  wasGeneratedBy(niiri:475a4f7f9c3392031b97984b42a5bd4b, niiri:5c74fef440631f9ccb7fe34d279272fc, 2016-01-11T10:12:18)
-  bundle niiri:475a4f7f9c3392031b97984b42a5bd4b
+  wasAssociatedWith(niiri:5208480176f629a6812b18fda01fd47b, niiri:f60eebb85e75a51b2f784027bd6c65f0, -)
+  wasGeneratedBy(niiri:3c6dc086c76678be7063859e84986baf, niiri:5208480176f629a6812b18fda01fd47b, 2016-01-11T10:34:35)
+  bundle niiri:3c6dc086c76678be7063859e84986baf
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -120,12 +120,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:0993d8ea9ed568082981469c3f11cb40,
+    agent(niiri:305f6d612e80d0ac7f38f2c4707cfa10,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:c0c9407bb918d90803b7a6e1a9e91d17,
+    entity(niiri:e58601fa87a65231a7d5f04d9abeb8ab,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -134,178 +134,178 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:d21298dd0f77e1213408eb61a4b9991d,
+    entity(niiri:0587895d96cc3d928268ee75cb0fb2d7,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:c86e41f85127fb83ac2b680ee5a731f2,
+    entity(niiri:eac3ba341a653c3f2f431a2f2191daeb,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:fbe8448b35a379424241f33a66d17652,
+    entity(niiri:09fc15666b65ec5e0b51db428e596afc,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:0f348577e4cfb7e07676904db7d97bb8',
+        dc:description = 'niiri:db6ec6e7212de8a96f98952b255e71ab',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:c86e41f85127fb83ac2b680ee5a731f2',
+        nidm_hasDriftModel: = 'niiri:eac3ba341a653c3f2f431a2f2191daeb',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:',
         nidm_hasHRFBasis: = 'spm_SPMsTemporalDerivative:'])
-    entity(niiri:0f348577e4cfb7e07676904db7d97bb8,
+    entity(niiri:db6ec6e7212de8a96f98952b255e71ab,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:b5afd1667ee7b0d7de03cd293ae8f183,
+    entity(niiri:aa63ccf32993ab6946641662c0b826f9,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:b13e0eadf32a4a01efad69f19c41cf22,
+    activity(niiri:0563a0d470bf09dae2ab32ec6e4e53b8,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:b13e0eadf32a4a01efad69f19c41cf22, niiri:0993d8ea9ed568082981469c3f11cb40, -)
-    used(niiri:b13e0eadf32a4a01efad69f19c41cf22, niiri:fbe8448b35a379424241f33a66d17652, -)
-    used(niiri:b13e0eadf32a4a01efad69f19c41cf22, niiri:d21298dd0f77e1213408eb61a4b9991d, -)
-    used(niiri:b13e0eadf32a4a01efad69f19c41cf22, niiri:b5afd1667ee7b0d7de03cd293ae8f183, -)
-    entity(niiri:588bac44c873c7a8f5b97ce1dd9a3692,
+    wasAssociatedWith(niiri:0563a0d470bf09dae2ab32ec6e4e53b8, niiri:305f6d612e80d0ac7f38f2c4707cfa10, -)
+    used(niiri:0563a0d470bf09dae2ab32ec6e4e53b8, niiri:09fc15666b65ec5e0b51db428e596afc, -)
+    used(niiri:0563a0d470bf09dae2ab32ec6e4e53b8, niiri:0587895d96cc3d928268ee75cb0fb2d7, -)
+    used(niiri:0563a0d470bf09dae2ab32ec6e4e53b8, niiri:aa63ccf32993ab6946641662c0b826f9, -)
+    entity(niiri:60b72a68a7d90c7546bd6a8c0159ab36,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:8bf26cbf0e1ee506254bba5ced7f5e80,
+    entity(niiri:df4480035b6ca748071681a72c956d53,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:588bac44c873c7a8f5b97ce1dd9a3692, niiri:8bf26cbf0e1ee506254bba5ced7f5e80, -, -, -)
-    wasGeneratedBy(niiri:588bac44c873c7a8f5b97ce1dd9a3692, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:926a4d8231c792875e710fdd8e7bd655,
+    wasDerivedFrom(niiri:60b72a68a7d90c7546bd6a8c0159ab36, niiri:df4480035b6ca748071681a72c956d53, -, -, -)
+    wasGeneratedBy(niiri:60b72a68a7d90c7546bd6a8c0159ab36, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:ecbcc5aff9d93b04dd5bed528c105a0c,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.554069519043" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         crypto:sha512 = "cd9a68897ec41212e51351c42135ef25ca8e0f20a78efeb7384fd90bd31b87de1dacd27c2320e59d3be730da14aa9139e74401a7942414518089ea8dcd808f5d" %% xsd:string])
-    wasGeneratedBy(niiri:926a4d8231c792875e710fdd8e7bd655, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:abf9b7bc82010c000834203906c153c7,
+    wasGeneratedBy(niiri:ecbcc5aff9d93b04dd5bed528c105a0c, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:a5ff1a49bd0d02d12709d779ec463354,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
-    entity(niiri:ab25d1607affbd06523e858b02a7cf34,
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
+    entity(niiri:4c397e405accc6b80e5533a92a239e51,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d14d038ad88a006ca6afd74c35b91715787ace3677a2c9a2fea05d43dc02fde023379242720516252ba79f85717d4d4bf943a4ab0b5deac4415d3d3cd33ff4dd" %% xsd:string])
-    wasDerivedFrom(niiri:abf9b7bc82010c000834203906c153c7, niiri:ab25d1607affbd06523e858b02a7cf34, -, -, -)
-    wasGeneratedBy(niiri:abf9b7bc82010c000834203906c153c7, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:27f40984bb13d1a3273ecc9fdbf9b12a,
+    wasDerivedFrom(niiri:a5ff1a49bd0d02d12709d779ec463354, niiri:4c397e405accc6b80e5533a92a239e51, -, -, -)
+    wasGeneratedBy(niiri:a5ff1a49bd0d02d12709d779ec463354, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:e418795fad65d93f647c66b4cafc44d3,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
-    entity(niiri:ad3eb9c1b465ccebd37062492c9cf918,
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
+    entity(niiri:b329517cdd0324fd17bc197ac363d942,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3d641f2628f4d10f4a105aec937f2a8715ac785644f23cecd51c0ef60598851826f703e6681c3a94c067adcd1832b2718dbd91f398bb2c79fc2cedd5b93c67ff" %% xsd:string])
-    wasDerivedFrom(niiri:27f40984bb13d1a3273ecc9fdbf9b12a, niiri:ad3eb9c1b465ccebd37062492c9cf918, -, -, -)
-    wasGeneratedBy(niiri:27f40984bb13d1a3273ecc9fdbf9b12a, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:93320d70dc9feb2baa5de49c63d2caeb,
+    wasDerivedFrom(niiri:e418795fad65d93f647c66b4cafc44d3, niiri:b329517cdd0324fd17bc197ac363d942, -, -, -)
+    wasGeneratedBy(niiri:e418795fad65d93f647c66b4cafc44d3, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:0120da9e3c4c2f68a90e4e07859e01a5,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
-    entity(niiri:203ee1fd098a5221f5b8684e888a4062,
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
+    entity(niiri:804259da565a8f875a2f6ae188ae3106,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "16f85e5e7f11ff93aafcd55124d9fcfe76b60f083ebb65d3354e3a31e4460318d91d4f6d546148ca6392dec705340612f7899445d9eaf64cf52ecb9a8d9d6a49" %% xsd:string])
-    wasDerivedFrom(niiri:93320d70dc9feb2baa5de49c63d2caeb, niiri:203ee1fd098a5221f5b8684e888a4062, -, -, -)
-    wasGeneratedBy(niiri:93320d70dc9feb2baa5de49c63d2caeb, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:7ad92a10a558b70e6e70b721b0cc6927,
+    wasDerivedFrom(niiri:0120da9e3c4c2f68a90e4e07859e01a5, niiri:804259da565a8f875a2f6ae188ae3106, -, -, -)
+    wasGeneratedBy(niiri:0120da9e3c4c2f68a90e4e07859e01a5, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:37b1f61f5f383179a1108cbeb18a7fc8,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 4" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
-    entity(niiri:07b3618fd6cbec28f7601abf3f7fe4bc,
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
+    entity(niiri:e37c798696d7e40fb64bd0b6c2d3e17f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0004.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "5a91e7e2139a66cb1402e4f1132476f384c5c02f402f73063b295ce5c365a7887e41e14bcc0324461f9d6cabae02318068185081d6b20466fb4f93829c4a8947" %% xsd:string])
-    wasDerivedFrom(niiri:7ad92a10a558b70e6e70b721b0cc6927, niiri:07b3618fd6cbec28f7601abf3f7fe4bc, -, -, -)
-    wasGeneratedBy(niiri:7ad92a10a558b70e6e70b721b0cc6927, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:01121d48d70e6a751b6941b4ebe8ceaa,
+    wasDerivedFrom(niiri:37b1f61f5f383179a1108cbeb18a7fc8, niiri:e37c798696d7e40fb64bd0b6c2d3e17f, -, -, -)
+    wasGeneratedBy(niiri:37b1f61f5f383179a1108cbeb18a7fc8, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:7f8e3b395832ae03175831efa814e15d,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 5" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
-    entity(niiri:616e84ce4d76e47ed2f323ba8865dd67,
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab'])
+    entity(niiri:523a5a385bac09773d12da89f2d1c547,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0005.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "1df2fce8ae0e72a428af31f2198e42ceefcc04f482480c5700513d29e6fd413327bb5579b9d7558281ce6036b22ca352cf17523adce6c574d3ef9dd8a0821b9b" %% xsd:string])
-    wasDerivedFrom(niiri:01121d48d70e6a751b6941b4ebe8ceaa, niiri:616e84ce4d76e47ed2f323ba8865dd67, -, -, -)
-    wasGeneratedBy(niiri:01121d48d70e6a751b6941b4ebe8ceaa, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:9f09840189403ef9f92b9d5b52eb5839,
+    wasDerivedFrom(niiri:7f8e3b395832ae03175831efa814e15d, niiri:523a5a385bac09773d12da89f2d1c547, -, -, -)
+    wasGeneratedBy(niiri:7f8e3b395832ae03175831efa814e15d, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:86f2c8c5518e16774d9bd82a5c1b451c,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         crypto:sha512 = "4e2e030b949c1b60b3560f5525cd528b84fd6a54e692647c9f002f96a46b06f1cfeef976d7ff3c63264582e55b8716d5cf57885aade6b1a5153ca8e3b2d79fde" %% xsd:string])
-    entity(niiri:470b754f98ad973ea1cde6ea1faf491b,
+    entity(niiri:eb2335b9a2a16ccbea2f07c7b833cf55,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "a9c63ba9a666166bb13156094cc2620daea103b764e8386540bd52bd4b42c7f6f61009d65275411044b63a513ff257dddcb1882f36a4c633be14275f847005f2" %% xsd:string])
-    wasDerivedFrom(niiri:9f09840189403ef9f92b9d5b52eb5839, niiri:470b754f98ad973ea1cde6ea1faf491b, -, -, -)
-    wasGeneratedBy(niiri:9f09840189403ef9f92b9d5b52eb5839, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:ac7d85d8e96744494156605fc6459728,
+    wasDerivedFrom(niiri:86f2c8c5518e16774d9bd82a5c1b451c, niiri:eb2335b9a2a16ccbea2f07c7b833cf55, -, -, -)
+    wasGeneratedBy(niiri:86f2c8c5518e16774d9bd82a5c1b451c, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:dfdd94c4bf399011a3075afb77f548c9,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         crypto:sha512 = "ef1340dc691e63767d8ee59ddd92b94aa8108415ecb57ae4d00aa2a2b3088a647cc031364ccfbe7c8bd246a0f64a5147eb9590975dd41e1eb2510559ccb1b121" %% xsd:string])
-    entity(niiri:4fd373905bd1df09403f74b6adf813ac,
+    entity(niiri:232af3b69fab7e03bf7daa3f28d65d79,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "38c048c905cbdc241bf470117e0f919457d92c8e7836b99e3eb9b70356b5b87f2733701a749b2e49af678bef88d6bddb7628d483702befc624a9933a5bcb5c85" %% xsd:string])
-    wasDerivedFrom(niiri:ac7d85d8e96744494156605fc6459728, niiri:4fd373905bd1df09403f74b6adf813ac, -, -, -)
-    wasGeneratedBy(niiri:ac7d85d8e96744494156605fc6459728, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
-    entity(niiri:e02c48030e3b34bd307fdfb76331f254,
+    wasDerivedFrom(niiri:dfdd94c4bf399011a3075afb77f548c9, niiri:232af3b69fab7e03bf7daa3f28d65d79, -, -, -)
+    wasGeneratedBy(niiri:dfdd94c4bf399011a3075afb77f548c9, niiri:0563a0d470bf09dae2ab32ec6e4e53b8, -)
+    entity(niiri:59f5a82e85ac6cc9b45ceb6e9896b7db,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, 0, -1, 0, 0]" %% xsd:string])
-    activity(niiri:88540c795e586c0f5becf14a247f805e,
+    activity(niiri:24047e30c15c9d7c34e301287b91b981,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:88540c795e586c0f5becf14a247f805e, niiri:0993d8ea9ed568082981469c3f11cb40, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:588bac44c873c7a8f5b97ce1dd9a3692, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:9f09840189403ef9f92b9d5b52eb5839, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:fbe8448b35a379424241f33a66d17652, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:e02c48030e3b34bd307fdfb76331f254, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:abf9b7bc82010c000834203906c153c7, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:27f40984bb13d1a3273ecc9fdbf9b12a, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:93320d70dc9feb2baa5de49c63d2caeb, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:7ad92a10a558b70e6e70b721b0cc6927, -)
-    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:01121d48d70e6a751b6941b4ebe8ceaa, -)
-    entity(niiri:3ee810d6896b3dc8ae8b86c839dfc96d,
+    wasAssociatedWith(niiri:24047e30c15c9d7c34e301287b91b981, niiri:305f6d612e80d0ac7f38f2c4707cfa10, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:60b72a68a7d90c7546bd6a8c0159ab36, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:86f2c8c5518e16774d9bd82a5c1b451c, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:09fc15666b65ec5e0b51db428e596afc, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:59f5a82e85ac6cc9b45ceb6e9896b7db, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:a5ff1a49bd0d02d12709d779ec463354, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:e418795fad65d93f647c66b4cafc44d3, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:0120da9e3c4c2f68a90e4e07859e01a5, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:37b1f61f5f383179a1108cbeb18a7fc8, -)
+    used(niiri:24047e30c15c9d7c34e301287b91b981, niiri:7f8e3b395832ae03175831efa814e15d, -)
+    entity(niiri:e6857ee15115bf5982f48cfda7a54ae1,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -315,103 +315,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "212.999999999914" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         crypto:sha512 = "4f4148b82d622f62a0b9842cc107d4d805da1fd2a2b7dd81c8077c78385094a5cf257e58be485665ae71549f14bbd5b373500b019912c16b148bf6139f2c9fab" %% xsd:string])
-    entity(niiri:654db00fe464d0dfb908d50ea4ec76c5,
+    entity(niiri:cccbadac1a5f632236cdbc06acb912cf,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "caed758baa658ea340614ee572505b07bb99c6b7522e49d910fcf107be3e222bfee02e569e70a12d6c977666a85015146e4b03a43813e4cbada9ff111a42bdad" %% xsd:string])
-    wasDerivedFrom(niiri:3ee810d6896b3dc8ae8b86c839dfc96d, niiri:654db00fe464d0dfb908d50ea4ec76c5, -, -, -)
-    wasGeneratedBy(niiri:3ee810d6896b3dc8ae8b86c839dfc96d, niiri:88540c795e586c0f5becf14a247f805e, -)
-    entity(niiri:14d4927fed2fd4e814c6b592305dbfc0,
+    wasDerivedFrom(niiri:e6857ee15115bf5982f48cfda7a54ae1, niiri:cccbadac1a5f632236cdbc06acb912cf, -, -, -)
+    wasGeneratedBy(niiri:e6857ee15115bf5982f48cfda7a54ae1, niiri:24047e30c15c9d7c34e301287b91b981, -)
+    entity(niiri:acaaa17be1f71e29539bda1ed50c9aa2,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         crypto:sha512 = "6258b3318e234dbcbfa4da6f3bd4b0cd6cbfd514b715dd7259452d0405cdaf92749fcffa37c20ce6cb758156f68ef45029c6718d0a58ad979174c1a2d5110d93" %% xsd:string])
-    entity(niiri:e27142899d98427864ddcb5649c4d9ed,
+    entity(niiri:4a8442f7e40f06f7fd28381d52f1cfab,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "e5b55cefb29fd399e8e8ee884704774197d2d239935a0c8fc9eb014e6a975180003e867dac7a60e4ad79bfd7f8349eccf6e4811020881055b7995d0b6f3e0db1" %% xsd:string])
-    wasDerivedFrom(niiri:14d4927fed2fd4e814c6b592305dbfc0, niiri:e27142899d98427864ddcb5649c4d9ed, -, -, -)
-    wasGeneratedBy(niiri:14d4927fed2fd4e814c6b592305dbfc0, niiri:88540c795e586c0f5becf14a247f805e, -)
-    entity(niiri:9f95ddd9637b1507796cdfdf83b5dfd4,
+    wasDerivedFrom(niiri:acaaa17be1f71e29539bda1ed50c9aa2, niiri:4a8442f7e40f06f7fd28381d52f1cfab, -, -, -)
+    wasGeneratedBy(niiri:acaaa17be1f71e29539bda1ed50c9aa2, niiri:24047e30c15c9d7c34e301287b91b981, -)
+    entity(niiri:23831cb16298fefad15200a03cc85773,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         crypto:sha512 = "5b685962b23bfa2ff341c7dc697adf20554dc001471f9971776835a5444cfd08e90f7e84528fe2ea2697ee30518711d41b43cf0f6a5fb629c6bf80ff3c682ce2" %% xsd:string])
-    wasGeneratedBy(niiri:9f95ddd9637b1507796cdfdf83b5dfd4, niiri:88540c795e586c0f5becf14a247f805e, -)
-    entity(niiri:68b0693a8273494acb82041c92a62569,
+    wasGeneratedBy(niiri:23831cb16298fefad15200a03cc85773, niiri:24047e30c15c9d7c34e301287b91b981, -)
+    entity(niiri:4685875d4c37edd35c7616b7984ac314,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
         prov:value = "0.000999500527674169" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:53b4968963700dadcf8f03ae7d63ecf4',
-        nidm_equivalentThreshold: = 'niiri:63d2ae1f21cc017f2c60cc3c5e8bf43a'])
-    entity(niiri:53b4968963700dadcf8f03ae7d63ecf4,
+        nidm_equivalentThreshold: = 'niiri:9439581215c093989e2cb9b9b2cfef2b',
+        nidm_equivalentThreshold: = 'niiri:2e586d635af17f2cac288422770f898f'])
+    entity(niiri:9439581215c093989e2cb9b9b2cfef2b,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12893352901528" %% xsd:float])
-    entity(niiri:63d2ae1f21cc017f2c60cc3c5e8bf43a,
+    entity(niiri:2e586d635af17f2cac288422770f898f,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999998805" %% xsd:float])
-    entity(niiri:73950c361e42dc36c16dca9cb73af5c8,
+    entity(niiri:6d104331bd48210744660822994327f2,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:93bf9e65710081edb2d9a3b32dd4490c',
-        nidm_equivalentThreshold: = 'niiri:21ea682a5f7356b33f4a3ad38d235115'])
-    entity(niiri:93bf9e65710081edb2d9a3b32dd4490c,
+        nidm_equivalentThreshold: = 'niiri:1b9f15d700e97915229a543ba32bd8a8',
+        nidm_equivalentThreshold: = 'niiri:3134a36023d8c49d230c67515678719c'])
+    entity(niiri:1b9f15d700e97915229a543ba32bd8a8,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:21ea682a5f7356b33f4a3ad38d235115,
+    entity(niiri:3134a36023d8c49d230c67515678719c,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:2d949a916931280b77b49a0241ec62d5,
+    entity(niiri:c4ba6790d5172238d71004c657c82986,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:bd8962e1f0f8c53eab468480e3c67799,
+    entity(niiri:6fbfbeb641d64d9bcff32d7e452d85e8,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:a63b6454408484775af0cc4b22c38164,
+    activity(niiri:4ce4c366179aebb1e0b39602e0016a6f,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:a63b6454408484775af0cc4b22c38164, niiri:0993d8ea9ed568082981469c3f11cb40, -)
-    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:68b0693a8273494acb82041c92a62569, -)
-    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:73950c361e42dc36c16dca9cb73af5c8, -)
-    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:3ee810d6896b3dc8ae8b86c839dfc96d, -)
-    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:ac7d85d8e96744494156605fc6459728, -)
-    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:588bac44c873c7a8f5b97ce1dd9a3692, -)
-    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:2d949a916931280b77b49a0241ec62d5, -)
-    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:bd8962e1f0f8c53eab468480e3c67799, -)
-    entity(niiri:b66bc89fd4437db99f4ec6ed233ef279,
+    wasAssociatedWith(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:305f6d612e80d0ac7f38f2c4707cfa10, -)
+    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:4685875d4c37edd35c7616b7984ac314, -)
+    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:6d104331bd48210744660822994327f2, -)
+    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:e6857ee15115bf5982f48cfda7a54ae1, -)
+    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:dfdd94c4bf399011a3075afb77f548c9, -)
+    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:60b72a68a7d90c7546bd6a8c0159ab36, -)
+    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:c4ba6790d5172238d71004c657c82986, -)
+    used(niiri:4ce4c366179aebb1e0b39602e0016a6f, niiri:6fbfbeb641d64d9bcff32d7e452d85e8, -)
+    entity(niiri:6edd5609affac25edaef6d72ee3e16c5,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.3737898804348" %% xsd:float,
@@ -427,8 +427,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:b66bc89fd4437db99f4ec6ed233ef279, niiri:a63b6454408484775af0cc4b22c38164, -)
-    entity(niiri:bb7fe36d73b5f025dfe59bd96afb31c0,
+    wasGeneratedBy(niiri:6edd5609affac25edaef6d72ee3e16c5, niiri:4ce4c366179aebb1e0b39602e0016a6f, -)
+    entity(niiri:814dac7697f054e96b414c81e163b5c9,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -436,20 +436,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:ecf541e7373c25705cceaeb0aa09773c',
-        nidm_hasMaximumIntensityProjection: = 'niiri:0c94b91fe2a71c93340a78e55a6f0d90',
-        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_hasClusterLabelsMap: = 'niiri:e790a6ab78f56df2937e78ef7a0da9c2',
+        nidm_hasMaximumIntensityProjection: = 'niiri:c977725ffc765ddf73f18a35c8f64c04',
+        nidm_inCoordinateSpace: = 'niiri:e58601fa87a65231a7d5f04d9abeb8ab',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:ecf541e7373c25705cceaeb0aa09773c,
+    entity(niiri:e790a6ab78f56df2937e78ef7a0da9c2,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:0c94b91fe2a71c93340a78e55a6f0d90,
+    entity(niiri:c977725ffc765ddf73f18a35c8f64c04,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:bb7fe36d73b5f025dfe59bd96afb31c0, niiri:a63b6454408484775af0cc4b22c38164, -)
+    wasGeneratedBy(niiri:814dac7697f054e96b414c81e163b5c9, niiri:4ce4c366179aebb1e0b39602e0016a6f, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_temporal_derivative/nidm.provn
+++ b/spmexport/ex_spm_temporal_derivative/nidm.provn
@@ -1,0 +1,455 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:475a4f7f9c3392031b97984b42a5bd4b,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:6d61c24dd3145fc5efad404e8bc6d4fc,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:5c74fef440631f9ccb7fe34d279272fc,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:5c74fef440631f9ccb7fe34d279272fc, niiri:6d61c24dd3145fc5efad404e8bc6d4fc, -)
+  wasGeneratedBy(niiri:475a4f7f9c3392031b97984b42a5bd4b, niiri:5c74fef440631f9ccb7fe34d279272fc, 2016-01-11T10:12:18)
+  bundle niiri:475a4f7f9c3392031b97984b42a5bd4b
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix spm_SPMsTemporalDerivative <http://purl.org/nidash/spm#SPM_0000006>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+
+    agent(niiri:0993d8ea9ed568082981469c3f11cb40,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:c0c9407bb918d90803b7a6e1a9e91d17,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:d21298dd0f77e1213408eb61a4b9991d,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:c86e41f85127fb83ac2b680ee5a731f2,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:fbe8448b35a379424241f33a66d17652,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:0f348577e4cfb7e07676904db7d97bb8',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:c86e41f85127fb83ac2b680ee5a731f2',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:',
+        nidm_hasHRFBasis: = 'spm_SPMsTemporalDerivative:'])
+    entity(niiri:0f348577e4cfb7e07676904db7d97bb8,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:b5afd1667ee7b0d7de03cd293ae8f183,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:b13e0eadf32a4a01efad69f19c41cf22,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:b13e0eadf32a4a01efad69f19c41cf22, niiri:0993d8ea9ed568082981469c3f11cb40, -)
+    used(niiri:b13e0eadf32a4a01efad69f19c41cf22, niiri:fbe8448b35a379424241f33a66d17652, -)
+    used(niiri:b13e0eadf32a4a01efad69f19c41cf22, niiri:d21298dd0f77e1213408eb61a4b9991d, -)
+    used(niiri:b13e0eadf32a4a01efad69f19c41cf22, niiri:b5afd1667ee7b0d7de03cd293ae8f183, -)
+    entity(niiri:588bac44c873c7a8f5b97ce1dd9a3692,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    entity(niiri:8bf26cbf0e1ee506254bba5ced7f5e80,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
+    wasDerivedFrom(niiri:588bac44c873c7a8f5b97ce1dd9a3692, niiri:8bf26cbf0e1ee506254bba5ced7f5e80, -, -, -)
+    wasGeneratedBy(niiri:588bac44c873c7a8f5b97ce1dd9a3692, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:926a4d8231c792875e710fdd8e7bd655,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "121.554069519043" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        crypto:sha512 = "cd9a68897ec41212e51351c42135ef25ca8e0f20a78efeb7384fd90bd31b87de1dacd27c2320e59d3be730da14aa9139e74401a7942414518089ea8dcd808f5d" %% xsd:string])
+    wasGeneratedBy(niiri:926a4d8231c792875e710fdd8e7bd655, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:abf9b7bc82010c000834203906c153c7,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
+    entity(niiri:ab25d1607affbd06523e858b02a7cf34,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d14d038ad88a006ca6afd74c35b91715787ace3677a2c9a2fea05d43dc02fde023379242720516252ba79f85717d4d4bf943a4ab0b5deac4415d3d3cd33ff4dd" %% xsd:string])
+    wasDerivedFrom(niiri:abf9b7bc82010c000834203906c153c7, niiri:ab25d1607affbd06523e858b02a7cf34, -, -, -)
+    wasGeneratedBy(niiri:abf9b7bc82010c000834203906c153c7, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:27f40984bb13d1a3273ecc9fdbf9b12a,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
+    entity(niiri:ad3eb9c1b465ccebd37062492c9cf918,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3d641f2628f4d10f4a105aec937f2a8715ac785644f23cecd51c0ef60598851826f703e6681c3a94c067adcd1832b2718dbd91f398bb2c79fc2cedd5b93c67ff" %% xsd:string])
+    wasDerivedFrom(niiri:27f40984bb13d1a3273ecc9fdbf9b12a, niiri:ad3eb9c1b465ccebd37062492c9cf918, -, -, -)
+    wasGeneratedBy(niiri:27f40984bb13d1a3273ecc9fdbf9b12a, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:93320d70dc9feb2baa5de49c63d2caeb,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
+    entity(niiri:203ee1fd098a5221f5b8684e888a4062,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "16f85e5e7f11ff93aafcd55124d9fcfe76b60f083ebb65d3354e3a31e4460318d91d4f6d546148ca6392dec705340612f7899445d9eaf64cf52ecb9a8d9d6a49" %% xsd:string])
+    wasDerivedFrom(niiri:93320d70dc9feb2baa5de49c63d2caeb, niiri:203ee1fd098a5221f5b8684e888a4062, -, -, -)
+    wasGeneratedBy(niiri:93320d70dc9feb2baa5de49c63d2caeb, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:7ad92a10a558b70e6e70b721b0cc6927,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 4" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
+    entity(niiri:07b3618fd6cbec28f7601abf3f7fe4bc,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0004.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "5a91e7e2139a66cb1402e4f1132476f384c5c02f402f73063b295ce5c365a7887e41e14bcc0324461f9d6cabae02318068185081d6b20466fb4f93829c4a8947" %% xsd:string])
+    wasDerivedFrom(niiri:7ad92a10a558b70e6e70b721b0cc6927, niiri:07b3618fd6cbec28f7601abf3f7fe4bc, -, -, -)
+    wasGeneratedBy(niiri:7ad92a10a558b70e6e70b721b0cc6927, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:01121d48d70e6a751b6941b4ebe8ceaa,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 5" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17'])
+    entity(niiri:616e84ce4d76e47ed2f323ba8865dd67,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0005.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "1df2fce8ae0e72a428af31f2198e42ceefcc04f482480c5700513d29e6fd413327bb5579b9d7558281ce6036b22ca352cf17523adce6c574d3ef9dd8a0821b9b" %% xsd:string])
+    wasDerivedFrom(niiri:01121d48d70e6a751b6941b4ebe8ceaa, niiri:616e84ce4d76e47ed2f323ba8865dd67, -, -, -)
+    wasGeneratedBy(niiri:01121d48d70e6a751b6941b4ebe8ceaa, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:9f09840189403ef9f92b9d5b52eb5839,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        crypto:sha512 = "4e2e030b949c1b60b3560f5525cd528b84fd6a54e692647c9f002f96a46b06f1cfeef976d7ff3c63264582e55b8716d5cf57885aade6b1a5153ca8e3b2d79fde" %% xsd:string])
+    entity(niiri:470b754f98ad973ea1cde6ea1faf491b,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "a9c63ba9a666166bb13156094cc2620daea103b764e8386540bd52bd4b42c7f6f61009d65275411044b63a513ff257dddcb1882f36a4c633be14275f847005f2" %% xsd:string])
+    wasDerivedFrom(niiri:9f09840189403ef9f92b9d5b52eb5839, niiri:470b754f98ad973ea1cde6ea1faf491b, -, -, -)
+    wasGeneratedBy(niiri:9f09840189403ef9f92b9d5b52eb5839, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:ac7d85d8e96744494156605fc6459728,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        crypto:sha512 = "ef1340dc691e63767d8ee59ddd92b94aa8108415ecb57ae4d00aa2a2b3088a647cc031364ccfbe7c8bd246a0f64a5147eb9590975dd41e1eb2510559ccb1b121" %% xsd:string])
+    entity(niiri:4fd373905bd1df09403f74b6adf813ac,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "38c048c905cbdc241bf470117e0f919457d92c8e7836b99e3eb9b70356b5b87f2733701a749b2e49af678bef88d6bddb7628d483702befc624a9933a5bcb5c85" %% xsd:string])
+    wasDerivedFrom(niiri:ac7d85d8e96744494156605fc6459728, niiri:4fd373905bd1df09403f74b6adf813ac, -, -, -)
+    wasGeneratedBy(niiri:ac7d85d8e96744494156605fc6459728, niiri:b13e0eadf32a4a01efad69f19c41cf22, -)
+    entity(niiri:e02c48030e3b34bd307fdfb76331f254,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        prov:label = "Contrast: pos vs neg" %% xsd:string,
+        prov:value = "[1, 0, -1, 0, 0]" %% xsd:string])
+    activity(niiri:88540c795e586c0f5becf14a247f805e,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:88540c795e586c0f5becf14a247f805e, niiri:0993d8ea9ed568082981469c3f11cb40, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:588bac44c873c7a8f5b97ce1dd9a3692, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:9f09840189403ef9f92b9d5b52eb5839, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:fbe8448b35a379424241f33a66d17652, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:e02c48030e3b34bd307fdfb76331f254, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:abf9b7bc82010c000834203906c153c7, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:27f40984bb13d1a3273ecc9fdbf9b12a, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:93320d70dc9feb2baa5de49c63d2caeb, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:7ad92a10a558b70e6e70b721b0cc6927, -)
+    used(niiri:88540c795e586c0f5becf14a247f805e, niiri:01121d48d70e6a751b6941b4ebe8ceaa, -)
+    entity(niiri:3ee810d6896b3dc8ae8b86c839dfc96d,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: pos vs neg" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "212.999999999914" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        crypto:sha512 = "4f4148b82d622f62a0b9842cc107d4d805da1fd2a2b7dd81c8077c78385094a5cf257e58be485665ae71549f14bbd5b373500b019912c16b148bf6139f2c9fab" %% xsd:string])
+    entity(niiri:654db00fe464d0dfb908d50ea4ec76c5,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "caed758baa658ea340614ee572505b07bb99c6b7522e49d910fcf107be3e222bfee02e569e70a12d6c977666a85015146e4b03a43813e4cbada9ff111a42bdad" %% xsd:string])
+    wasDerivedFrom(niiri:3ee810d6896b3dc8ae8b86c839dfc96d, niiri:654db00fe464d0dfb908d50ea4ec76c5, -, -, -)
+    wasGeneratedBy(niiri:3ee810d6896b3dc8ae8b86c839dfc96d, niiri:88540c795e586c0f5becf14a247f805e, -)
+    entity(niiri:14d4927fed2fd4e814c6b592305dbfc0,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: pos vs neg" %% xsd:string,
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        crypto:sha512 = "6258b3318e234dbcbfa4da6f3bd4b0cd6cbfd514b715dd7259452d0405cdaf92749fcffa37c20ce6cb758156f68ef45029c6718d0a58ad979174c1a2d5110d93" %% xsd:string])
+    entity(niiri:e27142899d98427864ddcb5649c4d9ed,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "e5b55cefb29fd399e8e8ee884704774197d2d239935a0c8fc9eb014e6a975180003e867dac7a60e4ad79bfd7f8349eccf6e4811020881055b7995d0b6f3e0db1" %% xsd:string])
+    wasDerivedFrom(niiri:14d4927fed2fd4e814c6b592305dbfc0, niiri:e27142899d98427864ddcb5649c4d9ed, -, -, -)
+    wasGeneratedBy(niiri:14d4927fed2fd4e814c6b592305dbfc0, niiri:88540c795e586c0f5becf14a247f805e, -)
+    entity(niiri:9f95ddd9637b1507796cdfdf83b5dfd4,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        crypto:sha512 = "5b685962b23bfa2ff341c7dc697adf20554dc001471f9971776835a5444cfd08e90f7e84528fe2ea2697ee30518711d41b43cf0f6a5fb629c6bf80ff3c682ce2" %% xsd:string])
+    wasGeneratedBy(niiri:9f95ddd9637b1507796cdfdf83b5dfd4, niiri:88540c795e586c0f5becf14a247f805e, -)
+    entity(niiri:68b0693a8273494acb82041c92a62569,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.001000 (unc.)" %% xsd:string,
+        prov:value = "0.000999500527674169" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:53b4968963700dadcf8f03ae7d63ecf4',
+        nidm_equivalentThreshold: = 'niiri:63d2ae1f21cc017f2c60cc3c5e8bf43a'])
+    entity(niiri:53b4968963700dadcf8f03ae7d63ecf4,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "3.12893352901528" %% xsd:float])
+    entity(niiri:63d2ae1f21cc017f2c60cc3c5e8bf43a,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.999999999998805" %% xsd:float])
+    entity(niiri:73950c361e42dc36c16dca9cb73af5c8,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:93bf9e65710081edb2d9a3b32dd4490c',
+        nidm_equivalentThreshold: = 'niiri:21ea682a5f7356b33f4a3ad38d235115'])
+    entity(niiri:93bf9e65710081edb2d9a3b32dd4490c,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:21ea682a5f7356b33f4a3ad38d235115,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:2d949a916931280b77b49a0241ec62d5,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:bd8962e1f0f8c53eab468480e3c67799,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:a63b6454408484775af0cc4b22c38164,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:a63b6454408484775af0cc4b22c38164, niiri:0993d8ea9ed568082981469c3f11cb40, -)
+    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:68b0693a8273494acb82041c92a62569, -)
+    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:73950c361e42dc36c16dca9cb73af5c8, -)
+    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:3ee810d6896b3dc8ae8b86c839dfc96d, -)
+    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:ac7d85d8e96744494156605fc6459728, -)
+    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:588bac44c873c7a8f5b97ce1dd9a3692, -)
+    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:2d949a916931280b77b49a0241ec62d5, -)
+    used(niiri:a63b6454408484775af0cc4b22c38164, niiri:bd8962e1f0f8c53eab468480e3c67799, -)
+    entity(niiri:b66bc89fd4437db99f4ec6ed233ef279,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
+        nidm_reselSizeInVoxels: = "71.3737898804348" %% xsd:float,
+        nidm_searchVolumeInResels: = "2667.99619746968" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[3, 68.7480482453344, 853.25625530838, 2667.99619746968]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.00671949295826, 4.06775760061697, 4.37919973569734]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.01343898591652, 8.13551520123394, 8.75839947139468]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "8.17710130718754" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "27.4532106277773" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.05413080658104" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    wasGeneratedBy(niiri:b66bc89fd4437db99f4ec6ed233ef279, niiri:a63b6454408484775af0cc4b22c38164, -)
+    entity(niiri:bb7fe36d73b5f025dfe59bd96afb31c0,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
+        nidm_pValue: = "NaN" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:ecf541e7373c25705cceaeb0aa09773c',
+        nidm_hasMaximumIntensityProjection: = 'niiri:0c94b91fe2a71c93340a78e55a6f0d90',
+        nidm_inCoordinateSpace: = 'niiri:c0c9407bb918d90803b7a6e1a9e91d17',
+        crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
+    entity(niiri:ecf541e7373c25705cceaeb0aa09773c,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:0c94b91fe2a71c93340a78e55a6f0d90,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:bb7fe36d73b5f025dfe59bd96afb31c0, niiri:a63b6454408484775af0cc4b22c38164, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_temporal_derivative/nidm.ttl
+++ b/spmexport/ex_spm_temporal_derivative/nidm.ttl
@@ -1,0 +1,546 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:475a4f7f9c3392031b97984b42a5bd4b
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:6d61c24dd3145fc5efad404e8bc6d4fc
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:5c74fef440631f9ccb7fe34d279272fc
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:5c74fef440631f9ccb7fe34d279272fc prov:wasAssociatedWith niiri:6d61c24dd3145fc5efad404e8bc6d4fc .
+
+_:blank5 a prov:Generation .
+
+niiri:475a4f7f9c3392031b97984b42a5bd4b prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:12:18"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix spm_SPMsTemporalDerivative: <http://purl.org/nidash/spm#SPM_0000006> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+
+niiri:0993d8ea9ed568082981469c3f11cb40
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:c0c9407bb918d90803b7a6e1a9e91d17
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:d21298dd0f77e1213408eb61a4b9991d
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:c86e41f85127fb83ac2b680ee5a731f2
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:fbe8448b35a379424241f33a66d17652
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:0f348577e4cfb7e07676904db7d97bb8 ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:c86e41f85127fb83ac2b680ee5a731f2 ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
+    nidm_hasHRFBasis: spm_SPMsTemporalDerivative: .
+
+niiri:0f348577e4cfb7e07676904db7d97bb8
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:b5afd1667ee7b0d7de03cd293ae8f183
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:b13e0eadf32a4a01efad69f19c41cf22
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:b13e0eadf32a4a01efad69f19c41cf22 prov:wasAssociatedWith niiri:0993d8ea9ed568082981469c3f11cb40 .
+
+niiri:b13e0eadf32a4a01efad69f19c41cf22 prov:used niiri:fbe8448b35a379424241f33a66d17652 .
+
+niiri:b13e0eadf32a4a01efad69f19c41cf22 prov:used niiri:d21298dd0f77e1213408eb61a4b9991d .
+
+niiri:b13e0eadf32a4a01efad69f19c41cf22 prov:used niiri:b5afd1667ee7b0d7de03cd293ae8f183 .
+
+niiri:588bac44c873c7a8f5b97ce1dd9a3692
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:8bf26cbf0e1ee506254bba5ced7f5e80
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
+
+niiri:588bac44c873c7a8f5b97ce1dd9a3692 prov:wasDerivedFrom niiri:8bf26cbf0e1ee506254bba5ced7f5e80 .
+
+niiri:588bac44c873c7a8f5b97ce1dd9a3692 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:926a4d8231c792875e710fdd8e7bd655
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "121.554069519043"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    crypto:sha512 "cd9a68897ec41212e51351c42135ef25ca8e0f20a78efeb7384fd90bd31b87de1dacd27c2320e59d3be730da14aa9139e74401a7942414518089ea8dcd808f5d"^^xsd:string .
+
+niiri:926a4d8231c792875e710fdd8e7bd655 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:abf9b7bc82010c000834203906c153c7
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+
+niiri:ab25d1607affbd06523e858b02a7cf34
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d14d038ad88a006ca6afd74c35b91715787ace3677a2c9a2fea05d43dc02fde023379242720516252ba79f85717d4d4bf943a4ab0b5deac4415d3d3cd33ff4dd"^^xsd:string .
+
+niiri:abf9b7bc82010c000834203906c153c7 prov:wasDerivedFrom niiri:ab25d1607affbd06523e858b02a7cf34 .
+
+niiri:abf9b7bc82010c000834203906c153c7 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:27f40984bb13d1a3273ecc9fdbf9b12a
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+
+niiri:ad3eb9c1b465ccebd37062492c9cf918
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3d641f2628f4d10f4a105aec937f2a8715ac785644f23cecd51c0ef60598851826f703e6681c3a94c067adcd1832b2718dbd91f398bb2c79fc2cedd5b93c67ff"^^xsd:string .
+
+niiri:27f40984bb13d1a3273ecc9fdbf9b12a prov:wasDerivedFrom niiri:ad3eb9c1b465ccebd37062492c9cf918 .
+
+niiri:27f40984bb13d1a3273ecc9fdbf9b12a prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:93320d70dc9feb2baa5de49c63d2caeb
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+
+niiri:203ee1fd098a5221f5b8684e888a4062
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "16f85e5e7f11ff93aafcd55124d9fcfe76b60f083ebb65d3354e3a31e4460318d91d4f6d546148ca6392dec705340612f7899445d9eaf64cf52ecb9a8d9d6a49"^^xsd:string .
+
+niiri:93320d70dc9feb2baa5de49c63d2caeb prov:wasDerivedFrom niiri:203ee1fd098a5221f5b8684e888a4062 .
+
+niiri:93320d70dc9feb2baa5de49c63d2caeb prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:7ad92a10a558b70e6e70b721b0cc6927
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 4" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+
+niiri:07b3618fd6cbec28f7601abf3f7fe4bc
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0004.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "5a91e7e2139a66cb1402e4f1132476f384c5c02f402f73063b295ce5c365a7887e41e14bcc0324461f9d6cabae02318068185081d6b20466fb4f93829c4a8947"^^xsd:string .
+
+niiri:7ad92a10a558b70e6e70b721b0cc6927 prov:wasDerivedFrom niiri:07b3618fd6cbec28f7601abf3f7fe4bc .
+
+niiri:7ad92a10a558b70e6e70b721b0cc6927 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:01121d48d70e6a751b6941b4ebe8ceaa
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 5" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+
+niiri:616e84ce4d76e47ed2f323ba8865dd67
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0005.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "1df2fce8ae0e72a428af31f2198e42ceefcc04f482480c5700513d29e6fd413327bb5579b9d7558281ce6036b22ca352cf17523adce6c574d3ef9dd8a0821b9b"^^xsd:string .
+
+niiri:01121d48d70e6a751b6941b4ebe8ceaa prov:wasDerivedFrom niiri:616e84ce4d76e47ed2f323ba8865dd67 .
+
+niiri:01121d48d70e6a751b6941b4ebe8ceaa prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:9f09840189403ef9f92b9d5b52eb5839
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    crypto:sha512 "4e2e030b949c1b60b3560f5525cd528b84fd6a54e692647c9f002f96a46b06f1cfeef976d7ff3c63264582e55b8716d5cf57885aade6b1a5153ca8e3b2d79fde"^^xsd:string .
+
+niiri:470b754f98ad973ea1cde6ea1faf491b
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "a9c63ba9a666166bb13156094cc2620daea103b764e8386540bd52bd4b42c7f6f61009d65275411044b63a513ff257dddcb1882f36a4c633be14275f847005f2"^^xsd:string .
+
+niiri:9f09840189403ef9f92b9d5b52eb5839 prov:wasDerivedFrom niiri:470b754f98ad973ea1cde6ea1faf491b .
+
+niiri:9f09840189403ef9f92b9d5b52eb5839 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:ac7d85d8e96744494156605fc6459728
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    crypto:sha512 "ef1340dc691e63767d8ee59ddd92b94aa8108415ecb57ae4d00aa2a2b3088a647cc031364ccfbe7c8bd246a0f64a5147eb9590975dd41e1eb2510559ccb1b121"^^xsd:string .
+
+niiri:4fd373905bd1df09403f74b6adf813ac
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "38c048c905cbdc241bf470117e0f919457d92c8e7836b99e3eb9b70356b5b87f2733701a749b2e49af678bef88d6bddb7628d483702befc624a9933a5bcb5c85"^^xsd:string .
+
+niiri:ac7d85d8e96744494156605fc6459728 prov:wasDerivedFrom niiri:4fd373905bd1df09403f74b6adf813ac .
+
+niiri:ac7d85d8e96744494156605fc6459728 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+
+niiri:e02c48030e3b34bd307fdfb76331f254
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    rdfs:label "Contrast: pos vs neg" ;
+    prov:value "[1, 0, -1, 0, 0]"^^xsd:string .
+
+niiri:88540c795e586c0f5becf14a247f805e
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:wasAssociatedWith niiri:0993d8ea9ed568082981469c3f11cb40 .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:588bac44c873c7a8f5b97ce1dd9a3692 .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:9f09840189403ef9f92b9d5b52eb5839 .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:fbe8448b35a379424241f33a66d17652 .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:e02c48030e3b34bd307fdfb76331f254 .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:abf9b7bc82010c000834203906c153c7 .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:27f40984bb13d1a3273ecc9fdbf9b12a .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:93320d70dc9feb2baa5de49c63d2caeb .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:7ad92a10a558b70e6e70b721b0cc6927 .
+
+niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:01121d48d70e6a751b6941b4ebe8ceaa .
+
+niiri:3ee810d6896b3dc8ae8b86c839dfc96d
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: pos vs neg" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "212.999999999914"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    crypto:sha512 "4f4148b82d622f62a0b9842cc107d4d805da1fd2a2b7dd81c8077c78385094a5cf257e58be485665ae71549f14bbd5b373500b019912c16b148bf6139f2c9fab"^^xsd:string .
+
+niiri:654db00fe464d0dfb908d50ea4ec76c5
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "caed758baa658ea340614ee572505b07bb99c6b7522e49d910fcf107be3e222bfee02e569e70a12d6c977666a85015146e4b03a43813e4cbada9ff111a42bdad"^^xsd:string .
+
+niiri:3ee810d6896b3dc8ae8b86c839dfc96d prov:wasDerivedFrom niiri:654db00fe464d0dfb908d50ea4ec76c5 .
+
+niiri:3ee810d6896b3dc8ae8b86c839dfc96d prov:wasGeneratedBy niiri:88540c795e586c0f5becf14a247f805e .
+
+niiri:14d4927fed2fd4e814c6b592305dbfc0
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: pos vs neg" ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    crypto:sha512 "6258b3318e234dbcbfa4da6f3bd4b0cd6cbfd514b715dd7259452d0405cdaf92749fcffa37c20ce6cb758156f68ef45029c6718d0a58ad979174c1a2d5110d93"^^xsd:string .
+
+niiri:e27142899d98427864ddcb5649c4d9ed
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "e5b55cefb29fd399e8e8ee884704774197d2d239935a0c8fc9eb014e6a975180003e867dac7a60e4ad79bfd7f8349eccf6e4811020881055b7995d0b6f3e0db1"^^xsd:string .
+
+niiri:14d4927fed2fd4e814c6b592305dbfc0 prov:wasDerivedFrom niiri:e27142899d98427864ddcb5649c4d9ed .
+
+niiri:14d4927fed2fd4e814c6b592305dbfc0 prov:wasGeneratedBy niiri:88540c795e586c0f5becf14a247f805e .
+
+niiri:9f95ddd9637b1507796cdfdf83b5dfd4
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    crypto:sha512 "5b685962b23bfa2ff341c7dc697adf20554dc001471f9971776835a5444cfd08e90f7e84528fe2ea2697ee30518711d41b43cf0f6a5fb629c6bf80ff3c682ce2"^^xsd:string .
+
+niiri:9f95ddd9637b1507796cdfdf83b5dfd4 prov:wasGeneratedBy niiri:88540c795e586c0f5becf14a247f805e .
+
+niiri:68b0693a8273494acb82041c92a62569
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    prov:value "0.000999500527674169"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:53b4968963700dadcf8f03ae7d63ecf4 ;
+    nidm_equivalentThreshold: niiri:63d2ae1f21cc017f2c60cc3c5e8bf43a .
+
+niiri:53b4968963700dadcf8f03ae7d63ecf4
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "3.12893352901528"^^xsd:float .
+
+niiri:63d2ae1f21cc017f2c60cc3c5e8bf43a
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.999999999998805"^^xsd:float .
+
+niiri:73950c361e42dc36c16dca9cb73af5c8
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:93bf9e65710081edb2d9a3b32dd4490c ;
+    nidm_equivalentThreshold: niiri:21ea682a5f7356b33f4a3ad38d235115 .
+
+niiri:93bf9e65710081edb2d9a3b32dd4490c
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:21ea682a5f7356b33f4a3ad38d235115
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:2d949a916931280b77b49a0241ec62d5
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:bd8962e1f0f8c53eab468480e3c67799
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:a63b6454408484775af0cc4b22c38164
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:a63b6454408484775af0cc4b22c38164 prov:wasAssociatedWith niiri:0993d8ea9ed568082981469c3f11cb40 .
+
+niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:68b0693a8273494acb82041c92a62569 .
+
+niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:73950c361e42dc36c16dca9cb73af5c8 .
+
+niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:3ee810d6896b3dc8ae8b86c839dfc96d .
+
+niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:ac7d85d8e96744494156605fc6459728 .
+
+niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:588bac44c873c7a8f5b97ce1dd9a3692 .
+
+niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:2d949a916931280b77b49a0241ec62d5 .
+
+niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:bd8962e1f0f8c53eab468480e3c67799 .
+
+niiri:b66bc89fd4437db99f4ec6ed233ef279
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
+    nidm_reselSizeInVoxels: "71.3737898804348"^^xsd:float ;
+    nidm_searchVolumeInResels: "2667.99619746968"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[3, 68.7480482453344, 853.25625530838, 2667.99619746968]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.00671949295826, 4.06775760061697, 4.37919973569734]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.01343898591652, 8.13551520123394, 8.75839947139468]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "8.17710130718754"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "27.4532106277773"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.05413080658104"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:b66bc89fd4437db99f4ec6ed233ef279 prov:wasGeneratedBy niiri:a63b6454408484775af0cc4b22c38164 .
+
+niiri:bb7fe36d73b5f025dfe59bd96afb31c0
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
+    nidm_pValue: "NaN"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:ecf541e7373c25705cceaeb0aa09773c ;
+    nidm_hasMaximumIntensityProjection: niiri:0c94b91fe2a71c93340a78e55a6f0d90 ;
+    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
+
+niiri:ecf541e7373c25705cceaeb0aa09773c
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:0c94b91fe2a71c93340a78e55a6f0d90
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:bb7fe36d73b5f025dfe59bd96afb31c0 prov:wasGeneratedBy niiri:a63b6454408484775af0cc4b22c38164 .
+

--- a/spmexport/ex_spm_temporal_derivative/nidm.ttl
+++ b/spmexport/ex_spm_temporal_derivative/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:3c6dc086c76678be7063859e84986baf
+niiri:e64702adc0e35cc1bd2b3e358bf7a7f8
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:f60eebb85e75a51b2f784027bd6c65f0
+niiri:0d47f7667162b705032684d55436c4fe
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:5208480176f629a6812b18fda01fd47b
+niiri:9d126fde60b32d6488e156ea10c53065
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:5208480176f629a6812b18fda01fd47b prov:wasAssociatedWith niiri:f60eebb85e75a51b2f784027bd6c65f0 .
+niiri:9d126fde60b32d6488e156ea10c53065 prov:wasAssociatedWith niiri:0d47f7667162b705032684d55436c4fe .
 
 _:blank5 a prov:Generation .
 
-niiri:3c6dc086c76678be7063859e84986baf prov:qualifiedGeneration _:blank5 .
+niiri:e64702adc0e35cc1bd2b3e358bf7a7f8 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:34:35"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:45:18"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -130,12 +130,12 @@ _:blank5 prov:atTime "2016-01-11T10:34:35"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:305f6d612e80d0ac7f38f2c4707cfa10
+niiri:3a62fb6ad2d39c5660be6897ee3c3e73
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:e58601fa87a65231a7d5f04d9abeb8ab
+niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -145,36 +145,36 @@ niiri:e58601fa87a65231a7d5f04d9abeb8ab
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:0587895d96cc3d928268ee75cb0fb2d7
+niiri:5a3c12bc7a1267841d000c61cf0343d3
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:eac3ba341a653c3f2f431a2f2191daeb
+niiri:c637c184fba84571528b3f45c6dc7f97
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:09fc15666b65ec5e0b51db428e596afc
+niiri:1b2d6f3c3e049fd1e78bc7a80520f259
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:db6ec6e7212de8a96f98952b255e71ab ;
+    dc:description niiri:784be6c513a5f5195c0010a862afe583 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:eac3ba341a653c3f2f431a2f2191daeb ;
+    nidm_hasDriftModel: niiri:c637c184fba84571528b3f45c6dc7f97 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
     nidm_hasHRFBasis: spm_SPMsTemporalDerivative: .
 
-niiri:db6ec6e7212de8a96f98952b255e71ab
+niiri:784be6c513a5f5195c0010a862afe583
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:aa63ccf32993ab6946641662c0b826f9
+niiri:2f2815f79f719eb33f62c88fe52f9bb8
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -182,196 +182,196 @@ niiri:aa63ccf32993ab6946641662c0b826f9
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:0563a0d470bf09dae2ab32ec6e4e53b8
+niiri:abcb1bebeb3a219b4710129779851f27
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:0563a0d470bf09dae2ab32ec6e4e53b8 prov:wasAssociatedWith niiri:305f6d612e80d0ac7f38f2c4707cfa10 .
+niiri:abcb1bebeb3a219b4710129779851f27 prov:wasAssociatedWith niiri:3a62fb6ad2d39c5660be6897ee3c3e73 .
 
-niiri:0563a0d470bf09dae2ab32ec6e4e53b8 prov:used niiri:09fc15666b65ec5e0b51db428e596afc .
+niiri:abcb1bebeb3a219b4710129779851f27 prov:used niiri:1b2d6f3c3e049fd1e78bc7a80520f259 .
 
-niiri:0563a0d470bf09dae2ab32ec6e4e53b8 prov:used niiri:0587895d96cc3d928268ee75cb0fb2d7 .
+niiri:abcb1bebeb3a219b4710129779851f27 prov:used niiri:5a3c12bc7a1267841d000c61cf0343d3 .
 
-niiri:0563a0d470bf09dae2ab32ec6e4e53b8 prov:used niiri:aa63ccf32993ab6946641662c0b826f9 .
+niiri:abcb1bebeb3a219b4710129779851f27 prov:used niiri:2f2815f79f719eb33f62c88fe52f9bb8 .
 
-niiri:60b72a68a7d90c7546bd6a8c0159ab36
+niiri:c0dd0e9c97451986d441709660e35e73
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:df4480035b6ca748071681a72c956d53
+niiri:25afb4a1bf7b03778e3914d4b622aed9
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:60b72a68a7d90c7546bd6a8c0159ab36 prov:wasDerivedFrom niiri:df4480035b6ca748071681a72c956d53 .
+niiri:c0dd0e9c97451986d441709660e35e73 prov:wasDerivedFrom niiri:25afb4a1bf7b03778e3914d4b622aed9 .
 
-niiri:60b72a68a7d90c7546bd6a8c0159ab36 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:c0dd0e9c97451986d441709660e35e73 prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:ecbcc5aff9d93b04dd5bed528c105a0c
+niiri:f288f760f9c5a20b9ef5ee46a8e8d86c
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.554069519043"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     crypto:sha512 "cd9a68897ec41212e51351c42135ef25ca8e0f20a78efeb7384fd90bd31b87de1dacd27c2320e59d3be730da14aa9139e74401a7942414518089ea8dcd808f5d"^^xsd:string .
 
-niiri:ecbcc5aff9d93b04dd5bed528c105a0c prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:f288f760f9c5a20b9ef5ee46a8e8d86c prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:a5ff1a49bd0d02d12709d779ec463354
+niiri:ec293a0de477afbef9957e9f47a1c702
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f .
 
-niiri:4c397e405accc6b80e5533a92a239e51
+niiri:3011bc0d1771062a2ffdf3e49be8b11f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d14d038ad88a006ca6afd74c35b91715787ace3677a2c9a2fea05d43dc02fde023379242720516252ba79f85717d4d4bf943a4ab0b5deac4415d3d3cd33ff4dd"^^xsd:string .
 
-niiri:a5ff1a49bd0d02d12709d779ec463354 prov:wasDerivedFrom niiri:4c397e405accc6b80e5533a92a239e51 .
+niiri:ec293a0de477afbef9957e9f47a1c702 prov:wasDerivedFrom niiri:3011bc0d1771062a2ffdf3e49be8b11f .
 
-niiri:a5ff1a49bd0d02d12709d779ec463354 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:ec293a0de477afbef9957e9f47a1c702 prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:e418795fad65d93f647c66b4cafc44d3
+niiri:f11b9ce477b25eb9c64a9090ee72bab8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f .
 
-niiri:b329517cdd0324fd17bc197ac363d942
+niiri:2696d8cec23d6b95ff92f685420ee58b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3d641f2628f4d10f4a105aec937f2a8715ac785644f23cecd51c0ef60598851826f703e6681c3a94c067adcd1832b2718dbd91f398bb2c79fc2cedd5b93c67ff"^^xsd:string .
 
-niiri:e418795fad65d93f647c66b4cafc44d3 prov:wasDerivedFrom niiri:b329517cdd0324fd17bc197ac363d942 .
+niiri:f11b9ce477b25eb9c64a9090ee72bab8 prov:wasDerivedFrom niiri:2696d8cec23d6b95ff92f685420ee58b .
 
-niiri:e418795fad65d93f647c66b4cafc44d3 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:f11b9ce477b25eb9c64a9090ee72bab8 prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:0120da9e3c4c2f68a90e4e07859e01a5
+niiri:0362da72912ae3440c96a8e8e17265b6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f .
 
-niiri:804259da565a8f875a2f6ae188ae3106
+niiri:1abd490970d36138556f36a5da162c30
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "16f85e5e7f11ff93aafcd55124d9fcfe76b60f083ebb65d3354e3a31e4460318d91d4f6d546148ca6392dec705340612f7899445d9eaf64cf52ecb9a8d9d6a49"^^xsd:string .
 
-niiri:0120da9e3c4c2f68a90e4e07859e01a5 prov:wasDerivedFrom niiri:804259da565a8f875a2f6ae188ae3106 .
+niiri:0362da72912ae3440c96a8e8e17265b6 prov:wasDerivedFrom niiri:1abd490970d36138556f36a5da162c30 .
 
-niiri:0120da9e3c4c2f68a90e4e07859e01a5 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:0362da72912ae3440c96a8e8e17265b6 prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:37b1f61f5f383179a1108cbeb18a7fc8
+niiri:70d10fe634f06ac32e487717a068ad91
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f .
 
-niiri:e37c798696d7e40fb64bd0b6c2d3e17f
+niiri:ccc7dc519c07c56740aae8333cc486aa
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5a91e7e2139a66cb1402e4f1132476f384c5c02f402f73063b295ce5c365a7887e41e14bcc0324461f9d6cabae02318068185081d6b20466fb4f93829c4a8947"^^xsd:string .
 
-niiri:37b1f61f5f383179a1108cbeb18a7fc8 prov:wasDerivedFrom niiri:e37c798696d7e40fb64bd0b6c2d3e17f .
+niiri:70d10fe634f06ac32e487717a068ad91 prov:wasDerivedFrom niiri:ccc7dc519c07c56740aae8333cc486aa .
 
-niiri:37b1f61f5f383179a1108cbeb18a7fc8 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:70d10fe634f06ac32e487717a068ad91 prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:7f8e3b395832ae03175831efa814e15d
+niiri:3664093d905bb224f173ac25c7b0b09c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f .
 
-niiri:523a5a385bac09773d12da89f2d1c547
+niiri:c1d441e1161da8bcb56ede99f8f76082
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1df2fce8ae0e72a428af31f2198e42ceefcc04f482480c5700513d29e6fd413327bb5579b9d7558281ce6036b22ca352cf17523adce6c574d3ef9dd8a0821b9b"^^xsd:string .
 
-niiri:7f8e3b395832ae03175831efa814e15d prov:wasDerivedFrom niiri:523a5a385bac09773d12da89f2d1c547 .
+niiri:3664093d905bb224f173ac25c7b0b09c prov:wasDerivedFrom niiri:c1d441e1161da8bcb56ede99f8f76082 .
 
-niiri:7f8e3b395832ae03175831efa814e15d prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:3664093d905bb224f173ac25c7b0b09c prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:86f2c8c5518e16774d9bd82a5c1b451c
+niiri:03ab2c2b25290bfbb92b205d06f30309
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     crypto:sha512 "4e2e030b949c1b60b3560f5525cd528b84fd6a54e692647c9f002f96a46b06f1cfeef976d7ff3c63264582e55b8716d5cf57885aade6b1a5153ca8e3b2d79fde"^^xsd:string .
 
-niiri:eb2335b9a2a16ccbea2f07c7b833cf55
+niiri:4a967fd750c7aa187bd625e049fe2ab2
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "a9c63ba9a666166bb13156094cc2620daea103b764e8386540bd52bd4b42c7f6f61009d65275411044b63a513ff257dddcb1882f36a4c633be14275f847005f2"^^xsd:string .
 
-niiri:86f2c8c5518e16774d9bd82a5c1b451c prov:wasDerivedFrom niiri:eb2335b9a2a16ccbea2f07c7b833cf55 .
+niiri:03ab2c2b25290bfbb92b205d06f30309 prov:wasDerivedFrom niiri:4a967fd750c7aa187bd625e049fe2ab2 .
 
-niiri:86f2c8c5518e16774d9bd82a5c1b451c prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:03ab2c2b25290bfbb92b205d06f30309 prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:dfdd94c4bf399011a3075afb77f548c9
+niiri:1c02618dddbb4d92e807a09c4813dff9
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     crypto:sha512 "ef1340dc691e63767d8ee59ddd92b94aa8108415ecb57ae4d00aa2a2b3088a647cc031364ccfbe7c8bd246a0f64a5147eb9590975dd41e1eb2510559ccb1b121"^^xsd:string .
 
-niiri:232af3b69fab7e03bf7daa3f28d65d79
+niiri:85c571232916f46e46796be93b6448a3
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "38c048c905cbdc241bf470117e0f919457d92c8e7836b99e3eb9b70356b5b87f2733701a749b2e49af678bef88d6bddb7628d483702befc624a9933a5bcb5c85"^^xsd:string .
 
-niiri:dfdd94c4bf399011a3075afb77f548c9 prov:wasDerivedFrom niiri:232af3b69fab7e03bf7daa3f28d65d79 .
+niiri:1c02618dddbb4d92e807a09c4813dff9 prov:wasDerivedFrom niiri:85c571232916f46e46796be93b6448a3 .
 
-niiri:dfdd94c4bf399011a3075afb77f548c9 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
+niiri:1c02618dddbb4d92e807a09c4813dff9 prov:wasGeneratedBy niiri:abcb1bebeb3a219b4710129779851f27 .
 
-niiri:59f5a82e85ac6cc9b45ceb6e9896b7db
+niiri:3a2ce7e48305fa577a002108c633bff0
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, 0, -1, 0, 0]"^^xsd:string .
 
-niiri:24047e30c15c9d7c34e301287b91b981
+niiri:8df5ae68cdbcac646e75a717043d3718
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:wasAssociatedWith niiri:305f6d612e80d0ac7f38f2c4707cfa10 .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:wasAssociatedWith niiri:3a62fb6ad2d39c5660be6897ee3c3e73 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:60b72a68a7d90c7546bd6a8c0159ab36 .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:c0dd0e9c97451986d441709660e35e73 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:86f2c8c5518e16774d9bd82a5c1b451c .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:03ab2c2b25290bfbb92b205d06f30309 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:09fc15666b65ec5e0b51db428e596afc .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:1b2d6f3c3e049fd1e78bc7a80520f259 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:59f5a82e85ac6cc9b45ceb6e9896b7db .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:3a2ce7e48305fa577a002108c633bff0 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:a5ff1a49bd0d02d12709d779ec463354 .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:ec293a0de477afbef9957e9f47a1c702 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:e418795fad65d93f647c66b4cafc44d3 .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:f11b9ce477b25eb9c64a9090ee72bab8 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:0120da9e3c4c2f68a90e4e07859e01a5 .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:0362da72912ae3440c96a8e8e17265b6 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:37b1f61f5f383179a1108cbeb18a7fc8 .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:70d10fe634f06ac32e487717a068ad91 .
 
-niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:7f8e3b395832ae03175831efa814e15d .
+niiri:8df5ae68cdbcac646e75a717043d3718 prov:used niiri:3664093d905bb224f173ac25c7b0b09c .
 
-niiri:e6857ee15115bf5982f48cfda7a54ae1
+niiri:4aceeb9a2a8ce680a59e8635f0d3047f
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -381,124 +381,124 @@ niiri:e6857ee15115bf5982f48cfda7a54ae1
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "212.999999999914"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     crypto:sha512 "4f4148b82d622f62a0b9842cc107d4d805da1fd2a2b7dd81c8077c78385094a5cf257e58be485665ae71549f14bbd5b373500b019912c16b148bf6139f2c9fab"^^xsd:string .
 
-niiri:cccbadac1a5f632236cdbc06acb912cf
+niiri:e0e04cb6635c9e16b86da8eeca18e0a7
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "caed758baa658ea340614ee572505b07bb99c6b7522e49d910fcf107be3e222bfee02e569e70a12d6c977666a85015146e4b03a43813e4cbada9ff111a42bdad"^^xsd:string .
 
-niiri:e6857ee15115bf5982f48cfda7a54ae1 prov:wasDerivedFrom niiri:cccbadac1a5f632236cdbc06acb912cf .
+niiri:4aceeb9a2a8ce680a59e8635f0d3047f prov:wasDerivedFrom niiri:e0e04cb6635c9e16b86da8eeca18e0a7 .
 
-niiri:e6857ee15115bf5982f48cfda7a54ae1 prov:wasGeneratedBy niiri:24047e30c15c9d7c34e301287b91b981 .
+niiri:4aceeb9a2a8ce680a59e8635f0d3047f prov:wasGeneratedBy niiri:8df5ae68cdbcac646e75a717043d3718 .
 
-niiri:acaaa17be1f71e29539bda1ed50c9aa2
+niiri:692d28943246a664b9e7e7e9206df663
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     crypto:sha512 "6258b3318e234dbcbfa4da6f3bd4b0cd6cbfd514b715dd7259452d0405cdaf92749fcffa37c20ce6cb758156f68ef45029c6718d0a58ad979174c1a2d5110d93"^^xsd:string .
 
-niiri:4a8442f7e40f06f7fd28381d52f1cfab
+niiri:b9303f1155f08e72e0dbd25761423b21
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "e5b55cefb29fd399e8e8ee884704774197d2d239935a0c8fc9eb014e6a975180003e867dac7a60e4ad79bfd7f8349eccf6e4811020881055b7995d0b6f3e0db1"^^xsd:string .
 
-niiri:acaaa17be1f71e29539bda1ed50c9aa2 prov:wasDerivedFrom niiri:4a8442f7e40f06f7fd28381d52f1cfab .
+niiri:692d28943246a664b9e7e7e9206df663 prov:wasDerivedFrom niiri:b9303f1155f08e72e0dbd25761423b21 .
 
-niiri:acaaa17be1f71e29539bda1ed50c9aa2 prov:wasGeneratedBy niiri:24047e30c15c9d7c34e301287b91b981 .
+niiri:692d28943246a664b9e7e7e9206df663 prov:wasGeneratedBy niiri:8df5ae68cdbcac646e75a717043d3718 .
 
-niiri:23831cb16298fefad15200a03cc85773
+niiri:8daeaf56bc70c0f5bf1a81764af0b2ca
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     crypto:sha512 "5b685962b23bfa2ff341c7dc697adf20554dc001471f9971776835a5444cfd08e90f7e84528fe2ea2697ee30518711d41b43cf0f6a5fb629c6bf80ff3c682ce2"^^xsd:string .
 
-niiri:23831cb16298fefad15200a03cc85773 prov:wasGeneratedBy niiri:24047e30c15c9d7c34e301287b91b981 .
+niiri:8daeaf56bc70c0f5bf1a81764af0b2ca prov:wasGeneratedBy niiri:8df5ae68cdbcac646e75a717043d3718 .
 
-niiri:4685875d4c37edd35c7616b7984ac314
+niiri:dcb306a40fa1effcc0e24151e72d9a00
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500527674169"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:9439581215c093989e2cb9b9b2cfef2b ;
-    nidm_equivalentThreshold: niiri:2e586d635af17f2cac288422770f898f .
+    nidm_equivalentThreshold: niiri:16f8f2d187ac448f0820206896f8d974 ;
+    nidm_equivalentThreshold: niiri:2d9a21c41805947505308d4381ed1646 .
 
-niiri:9439581215c093989e2cb9b9b2cfef2b
+niiri:16f8f2d187ac448f0820206896f8d974
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12893352901528"^^xsd:float .
 
-niiri:2e586d635af17f2cac288422770f898f
+niiri:2d9a21c41805947505308d4381ed1646
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999998805"^^xsd:float .
 
-niiri:6d104331bd48210744660822994327f2
+niiri:405a3e3b2d43c2b49fe2845cee377f20
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:1b9f15d700e97915229a543ba32bd8a8 ;
-    nidm_equivalentThreshold: niiri:3134a36023d8c49d230c67515678719c .
+    nidm_equivalentThreshold: niiri:b16ffc8a4586ea9d2a92c621c6dbc2b7 ;
+    nidm_equivalentThreshold: niiri:9c1b8d55c87073d44c156d77d64cebc8 .
 
-niiri:1b9f15d700e97915229a543ba32bd8a8
+niiri:b16ffc8a4586ea9d2a92c621c6dbc2b7
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:3134a36023d8c49d230c67515678719c
+niiri:9c1b8d55c87073d44c156d77d64cebc8
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:c4ba6790d5172238d71004c657c82986
+niiri:c13f56c81e56b4bf430e9ad8c59ed9c9
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:6fbfbeb641d64d9bcff32d7e452d85e8
+niiri:d245e44445df3c547ce27e85b2b279e3
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f
+niiri:67a3a091ab8d2be44d931d38ab79b7e5
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f prov:wasAssociatedWith niiri:305f6d612e80d0ac7f38f2c4707cfa10 .
+niiri:67a3a091ab8d2be44d931d38ab79b7e5 prov:wasAssociatedWith niiri:3a62fb6ad2d39c5660be6897ee3c3e73 .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:4685875d4c37edd35c7616b7984ac314 .
+niiri:67a3a091ab8d2be44d931d38ab79b7e5 prov:used niiri:dcb306a40fa1effcc0e24151e72d9a00 .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:6d104331bd48210744660822994327f2 .
+niiri:67a3a091ab8d2be44d931d38ab79b7e5 prov:used niiri:405a3e3b2d43c2b49fe2845cee377f20 .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:e6857ee15115bf5982f48cfda7a54ae1 .
+niiri:67a3a091ab8d2be44d931d38ab79b7e5 prov:used niiri:4aceeb9a2a8ce680a59e8635f0d3047f .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:dfdd94c4bf399011a3075afb77f548c9 .
+niiri:67a3a091ab8d2be44d931d38ab79b7e5 prov:used niiri:1c02618dddbb4d92e807a09c4813dff9 .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:60b72a68a7d90c7546bd6a8c0159ab36 .
+niiri:67a3a091ab8d2be44d931d38ab79b7e5 prov:used niiri:c0dd0e9c97451986d441709660e35e73 .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:c4ba6790d5172238d71004c657c82986 .
+niiri:67a3a091ab8d2be44d931d38ab79b7e5 prov:used niiri:c13f56c81e56b4bf430e9ad8c59ed9c9 .
 
-niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:6fbfbeb641d64d9bcff32d7e452d85e8 .
+niiri:67a3a091ab8d2be44d931d38ab79b7e5 prov:used niiri:d245e44445df3c547ce27e85b2b279e3 .
 
-niiri:6edd5609affac25edaef6d72ee3e16c5
+niiri:484a553efa3623dde693658e447c2636
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.3737898804348"^^xsd:float ;
@@ -515,9 +515,9 @@ niiri:6edd5609affac25edaef6d72ee3e16c5
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:6edd5609affac25edaef6d72ee3e16c5 prov:wasGeneratedBy niiri:4ce4c366179aebb1e0b39602e0016a6f .
+niiri:484a553efa3623dde693658e447c2636 prov:wasGeneratedBy niiri:67a3a091ab8d2be44d931d38ab79b7e5 .
 
-niiri:814dac7697f054e96b414c81e163b5c9
+niiri:04474cbbc5a7e57a5b71f4b30c61a2a5
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -525,22 +525,22 @@ niiri:814dac7697f054e96b414c81e163b5c9
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:e790a6ab78f56df2937e78ef7a0da9c2 ;
-    nidm_hasMaximumIntensityProjection: niiri:c977725ffc765ddf73f18a35c8f64c04 ;
-    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
+    nidm_hasClusterLabelsMap: niiri:357689e63ba5127bf2e86eaa3173c9d7 ;
+    nidm_hasMaximumIntensityProjection: niiri:121c8fb35d94f7d4b9f4bfbed0262915 ;
+    nidm_inCoordinateSpace: niiri:7ea96cc6a2ee2cdb2f0bf11666d8123f ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:e790a6ab78f56df2937e78ef7a0da9c2
+niiri:357689e63ba5127bf2e86eaa3173c9d7
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:c977725ffc765ddf73f18a35c8f64c04
+niiri:121c8fb35d94f7d4b9f4bfbed0262915
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:814dac7697f054e96b414c81e163b5c9 prov:wasGeneratedBy niiri:4ce4c366179aebb1e0b39602e0016a6f .
+niiri:04474cbbc5a7e57a5b71f4b30c61a2a5 prov:wasGeneratedBy niiri:67a3a091ab8d2be44d931d38ab79b7e5 .
 

--- a/spmexport/ex_spm_temporal_derivative/nidm.ttl
+++ b/spmexport/ex_spm_temporal_derivative/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:475a4f7f9c3392031b97984b42a5bd4b
+niiri:3c6dc086c76678be7063859e84986baf
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:6d61c24dd3145fc5efad404e8bc6d4fc
+niiri:f60eebb85e75a51b2f784027bd6c65f0
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:5c74fef440631f9ccb7fe34d279272fc
+niiri:5208480176f629a6812b18fda01fd47b
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:5c74fef440631f9ccb7fe34d279272fc prov:wasAssociatedWith niiri:6d61c24dd3145fc5efad404e8bc6d4fc .
+niiri:5208480176f629a6812b18fda01fd47b prov:wasAssociatedWith niiri:f60eebb85e75a51b2f784027bd6c65f0 .
 
 _:blank5 a prov:Generation .
 
-niiri:475a4f7f9c3392031b97984b42a5bd4b prov:qualifiedGeneration _:blank5 .
+niiri:3c6dc086c76678be7063859e84986baf prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:12:18"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:34:35"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -130,12 +130,12 @@ _:blank5 prov:atTime "2016-01-11T10:12:18"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:0993d8ea9ed568082981469c3f11cb40
+niiri:305f6d612e80d0ac7f38f2c4707cfa10
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:c0c9407bb918d90803b7a6e1a9e91d17
+niiri:e58601fa87a65231a7d5f04d9abeb8ab
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -145,36 +145,36 @@ niiri:c0c9407bb918d90803b7a6e1a9e91d17
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:d21298dd0f77e1213408eb61a4b9991d
+niiri:0587895d96cc3d928268ee75cb0fb2d7
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:c86e41f85127fb83ac2b680ee5a731f2
+niiri:eac3ba341a653c3f2f431a2f2191daeb
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:fbe8448b35a379424241f33a66d17652
+niiri:09fc15666b65ec5e0b51db428e596afc
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:0f348577e4cfb7e07676904db7d97bb8 ;
+    dc:description niiri:db6ec6e7212de8a96f98952b255e71ab ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) positive feedback\ntask001 co*bf(2)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(2)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:c86e41f85127fb83ac2b680ee5a731f2 ;
+    nidm_hasDriftModel: niiri:eac3ba341a653c3f2f431a2f2191daeb ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
     nidm_hasHRFBasis: spm_SPMsTemporalDerivative: .
 
-niiri:0f348577e4cfb7e07676904db7d97bb8
+niiri:db6ec6e7212de8a96f98952b255e71ab
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:b5afd1667ee7b0d7de03cd293ae8f183
+niiri:aa63ccf32993ab6946641662c0b826f9
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -182,196 +182,196 @@ niiri:b5afd1667ee7b0d7de03cd293ae8f183
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:b13e0eadf32a4a01efad69f19c41cf22
+niiri:0563a0d470bf09dae2ab32ec6e4e53b8
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:b13e0eadf32a4a01efad69f19c41cf22 prov:wasAssociatedWith niiri:0993d8ea9ed568082981469c3f11cb40 .
+niiri:0563a0d470bf09dae2ab32ec6e4e53b8 prov:wasAssociatedWith niiri:305f6d612e80d0ac7f38f2c4707cfa10 .
 
-niiri:b13e0eadf32a4a01efad69f19c41cf22 prov:used niiri:fbe8448b35a379424241f33a66d17652 .
+niiri:0563a0d470bf09dae2ab32ec6e4e53b8 prov:used niiri:09fc15666b65ec5e0b51db428e596afc .
 
-niiri:b13e0eadf32a4a01efad69f19c41cf22 prov:used niiri:d21298dd0f77e1213408eb61a4b9991d .
+niiri:0563a0d470bf09dae2ab32ec6e4e53b8 prov:used niiri:0587895d96cc3d928268ee75cb0fb2d7 .
 
-niiri:b13e0eadf32a4a01efad69f19c41cf22 prov:used niiri:b5afd1667ee7b0d7de03cd293ae8f183 .
+niiri:0563a0d470bf09dae2ab32ec6e4e53b8 prov:used niiri:aa63ccf32993ab6946641662c0b826f9 .
 
-niiri:588bac44c873c7a8f5b97ce1dd9a3692
+niiri:60b72a68a7d90c7546bd6a8c0159ab36
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:8bf26cbf0e1ee506254bba5ced7f5e80
+niiri:df4480035b6ca748071681a72c956d53
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:588bac44c873c7a8f5b97ce1dd9a3692 prov:wasDerivedFrom niiri:8bf26cbf0e1ee506254bba5ced7f5e80 .
+niiri:60b72a68a7d90c7546bd6a8c0159ab36 prov:wasDerivedFrom niiri:df4480035b6ca748071681a72c956d53 .
 
-niiri:588bac44c873c7a8f5b97ce1dd9a3692 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:60b72a68a7d90c7546bd6a8c0159ab36 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:926a4d8231c792875e710fdd8e7bd655
+niiri:ecbcc5aff9d93b04dd5bed528c105a0c
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.554069519043"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     crypto:sha512 "cd9a68897ec41212e51351c42135ef25ca8e0f20a78efeb7384fd90bd31b87de1dacd27c2320e59d3be730da14aa9139e74401a7942414518089ea8dcd808f5d"^^xsd:string .
 
-niiri:926a4d8231c792875e710fdd8e7bd655 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:ecbcc5aff9d93b04dd5bed528c105a0c prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:abf9b7bc82010c000834203906c153c7
+niiri:a5ff1a49bd0d02d12709d779ec463354
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
 
-niiri:ab25d1607affbd06523e858b02a7cf34
+niiri:4c397e405accc6b80e5533a92a239e51
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d14d038ad88a006ca6afd74c35b91715787ace3677a2c9a2fea05d43dc02fde023379242720516252ba79f85717d4d4bf943a4ab0b5deac4415d3d3cd33ff4dd"^^xsd:string .
 
-niiri:abf9b7bc82010c000834203906c153c7 prov:wasDerivedFrom niiri:ab25d1607affbd06523e858b02a7cf34 .
+niiri:a5ff1a49bd0d02d12709d779ec463354 prov:wasDerivedFrom niiri:4c397e405accc6b80e5533a92a239e51 .
 
-niiri:abf9b7bc82010c000834203906c153c7 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:a5ff1a49bd0d02d12709d779ec463354 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:27f40984bb13d1a3273ecc9fdbf9b12a
+niiri:e418795fad65d93f647c66b4cafc44d3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
 
-niiri:ad3eb9c1b465ccebd37062492c9cf918
+niiri:b329517cdd0324fd17bc197ac363d942
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3d641f2628f4d10f4a105aec937f2a8715ac785644f23cecd51c0ef60598851826f703e6681c3a94c067adcd1832b2718dbd91f398bb2c79fc2cedd5b93c67ff"^^xsd:string .
 
-niiri:27f40984bb13d1a3273ecc9fdbf9b12a prov:wasDerivedFrom niiri:ad3eb9c1b465ccebd37062492c9cf918 .
+niiri:e418795fad65d93f647c66b4cafc44d3 prov:wasDerivedFrom niiri:b329517cdd0324fd17bc197ac363d942 .
 
-niiri:27f40984bb13d1a3273ecc9fdbf9b12a prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:e418795fad65d93f647c66b4cafc44d3 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:93320d70dc9feb2baa5de49c63d2caeb
+niiri:0120da9e3c4c2f68a90e4e07859e01a5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
 
-niiri:203ee1fd098a5221f5b8684e888a4062
+niiri:804259da565a8f875a2f6ae188ae3106
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "16f85e5e7f11ff93aafcd55124d9fcfe76b60f083ebb65d3354e3a31e4460318d91d4f6d546148ca6392dec705340612f7899445d9eaf64cf52ecb9a8d9d6a49"^^xsd:string .
 
-niiri:93320d70dc9feb2baa5de49c63d2caeb prov:wasDerivedFrom niiri:203ee1fd098a5221f5b8684e888a4062 .
+niiri:0120da9e3c4c2f68a90e4e07859e01a5 prov:wasDerivedFrom niiri:804259da565a8f875a2f6ae188ae3106 .
 
-niiri:93320d70dc9feb2baa5de49c63d2caeb prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:0120da9e3c4c2f68a90e4e07859e01a5 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:7ad92a10a558b70e6e70b721b0cc6927
+niiri:37b1f61f5f383179a1108cbeb18a7fc8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 4" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
 
-niiri:07b3618fd6cbec28f7601abf3f7fe4bc
+niiri:e37c798696d7e40fb64bd0b6c2d3e17f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5a91e7e2139a66cb1402e4f1132476f384c5c02f402f73063b295ce5c365a7887e41e14bcc0324461f9d6cabae02318068185081d6b20466fb4f93829c4a8947"^^xsd:string .
 
-niiri:7ad92a10a558b70e6e70b721b0cc6927 prov:wasDerivedFrom niiri:07b3618fd6cbec28f7601abf3f7fe4bc .
+niiri:37b1f61f5f383179a1108cbeb18a7fc8 prov:wasDerivedFrom niiri:e37c798696d7e40fb64bd0b6c2d3e17f .
 
-niiri:7ad92a10a558b70e6e70b721b0cc6927 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:37b1f61f5f383179a1108cbeb18a7fc8 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:01121d48d70e6a751b6941b4ebe8ceaa
+niiri:7f8e3b395832ae03175831efa814e15d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 5" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 .
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab .
 
-niiri:616e84ce4d76e47ed2f323ba8865dd67
+niiri:523a5a385bac09773d12da89f2d1c547
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1df2fce8ae0e72a428af31f2198e42ceefcc04f482480c5700513d29e6fd413327bb5579b9d7558281ce6036b22ca352cf17523adce6c574d3ef9dd8a0821b9b"^^xsd:string .
 
-niiri:01121d48d70e6a751b6941b4ebe8ceaa prov:wasDerivedFrom niiri:616e84ce4d76e47ed2f323ba8865dd67 .
+niiri:7f8e3b395832ae03175831efa814e15d prov:wasDerivedFrom niiri:523a5a385bac09773d12da89f2d1c547 .
 
-niiri:01121d48d70e6a751b6941b4ebe8ceaa prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:7f8e3b395832ae03175831efa814e15d prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:9f09840189403ef9f92b9d5b52eb5839
+niiri:86f2c8c5518e16774d9bd82a5c1b451c
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     crypto:sha512 "4e2e030b949c1b60b3560f5525cd528b84fd6a54e692647c9f002f96a46b06f1cfeef976d7ff3c63264582e55b8716d5cf57885aade6b1a5153ca8e3b2d79fde"^^xsd:string .
 
-niiri:470b754f98ad973ea1cde6ea1faf491b
+niiri:eb2335b9a2a16ccbea2f07c7b833cf55
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "a9c63ba9a666166bb13156094cc2620daea103b764e8386540bd52bd4b42c7f6f61009d65275411044b63a513ff257dddcb1882f36a4c633be14275f847005f2"^^xsd:string .
 
-niiri:9f09840189403ef9f92b9d5b52eb5839 prov:wasDerivedFrom niiri:470b754f98ad973ea1cde6ea1faf491b .
+niiri:86f2c8c5518e16774d9bd82a5c1b451c prov:wasDerivedFrom niiri:eb2335b9a2a16ccbea2f07c7b833cf55 .
 
-niiri:9f09840189403ef9f92b9d5b52eb5839 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:86f2c8c5518e16774d9bd82a5c1b451c prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:ac7d85d8e96744494156605fc6459728
+niiri:dfdd94c4bf399011a3075afb77f548c9
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     crypto:sha512 "ef1340dc691e63767d8ee59ddd92b94aa8108415ecb57ae4d00aa2a2b3088a647cc031364ccfbe7c8bd246a0f64a5147eb9590975dd41e1eb2510559ccb1b121"^^xsd:string .
 
-niiri:4fd373905bd1df09403f74b6adf813ac
+niiri:232af3b69fab7e03bf7daa3f28d65d79
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "38c048c905cbdc241bf470117e0f919457d92c8e7836b99e3eb9b70356b5b87f2733701a749b2e49af678bef88d6bddb7628d483702befc624a9933a5bcb5c85"^^xsd:string .
 
-niiri:ac7d85d8e96744494156605fc6459728 prov:wasDerivedFrom niiri:4fd373905bd1df09403f74b6adf813ac .
+niiri:dfdd94c4bf399011a3075afb77f548c9 prov:wasDerivedFrom niiri:232af3b69fab7e03bf7daa3f28d65d79 .
 
-niiri:ac7d85d8e96744494156605fc6459728 prov:wasGeneratedBy niiri:b13e0eadf32a4a01efad69f19c41cf22 .
+niiri:dfdd94c4bf399011a3075afb77f548c9 prov:wasGeneratedBy niiri:0563a0d470bf09dae2ab32ec6e4e53b8 .
 
-niiri:e02c48030e3b34bd307fdfb76331f254
+niiri:59f5a82e85ac6cc9b45ceb6e9896b7db
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, 0, -1, 0, 0]"^^xsd:string .
 
-niiri:88540c795e586c0f5becf14a247f805e
+niiri:24047e30c15c9d7c34e301287b91b981
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:wasAssociatedWith niiri:0993d8ea9ed568082981469c3f11cb40 .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:wasAssociatedWith niiri:305f6d612e80d0ac7f38f2c4707cfa10 .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:588bac44c873c7a8f5b97ce1dd9a3692 .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:60b72a68a7d90c7546bd6a8c0159ab36 .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:9f09840189403ef9f92b9d5b52eb5839 .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:86f2c8c5518e16774d9bd82a5c1b451c .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:fbe8448b35a379424241f33a66d17652 .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:09fc15666b65ec5e0b51db428e596afc .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:e02c48030e3b34bd307fdfb76331f254 .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:59f5a82e85ac6cc9b45ceb6e9896b7db .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:abf9b7bc82010c000834203906c153c7 .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:a5ff1a49bd0d02d12709d779ec463354 .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:27f40984bb13d1a3273ecc9fdbf9b12a .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:e418795fad65d93f647c66b4cafc44d3 .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:93320d70dc9feb2baa5de49c63d2caeb .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:0120da9e3c4c2f68a90e4e07859e01a5 .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:7ad92a10a558b70e6e70b721b0cc6927 .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:37b1f61f5f383179a1108cbeb18a7fc8 .
 
-niiri:88540c795e586c0f5becf14a247f805e prov:used niiri:01121d48d70e6a751b6941b4ebe8ceaa .
+niiri:24047e30c15c9d7c34e301287b91b981 prov:used niiri:7f8e3b395832ae03175831efa814e15d .
 
-niiri:3ee810d6896b3dc8ae8b86c839dfc96d
+niiri:e6857ee15115bf5982f48cfda7a54ae1
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -381,124 +381,124 @@ niiri:3ee810d6896b3dc8ae8b86c839dfc96d
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "212.999999999914"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     crypto:sha512 "4f4148b82d622f62a0b9842cc107d4d805da1fd2a2b7dd81c8077c78385094a5cf257e58be485665ae71549f14bbd5b373500b019912c16b148bf6139f2c9fab"^^xsd:string .
 
-niiri:654db00fe464d0dfb908d50ea4ec76c5
+niiri:cccbadac1a5f632236cdbc06acb912cf
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "caed758baa658ea340614ee572505b07bb99c6b7522e49d910fcf107be3e222bfee02e569e70a12d6c977666a85015146e4b03a43813e4cbada9ff111a42bdad"^^xsd:string .
 
-niiri:3ee810d6896b3dc8ae8b86c839dfc96d prov:wasDerivedFrom niiri:654db00fe464d0dfb908d50ea4ec76c5 .
+niiri:e6857ee15115bf5982f48cfda7a54ae1 prov:wasDerivedFrom niiri:cccbadac1a5f632236cdbc06acb912cf .
 
-niiri:3ee810d6896b3dc8ae8b86c839dfc96d prov:wasGeneratedBy niiri:88540c795e586c0f5becf14a247f805e .
+niiri:e6857ee15115bf5982f48cfda7a54ae1 prov:wasGeneratedBy niiri:24047e30c15c9d7c34e301287b91b981 .
 
-niiri:14d4927fed2fd4e814c6b592305dbfc0
+niiri:acaaa17be1f71e29539bda1ed50c9aa2
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     crypto:sha512 "6258b3318e234dbcbfa4da6f3bd4b0cd6cbfd514b715dd7259452d0405cdaf92749fcffa37c20ce6cb758156f68ef45029c6718d0a58ad979174c1a2d5110d93"^^xsd:string .
 
-niiri:e27142899d98427864ddcb5649c4d9ed
+niiri:4a8442f7e40f06f7fd28381d52f1cfab
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "e5b55cefb29fd399e8e8ee884704774197d2d239935a0c8fc9eb014e6a975180003e867dac7a60e4ad79bfd7f8349eccf6e4811020881055b7995d0b6f3e0db1"^^xsd:string .
 
-niiri:14d4927fed2fd4e814c6b592305dbfc0 prov:wasDerivedFrom niiri:e27142899d98427864ddcb5649c4d9ed .
+niiri:acaaa17be1f71e29539bda1ed50c9aa2 prov:wasDerivedFrom niiri:4a8442f7e40f06f7fd28381d52f1cfab .
 
-niiri:14d4927fed2fd4e814c6b592305dbfc0 prov:wasGeneratedBy niiri:88540c795e586c0f5becf14a247f805e .
+niiri:acaaa17be1f71e29539bda1ed50c9aa2 prov:wasGeneratedBy niiri:24047e30c15c9d7c34e301287b91b981 .
 
-niiri:9f95ddd9637b1507796cdfdf83b5dfd4
+niiri:23831cb16298fefad15200a03cc85773
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     crypto:sha512 "5b685962b23bfa2ff341c7dc697adf20554dc001471f9971776835a5444cfd08e90f7e84528fe2ea2697ee30518711d41b43cf0f6a5fb629c6bf80ff3c682ce2"^^xsd:string .
 
-niiri:9f95ddd9637b1507796cdfdf83b5dfd4 prov:wasGeneratedBy niiri:88540c795e586c0f5becf14a247f805e .
+niiri:23831cb16298fefad15200a03cc85773 prov:wasGeneratedBy niiri:24047e30c15c9d7c34e301287b91b981 .
 
-niiri:68b0693a8273494acb82041c92a62569
+niiri:4685875d4c37edd35c7616b7984ac314
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
     prov:value "0.000999500527674169"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:53b4968963700dadcf8f03ae7d63ecf4 ;
-    nidm_equivalentThreshold: niiri:63d2ae1f21cc017f2c60cc3c5e8bf43a .
+    nidm_equivalentThreshold: niiri:9439581215c093989e2cb9b9b2cfef2b ;
+    nidm_equivalentThreshold: niiri:2e586d635af17f2cac288422770f898f .
 
-niiri:53b4968963700dadcf8f03ae7d63ecf4
+niiri:9439581215c093989e2cb9b9b2cfef2b
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12893352901528"^^xsd:float .
 
-niiri:63d2ae1f21cc017f2c60cc3c5e8bf43a
+niiri:2e586d635af17f2cac288422770f898f
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999998805"^^xsd:float .
 
-niiri:73950c361e42dc36c16dca9cb73af5c8
+niiri:6d104331bd48210744660822994327f2
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:93bf9e65710081edb2d9a3b32dd4490c ;
-    nidm_equivalentThreshold: niiri:21ea682a5f7356b33f4a3ad38d235115 .
+    nidm_equivalentThreshold: niiri:1b9f15d700e97915229a543ba32bd8a8 ;
+    nidm_equivalentThreshold: niiri:3134a36023d8c49d230c67515678719c .
 
-niiri:93bf9e65710081edb2d9a3b32dd4490c
+niiri:1b9f15d700e97915229a543ba32bd8a8
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:21ea682a5f7356b33f4a3ad38d235115
+niiri:3134a36023d8c49d230c67515678719c
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:2d949a916931280b77b49a0241ec62d5
+niiri:c4ba6790d5172238d71004c657c82986
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:bd8962e1f0f8c53eab468480e3c67799
+niiri:6fbfbeb641d64d9bcff32d7e452d85e8
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:a63b6454408484775af0cc4b22c38164
+niiri:4ce4c366179aebb1e0b39602e0016a6f
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:a63b6454408484775af0cc4b22c38164 prov:wasAssociatedWith niiri:0993d8ea9ed568082981469c3f11cb40 .
+niiri:4ce4c366179aebb1e0b39602e0016a6f prov:wasAssociatedWith niiri:305f6d612e80d0ac7f38f2c4707cfa10 .
 
-niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:68b0693a8273494acb82041c92a62569 .
+niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:4685875d4c37edd35c7616b7984ac314 .
 
-niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:73950c361e42dc36c16dca9cb73af5c8 .
+niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:6d104331bd48210744660822994327f2 .
 
-niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:3ee810d6896b3dc8ae8b86c839dfc96d .
+niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:e6857ee15115bf5982f48cfda7a54ae1 .
 
-niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:ac7d85d8e96744494156605fc6459728 .
+niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:dfdd94c4bf399011a3075afb77f548c9 .
 
-niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:588bac44c873c7a8f5b97ce1dd9a3692 .
+niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:60b72a68a7d90c7546bd6a8c0159ab36 .
 
-niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:2d949a916931280b77b49a0241ec62d5 .
+niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:c4ba6790d5172238d71004c657c82986 .
 
-niiri:a63b6454408484775af0cc4b22c38164 prov:used niiri:bd8962e1f0f8c53eab468480e3c67799 .
+niiri:4ce4c366179aebb1e0b39602e0016a6f prov:used niiri:6fbfbeb641d64d9bcff32d7e452d85e8 .
 
-niiri:b66bc89fd4437db99f4ec6ed233ef279
+niiri:6edd5609affac25edaef6d72ee3e16c5
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.3737898804348"^^xsd:float ;
@@ -515,9 +515,9 @@ niiri:b66bc89fd4437db99f4ec6ed233ef279
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:b66bc89fd4437db99f4ec6ed233ef279 prov:wasGeneratedBy niiri:a63b6454408484775af0cc4b22c38164 .
+niiri:6edd5609affac25edaef6d72ee3e16c5 prov:wasGeneratedBy niiri:4ce4c366179aebb1e0b39602e0016a6f .
 
-niiri:bb7fe36d73b5f025dfe59bd96afb31c0
+niiri:814dac7697f054e96b414c81e163b5c9
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -525,22 +525,22 @@ niiri:bb7fe36d73b5f025dfe59bd96afb31c0
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:ecf541e7373c25705cceaeb0aa09773c ;
-    nidm_hasMaximumIntensityProjection: niiri:0c94b91fe2a71c93340a78e55a6f0d90 ;
-    nidm_inCoordinateSpace: niiri:c0c9407bb918d90803b7a6e1a9e91d17 ;
+    nidm_hasClusterLabelsMap: niiri:e790a6ab78f56df2937e78ef7a0da9c2 ;
+    nidm_hasMaximumIntensityProjection: niiri:c977725ffc765ddf73f18a35c8f64c04 ;
+    nidm_inCoordinateSpace: niiri:e58601fa87a65231a7d5f04d9abeb8ab ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:ecf541e7373c25705cceaeb0aa09773c
+niiri:e790a6ab78f56df2937e78ef7a0da9c2
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:0c94b91fe2a71c93340a78e55a6f0d90
+niiri:c977725ffc765ddf73f18a35c8f64c04
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:bb7fe36d73b5f025dfe59bd96afb31c0 prov:wasGeneratedBy niiri:a63b6454408484775af0cc4b22c38164 .
+niiri:814dac7697f054e96b414c81e163b5c9 prov:wasGeneratedBy niiri:4ce4c366179aebb1e0b39602e0016a6f .
 

--- a/spmexport/ex_spm_voxelwise_p0001/config.json
+++ b/spmexport/ex_spm_voxelwise_p0001/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["voxel_uncorrected_p_001/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_voxelwise_p0001/nidm.provn
+++ b/spmexport/ex_spm_voxelwise_p0001/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:76aab825d22183ff1a24b9b636256326,
+  entity(niiri:0398942e4b946d453199fd16f4261f4b,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:12af50e283cb51a28723b451e53de7fa,
+  agent(niiri:86a784cc57b09951d603daea03ef2c00,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:aa7c94a6ec5280b8fa95e970683082ea,
+  activity(niiri:33aee10c8b0b2e234d94b1f33f2258a8,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:aa7c94a6ec5280b8fa95e970683082ea, niiri:12af50e283cb51a28723b451e53de7fa, -)
-  wasGeneratedBy(niiri:76aab825d22183ff1a24b9b636256326, niiri:aa7c94a6ec5280b8fa95e970683082ea, 2016-01-11T10:34:39)
-  bundle niiri:76aab825d22183ff1a24b9b636256326
+  wasAssociatedWith(niiri:33aee10c8b0b2e234d94b1f33f2258a8, niiri:86a784cc57b09951d603daea03ef2c00, -)
+  wasGeneratedBy(niiri:0398942e4b946d453199fd16f4261f4b, niiri:33aee10c8b0b2e234d94b1f33f2258a8, 2016-01-11T10:45:23)
+  bundle niiri:0398942e4b946d453199fd16f4261f4b
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:795198cbb8fe4e4cf2a89670620ad4dd,
+    agent(niiri:b4e0fd763b7fb1e20eada9a377d33677,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:e920422de7c868392b9495c42c8e55ce,
+    entity(niiri:3006d63db354ce97f02aa70056f61536,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:f96f232992c72733da5af4612ce6db6c,
+    entity(niiri:11922fa8e9227f8a1d08d0a12ec1050c,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:22d95e76835ad64dd94961e226c89be8,
+    entity(niiri:0e39ae195d8b77fe14a4ff541987e826,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:d426ffcc76be9b32dce59c64fd0df44f,
+    entity(niiri:a8c7bc3513943e88e50811a9c8d2f25c,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:a5e15227b86578a78871a3900ce2545d',
+        dc:description = 'niiri:d807a94312f908e6c11f2f6e5abb3509',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:22d95e76835ad64dd94961e226c89be8',
+        nidm_hasDriftModel: = 'niiri:0e39ae195d8b77fe14a4ff541987e826',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:a5e15227b86578a78871a3900ce2545d,
+    entity(niiri:d807a94312f908e6c11f2f6e5abb3509,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:ad1f4fb679728882b48781cecd81338b,
+    entity(niiri:275845c29ac5fe7809ca9e7346773e2d,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:3ae557ea4446abb02471ea2810538989,
+    activity(niiri:4c664e3343de77596f38de2ddfd6228b,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:3ae557ea4446abb02471ea2810538989, niiri:795198cbb8fe4e4cf2a89670620ad4dd, -)
-    used(niiri:3ae557ea4446abb02471ea2810538989, niiri:d426ffcc76be9b32dce59c64fd0df44f, -)
-    used(niiri:3ae557ea4446abb02471ea2810538989, niiri:f96f232992c72733da5af4612ce6db6c, -)
-    used(niiri:3ae557ea4446abb02471ea2810538989, niiri:ad1f4fb679728882b48781cecd81338b, -)
-    entity(niiri:a8f6a850eb194f571c3c571b3aea296c,
+    wasAssociatedWith(niiri:4c664e3343de77596f38de2ddfd6228b, niiri:b4e0fd763b7fb1e20eada9a377d33677, -)
+    used(niiri:4c664e3343de77596f38de2ddfd6228b, niiri:a8c7bc3513943e88e50811a9c8d2f25c, -)
+    used(niiri:4c664e3343de77596f38de2ddfd6228b, niiri:11922fa8e9227f8a1d08d0a12ec1050c, -)
+    used(niiri:4c664e3343de77596f38de2ddfd6228b, niiri:275845c29ac5fe7809ca9e7346773e2d, -)
+    entity(niiri:f42770fc9a9e7cb8156b3fd705fe80ab,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:a4b8f76a93e7666d816a6d42102727e5,
+    entity(niiri:8bc491db5cf9d7c785831050dce08f04,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:a8f6a850eb194f571c3c571b3aea296c, niiri:a4b8f76a93e7666d816a6d42102727e5, -, -, -)
-    wasGeneratedBy(niiri:a8f6a850eb194f571c3c571b3aea296c, niiri:3ae557ea4446abb02471ea2810538989, -)
-    entity(niiri:a4f3c31231f54dc697346b216b3d057b,
+    wasDerivedFrom(niiri:f42770fc9a9e7cb8156b3fd705fe80ab, niiri:8bc491db5cf9d7c785831050dce08f04, -, -, -)
+    wasGeneratedBy(niiri:f42770fc9a9e7cb8156b3fd705fe80ab, niiri:4c664e3343de77596f38de2ddfd6228b, -)
+    entity(niiri:b6fc563c55501c57b35341d05a340b65,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:a4f3c31231f54dc697346b216b3d057b, niiri:3ae557ea4446abb02471ea2810538989, -)
-    entity(niiri:8d2cf4bc506149257791cf9c56c81b15,
+    wasGeneratedBy(niiri:b6fc563c55501c57b35341d05a340b65, niiri:4c664e3343de77596f38de2ddfd6228b, -)
+    entity(niiri:769f87acda9e114d605ef2d4231f8665,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce'])
-    entity(niiri:5a89d4809da4a0f995f5c5b07c751512,
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536'])
+    entity(niiri:2cc60bef5b42f2b7b1ae48bc7d86d504,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:8d2cf4bc506149257791cf9c56c81b15, niiri:5a89d4809da4a0f995f5c5b07c751512, -, -, -)
-    wasGeneratedBy(niiri:8d2cf4bc506149257791cf9c56c81b15, niiri:3ae557ea4446abb02471ea2810538989, -)
-    entity(niiri:7a69b23cc081f3ca30a03eee82375536,
+    wasDerivedFrom(niiri:769f87acda9e114d605ef2d4231f8665, niiri:2cc60bef5b42f2b7b1ae48bc7d86d504, -, -, -)
+    wasGeneratedBy(niiri:769f87acda9e114d605ef2d4231f8665, niiri:4c664e3343de77596f38de2ddfd6228b, -)
+    entity(niiri:904c278d5e5eabe054b02dacd9765fe6,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce'])
-    entity(niiri:fa6b9fd34f3145b09a6b6a0312c43f2b,
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536'])
+    entity(niiri:7e4743196a84ad2de96f97b584450e95,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:7a69b23cc081f3ca30a03eee82375536, niiri:fa6b9fd34f3145b09a6b6a0312c43f2b, -, -, -)
-    wasGeneratedBy(niiri:7a69b23cc081f3ca30a03eee82375536, niiri:3ae557ea4446abb02471ea2810538989, -)
-    entity(niiri:660d160186946791c4ab03232091068e,
+    wasDerivedFrom(niiri:904c278d5e5eabe054b02dacd9765fe6, niiri:7e4743196a84ad2de96f97b584450e95, -, -, -)
+    wasGeneratedBy(niiri:904c278d5e5eabe054b02dacd9765fe6, niiri:4c664e3343de77596f38de2ddfd6228b, -)
+    entity(niiri:3fc566d96feb851585efed8db3330556,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce'])
-    entity(niiri:d98651c88439c0b6a1b7247245d716fb,
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536'])
+    entity(niiri:07b4edd7479f9186f694d7c5f3c18e0b,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:660d160186946791c4ab03232091068e, niiri:d98651c88439c0b6a1b7247245d716fb, -, -, -)
-    wasGeneratedBy(niiri:660d160186946791c4ab03232091068e, niiri:3ae557ea4446abb02471ea2810538989, -)
-    entity(niiri:c9b3f695b173b18f48a74cc662baa13b,
+    wasDerivedFrom(niiri:3fc566d96feb851585efed8db3330556, niiri:07b4edd7479f9186f694d7c5f3c18e0b, -, -, -)
+    wasGeneratedBy(niiri:3fc566d96feb851585efed8db3330556, niiri:4c664e3343de77596f38de2ddfd6228b, -)
+    entity(niiri:91e5b47bdc7e5facebd81c67e64f2380,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:558d2b1f3f13d94ed022edde592a0165,
+    entity(niiri:fd7fef7b41069a72f91958c7b6331df3,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:c9b3f695b173b18f48a74cc662baa13b, niiri:558d2b1f3f13d94ed022edde592a0165, -, -, -)
-    wasGeneratedBy(niiri:c9b3f695b173b18f48a74cc662baa13b, niiri:3ae557ea4446abb02471ea2810538989, -)
-    entity(niiri:57850195b4488bda06d9670b07e9f5ef,
+    wasDerivedFrom(niiri:91e5b47bdc7e5facebd81c67e64f2380, niiri:fd7fef7b41069a72f91958c7b6331df3, -, -, -)
+    wasGeneratedBy(niiri:91e5b47bdc7e5facebd81c67e64f2380, niiri:4c664e3343de77596f38de2ddfd6228b, -)
+    entity(niiri:78bbe3875adae6ef4c69dffe0855a4cc,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:e7aeca8d155aaee652c539a052d17bff,
+    entity(niiri:e52c8c7f38dcdbb477515b82a4d48497,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:57850195b4488bda06d9670b07e9f5ef, niiri:e7aeca8d155aaee652c539a052d17bff, -, -, -)
-    wasGeneratedBy(niiri:57850195b4488bda06d9670b07e9f5ef, niiri:3ae557ea4446abb02471ea2810538989, -)
-    entity(niiri:3a102c0edd804b4301ddde40ff2d180e,
+    wasDerivedFrom(niiri:78bbe3875adae6ef4c69dffe0855a4cc, niiri:e52c8c7f38dcdbb477515b82a4d48497, -, -, -)
+    wasGeneratedBy(niiri:78bbe3875adae6ef4c69dffe0855a4cc, niiri:4c664e3343de77596f38de2ddfd6228b, -)
+    entity(niiri:3bfa4a9b34f52fecfbd7d8b6eac4205d,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:806111cde985716a5655e3f8d0abe680,
+    activity(niiri:e714834c90d2c6bcdedd0652d75a1421,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:806111cde985716a5655e3f8d0abe680, niiri:795198cbb8fe4e4cf2a89670620ad4dd, -)
-    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:a8f6a850eb194f571c3c571b3aea296c, -)
-    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:c9b3f695b173b18f48a74cc662baa13b, -)
-    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:d426ffcc76be9b32dce59c64fd0df44f, -)
-    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:3a102c0edd804b4301ddde40ff2d180e, -)
-    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:8d2cf4bc506149257791cf9c56c81b15, -)
-    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:7a69b23cc081f3ca30a03eee82375536, -)
-    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:660d160186946791c4ab03232091068e, -)
-    entity(niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2,
+    wasAssociatedWith(niiri:e714834c90d2c6bcdedd0652d75a1421, niiri:b4e0fd763b7fb1e20eada9a377d33677, -)
+    used(niiri:e714834c90d2c6bcdedd0652d75a1421, niiri:f42770fc9a9e7cb8156b3fd705fe80ab, -)
+    used(niiri:e714834c90d2c6bcdedd0652d75a1421, niiri:91e5b47bdc7e5facebd81c67e64f2380, -)
+    used(niiri:e714834c90d2c6bcdedd0652d75a1421, niiri:a8c7bc3513943e88e50811a9c8d2f25c, -)
+    used(niiri:e714834c90d2c6bcdedd0652d75a1421, niiri:3bfa4a9b34f52fecfbd7d8b6eac4205d, -)
+    used(niiri:e714834c90d2c6bcdedd0652d75a1421, niiri:769f87acda9e114d605ef2d4231f8665, -)
+    used(niiri:e714834c90d2c6bcdedd0652d75a1421, niiri:904c278d5e5eabe054b02dacd9765fe6, -)
+    used(niiri:e714834c90d2c6bcdedd0652d75a1421, niiri:3fc566d96feb851585efed8db3330556, -)
+    entity(niiri:6bf799b363d775730ec73162b9354090,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:e7de197a7d6d70ffa3532d33bc50a948,
+    entity(niiri:5ee31d6aa467924994ace5f81f2c23b7,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2, niiri:e7de197a7d6d70ffa3532d33bc50a948, -, -, -)
-    wasGeneratedBy(niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2, niiri:806111cde985716a5655e3f8d0abe680, -)
-    entity(niiri:49c74cabef4221d6927cd12a48703bb6,
+    wasDerivedFrom(niiri:6bf799b363d775730ec73162b9354090, niiri:5ee31d6aa467924994ace5f81f2c23b7, -, -, -)
+    wasGeneratedBy(niiri:6bf799b363d775730ec73162b9354090, niiri:e714834c90d2c6bcdedd0652d75a1421, -)
+    entity(niiri:445ab286cf4f0e9ab88c446a0a13100a,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:ae059877c7ed4ef05f57bd13377d449d,
+    entity(niiri:836d8ecc9488c3deec52a5338665386c,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:49c74cabef4221d6927cd12a48703bb6, niiri:ae059877c7ed4ef05f57bd13377d449d, -, -, -)
-    wasGeneratedBy(niiri:49c74cabef4221d6927cd12a48703bb6, niiri:806111cde985716a5655e3f8d0abe680, -)
-    entity(niiri:52a3b6d2a4a6441b2742f02cda3546be,
+    wasDerivedFrom(niiri:445ab286cf4f0e9ab88c446a0a13100a, niiri:836d8ecc9488c3deec52a5338665386c, -, -, -)
+    wasGeneratedBy(niiri:445ab286cf4f0e9ab88c446a0a13100a, niiri:e714834c90d2c6bcdedd0652d75a1421, -)
+    entity(niiri:45606945462477526dd713e0431ad37a,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:52a3b6d2a4a6441b2742f02cda3546be, niiri:806111cde985716a5655e3f8d0abe680, -)
-    entity(niiri:74fb3ab697e23b1fe355c9c125a1fce5,
+    wasGeneratedBy(niiri:45606945462477526dd713e0431ad37a, niiri:e714834c90d2c6bcdedd0652d75a1421, -)
+    entity(niiri:ed3191eeed0594168fc6232f9b00a1c4,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
         prov:value = "0.000999499751574873" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:d4dd1fe0bb7a8bfea546011249378492',
-        nidm_equivalentThreshold: = 'niiri:18b28e49f671f5935e8da1eb3bdcb057'])
-    entity(niiri:d4dd1fe0bb7a8bfea546011249378492,
+        nidm_equivalentThreshold: = 'niiri:d999170762777f4478a6f3275e4d7915',
+        nidm_equivalentThreshold: = 'niiri:1006a56b84a51eaf1eee50ec8a309292'])
+    entity(niiri:d999170762777f4478a6f3275e4d7915,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12856968604193" %% xsd:float])
-    entity(niiri:18b28e49f671f5935e8da1eb3bdcb057,
+    entity(niiri:1006a56b84a51eaf1eee50ec8a309292,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999998566" %% xsd:float])
-    entity(niiri:394c0a8b443df420c26d9e571e970c52,
+    entity(niiri:9ef3c500027232d4bac68a62c9407f62,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:d89d94a7efe89b1ed64afd9d81eb9786',
-        nidm_equivalentThreshold: = 'niiri:41cf8551c9a74ce7bf6845e0ab154184'])
-    entity(niiri:d89d94a7efe89b1ed64afd9d81eb9786,
+        nidm_equivalentThreshold: = 'niiri:5ae66684f0409fa7ba34b53f68d80bb9',
+        nidm_equivalentThreshold: = 'niiri:b37792f661991bfe03df2a3866f16873'])
+    entity(niiri:5ae66684f0409fa7ba34b53f68d80bb9,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:41cf8551c9a74ce7bf6845e0ab154184,
+    entity(niiri:b37792f661991bfe03df2a3866f16873,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:878167535d7b9785734967b95a884d0e,
+    entity(niiri:6334a7c4c4c4df9714bdfa329acf5924,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:981ac790b32b9305897ba5ac86f1edbc,
+    entity(niiri:0e3eefff5fa60de8da843cc2a1b4a816,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:da118d0af6e844ed6166493cb6e62bbc,
+    activity(niiri:3d093fa4e163ac33e09d43ef0cd86320,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:795198cbb8fe4e4cf2a89670620ad4dd, -)
-    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:74fb3ab697e23b1fe355c9c125a1fce5, -)
-    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:394c0a8b443df420c26d9e571e970c52, -)
-    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2, -)
-    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:57850195b4488bda06d9670b07e9f5ef, -)
-    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:a8f6a850eb194f571c3c571b3aea296c, -)
-    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:878167535d7b9785734967b95a884d0e, -)
-    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:981ac790b32b9305897ba5ac86f1edbc, -)
-    entity(niiri:9b4cab1186d59ca3792cf63cf7c668d4,
+    wasAssociatedWith(niiri:3d093fa4e163ac33e09d43ef0cd86320, niiri:b4e0fd763b7fb1e20eada9a377d33677, -)
+    used(niiri:3d093fa4e163ac33e09d43ef0cd86320, niiri:ed3191eeed0594168fc6232f9b00a1c4, -)
+    used(niiri:3d093fa4e163ac33e09d43ef0cd86320, niiri:9ef3c500027232d4bac68a62c9407f62, -)
+    used(niiri:3d093fa4e163ac33e09d43ef0cd86320, niiri:6bf799b363d775730ec73162b9354090, -)
+    used(niiri:3d093fa4e163ac33e09d43ef0cd86320, niiri:78bbe3875adae6ef4c69dffe0855a4cc, -)
+    used(niiri:3d093fa4e163ac33e09d43ef0cd86320, niiri:f42770fc9a9e7cb8156b3fd705fe80ab, -)
+    used(niiri:3d093fa4e163ac33e09d43ef0cd86320, niiri:6334a7c4c4c4df9714bdfa329acf5924, -)
+    used(niiri:3d093fa4e163ac33e09d43ef0cd86320, niiri:0e3eefff5fa60de8da843cc2a1b4a816, -)
+    entity(niiri:70240183433c408afdbb5ffb5f7e4b39,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:9b4cab1186d59ca3792cf63cf7c668d4, niiri:da118d0af6e844ed6166493cb6e62bbc, -)
-    entity(niiri:e5387924e8c07fd3d7adc43281757dd4,
+    wasGeneratedBy(niiri:70240183433c408afdbb5ffb5f7e4b39, niiri:3d093fa4e163ac33e09d43ef0cd86320, -)
+    entity(niiri:b2f94ff105e83306ad10a583f6ca3ded,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:cafb53072ecf4b68631c9ed0fb1f2f79',
-        nidm_hasMaximumIntensityProjection: = 'niiri:89d0e6ee2aadeaea82e8f4417c24d9d4',
-        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
+        nidm_hasClusterLabelsMap: = 'niiri:cb3f49e7585256e51bdd08d13e61ce91',
+        nidm_hasMaximumIntensityProjection: = 'niiri:c2eec03418f9344d4648ee6b884238be',
+        nidm_inCoordinateSpace: = 'niiri:3006d63db354ce97f02aa70056f61536',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:cafb53072ecf4b68631c9ed0fb1f2f79,
+    entity(niiri:cb3f49e7585256e51bdd08d13e61ce91,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:89d0e6ee2aadeaea82e8f4417c24d9d4,
+    entity(niiri:c2eec03418f9344d4648ee6b884238be,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:e5387924e8c07fd3d7adc43281757dd4, niiri:da118d0af6e844ed6166493cb6e62bbc, -)
+    wasGeneratedBy(niiri:b2f94ff105e83306ad10a583f6ca3ded, niiri:3d093fa4e163ac33e09d43ef0cd86320, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_voxelwise_p0001/nidm.provn
+++ b/spmexport/ex_spm_voxelwise_p0001/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:b64bdec9b9c7e6a23af510b72acb6e67,
+  entity(niiri:76aab825d22183ff1a24b9b636256326,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:29e7b7953663243ec8dfb65b1c168597,
+  agent(niiri:12af50e283cb51a28723b451e53de7fa,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:72167a2e3e27d6635051cc6895fc8a2d,
+  activity(niiri:aa7c94a6ec5280b8fa95e970683082ea,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:72167a2e3e27d6635051cc6895fc8a2d, niiri:29e7b7953663243ec8dfb65b1c168597, -)
-  wasGeneratedBy(niiri:b64bdec9b9c7e6a23af510b72acb6e67, niiri:72167a2e3e27d6635051cc6895fc8a2d, 2016-01-11T10:12:23)
-  bundle niiri:b64bdec9b9c7e6a23af510b72acb6e67
+  wasAssociatedWith(niiri:aa7c94a6ec5280b8fa95e970683082ea, niiri:12af50e283cb51a28723b451e53de7fa, -)
+  wasGeneratedBy(niiri:76aab825d22183ff1a24b9b636256326, niiri:aa7c94a6ec5280b8fa95e970683082ea, 2016-01-11T10:34:39)
+  bundle niiri:76aab825d22183ff1a24b9b636256326
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:693a3599a964371c83a2ec0cb5aa6be4,
+    agent(niiri:795198cbb8fe4e4cf2a89670620ad4dd,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:797028115af68a6b59077425735d58ea,
+    entity(niiri:e920422de7c868392b9495c42c8e55ce,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:98b0c7257c519f61a37aa58faca9860a,
+    entity(niiri:f96f232992c72733da5af4612ce6db6c,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:2a1fc19f8bd99b52d3aacff50997628b,
+    entity(niiri:22d95e76835ad64dd94961e226c89be8,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:7c93d0c68830bf0c3b19451ce90f214a,
+    entity(niiri:d426ffcc76be9b32dce59c64fd0df44f,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:b462d4be3e2879edf7ec883db32c9bdd',
+        dc:description = 'niiri:a5e15227b86578a78871a3900ce2545d',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:2a1fc19f8bd99b52d3aacff50997628b',
+        nidm_hasDriftModel: = 'niiri:22d95e76835ad64dd94961e226c89be8',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:b462d4be3e2879edf7ec883db32c9bdd,
+    entity(niiri:a5e15227b86578a78871a3900ce2545d,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0,
+    entity(niiri:ad1f4fb679728882b48781cecd81338b,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:be25cc5da226dcdce7c1db2041ff0287,
+    activity(niiri:3ae557ea4446abb02471ea2810538989,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:be25cc5da226dcdce7c1db2041ff0287, niiri:693a3599a964371c83a2ec0cb5aa6be4, -)
-    used(niiri:be25cc5da226dcdce7c1db2041ff0287, niiri:7c93d0c68830bf0c3b19451ce90f214a, -)
-    used(niiri:be25cc5da226dcdce7c1db2041ff0287, niiri:98b0c7257c519f61a37aa58faca9860a, -)
-    used(niiri:be25cc5da226dcdce7c1db2041ff0287, niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0, -)
-    entity(niiri:5bdd362b26678583adbf997f0aa0dab5,
+    wasAssociatedWith(niiri:3ae557ea4446abb02471ea2810538989, niiri:795198cbb8fe4e4cf2a89670620ad4dd, -)
+    used(niiri:3ae557ea4446abb02471ea2810538989, niiri:d426ffcc76be9b32dce59c64fd0df44f, -)
+    used(niiri:3ae557ea4446abb02471ea2810538989, niiri:f96f232992c72733da5af4612ce6db6c, -)
+    used(niiri:3ae557ea4446abb02471ea2810538989, niiri:ad1f4fb679728882b48781cecd81338b, -)
+    entity(niiri:a8f6a850eb194f571c3c571b3aea296c,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:b34ee26960c2e676bda4382cecba1272,
+    entity(niiri:a4b8f76a93e7666d816a6d42102727e5,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:5bdd362b26678583adbf997f0aa0dab5, niiri:b34ee26960c2e676bda4382cecba1272, -, -, -)
-    wasGeneratedBy(niiri:5bdd362b26678583adbf997f0aa0dab5, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
-    entity(niiri:5d521601816b6479d6e9eab9032647ef,
+    wasDerivedFrom(niiri:a8f6a850eb194f571c3c571b3aea296c, niiri:a4b8f76a93e7666d816a6d42102727e5, -, -, -)
+    wasGeneratedBy(niiri:a8f6a850eb194f571c3c571b3aea296c, niiri:3ae557ea4446abb02471ea2810538989, -)
+    entity(niiri:a4f3c31231f54dc697346b216b3d057b,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:5d521601816b6479d6e9eab9032647ef, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
-    entity(niiri:12d10179a56c837944e25a6d2090020c,
+    wasGeneratedBy(niiri:a4f3c31231f54dc697346b216b3d057b, niiri:3ae557ea4446abb02471ea2810538989, -)
+    entity(niiri:8d2cf4bc506149257791cf9c56c81b15,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea'])
-    entity(niiri:35306384388ada95614e4eb3a6348111,
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce'])
+    entity(niiri:5a89d4809da4a0f995f5c5b07c751512,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:12d10179a56c837944e25a6d2090020c, niiri:35306384388ada95614e4eb3a6348111, -, -, -)
-    wasGeneratedBy(niiri:12d10179a56c837944e25a6d2090020c, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
-    entity(niiri:5e2d4659031ebb240110eb2fc555c40c,
+    wasDerivedFrom(niiri:8d2cf4bc506149257791cf9c56c81b15, niiri:5a89d4809da4a0f995f5c5b07c751512, -, -, -)
+    wasGeneratedBy(niiri:8d2cf4bc506149257791cf9c56c81b15, niiri:3ae557ea4446abb02471ea2810538989, -)
+    entity(niiri:7a69b23cc081f3ca30a03eee82375536,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea'])
-    entity(niiri:a70a31f7531a7fcb63c43826d1fb6901,
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce'])
+    entity(niiri:fa6b9fd34f3145b09a6b6a0312c43f2b,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:5e2d4659031ebb240110eb2fc555c40c, niiri:a70a31f7531a7fcb63c43826d1fb6901, -, -, -)
-    wasGeneratedBy(niiri:5e2d4659031ebb240110eb2fc555c40c, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
-    entity(niiri:caa29f50cebec8a31ba04b81cd00c901,
+    wasDerivedFrom(niiri:7a69b23cc081f3ca30a03eee82375536, niiri:fa6b9fd34f3145b09a6b6a0312c43f2b, -, -, -)
+    wasGeneratedBy(niiri:7a69b23cc081f3ca30a03eee82375536, niiri:3ae557ea4446abb02471ea2810538989, -)
+    entity(niiri:660d160186946791c4ab03232091068e,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea'])
-    entity(niiri:18026b1791efb3a58b2a90d60be705cf,
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce'])
+    entity(niiri:d98651c88439c0b6a1b7247245d716fb,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:caa29f50cebec8a31ba04b81cd00c901, niiri:18026b1791efb3a58b2a90d60be705cf, -, -, -)
-    wasGeneratedBy(niiri:caa29f50cebec8a31ba04b81cd00c901, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
-    entity(niiri:25dad247cbcdcd6515ebc7f2b3e4d169,
+    wasDerivedFrom(niiri:660d160186946791c4ab03232091068e, niiri:d98651c88439c0b6a1b7247245d716fb, -, -, -)
+    wasGeneratedBy(niiri:660d160186946791c4ab03232091068e, niiri:3ae557ea4446abb02471ea2810538989, -)
+    entity(niiri:c9b3f695b173b18f48a74cc662baa13b,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:4326a080627d5d6d482f963cb1c875ca,
+    entity(niiri:558d2b1f3f13d94ed022edde592a0165,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:25dad247cbcdcd6515ebc7f2b3e4d169, niiri:4326a080627d5d6d482f963cb1c875ca, -, -, -)
-    wasGeneratedBy(niiri:25dad247cbcdcd6515ebc7f2b3e4d169, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
-    entity(niiri:5c1178f3140872b7a8e46365ed5827f8,
+    wasDerivedFrom(niiri:c9b3f695b173b18f48a74cc662baa13b, niiri:558d2b1f3f13d94ed022edde592a0165, -, -, -)
+    wasGeneratedBy(niiri:c9b3f695b173b18f48a74cc662baa13b, niiri:3ae557ea4446abb02471ea2810538989, -)
+    entity(niiri:57850195b4488bda06d9670b07e9f5ef,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:1e5eb5cc2d39d4d87f43a8f5d67edf33,
+    entity(niiri:e7aeca8d155aaee652c539a052d17bff,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:5c1178f3140872b7a8e46365ed5827f8, niiri:1e5eb5cc2d39d4d87f43a8f5d67edf33, -, -, -)
-    wasGeneratedBy(niiri:5c1178f3140872b7a8e46365ed5827f8, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
-    entity(niiri:b92b60ee8e091a79725fbb24b8a95ca9,
+    wasDerivedFrom(niiri:57850195b4488bda06d9670b07e9f5ef, niiri:e7aeca8d155aaee652c539a052d17bff, -, -, -)
+    wasGeneratedBy(niiri:57850195b4488bda06d9670b07e9f5ef, niiri:3ae557ea4446abb02471ea2810538989, -)
+    entity(niiri:3a102c0edd804b4301ddde40ff2d180e,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:d92a89b9a51adc36e400d999e4292160,
+    activity(niiri:806111cde985716a5655e3f8d0abe680,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:d92a89b9a51adc36e400d999e4292160, niiri:693a3599a964371c83a2ec0cb5aa6be4, -)
-    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:5bdd362b26678583adbf997f0aa0dab5, -)
-    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:25dad247cbcdcd6515ebc7f2b3e4d169, -)
-    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:7c93d0c68830bf0c3b19451ce90f214a, -)
-    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:b92b60ee8e091a79725fbb24b8a95ca9, -)
-    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:12d10179a56c837944e25a6d2090020c, -)
-    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:5e2d4659031ebb240110eb2fc555c40c, -)
-    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:caa29f50cebec8a31ba04b81cd00c901, -)
-    entity(niiri:05476ea39b68cd6ce954710ab9a6512f,
+    wasAssociatedWith(niiri:806111cde985716a5655e3f8d0abe680, niiri:795198cbb8fe4e4cf2a89670620ad4dd, -)
+    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:a8f6a850eb194f571c3c571b3aea296c, -)
+    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:c9b3f695b173b18f48a74cc662baa13b, -)
+    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:d426ffcc76be9b32dce59c64fd0df44f, -)
+    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:3a102c0edd804b4301ddde40ff2d180e, -)
+    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:8d2cf4bc506149257791cf9c56c81b15, -)
+    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:7a69b23cc081f3ca30a03eee82375536, -)
+    used(niiri:806111cde985716a5655e3f8d0abe680, niiri:660d160186946791c4ab03232091068e, -)
+    entity(niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:73905f3aac46fbb1357b6b89001c335c,
+    entity(niiri:e7de197a7d6d70ffa3532d33bc50a948,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:05476ea39b68cd6ce954710ab9a6512f, niiri:73905f3aac46fbb1357b6b89001c335c, -, -, -)
-    wasGeneratedBy(niiri:05476ea39b68cd6ce954710ab9a6512f, niiri:d92a89b9a51adc36e400d999e4292160, -)
-    entity(niiri:611efb7aa685964d73e0a80747ee0d13,
+    wasDerivedFrom(niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2, niiri:e7de197a7d6d70ffa3532d33bc50a948, -, -, -)
+    wasGeneratedBy(niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2, niiri:806111cde985716a5655e3f8d0abe680, -)
+    entity(niiri:49c74cabef4221d6927cd12a48703bb6,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:29494dce8eba85b4d0bf2422fd31cd7e,
+    entity(niiri:ae059877c7ed4ef05f57bd13377d449d,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:611efb7aa685964d73e0a80747ee0d13, niiri:29494dce8eba85b4d0bf2422fd31cd7e, -, -, -)
-    wasGeneratedBy(niiri:611efb7aa685964d73e0a80747ee0d13, niiri:d92a89b9a51adc36e400d999e4292160, -)
-    entity(niiri:22b72372f61d640a78c1e5970a0dc2f5,
+    wasDerivedFrom(niiri:49c74cabef4221d6927cd12a48703bb6, niiri:ae059877c7ed4ef05f57bd13377d449d, -, -, -)
+    wasGeneratedBy(niiri:49c74cabef4221d6927cd12a48703bb6, niiri:806111cde985716a5655e3f8d0abe680, -)
+    entity(niiri:52a3b6d2a4a6441b2742f02cda3546be,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:22b72372f61d640a78c1e5970a0dc2f5, niiri:d92a89b9a51adc36e400d999e4292160, -)
-    entity(niiri:552d1b8029c0424db6aa0efe1b4ff168,
+    wasGeneratedBy(niiri:52a3b6d2a4a6441b2742f02cda3546be, niiri:806111cde985716a5655e3f8d0abe680, -)
+    entity(niiri:74fb3ab697e23b1fe355c9c125a1fce5,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
         prov:value = "0.000999499751574873" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:358a4ad660a0967ebefabc42f52c54da',
-        nidm_equivalentThreshold: = 'niiri:2ace48e3e0732e8d5798cd6bf5ec7e72'])
-    entity(niiri:358a4ad660a0967ebefabc42f52c54da,
+        nidm_equivalentThreshold: = 'niiri:d4dd1fe0bb7a8bfea546011249378492',
+        nidm_equivalentThreshold: = 'niiri:18b28e49f671f5935e8da1eb3bdcb057'])
+    entity(niiri:d4dd1fe0bb7a8bfea546011249378492,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "3.12856968604193" %% xsd:float])
-    entity(niiri:2ace48e3e0732e8d5798cd6bf5ec7e72,
+    entity(niiri:18b28e49f671f5935e8da1eb3bdcb057,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.999999999998566" %% xsd:float])
-    entity(niiri:70e6239840fed7ac0f68d10762241e03,
+    entity(niiri:394c0a8b443df420c26d9e571e970c52,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:f0fa9ada07095bbc2e38a690e9d60084',
-        nidm_equivalentThreshold: = 'niiri:dcd6f7ae020d3ea1cca0234e387fdd81'])
-    entity(niiri:f0fa9ada07095bbc2e38a690e9d60084,
+        nidm_equivalentThreshold: = 'niiri:d89d94a7efe89b1ed64afd9d81eb9786',
+        nidm_equivalentThreshold: = 'niiri:41cf8551c9a74ce7bf6845e0ab154184'])
+    entity(niiri:d89d94a7efe89b1ed64afd9d81eb9786,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:dcd6f7ae020d3ea1cca0234e387fdd81,
+    entity(niiri:41cf8551c9a74ce7bf6845e0ab154184,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:cc550ca1ac8e429a5d4144d95af3345b,
+    entity(niiri:878167535d7b9785734967b95a884d0e,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:daf684b55626b991b1a1bb3bd826b3f9,
+    entity(niiri:981ac790b32b9305897ba5ac86f1edbc,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:e6d98152416877282c812e014d2eca94,
+    activity(niiri:da118d0af6e844ed6166493cb6e62bbc,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:e6d98152416877282c812e014d2eca94, niiri:693a3599a964371c83a2ec0cb5aa6be4, -)
-    used(niiri:e6d98152416877282c812e014d2eca94, niiri:552d1b8029c0424db6aa0efe1b4ff168, -)
-    used(niiri:e6d98152416877282c812e014d2eca94, niiri:70e6239840fed7ac0f68d10762241e03, -)
-    used(niiri:e6d98152416877282c812e014d2eca94, niiri:05476ea39b68cd6ce954710ab9a6512f, -)
-    used(niiri:e6d98152416877282c812e014d2eca94, niiri:5c1178f3140872b7a8e46365ed5827f8, -)
-    used(niiri:e6d98152416877282c812e014d2eca94, niiri:5bdd362b26678583adbf997f0aa0dab5, -)
-    used(niiri:e6d98152416877282c812e014d2eca94, niiri:cc550ca1ac8e429a5d4144d95af3345b, -)
-    used(niiri:e6d98152416877282c812e014d2eca94, niiri:daf684b55626b991b1a1bb3bd826b3f9, -)
-    entity(niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61,
+    wasAssociatedWith(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:795198cbb8fe4e4cf2a89670620ad4dd, -)
+    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:74fb3ab697e23b1fe355c9c125a1fce5, -)
+    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:394c0a8b443df420c26d9e571e970c52, -)
+    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2, -)
+    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:57850195b4488bda06d9670b07e9f5ef, -)
+    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:a8f6a850eb194f571c3c571b3aea296c, -)
+    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:878167535d7b9785734967b95a884d0e, -)
+    used(niiri:da118d0af6e844ed6166493cb6e62bbc, niiri:981ac790b32b9305897ba5ac86f1edbc, -)
+    entity(niiri:9b4cab1186d59ca3792cf63cf7c668d4,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61, niiri:e6d98152416877282c812e014d2eca94, -)
-    entity(niiri:c8cd6bc0a8628627c7ed0719821daf24,
+    wasGeneratedBy(niiri:9b4cab1186d59ca3792cf63cf7c668d4, niiri:da118d0af6e844ed6166493cb6e62bbc, -)
+    entity(niiri:e5387924e8c07fd3d7adc43281757dd4,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:165d3eec8b06fe8883625084f3310a30',
-        nidm_hasMaximumIntensityProjection: = 'niiri:d359bb028863af68e706c8f23c59562c',
-        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_hasClusterLabelsMap: = 'niiri:cafb53072ecf4b68631c9ed0fb1f2f79',
+        nidm_hasMaximumIntensityProjection: = 'niiri:89d0e6ee2aadeaea82e8f4417c24d9d4',
+        nidm_inCoordinateSpace: = 'niiri:e920422de7c868392b9495c42c8e55ce',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:165d3eec8b06fe8883625084f3310a30,
+    entity(niiri:cafb53072ecf4b68631c9ed0fb1f2f79,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:d359bb028863af68e706c8f23c59562c,
+    entity(niiri:89d0e6ee2aadeaea82e8f4417c24d9d4,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:c8cd6bc0a8628627c7ed0719821daf24, niiri:e6d98152416877282c812e014d2eca94, -)
+    wasGeneratedBy(niiri:e5387924e8c07fd3d7adc43281757dd4, niiri:da118d0af6e844ed6166493cb6e62bbc, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_voxelwise_p0001/nidm.provn
+++ b/spmexport/ex_spm_voxelwise_p0001/nidm.provn
@@ -1,0 +1,429 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:b64bdec9b9c7e6a23af510b72acb6e67,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:29e7b7953663243ec8dfb65b1c168597,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:72167a2e3e27d6635051cc6895fc8a2d,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:72167a2e3e27d6635051cc6895fc8a2d, niiri:29e7b7953663243ec8dfb65b1c168597, -)
+  wasGeneratedBy(niiri:b64bdec9b9c7e6a23af510b72acb6e67, niiri:72167a2e3e27d6635051cc6895fc8a2d, 2016-01-11T10:12:23)
+  bundle niiri:b64bdec9b9c7e6a23af510b72acb6e67
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+
+    agent(niiri:693a3599a964371c83a2ec0cb5aa6be4,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:797028115af68a6b59077425735d58ea,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:98b0c7257c519f61a37aa58faca9860a,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:2a1fc19f8bd99b52d3aacff50997628b,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:7c93d0c68830bf0c3b19451ce90f214a,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:b462d4be3e2879edf7ec883db32c9bdd',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:2a1fc19f8bd99b52d3aacff50997628b',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:b462d4be3e2879edf7ec883db32c9bdd,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:be25cc5da226dcdce7c1db2041ff0287,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:be25cc5da226dcdce7c1db2041ff0287, niiri:693a3599a964371c83a2ec0cb5aa6be4, -)
+    used(niiri:be25cc5da226dcdce7c1db2041ff0287, niiri:7c93d0c68830bf0c3b19451ce90f214a, -)
+    used(niiri:be25cc5da226dcdce7c1db2041ff0287, niiri:98b0c7257c519f61a37aa58faca9860a, -)
+    used(niiri:be25cc5da226dcdce7c1db2041ff0287, niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0, -)
+    entity(niiri:5bdd362b26678583adbf997f0aa0dab5,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    entity(niiri:b34ee26960c2e676bda4382cecba1272,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
+    wasDerivedFrom(niiri:5bdd362b26678583adbf997f0aa0dab5, niiri:b34ee26960c2e676bda4382cecba1272, -, -, -)
+    wasGeneratedBy(niiri:5bdd362b26678583adbf997f0aa0dab5, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
+    entity(niiri:5d521601816b6479d6e9eab9032647ef,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "121.744659423828" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
+    wasGeneratedBy(niiri:5d521601816b6479d6e9eab9032647ef, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
+    entity(niiri:12d10179a56c837944e25a6d2090020c,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea'])
+    entity(niiri:35306384388ada95614e4eb3a6348111,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
+    wasDerivedFrom(niiri:12d10179a56c837944e25a6d2090020c, niiri:35306384388ada95614e4eb3a6348111, -, -, -)
+    wasGeneratedBy(niiri:12d10179a56c837944e25a6d2090020c, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
+    entity(niiri:5e2d4659031ebb240110eb2fc555c40c,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea'])
+    entity(niiri:a70a31f7531a7fcb63c43826d1fb6901,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
+    wasDerivedFrom(niiri:5e2d4659031ebb240110eb2fc555c40c, niiri:a70a31f7531a7fcb63c43826d1fb6901, -, -, -)
+    wasGeneratedBy(niiri:5e2d4659031ebb240110eb2fc555c40c, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
+    entity(niiri:caa29f50cebec8a31ba04b81cd00c901,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea'])
+    entity(niiri:18026b1791efb3a58b2a90d60be705cf,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
+    wasDerivedFrom(niiri:caa29f50cebec8a31ba04b81cd00c901, niiri:18026b1791efb3a58b2a90d60be705cf, -, -, -)
+    wasGeneratedBy(niiri:caa29f50cebec8a31ba04b81cd00c901, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
+    entity(niiri:25dad247cbcdcd6515ebc7f2b3e4d169,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
+    entity(niiri:4326a080627d5d6d482f963cb1c875ca,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
+    wasDerivedFrom(niiri:25dad247cbcdcd6515ebc7f2b3e4d169, niiri:4326a080627d5d6d482f963cb1c875ca, -, -, -)
+    wasGeneratedBy(niiri:25dad247cbcdcd6515ebc7f2b3e4d169, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
+    entity(niiri:5c1178f3140872b7a8e46365ed5827f8,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
+    entity(niiri:1e5eb5cc2d39d4d87f43a8f5d67edf33,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
+    wasDerivedFrom(niiri:5c1178f3140872b7a8e46365ed5827f8, niiri:1e5eb5cc2d39d4d87f43a8f5d67edf33, -, -, -)
+    wasGeneratedBy(niiri:5c1178f3140872b7a8e46365ed5827f8, niiri:be25cc5da226dcdce7c1db2041ff0287, -)
+    entity(niiri:b92b60ee8e091a79725fbb24b8a95ca9,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        prov:label = "Contrast: pos vs neg" %% xsd:string,
+        prov:value = "[1, -1, 0]" %% xsd:string])
+    activity(niiri:d92a89b9a51adc36e400d999e4292160,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:d92a89b9a51adc36e400d999e4292160, niiri:693a3599a964371c83a2ec0cb5aa6be4, -)
+    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:5bdd362b26678583adbf997f0aa0dab5, -)
+    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:25dad247cbcdcd6515ebc7f2b3e4d169, -)
+    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:7c93d0c68830bf0c3b19451ce90f214a, -)
+    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:b92b60ee8e091a79725fbb24b8a95ca9, -)
+    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:12d10179a56c837944e25a6d2090020c, -)
+    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:5e2d4659031ebb240110eb2fc555c40c, -)
+    used(niiri:d92a89b9a51adc36e400d999e4292160, niiri:caa29f50cebec8a31ba04b81cd00c901, -)
+    entity(niiri:05476ea39b68cd6ce954710ab9a6512f,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: pos vs neg" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
+    entity(niiri:73905f3aac46fbb1357b6b89001c335c,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
+    wasDerivedFrom(niiri:05476ea39b68cd6ce954710ab9a6512f, niiri:73905f3aac46fbb1357b6b89001c335c, -, -, -)
+    wasGeneratedBy(niiri:05476ea39b68cd6ce954710ab9a6512f, niiri:d92a89b9a51adc36e400d999e4292160, -)
+    entity(niiri:611efb7aa685964d73e0a80747ee0d13,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: pos vs neg" %% xsd:string,
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
+    entity(niiri:29494dce8eba85b4d0bf2422fd31cd7e,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
+    wasDerivedFrom(niiri:611efb7aa685964d73e0a80747ee0d13, niiri:29494dce8eba85b4d0bf2422fd31cd7e, -, -, -)
+    wasGeneratedBy(niiri:611efb7aa685964d73e0a80747ee0d13, niiri:d92a89b9a51adc36e400d999e4292160, -)
+    entity(niiri:22b72372f61d640a78c1e5970a0dc2f5,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
+    wasGeneratedBy(niiri:22b72372f61d640a78c1e5970a0dc2f5, niiri:d92a89b9a51adc36e400d999e4292160, -)
+    entity(niiri:552d1b8029c0424db6aa0efe1b4ff168,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold: p<0.000999 (unc.)" %% xsd:string,
+        prov:value = "0.000999499751574873" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:358a4ad660a0967ebefabc42f52c54da',
+        nidm_equivalentThreshold: = 'niiri:2ace48e3e0732e8d5798cd6bf5ec7e72'])
+    entity(niiri:358a4ad660a0967ebefabc42f52c54da,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "3.12856968604193" %% xsd:float])
+    entity(niiri:2ace48e3e0732e8d5798cd6bf5ec7e72,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.999999999998566" %% xsd:float])
+    entity(niiri:70e6239840fed7ac0f68d10762241e03,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:f0fa9ada07095bbc2e38a690e9d60084',
+        nidm_equivalentThreshold: = 'niiri:dcd6f7ae020d3ea1cca0234e387fdd81'])
+    entity(niiri:f0fa9ada07095bbc2e38a690e9d60084,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:dcd6f7ae020d3ea1cca0234e387fdd81,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:cc550ca1ac8e429a5d4144d95af3345b,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:daf684b55626b991b1a1bb3bd826b3f9,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:e6d98152416877282c812e014d2eca94,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:e6d98152416877282c812e014d2eca94, niiri:693a3599a964371c83a2ec0cb5aa6be4, -)
+    used(niiri:e6d98152416877282c812e014d2eca94, niiri:552d1b8029c0424db6aa0efe1b4ff168, -)
+    used(niiri:e6d98152416877282c812e014d2eca94, niiri:70e6239840fed7ac0f68d10762241e03, -)
+    used(niiri:e6d98152416877282c812e014d2eca94, niiri:05476ea39b68cd6ce954710ab9a6512f, -)
+    used(niiri:e6d98152416877282c812e014d2eca94, niiri:5c1178f3140872b7a8e46365ed5827f8, -)
+    used(niiri:e6d98152416877282c812e014d2eca94, niiri:5bdd362b26678583adbf997f0aa0dab5, -)
+    used(niiri:e6d98152416877282c812e014d2eca94, niiri:cc550ca1ac8e429a5d4144d95af3345b, -)
+    used(niiri:e6d98152416877282c812e014d2eca94, niiri:daf684b55626b991b1a1bb3bd826b3f9, -)
+    entity(niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
+        nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
+        nidm_searchVolumeInResels: = "2650.12011223711" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.01704921884936, 4.07618247398105, 4.38831339907177]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.03409843769872, 8.1523649479621, 8.77662679814353]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "8.23486077915088" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "27.2707251644655" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.05094049746367" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    wasGeneratedBy(niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61, niiri:e6d98152416877282c812e014d2eca94, -)
+    entity(niiri:c8cd6bc0a8628627c7ed0719821daf24,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
+        nidm_pValue: = "NaN" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:165d3eec8b06fe8883625084f3310a30',
+        nidm_hasMaximumIntensityProjection: = 'niiri:d359bb028863af68e706c8f23c59562c',
+        nidm_inCoordinateSpace: = 'niiri:797028115af68a6b59077425735d58ea',
+        crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
+    entity(niiri:165d3eec8b06fe8883625084f3310a30,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:d359bb028863af68e706c8f23c59562c,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:c8cd6bc0a8628627c7ed0719821daf24, niiri:e6d98152416877282c812e014d2eca94, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_voxelwise_p0001/nidm.ttl
+++ b/spmexport/ex_spm_voxelwise_p0001/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:76aab825d22183ff1a24b9b636256326
+niiri:0398942e4b946d453199fd16f4261f4b
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:12af50e283cb51a28723b451e53de7fa
+niiri:86a784cc57b09951d603daea03ef2c00
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:aa7c94a6ec5280b8fa95e970683082ea
+niiri:33aee10c8b0b2e234d94b1f33f2258a8
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:aa7c94a6ec5280b8fa95e970683082ea prov:wasAssociatedWith niiri:12af50e283cb51a28723b451e53de7fa .
+niiri:33aee10c8b0b2e234d94b1f33f2258a8 prov:wasAssociatedWith niiri:86a784cc57b09951d603daea03ef2c00 .
 
 _:blank5 a prov:Generation .
 
-niiri:76aab825d22183ff1a24b9b636256326 prov:qualifiedGeneration _:blank5 .
+niiri:0398942e4b946d453199fd16f4261f4b prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:34:39"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:45:23"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:34:39"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:795198cbb8fe4e4cf2a89670620ad4dd
+niiri:b4e0fd763b7fb1e20eada9a377d33677
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:e920422de7c868392b9495c42c8e55ce
+niiri:3006d63db354ce97f02aa70056f61536
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:e920422de7c868392b9495c42c8e55ce
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:f96f232992c72733da5af4612ce6db6c
+niiri:11922fa8e9227f8a1d08d0a12ec1050c
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:22d95e76835ad64dd94961e226c89be8
+niiri:0e39ae195d8b77fe14a4ff541987e826
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:d426ffcc76be9b32dce59c64fd0df44f
+niiri:a8c7bc3513943e88e50811a9c8d2f25c
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:a5e15227b86578a78871a3900ce2545d ;
+    dc:description niiri:d807a94312f908e6c11f2f6e5abb3509 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:22d95e76835ad64dd94961e226c89be8 ;
+    nidm_hasDriftModel: niiri:0e39ae195d8b77fe14a4ff541987e826 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:a5e15227b86578a78871a3900ce2545d
+niiri:d807a94312f908e6c11f2f6e5abb3509
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:ad1f4fb679728882b48781cecd81338b
+niiri:275845c29ac5fe7809ca9e7346773e2d
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:ad1f4fb679728882b48781cecd81338b
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:3ae557ea4446abb02471ea2810538989
+niiri:4c664e3343de77596f38de2ddfd6228b
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:3ae557ea4446abb02471ea2810538989 prov:wasAssociatedWith niiri:795198cbb8fe4e4cf2a89670620ad4dd .
+niiri:4c664e3343de77596f38de2ddfd6228b prov:wasAssociatedWith niiri:b4e0fd763b7fb1e20eada9a377d33677 .
 
-niiri:3ae557ea4446abb02471ea2810538989 prov:used niiri:d426ffcc76be9b32dce59c64fd0df44f .
+niiri:4c664e3343de77596f38de2ddfd6228b prov:used niiri:a8c7bc3513943e88e50811a9c8d2f25c .
 
-niiri:3ae557ea4446abb02471ea2810538989 prov:used niiri:f96f232992c72733da5af4612ce6db6c .
+niiri:4c664e3343de77596f38de2ddfd6228b prov:used niiri:11922fa8e9227f8a1d08d0a12ec1050c .
 
-niiri:3ae557ea4446abb02471ea2810538989 prov:used niiri:ad1f4fb679728882b48781cecd81338b .
+niiri:4c664e3343de77596f38de2ddfd6228b prov:used niiri:275845c29ac5fe7809ca9e7346773e2d .
 
-niiri:a8f6a850eb194f571c3c571b3aea296c
+niiri:f42770fc9a9e7cb8156b3fd705fe80ab
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:a4b8f76a93e7666d816a6d42102727e5
+niiri:8bc491db5cf9d7c785831050dce08f04
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:a8f6a850eb194f571c3c571b3aea296c prov:wasDerivedFrom niiri:a4b8f76a93e7666d816a6d42102727e5 .
+niiri:f42770fc9a9e7cb8156b3fd705fe80ab prov:wasDerivedFrom niiri:8bc491db5cf9d7c785831050dce08f04 .
 
-niiri:a8f6a850eb194f571c3c571b3aea296c prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
+niiri:f42770fc9a9e7cb8156b3fd705fe80ab prov:wasGeneratedBy niiri:4c664e3343de77596f38de2ddfd6228b .
 
-niiri:a4f3c31231f54dc697346b216b3d057b
+niiri:b6fc563c55501c57b35341d05a340b65
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:a4f3c31231f54dc697346b216b3d057b prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
+niiri:b6fc563c55501c57b35341d05a340b65 prov:wasGeneratedBy niiri:4c664e3343de77596f38de2ddfd6228b .
 
-niiri:8d2cf4bc506149257791cf9c56c81b15
+niiri:769f87acda9e114d605ef2d4231f8665
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce .
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 .
 
-niiri:5a89d4809da4a0f995f5c5b07c751512
+niiri:2cc60bef5b42f2b7b1ae48bc7d86d504
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:8d2cf4bc506149257791cf9c56c81b15 prov:wasDerivedFrom niiri:5a89d4809da4a0f995f5c5b07c751512 .
+niiri:769f87acda9e114d605ef2d4231f8665 prov:wasDerivedFrom niiri:2cc60bef5b42f2b7b1ae48bc7d86d504 .
 
-niiri:8d2cf4bc506149257791cf9c56c81b15 prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
+niiri:769f87acda9e114d605ef2d4231f8665 prov:wasGeneratedBy niiri:4c664e3343de77596f38de2ddfd6228b .
 
-niiri:7a69b23cc081f3ca30a03eee82375536
+niiri:904c278d5e5eabe054b02dacd9765fe6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce .
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 .
 
-niiri:fa6b9fd34f3145b09a6b6a0312c43f2b
+niiri:7e4743196a84ad2de96f97b584450e95
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:7a69b23cc081f3ca30a03eee82375536 prov:wasDerivedFrom niiri:fa6b9fd34f3145b09a6b6a0312c43f2b .
+niiri:904c278d5e5eabe054b02dacd9765fe6 prov:wasDerivedFrom niiri:7e4743196a84ad2de96f97b584450e95 .
 
-niiri:7a69b23cc081f3ca30a03eee82375536 prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
+niiri:904c278d5e5eabe054b02dacd9765fe6 prov:wasGeneratedBy niiri:4c664e3343de77596f38de2ddfd6228b .
 
-niiri:660d160186946791c4ab03232091068e
+niiri:3fc566d96feb851585efed8db3330556
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce .
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 .
 
-niiri:d98651c88439c0b6a1b7247245d716fb
+niiri:07b4edd7479f9186f694d7c5f3c18e0b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:660d160186946791c4ab03232091068e prov:wasDerivedFrom niiri:d98651c88439c0b6a1b7247245d716fb .
+niiri:3fc566d96feb851585efed8db3330556 prov:wasDerivedFrom niiri:07b4edd7479f9186f694d7c5f3c18e0b .
 
-niiri:660d160186946791c4ab03232091068e prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
+niiri:3fc566d96feb851585efed8db3330556 prov:wasGeneratedBy niiri:4c664e3343de77596f38de2ddfd6228b .
 
-niiri:c9b3f695b173b18f48a74cc662baa13b
+niiri:91e5b47bdc7e5facebd81c67e64f2380
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:558d2b1f3f13d94ed022edde592a0165
+niiri:fd7fef7b41069a72f91958c7b6331df3
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:c9b3f695b173b18f48a74cc662baa13b prov:wasDerivedFrom niiri:558d2b1f3f13d94ed022edde592a0165 .
+niiri:91e5b47bdc7e5facebd81c67e64f2380 prov:wasDerivedFrom niiri:fd7fef7b41069a72f91958c7b6331df3 .
 
-niiri:c9b3f695b173b18f48a74cc662baa13b prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
+niiri:91e5b47bdc7e5facebd81c67e64f2380 prov:wasGeneratedBy niiri:4c664e3343de77596f38de2ddfd6228b .
 
-niiri:57850195b4488bda06d9670b07e9f5ef
+niiri:78bbe3875adae6ef4c69dffe0855a4cc
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:e7aeca8d155aaee652c539a052d17bff
+niiri:e52c8c7f38dcdbb477515b82a4d48497
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:57850195b4488bda06d9670b07e9f5ef prov:wasDerivedFrom niiri:e7aeca8d155aaee652c539a052d17bff .
+niiri:78bbe3875adae6ef4c69dffe0855a4cc prov:wasDerivedFrom niiri:e52c8c7f38dcdbb477515b82a4d48497 .
 
-niiri:57850195b4488bda06d9670b07e9f5ef prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
+niiri:78bbe3875adae6ef4c69dffe0855a4cc prov:wasGeneratedBy niiri:4c664e3343de77596f38de2ddfd6228b .
 
-niiri:3a102c0edd804b4301ddde40ff2d180e
+niiri:3bfa4a9b34f52fecfbd7d8b6eac4205d
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:806111cde985716a5655e3f8d0abe680
+niiri:e714834c90d2c6bcdedd0652d75a1421
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:806111cde985716a5655e3f8d0abe680 prov:wasAssociatedWith niiri:795198cbb8fe4e4cf2a89670620ad4dd .
+niiri:e714834c90d2c6bcdedd0652d75a1421 prov:wasAssociatedWith niiri:b4e0fd763b7fb1e20eada9a377d33677 .
 
-niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:a8f6a850eb194f571c3c571b3aea296c .
+niiri:e714834c90d2c6bcdedd0652d75a1421 prov:used niiri:f42770fc9a9e7cb8156b3fd705fe80ab .
 
-niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:c9b3f695b173b18f48a74cc662baa13b .
+niiri:e714834c90d2c6bcdedd0652d75a1421 prov:used niiri:91e5b47bdc7e5facebd81c67e64f2380 .
 
-niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:d426ffcc76be9b32dce59c64fd0df44f .
+niiri:e714834c90d2c6bcdedd0652d75a1421 prov:used niiri:a8c7bc3513943e88e50811a9c8d2f25c .
 
-niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:3a102c0edd804b4301ddde40ff2d180e .
+niiri:e714834c90d2c6bcdedd0652d75a1421 prov:used niiri:3bfa4a9b34f52fecfbd7d8b6eac4205d .
 
-niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:8d2cf4bc506149257791cf9c56c81b15 .
+niiri:e714834c90d2c6bcdedd0652d75a1421 prov:used niiri:769f87acda9e114d605ef2d4231f8665 .
 
-niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:7a69b23cc081f3ca30a03eee82375536 .
+niiri:e714834c90d2c6bcdedd0652d75a1421 prov:used niiri:904c278d5e5eabe054b02dacd9765fe6 .
 
-niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:660d160186946791c4ab03232091068e .
+niiri:e714834c90d2c6bcdedd0652d75a1421 prov:used niiri:3fc566d96feb851585efed8db3330556 .
 
-niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2
+niiri:6bf799b363d775730ec73162b9354090
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:e7de197a7d6d70ffa3532d33bc50a948
+niiri:5ee31d6aa467924994ace5f81f2c23b7
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2 prov:wasDerivedFrom niiri:e7de197a7d6d70ffa3532d33bc50a948 .
+niiri:6bf799b363d775730ec73162b9354090 prov:wasDerivedFrom niiri:5ee31d6aa467924994ace5f81f2c23b7 .
 
-niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2 prov:wasGeneratedBy niiri:806111cde985716a5655e3f8d0abe680 .
+niiri:6bf799b363d775730ec73162b9354090 prov:wasGeneratedBy niiri:e714834c90d2c6bcdedd0652d75a1421 .
 
-niiri:49c74cabef4221d6927cd12a48703bb6
+niiri:445ab286cf4f0e9ab88c446a0a13100a
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:ae059877c7ed4ef05f57bd13377d449d
+niiri:836d8ecc9488c3deec52a5338665386c
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:49c74cabef4221d6927cd12a48703bb6 prov:wasDerivedFrom niiri:ae059877c7ed4ef05f57bd13377d449d .
+niiri:445ab286cf4f0e9ab88c446a0a13100a prov:wasDerivedFrom niiri:836d8ecc9488c3deec52a5338665386c .
 
-niiri:49c74cabef4221d6927cd12a48703bb6 prov:wasGeneratedBy niiri:806111cde985716a5655e3f8d0abe680 .
+niiri:445ab286cf4f0e9ab88c446a0a13100a prov:wasGeneratedBy niiri:e714834c90d2c6bcdedd0652d75a1421 .
 
-niiri:52a3b6d2a4a6441b2742f02cda3546be
+niiri:45606945462477526dd713e0431ad37a
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:52a3b6d2a4a6441b2742f02cda3546be prov:wasGeneratedBy niiri:806111cde985716a5655e3f8d0abe680 .
+niiri:45606945462477526dd713e0431ad37a prov:wasGeneratedBy niiri:e714834c90d2c6bcdedd0652d75a1421 .
 
-niiri:74fb3ab697e23b1fe355c9c125a1fce5
+niiri:ed3191eeed0594168fc6232f9b00a1c4
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
     prov:value "0.000999499751574873"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:d4dd1fe0bb7a8bfea546011249378492 ;
-    nidm_equivalentThreshold: niiri:18b28e49f671f5935e8da1eb3bdcb057 .
+    nidm_equivalentThreshold: niiri:d999170762777f4478a6f3275e4d7915 ;
+    nidm_equivalentThreshold: niiri:1006a56b84a51eaf1eee50ec8a309292 .
 
-niiri:d4dd1fe0bb7a8bfea546011249378492
+niiri:d999170762777f4478a6f3275e4d7915
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12856968604193"^^xsd:float .
 
-niiri:18b28e49f671f5935e8da1eb3bdcb057
+niiri:1006a56b84a51eaf1eee50ec8a309292
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999998566"^^xsd:float .
 
-niiri:394c0a8b443df420c26d9e571e970c52
+niiri:9ef3c500027232d4bac68a62c9407f62
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:d89d94a7efe89b1ed64afd9d81eb9786 ;
-    nidm_equivalentThreshold: niiri:41cf8551c9a74ce7bf6845e0ab154184 .
+    nidm_equivalentThreshold: niiri:5ae66684f0409fa7ba34b53f68d80bb9 ;
+    nidm_equivalentThreshold: niiri:b37792f661991bfe03df2a3866f16873 .
 
-niiri:d89d94a7efe89b1ed64afd9d81eb9786
+niiri:5ae66684f0409fa7ba34b53f68d80bb9
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:41cf8551c9a74ce7bf6845e0ab154184
+niiri:b37792f661991bfe03df2a3866f16873
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:878167535d7b9785734967b95a884d0e
+niiri:6334a7c4c4c4df9714bdfa329acf5924
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:981ac790b32b9305897ba5ac86f1edbc
+niiri:0e3eefff5fa60de8da843cc2a1b4a816
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc
+niiri:3d093fa4e163ac33e09d43ef0cd86320
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc prov:wasAssociatedWith niiri:795198cbb8fe4e4cf2a89670620ad4dd .
+niiri:3d093fa4e163ac33e09d43ef0cd86320 prov:wasAssociatedWith niiri:b4e0fd763b7fb1e20eada9a377d33677 .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:74fb3ab697e23b1fe355c9c125a1fce5 .
+niiri:3d093fa4e163ac33e09d43ef0cd86320 prov:used niiri:ed3191eeed0594168fc6232f9b00a1c4 .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:394c0a8b443df420c26d9e571e970c52 .
+niiri:3d093fa4e163ac33e09d43ef0cd86320 prov:used niiri:9ef3c500027232d4bac68a62c9407f62 .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2 .
+niiri:3d093fa4e163ac33e09d43ef0cd86320 prov:used niiri:6bf799b363d775730ec73162b9354090 .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:57850195b4488bda06d9670b07e9f5ef .
+niiri:3d093fa4e163ac33e09d43ef0cd86320 prov:used niiri:78bbe3875adae6ef4c69dffe0855a4cc .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:a8f6a850eb194f571c3c571b3aea296c .
+niiri:3d093fa4e163ac33e09d43ef0cd86320 prov:used niiri:f42770fc9a9e7cb8156b3fd705fe80ab .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:878167535d7b9785734967b95a884d0e .
+niiri:3d093fa4e163ac33e09d43ef0cd86320 prov:used niiri:6334a7c4c4c4df9714bdfa329acf5924 .
 
-niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:981ac790b32b9305897ba5ac86f1edbc .
+niiri:3d093fa4e163ac33e09d43ef0cd86320 prov:used niiri:0e3eefff5fa60de8da843cc2a1b4a816 .
 
-niiri:9b4cab1186d59ca3792cf63cf7c668d4
+niiri:70240183433c408afdbb5ffb5f7e4b39
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:9b4cab1186d59ca3792cf63cf7c668d4
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:9b4cab1186d59ca3792cf63cf7c668d4 prov:wasGeneratedBy niiri:da118d0af6e844ed6166493cb6e62bbc .
+niiri:70240183433c408afdbb5ffb5f7e4b39 prov:wasGeneratedBy niiri:3d093fa4e163ac33e09d43ef0cd86320 .
 
-niiri:e5387924e8c07fd3d7adc43281757dd4
+niiri:b2f94ff105e83306ad10a583f6ca3ded
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:e5387924e8c07fd3d7adc43281757dd4
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:cafb53072ecf4b68631c9ed0fb1f2f79 ;
-    nidm_hasMaximumIntensityProjection: niiri:89d0e6ee2aadeaea82e8f4417c24d9d4 ;
-    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
+    nidm_hasClusterLabelsMap: niiri:cb3f49e7585256e51bdd08d13e61ce91 ;
+    nidm_hasMaximumIntensityProjection: niiri:c2eec03418f9344d4648ee6b884238be ;
+    nidm_inCoordinateSpace: niiri:3006d63db354ce97f02aa70056f61536 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:cafb53072ecf4b68631c9ed0fb1f2f79
+niiri:cb3f49e7585256e51bdd08d13e61ce91
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:89d0e6ee2aadeaea82e8f4417c24d9d4
+niiri:c2eec03418f9344d4648ee6b884238be
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:e5387924e8c07fd3d7adc43281757dd4 prov:wasGeneratedBy niiri:da118d0af6e844ed6166493cb6e62bbc .
+niiri:b2f94ff105e83306ad10a583f6ca3ded prov:wasGeneratedBy niiri:3d093fa4e163ac33e09d43ef0cd86320 .
 

--- a/spmexport/ex_spm_voxelwise_p0001/nidm.ttl
+++ b/spmexport/ex_spm_voxelwise_p0001/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:b64bdec9b9c7e6a23af510b72acb6e67
+niiri:76aab825d22183ff1a24b9b636256326
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:29e7b7953663243ec8dfb65b1c168597
+niiri:12af50e283cb51a28723b451e53de7fa
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:72167a2e3e27d6635051cc6895fc8a2d
+niiri:aa7c94a6ec5280b8fa95e970683082ea
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:72167a2e3e27d6635051cc6895fc8a2d prov:wasAssociatedWith niiri:29e7b7953663243ec8dfb65b1c168597 .
+niiri:aa7c94a6ec5280b8fa95e970683082ea prov:wasAssociatedWith niiri:12af50e283cb51a28723b451e53de7fa .
 
 _:blank5 a prov:Generation .
 
-niiri:b64bdec9b9c7e6a23af510b72acb6e67 prov:qualifiedGeneration _:blank5 .
+niiri:76aab825d22183ff1a24b9b636256326 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:12:23"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:34:39"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:12:23"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:693a3599a964371c83a2ec0cb5aa6be4
+niiri:795198cbb8fe4e4cf2a89670620ad4dd
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:797028115af68a6b59077425735d58ea
+niiri:e920422de7c868392b9495c42c8e55ce
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:797028115af68a6b59077425735d58ea
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:98b0c7257c519f61a37aa58faca9860a
+niiri:f96f232992c72733da5af4612ce6db6c
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:2a1fc19f8bd99b52d3aacff50997628b
+niiri:22d95e76835ad64dd94961e226c89be8
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:7c93d0c68830bf0c3b19451ce90f214a
+niiri:d426ffcc76be9b32dce59c64fd0df44f
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:b462d4be3e2879edf7ec883db32c9bdd ;
+    dc:description niiri:a5e15227b86578a78871a3900ce2545d ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:2a1fc19f8bd99b52d3aacff50997628b ;
+    nidm_hasDriftModel: niiri:22d95e76835ad64dd94961e226c89be8 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:b462d4be3e2879edf7ec883db32c9bdd
+niiri:a5e15227b86578a78871a3900ce2545d
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0
+niiri:ad1f4fb679728882b48781cecd81338b
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:be25cc5da226dcdce7c1db2041ff0287
+niiri:3ae557ea4446abb02471ea2810538989
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:be25cc5da226dcdce7c1db2041ff0287 prov:wasAssociatedWith niiri:693a3599a964371c83a2ec0cb5aa6be4 .
+niiri:3ae557ea4446abb02471ea2810538989 prov:wasAssociatedWith niiri:795198cbb8fe4e4cf2a89670620ad4dd .
 
-niiri:be25cc5da226dcdce7c1db2041ff0287 prov:used niiri:7c93d0c68830bf0c3b19451ce90f214a .
+niiri:3ae557ea4446abb02471ea2810538989 prov:used niiri:d426ffcc76be9b32dce59c64fd0df44f .
 
-niiri:be25cc5da226dcdce7c1db2041ff0287 prov:used niiri:98b0c7257c519f61a37aa58faca9860a .
+niiri:3ae557ea4446abb02471ea2810538989 prov:used niiri:f96f232992c72733da5af4612ce6db6c .
 
-niiri:be25cc5da226dcdce7c1db2041ff0287 prov:used niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0 .
+niiri:3ae557ea4446abb02471ea2810538989 prov:used niiri:ad1f4fb679728882b48781cecd81338b .
 
-niiri:5bdd362b26678583adbf997f0aa0dab5
+niiri:a8f6a850eb194f571c3c571b3aea296c
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:b34ee26960c2e676bda4382cecba1272
+niiri:a4b8f76a93e7666d816a6d42102727e5
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:5bdd362b26678583adbf997f0aa0dab5 prov:wasDerivedFrom niiri:b34ee26960c2e676bda4382cecba1272 .
+niiri:a8f6a850eb194f571c3c571b3aea296c prov:wasDerivedFrom niiri:a4b8f76a93e7666d816a6d42102727e5 .
 
-niiri:5bdd362b26678583adbf997f0aa0dab5 prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+niiri:a8f6a850eb194f571c3c571b3aea296c prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
 
-niiri:5d521601816b6479d6e9eab9032647ef
+niiri:a4f3c31231f54dc697346b216b3d057b
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:5d521601816b6479d6e9eab9032647ef prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+niiri:a4f3c31231f54dc697346b216b3d057b prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
 
-niiri:12d10179a56c837944e25a6d2090020c
+niiri:8d2cf4bc506149257791cf9c56c81b15
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea .
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce .
 
-niiri:35306384388ada95614e4eb3a6348111
+niiri:5a89d4809da4a0f995f5c5b07c751512
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:12d10179a56c837944e25a6d2090020c prov:wasDerivedFrom niiri:35306384388ada95614e4eb3a6348111 .
+niiri:8d2cf4bc506149257791cf9c56c81b15 prov:wasDerivedFrom niiri:5a89d4809da4a0f995f5c5b07c751512 .
 
-niiri:12d10179a56c837944e25a6d2090020c prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+niiri:8d2cf4bc506149257791cf9c56c81b15 prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
 
-niiri:5e2d4659031ebb240110eb2fc555c40c
+niiri:7a69b23cc081f3ca30a03eee82375536
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea .
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce .
 
-niiri:a70a31f7531a7fcb63c43826d1fb6901
+niiri:fa6b9fd34f3145b09a6b6a0312c43f2b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:5e2d4659031ebb240110eb2fc555c40c prov:wasDerivedFrom niiri:a70a31f7531a7fcb63c43826d1fb6901 .
+niiri:7a69b23cc081f3ca30a03eee82375536 prov:wasDerivedFrom niiri:fa6b9fd34f3145b09a6b6a0312c43f2b .
 
-niiri:5e2d4659031ebb240110eb2fc555c40c prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+niiri:7a69b23cc081f3ca30a03eee82375536 prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
 
-niiri:caa29f50cebec8a31ba04b81cd00c901
+niiri:660d160186946791c4ab03232091068e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea .
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce .
 
-niiri:18026b1791efb3a58b2a90d60be705cf
+niiri:d98651c88439c0b6a1b7247245d716fb
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:caa29f50cebec8a31ba04b81cd00c901 prov:wasDerivedFrom niiri:18026b1791efb3a58b2a90d60be705cf .
+niiri:660d160186946791c4ab03232091068e prov:wasDerivedFrom niiri:d98651c88439c0b6a1b7247245d716fb .
 
-niiri:caa29f50cebec8a31ba04b81cd00c901 prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+niiri:660d160186946791c4ab03232091068e prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
 
-niiri:25dad247cbcdcd6515ebc7f2b3e4d169
+niiri:c9b3f695b173b18f48a74cc662baa13b
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:4326a080627d5d6d482f963cb1c875ca
+niiri:558d2b1f3f13d94ed022edde592a0165
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:25dad247cbcdcd6515ebc7f2b3e4d169 prov:wasDerivedFrom niiri:4326a080627d5d6d482f963cb1c875ca .
+niiri:c9b3f695b173b18f48a74cc662baa13b prov:wasDerivedFrom niiri:558d2b1f3f13d94ed022edde592a0165 .
 
-niiri:25dad247cbcdcd6515ebc7f2b3e4d169 prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+niiri:c9b3f695b173b18f48a74cc662baa13b prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
 
-niiri:5c1178f3140872b7a8e46365ed5827f8
+niiri:57850195b4488bda06d9670b07e9f5ef
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:1e5eb5cc2d39d4d87f43a8f5d67edf33
+niiri:e7aeca8d155aaee652c539a052d17bff
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:5c1178f3140872b7a8e46365ed5827f8 prov:wasDerivedFrom niiri:1e5eb5cc2d39d4d87f43a8f5d67edf33 .
+niiri:57850195b4488bda06d9670b07e9f5ef prov:wasDerivedFrom niiri:e7aeca8d155aaee652c539a052d17bff .
 
-niiri:5c1178f3140872b7a8e46365ed5827f8 prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+niiri:57850195b4488bda06d9670b07e9f5ef prov:wasGeneratedBy niiri:3ae557ea4446abb02471ea2810538989 .
 
-niiri:b92b60ee8e091a79725fbb24b8a95ca9
+niiri:3a102c0edd804b4301ddde40ff2d180e
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:d92a89b9a51adc36e400d999e4292160
+niiri:806111cde985716a5655e3f8d0abe680
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:d92a89b9a51adc36e400d999e4292160 prov:wasAssociatedWith niiri:693a3599a964371c83a2ec0cb5aa6be4 .
+niiri:806111cde985716a5655e3f8d0abe680 prov:wasAssociatedWith niiri:795198cbb8fe4e4cf2a89670620ad4dd .
 
-niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:5bdd362b26678583adbf997f0aa0dab5 .
+niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:a8f6a850eb194f571c3c571b3aea296c .
 
-niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:25dad247cbcdcd6515ebc7f2b3e4d169 .
+niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:c9b3f695b173b18f48a74cc662baa13b .
 
-niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:7c93d0c68830bf0c3b19451ce90f214a .
+niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:d426ffcc76be9b32dce59c64fd0df44f .
 
-niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:b92b60ee8e091a79725fbb24b8a95ca9 .
+niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:3a102c0edd804b4301ddde40ff2d180e .
 
-niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:12d10179a56c837944e25a6d2090020c .
+niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:8d2cf4bc506149257791cf9c56c81b15 .
 
-niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:5e2d4659031ebb240110eb2fc555c40c .
+niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:7a69b23cc081f3ca30a03eee82375536 .
 
-niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:caa29f50cebec8a31ba04b81cd00c901 .
+niiri:806111cde985716a5655e3f8d0abe680 prov:used niiri:660d160186946791c4ab03232091068e .
 
-niiri:05476ea39b68cd6ce954710ab9a6512f
+niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:05476ea39b68cd6ce954710ab9a6512f
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:73905f3aac46fbb1357b6b89001c335c
+niiri:e7de197a7d6d70ffa3532d33bc50a948
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:05476ea39b68cd6ce954710ab9a6512f prov:wasDerivedFrom niiri:73905f3aac46fbb1357b6b89001c335c .
+niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2 prov:wasDerivedFrom niiri:e7de197a7d6d70ffa3532d33bc50a948 .
 
-niiri:05476ea39b68cd6ce954710ab9a6512f prov:wasGeneratedBy niiri:d92a89b9a51adc36e400d999e4292160 .
+niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2 prov:wasGeneratedBy niiri:806111cde985716a5655e3f8d0abe680 .
 
-niiri:611efb7aa685964d73e0a80747ee0d13
+niiri:49c74cabef4221d6927cd12a48703bb6
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:29494dce8eba85b4d0bf2422fd31cd7e
+niiri:ae059877c7ed4ef05f57bd13377d449d
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:611efb7aa685964d73e0a80747ee0d13 prov:wasDerivedFrom niiri:29494dce8eba85b4d0bf2422fd31cd7e .
+niiri:49c74cabef4221d6927cd12a48703bb6 prov:wasDerivedFrom niiri:ae059877c7ed4ef05f57bd13377d449d .
 
-niiri:611efb7aa685964d73e0a80747ee0d13 prov:wasGeneratedBy niiri:d92a89b9a51adc36e400d999e4292160 .
+niiri:49c74cabef4221d6927cd12a48703bb6 prov:wasGeneratedBy niiri:806111cde985716a5655e3f8d0abe680 .
 
-niiri:22b72372f61d640a78c1e5970a0dc2f5
+niiri:52a3b6d2a4a6441b2742f02cda3546be
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:22b72372f61d640a78c1e5970a0dc2f5 prov:wasGeneratedBy niiri:d92a89b9a51adc36e400d999e4292160 .
+niiri:52a3b6d2a4a6441b2742f02cda3546be prov:wasGeneratedBy niiri:806111cde985716a5655e3f8d0abe680 .
 
-niiri:552d1b8029c0424db6aa0efe1b4ff168
+niiri:74fb3ab697e23b1fe355c9c125a1fce5
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
     prov:value "0.000999499751574873"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:358a4ad660a0967ebefabc42f52c54da ;
-    nidm_equivalentThreshold: niiri:2ace48e3e0732e8d5798cd6bf5ec7e72 .
+    nidm_equivalentThreshold: niiri:d4dd1fe0bb7a8bfea546011249378492 ;
+    nidm_equivalentThreshold: niiri:18b28e49f671f5935e8da1eb3bdcb057 .
 
-niiri:358a4ad660a0967ebefabc42f52c54da
+niiri:d4dd1fe0bb7a8bfea546011249378492
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold" ;
     prov:value "3.12856968604193"^^xsd:float .
 
-niiri:2ace48e3e0732e8d5798cd6bf5ec7e72
+niiri:18b28e49f671f5935e8da1eb3bdcb057
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.999999999998566"^^xsd:float .
 
-niiri:70e6239840fed7ac0f68d10762241e03
+niiri:394c0a8b443df420c26d9e571e970c52
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:f0fa9ada07095bbc2e38a690e9d60084 ;
-    nidm_equivalentThreshold: niiri:dcd6f7ae020d3ea1cca0234e387fdd81 .
+    nidm_equivalentThreshold: niiri:d89d94a7efe89b1ed64afd9d81eb9786 ;
+    nidm_equivalentThreshold: niiri:41cf8551c9a74ce7bf6845e0ab154184 .
 
-niiri:f0fa9ada07095bbc2e38a690e9d60084
+niiri:d89d94a7efe89b1ed64afd9d81eb9786
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:dcd6f7ae020d3ea1cca0234e387fdd81
+niiri:41cf8551c9a74ce7bf6845e0ab154184
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:cc550ca1ac8e429a5d4144d95af3345b
+niiri:878167535d7b9785734967b95a884d0e
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:daf684b55626b991b1a1bb3bd826b3f9
+niiri:981ac790b32b9305897ba5ac86f1edbc
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:e6d98152416877282c812e014d2eca94
+niiri:da118d0af6e844ed6166493cb6e62bbc
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:e6d98152416877282c812e014d2eca94 prov:wasAssociatedWith niiri:693a3599a964371c83a2ec0cb5aa6be4 .
+niiri:da118d0af6e844ed6166493cb6e62bbc prov:wasAssociatedWith niiri:795198cbb8fe4e4cf2a89670620ad4dd .
 
-niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:552d1b8029c0424db6aa0efe1b4ff168 .
+niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:74fb3ab697e23b1fe355c9c125a1fce5 .
 
-niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:70e6239840fed7ac0f68d10762241e03 .
+niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:394c0a8b443df420c26d9e571e970c52 .
 
-niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:05476ea39b68cd6ce954710ab9a6512f .
+niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:0c3ae52030d4ae4fa1ca9421b6d8eaf2 .
 
-niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:5c1178f3140872b7a8e46365ed5827f8 .
+niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:57850195b4488bda06d9670b07e9f5ef .
 
-niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:5bdd362b26678583adbf997f0aa0dab5 .
+niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:a8f6a850eb194f571c3c571b3aea296c .
 
-niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:cc550ca1ac8e429a5d4144d95af3345b .
+niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:878167535d7b9785734967b95a884d0e .
 
-niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:daf684b55626b991b1a1bb3bd826b3f9 .
+niiri:da118d0af6e844ed6166493cb6e62bbc prov:used niiri:981ac790b32b9305897ba5ac86f1edbc .
 
-niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61
+niiri:9b4cab1186d59ca3792cf63cf7c668d4
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61 prov:wasGeneratedBy niiri:e6d98152416877282c812e014d2eca94 .
+niiri:9b4cab1186d59ca3792cf63cf7c668d4 prov:wasGeneratedBy niiri:da118d0af6e844ed6166493cb6e62bbc .
 
-niiri:c8cd6bc0a8628627c7ed0719821daf24
+niiri:e5387924e8c07fd3d7adc43281757dd4
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:c8cd6bc0a8628627c7ed0719821daf24
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:165d3eec8b06fe8883625084f3310a30 ;
-    nidm_hasMaximumIntensityProjection: niiri:d359bb028863af68e706c8f23c59562c ;
-    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_hasClusterLabelsMap: niiri:cafb53072ecf4b68631c9ed0fb1f2f79 ;
+    nidm_hasMaximumIntensityProjection: niiri:89d0e6ee2aadeaea82e8f4417c24d9d4 ;
+    nidm_inCoordinateSpace: niiri:e920422de7c868392b9495c42c8e55ce ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:165d3eec8b06fe8883625084f3310a30
+niiri:cafb53072ecf4b68631c9ed0fb1f2f79
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:d359bb028863af68e706c8f23c59562c
+niiri:89d0e6ee2aadeaea82e8f4417c24d9d4
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:c8cd6bc0a8628627c7ed0719821daf24 prov:wasGeneratedBy niiri:e6d98152416877282c812e014d2eca94 .
+niiri:e5387924e8c07fd3d7adc43281757dd4 prov:wasGeneratedBy niiri:da118d0af6e844ed6166493cb6e62bbc .
 

--- a/spmexport/ex_spm_voxelwise_p0001/nidm.ttl
+++ b/spmexport/ex_spm_voxelwise_p0001/nidm.ttl
@@ -1,0 +1,510 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:b64bdec9b9c7e6a23af510b72acb6e67
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:29e7b7953663243ec8dfb65b1c168597
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:72167a2e3e27d6635051cc6895fc8a2d
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:72167a2e3e27d6635051cc6895fc8a2d prov:wasAssociatedWith niiri:29e7b7953663243ec8dfb65b1c168597 .
+
+_:blank5 a prov:Generation .
+
+niiri:b64bdec9b9c7e6a23af510b72acb6e67 prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:12:23"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+
+niiri:693a3599a964371c83a2ec0cb5aa6be4
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:797028115af68a6b59077425735d58ea
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:98b0c7257c519f61a37aa58faca9860a
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:2a1fc19f8bd99b52d3aacff50997628b
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:7c93d0c68830bf0c3b19451ce90f214a
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:b462d4be3e2879edf7ec883db32c9bdd ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:2a1fc19f8bd99b52d3aacff50997628b ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:b462d4be3e2879edf7ec883db32c9bdd
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:be25cc5da226dcdce7c1db2041ff0287
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:be25cc5da226dcdce7c1db2041ff0287 prov:wasAssociatedWith niiri:693a3599a964371c83a2ec0cb5aa6be4 .
+
+niiri:be25cc5da226dcdce7c1db2041ff0287 prov:used niiri:7c93d0c68830bf0c3b19451ce90f214a .
+
+niiri:be25cc5da226dcdce7c1db2041ff0287 prov:used niiri:98b0c7257c519f61a37aa58faca9860a .
+
+niiri:be25cc5da226dcdce7c1db2041ff0287 prov:used niiri:b1c04ebb2fddd8f8acad7e7bb408b0d0 .
+
+niiri:5bdd362b26678583adbf997f0aa0dab5
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:b34ee26960c2e676bda4382cecba1272
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
+
+niiri:5bdd362b26678583adbf997f0aa0dab5 prov:wasDerivedFrom niiri:b34ee26960c2e676bda4382cecba1272 .
+
+niiri:5bdd362b26678583adbf997f0aa0dab5 prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+
+niiri:5d521601816b6479d6e9eab9032647ef
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "121.744659423828"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
+
+niiri:5d521601816b6479d6e9eab9032647ef prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+
+niiri:12d10179a56c837944e25a6d2090020c
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea .
+
+niiri:35306384388ada95614e4eb3a6348111
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
+
+niiri:12d10179a56c837944e25a6d2090020c prov:wasDerivedFrom niiri:35306384388ada95614e4eb3a6348111 .
+
+niiri:12d10179a56c837944e25a6d2090020c prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+
+niiri:5e2d4659031ebb240110eb2fc555c40c
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea .
+
+niiri:a70a31f7531a7fcb63c43826d1fb6901
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
+
+niiri:5e2d4659031ebb240110eb2fc555c40c prov:wasDerivedFrom niiri:a70a31f7531a7fcb63c43826d1fb6901 .
+
+niiri:5e2d4659031ebb240110eb2fc555c40c prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+
+niiri:caa29f50cebec8a31ba04b81cd00c901
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea .
+
+niiri:18026b1791efb3a58b2a90d60be705cf
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
+
+niiri:caa29f50cebec8a31ba04b81cd00c901 prov:wasDerivedFrom niiri:18026b1791efb3a58b2a90d60be705cf .
+
+niiri:caa29f50cebec8a31ba04b81cd00c901 prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+
+niiri:25dad247cbcdcd6515ebc7f2b3e4d169
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
+
+niiri:4326a080627d5d6d482f963cb1c875ca
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
+
+niiri:25dad247cbcdcd6515ebc7f2b3e4d169 prov:wasDerivedFrom niiri:4326a080627d5d6d482f963cb1c875ca .
+
+niiri:25dad247cbcdcd6515ebc7f2b3e4d169 prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+
+niiri:5c1178f3140872b7a8e46365ed5827f8
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
+
+niiri:1e5eb5cc2d39d4d87f43a8f5d67edf33
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
+
+niiri:5c1178f3140872b7a8e46365ed5827f8 prov:wasDerivedFrom niiri:1e5eb5cc2d39d4d87f43a8f5d67edf33 .
+
+niiri:5c1178f3140872b7a8e46365ed5827f8 prov:wasGeneratedBy niiri:be25cc5da226dcdce7c1db2041ff0287 .
+
+niiri:b92b60ee8e091a79725fbb24b8a95ca9
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    rdfs:label "Contrast: pos vs neg" ;
+    prov:value "[1, -1, 0]"^^xsd:string .
+
+niiri:d92a89b9a51adc36e400d999e4292160
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:d92a89b9a51adc36e400d999e4292160 prov:wasAssociatedWith niiri:693a3599a964371c83a2ec0cb5aa6be4 .
+
+niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:5bdd362b26678583adbf997f0aa0dab5 .
+
+niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:25dad247cbcdcd6515ebc7f2b3e4d169 .
+
+niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:7c93d0c68830bf0c3b19451ce90f214a .
+
+niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:b92b60ee8e091a79725fbb24b8a95ca9 .
+
+niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:12d10179a56c837944e25a6d2090020c .
+
+niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:5e2d4659031ebb240110eb2fc555c40c .
+
+niiri:d92a89b9a51adc36e400d999e4292160 prov:used niiri:caa29f50cebec8a31ba04b81cd00c901 .
+
+niiri:05476ea39b68cd6ce954710ab9a6512f
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: pos vs neg" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
+
+niiri:73905f3aac46fbb1357b6b89001c335c
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
+
+niiri:05476ea39b68cd6ce954710ab9a6512f prov:wasDerivedFrom niiri:73905f3aac46fbb1357b6b89001c335c .
+
+niiri:05476ea39b68cd6ce954710ab9a6512f prov:wasGeneratedBy niiri:d92a89b9a51adc36e400d999e4292160 .
+
+niiri:611efb7aa685964d73e0a80747ee0d13
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: pos vs neg" ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
+
+niiri:29494dce8eba85b4d0bf2422fd31cd7e
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
+
+niiri:611efb7aa685964d73e0a80747ee0d13 prov:wasDerivedFrom niiri:29494dce8eba85b4d0bf2422fd31cd7e .
+
+niiri:611efb7aa685964d73e0a80747ee0d13 prov:wasGeneratedBy niiri:d92a89b9a51adc36e400d999e4292160 .
+
+niiri:22b72372f61d640a78c1e5970a0dc2f5
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
+
+niiri:22b72372f61d640a78c1e5970a0dc2f5 prov:wasGeneratedBy niiri:d92a89b9a51adc36e400d999e4292160 .
+
+niiri:552d1b8029c0424db6aa0efe1b4ff168
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
+    prov:value "0.000999499751574873"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:358a4ad660a0967ebefabc42f52c54da ;
+    nidm_equivalentThreshold: niiri:2ace48e3e0732e8d5798cd6bf5ec7e72 .
+
+niiri:358a4ad660a0967ebefabc42f52c54da
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "3.12856968604193"^^xsd:float .
+
+niiri:2ace48e3e0732e8d5798cd6bf5ec7e72
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.999999999998566"^^xsd:float .
+
+niiri:70e6239840fed7ac0f68d10762241e03
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:f0fa9ada07095bbc2e38a690e9d60084 ;
+    nidm_equivalentThreshold: niiri:dcd6f7ae020d3ea1cca0234e387fdd81 .
+
+niiri:f0fa9ada07095bbc2e38a690e9d60084
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:dcd6f7ae020d3ea1cca0234e387fdd81
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:cc550ca1ac8e429a5d4144d95af3345b
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:daf684b55626b991b1a1bb3bd826b3f9
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:e6d98152416877282c812e014d2eca94
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:e6d98152416877282c812e014d2eca94 prov:wasAssociatedWith niiri:693a3599a964371c83a2ec0cb5aa6be4 .
+
+niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:552d1b8029c0424db6aa0efe1b4ff168 .
+
+niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:70e6239840fed7ac0f68d10762241e03 .
+
+niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:05476ea39b68cd6ce954710ab9a6512f .
+
+niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:5c1178f3140872b7a8e46365ed5827f8 .
+
+niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:5bdd362b26678583adbf997f0aa0dab5 .
+
+niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:cc550ca1ac8e429a5d4144d95af3345b .
+
+niiri:e6d98152416877282c812e014d2eca94 prov:used niiri:daf684b55626b991b1a1bb3bd826b3f9 .
+
+niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
+    nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
+    nidm_searchVolumeInResels: "2650.12011223711"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.01704921884936, 4.07618247398105, 4.38831339907177]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.03409843769872, 8.1523649479621, 8.77662679814353]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "8.23486077915088"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "27.2707251644655"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.05094049746367"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:3a8dd2ac81fbc2c0f516b1e293e9cc61 prov:wasGeneratedBy niiri:e6d98152416877282c812e014d2eca94 .
+
+niiri:c8cd6bc0a8628627c7ed0719821daf24
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
+    nidm_pValue: "NaN"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:165d3eec8b06fe8883625084f3310a30 ;
+    nidm_hasMaximumIntensityProjection: niiri:d359bb028863af68e706c8f23c59562c ;
+    nidm_inCoordinateSpace: niiri:797028115af68a6b59077425735d58ea ;
+    crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
+
+niiri:165d3eec8b06fe8883625084f3310a30
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:d359bb028863af68e706c8f23c59562c
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:c8cd6bc0a8628627c7ed0719821daf24 prov:wasGeneratedBy niiri:e6d98152416877282c812e014d2eca94 .
+

--- a/spmexport/ex_spm_voxelwise_t=4/config.json
+++ b/spmexport/ex_spm_voxelwise_t=4/config.json
@@ -1,0 +1,7 @@
+
+{
+"software": "spm",
+"ground_truth": ["voxel_t=4/nidm.ttl"],
+"inclusive": true,
+"version": "1.1.0"
+}

--- a/spmexport/ex_spm_voxelwise_t=4/nidm.provn
+++ b/spmexport/ex_spm_voxelwise_t=4/nidm.provn
@@ -1,0 +1,429 @@
+document
+  prefix nidm <http://purl.org/nidash/nidm#>
+  prefix niiri <http://iri.nidash.org/>
+  prefix spm <http://purl.org/nidash/spm#>
+  prefix neurolex <http://neurolex.org/wiki/>
+  prefix crypto <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#>
+  prefix dct <http://purl.org/dc/terms/>
+  prefix nfo <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  prefix dc <http://purl.org/dc/elements/1.1/>
+  prefix dctype <http://purl.org/dc/dcmitype/>
+  prefix obo <http://purl.obolibrary.org/obo/>
+  prefix nidm_NIDMResults <http://purl.org/nidash/nidm#NIDM_0000027>
+  prefix nidm_version <http://purl.org/nidash/nidm#NIDM_0000127>
+  prefix nidm_spm_results_nidm <http://purl.org/nidash/nidm#NIDM_0000168>
+  prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+  prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
+
+  entity(niiri:806349bd3ad6f46e7d9750491347fd39,
+    [prov:type = 'prov:Bundle',
+    prov:type = 'nidm_NIDMResults:',
+    prov:label = "NIDM-Results",
+    nidm_version: = "1.2.0" %% xsd:string])
+  agent(niiri:ce2087481eef3055e103b0093848e983,
+    [prov:type = 'nidm_spm_results_nidm:',
+    prov:type = 'prov:SoftwareAgent',
+    prov:label = "spm_results_nidm" %% xsd:string,
+    nidm_softwareVersion: = "12.6646" %% xsd:string])
+  activity(niiri:35b73388a8bf62cc251e81b0ce66bca1,
+    [prov:type = 'nidm_NIDMResultsExport:',
+    prov:label = "NIDM-Results export"])
+  wasAssociatedWith(niiri:35b73388a8bf62cc251e81b0ce66bca1, niiri:ce2087481eef3055e103b0093848e983, -)
+  wasGeneratedBy(niiri:806349bd3ad6f46e7d9750491347fd39, niiri:35b73388a8bf62cc251e81b0ce66bca1, 2016-01-11T10:12:28)
+  bundle niiri:806349bd3ad6f46e7d9750491347fd39
+    prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
+    prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
+    prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
+    prefix nidm_voxelUnits <http://purl.org/nidash/nidm#NIDM_0000133>
+    prefix nidm_voxelSize <http://purl.org/nidash/nidm#NIDM_0000131>
+    prefix nidm_inWorldCoordinateSystem <http://purl.org/nidash/nidm#NIDM_0000105>
+    prefix nidm_numberOfDimensions <http://purl.org/nidash/nidm#NIDM_0000112>
+    prefix nidm_dimensionsInVoxels <http://purl.org/nidash/nidm#NIDM_0000090>
+    prefix nidm_grandMeanScaling <http://purl.org/nidash/nidm#NIDM_0000096>
+    prefix nidm_targetIntensity <http://purl.org/nidash/nidm#NIDM_0000124>
+    prefix nidm_DataScaling <http://purl.org/nidash/nidm#NIDM_0000018>
+    prefix spm_DCTDriftModel <http://purl.org/nidash/spm#SPM_0000002>
+    prefix spm_SPMsDriftCutoffPeriod <http://purl.org/nidash/spm#SPM_0000001>
+    prefix nidm_hasDriftModel <http://purl.org/nidash/nidm#NIDM_0000088>
+    prefix nidm_hasHRFBasis <http://purl.org/nidash/nidm#NIDM_0000102>
+    prefix spm_SPMsCanonicalHRF <http://purl.org/nidash/spm#SPM_0000004>
+    prefix nidm_DesignMatrix <http://purl.org/nidash/nidm#NIDM_0000019>
+    prefix nidm_regressorNames <http://purl.org/nidash/nidm#NIDM_0000021>
+    prefix nidm_hasErrorDependence <http://purl.org/nidash/nidm#NIDM_0000100>
+    prefix stato_ToeplitzCovarianceStructure <http://purl.obolibrary.org/obo/STATO_0000357>
+    prefix nidm_dependenceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000089>
+    prefix nidm_ConstantParameter <http://purl.org/nidash/nidm#NIDM_0000072>
+    prefix nidm_errorVarianceHomogeneous <http://purl.org/nidash/nidm#NIDM_0000094>
+    prefix nidm_varianceMapWiseDependence <http://purl.org/nidash/nidm#NIDM_0000126>
+    prefix nidm_IndependentParameter <http://purl.org/nidash/nidm#NIDM_0000073>
+    prefix nidm_withEstimationMethod <http://purl.org/nidash/nidm#NIDM_0000134>
+    prefix stato_GLS <http://purl.obolibrary.org/obo/STATO_0000372>
+    prefix nidm_ErrorModel <http://purl.org/nidash/nidm#NIDM_0000023>
+    prefix nidm_hasErrorDistribution <http://purl.org/nidash/nidm#NIDM_0000101>
+    prefix stato_GaussianDistribution <http://purl.obolibrary.org/obo/STATO_0000227>
+    prefix nidm_ModelParametersEstimation <http://purl.org/nidash/nidm#NIDM_0000056>
+    prefix nidm_MaskMap <http://purl.org/nidash/nidm#NIDM_0000054>
+    prefix nidm_isUserDefined <http://purl.org/nidash/nidm#NIDM_0000106>
+    prefix nidm_inCoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000104>
+    prefix nidm_GrandMeanMap <http://purl.org/nidash/nidm#NIDM_0000033>
+    prefix nidm_maskedMedian <http://purl.org/nidash/nidm#NIDM_0000107>
+    prefix nidm_ParameterEstimateMap <http://purl.org/nidash/nidm#NIDM_0000061>
+    prefix nidm_ResidualMeanSquaresMap <http://purl.org/nidash/nidm#NIDM_0000066>
+    prefix nidm_ReselsPerVoxelMap <http://purl.org/nidash/nidm#NIDM_0000144>
+    prefix stato_ContrastWeightMatrix <http://purl.obolibrary.org/obo/STATO_0000323>
+    prefix nidm_statisticType <http://purl.org/nidash/nidm#NIDM_0000123>
+    prefix stato_TStatistic <http://purl.obolibrary.org/obo/STATO_0000176>
+    prefix nidm_contrastName <http://purl.org/nidash/nidm#NIDM_0000085>
+    prefix nidm_ContrastEstimation <http://purl.org/nidash/nidm#NIDM_0000001>
+    prefix nidm_StatisticMap <http://purl.org/nidash/nidm#NIDM_0000076>
+    prefix nidm_errorDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000093>
+    prefix nidm_effectDegreesOfFreedom <http://purl.org/nidash/nidm#NIDM_0000091>
+    prefix nidm_ContrastMap <http://purl.org/nidash/nidm#NIDM_0000002>
+    prefix nidm_ContrastStandardErrorMap <http://purl.org/nidash/nidm#NIDM_0000013>
+    prefix obo_Statistic <http://purl.obolibrary.org/obo/STATO_0000039>
+    prefix nidm_PValueUncorrected <http://purl.org/nidash/nidm#NIDM_0000160>
+    prefix obo_pValueFWER <http://purl.obolibrary.org/obo/OBI_0001265>
+    prefix nidm_HeightThreshold <http://purl.org/nidash/nidm#NIDM_0000034>
+    prefix nidm_equivalentThreshold <http://purl.org/nidash/nidm#NIDM_0000161>
+    prefix nidm_ExtentThreshold <http://purl.org/nidash/nidm#NIDM_0000026>
+    prefix nidm_clusterSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000084>
+    prefix nidm_clusterSizeInResels <http://purl.org/nidash/nidm#NIDM_0000156>
+    prefix nidm_PeakDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000063>
+    prefix nidm_maxNumberOfPeaksPerCluster <http://purl.org/nidash/nidm#NIDM_0000108>
+    prefix nidm_minDistanceBetweenPeaks <http://purl.org/nidash/nidm#NIDM_0000109>
+    prefix nidm_ClusterDefinitionCriteria <http://purl.org/nidash/nidm#NIDM_0000007>
+    prefix nidm_hasConnectivityCriterion <http://purl.org/nidash/nidm#NIDM_0000099>
+    prefix nidm_voxel18connected <http://purl.org/nidash/nidm#NIDM_0000128>
+    prefix nidm_Inference <http://purl.org/nidash/nidm#NIDM_0000049>
+    prefix nidm_hasAlternativeHypothesis <http://purl.org/nidash/nidm#NIDM_0000097>
+    prefix nidm_OneTailedTest <http://purl.org/nidash/nidm#NIDM_0000060>
+    prefix nidm_SearchSpaceMaskMap <http://purl.org/nidash/nidm#NIDM_0000068>
+    prefix nidm_searchVolumeInVoxels <http://purl.org/nidash/nidm#NIDM_0000121>
+    prefix nidm_searchVolumeInUnits <http://purl.org/nidash/nidm#NIDM_0000136>
+    prefix nidm_reselSizeInVoxels <http://purl.org/nidash/nidm#NIDM_0000148>
+    prefix nidm_searchVolumeInResels <http://purl.org/nidash/nidm#NIDM_0000149>
+    prefix spm_searchVolumeReselsGeometry <http://purl.org/nidash/spm#SPM_0000010>
+    prefix nidm_noiseFWHMInVoxels <http://purl.org/nidash/nidm#NIDM_0000159>
+    prefix nidm_noiseFWHMInUnits <http://purl.org/nidash/nidm#NIDM_0000157>
+    prefix nidm_randomFieldStationarity <http://purl.org/nidash/nidm#NIDM_0000120>
+    prefix nidm_expectedNumberOfVoxelsPerCluster <http://purl.org/nidash/nidm#NIDM_0000143>
+    prefix nidm_expectedNumberOfClusters <http://purl.org/nidash/nidm#NIDM_0000141>
+    prefix nidm_heightCriticalThresholdFWE05 <http://purl.org/nidash/nidm#NIDM_0000147>
+    prefix nidm_heightCriticalThresholdFDR05 <http://purl.org/nidash/nidm#NIDM_0000146>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05 <http://purl.org/nidash/spm#SPM_0000014>
+    prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05 <http://purl.org/nidash/spm#SPM_0000013>
+    prefix nidm_ExcursionSetMap <http://purl.org/nidash/nidm#NIDM_0000025>
+    prefix nidm_numberOfSupraThresholdClusters <http://purl.org/nidash/nidm#NIDM_0000111>
+    prefix nidm_pValue <http://purl.org/nidash/nidm#NIDM_0000114>
+    prefix nidm_hasClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000098>
+    prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
+    prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
+
+    agent(niiri:7283130bdaae614053b66a993e6bed87,
+        [prov:type = 'neurolex_SPM:',
+        prov:type = 'prov:SoftwareAgent',
+        prov:label = "SPM" %% xsd:string,
+        nidm_softwareVersion: = "12.6470" %% xsd:string])
+    entity(niiri:0639cddb4b02210cdc4db993b0fc3874,
+        [prov:type = 'nidm_CoordinateSpace:',
+        prov:label = "Coordinate space 1" %% xsd:string,
+        nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
+        nidm_voxelUnits: = "[\"mm\", \"mm\", \"mm\"]" %% xsd:string,
+        nidm_voxelSize: = "[2, 2, 2]" %% xsd:string,
+        nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
+        nidm_numberOfDimensions: = "3" %% xsd:int,
+        nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
+    entity(niiri:7c6f7eb8aee640b6c0c51daba9b1ef03,
+        [prov:type = 'prov:Collection',
+        prov:type = 'nidm_DataScaling:',
+        prov:label = "Data" %% xsd:string,
+        nidm_grandMeanScaling: = "true" %% xsd:boolean,
+        nidm_targetIntensity: = "100" %% xsd:float])
+    entity(niiri:52daeace90e362ef7487f294bf147d54,
+        [prov:type = 'spm_DCTDriftModel:',
+        prov:label = "SPM's DCT Drift Model",
+        spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
+    entity(niiri:941e9bbf9c32fd5d3adefb829c4faf73,
+        [prov:type = 'nidm_DesignMatrix:',
+        prov:location = "DesignMatrix.csv" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.csv" %% xsd:string,
+        dct:format = "text/csv" %% xsd:string,
+        dc:description = 'niiri:78be9fd9ec65c96167e098000f81fb4f',
+        prov:label = "Design Matrix" %% xsd:string,
+        nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
+        nidm_hasDriftModel: = 'niiri:52daeace90e362ef7487f294bf147d54',
+        nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
+    entity(niiri:78be9fd9ec65c96167e098000f81fb4f,
+        [prov:type = 'dctype:Image',
+        prov:location = "DesignMatrix.png" %% xsd:anyURI,
+        nfo:fileName = "DesignMatrix.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    entity(niiri:bce50bde3a0b50f9b261367175337634,
+        [prov:type = 'nidm_ErrorModel:',
+        nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
+        nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
+        nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
+        nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
+        nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
+    activity(niiri:6e7bddf230024f1964840b0266c76020,
+        [prov:type = 'nidm_ModelParametersEstimation:',
+        prov:label = "Model parameters estimation",
+        nidm_withEstimationMethod: = 'stato_GLS:'])
+    wasAssociatedWith(niiri:6e7bddf230024f1964840b0266c76020, niiri:7283130bdaae614053b66a993e6bed87, -)
+    used(niiri:6e7bddf230024f1964840b0266c76020, niiri:941e9bbf9c32fd5d3adefb829c4faf73, -)
+    used(niiri:6e7bddf230024f1964840b0266c76020, niiri:7c6f7eb8aee640b6c0c51daba9b1ef03, -)
+    used(niiri:6e7bddf230024f1964840b0266c76020, niiri:bce50bde3a0b50f9b261367175337634, -)
+    entity(niiri:0c1e97eda14902ae1fa46b66fa317472,
+        [prov:type = 'nidm_MaskMap:',
+        prov:location = "Mask.nii.gz" %% xsd:anyURI,
+        nidm_isUserDefined: = "false" %% xsd:boolean,
+        nfo:fileName = "Mask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Mask" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    entity(niiri:753e5f49599ebe54312a7accd2ab3d02,
+        [prov:type = 'nidm_MaskMap:',
+        nfo:fileName = "mask.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
+    wasDerivedFrom(niiri:0c1e97eda14902ae1fa46b66fa317472, niiri:753e5f49599ebe54312a7accd2ab3d02, -, -, -)
+    wasGeneratedBy(niiri:0c1e97eda14902ae1fa46b66fa317472, niiri:6e7bddf230024f1964840b0266c76020, -)
+    entity(niiri:4e691a10b1fc379276ded79577f2f6a0,
+        [prov:type = 'nidm_GrandMeanMap:',
+        prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Grand Mean Map" %% xsd:string,
+        nidm_maskedMedian: = "121.744659423828" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
+    wasGeneratedBy(niiri:4e691a10b1fc379276ded79577f2f6a0, niiri:6e7bddf230024f1964840b0266c76020, -)
+    entity(niiri:8f4893f367edf8f3923730a046a36bda,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 1" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874'])
+    entity(niiri:33d8598e2f3352fb20eff97fc152c90f,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
+    wasDerivedFrom(niiri:8f4893f367edf8f3923730a046a36bda, niiri:33d8598e2f3352fb20eff97fc152c90f, -, -, -)
+    wasGeneratedBy(niiri:8f4893f367edf8f3923730a046a36bda, niiri:6e7bddf230024f1964840b0266c76020, -)
+    entity(niiri:d397c8020fa4e33527facc866b1a20a7,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 2" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874'])
+    entity(niiri:1958601fc5c3f56cb310fc0baabed2be,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0002.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
+    wasDerivedFrom(niiri:d397c8020fa4e33527facc866b1a20a7, niiri:1958601fc5c3f56cb310fc0baabed2be, -, -, -)
+    wasGeneratedBy(niiri:d397c8020fa4e33527facc866b1a20a7, niiri:6e7bddf230024f1964840b0266c76020, -)
+    entity(niiri:32132c18bf4103567994106215344329,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        prov:label = "Beta Map 3" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874'])
+    entity(niiri:b5594e8e07cd6eb1e4012d4ee6a28fea,
+        [prov:type = 'nidm_ParameterEstimateMap:',
+        nfo:fileName = "beta_0003.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
+    wasDerivedFrom(niiri:32132c18bf4103567994106215344329, niiri:b5594e8e07cd6eb1e4012d4ee6a28fea, -, -, -)
+    wasGeneratedBy(niiri:32132c18bf4103567994106215344329, niiri:6e7bddf230024f1964840b0266c76020, -)
+    entity(niiri:22ad7ded0ac1d711e8a0487cfc836029,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Residual Mean Squares Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
+    entity(niiri:8a1a9df782badc0bbaca933d0ac3571f,
+        [prov:type = 'nidm_ResidualMeanSquaresMap:',
+        nfo:fileName = "ResMS.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
+    wasDerivedFrom(niiri:22ad7ded0ac1d711e8a0487cfc836029, niiri:8a1a9df782badc0bbaca933d0ac3571f, -, -, -)
+    wasGeneratedBy(niiri:22ad7ded0ac1d711e8a0487cfc836029, niiri:6e7bddf230024f1964840b0266c76020, -)
+    entity(niiri:099512568a9246b3c907bed89316bb8e,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Resels per Voxel Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
+    entity(niiri:8840e7e42f24e4dae1b15d56a8415d4e,
+        [prov:type = 'nidm_ReselsPerVoxelMap:',
+        nfo:fileName = "RPV.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
+    wasDerivedFrom(niiri:099512568a9246b3c907bed89316bb8e, niiri:8840e7e42f24e4dae1b15d56a8415d4e, -, -, -)
+    wasGeneratedBy(niiri:099512568a9246b3c907bed89316bb8e, niiri:6e7bddf230024f1964840b0266c76020, -)
+    entity(niiri:fc096c306109a662a505b528a003df77,
+        [prov:type = 'stato_ContrastWeightMatrix:',
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        prov:label = "Contrast: pos vs neg" %% xsd:string,
+        prov:value = "[1, -1, 0]" %% xsd:string])
+    activity(niiri:2831de2cddf960bc84248af0cd98e7e7,
+        [prov:type = 'nidm_ContrastEstimation:',
+        prov:label = "Contrast estimation"])
+    wasAssociatedWith(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:7283130bdaae614053b66a993e6bed87, -)
+    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:0c1e97eda14902ae1fa46b66fa317472, -)
+    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:22ad7ded0ac1d711e8a0487cfc836029, -)
+    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:941e9bbf9c32fd5d3adefb829c4faf73, -)
+    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:fc096c306109a662a505b528a003df77, -)
+    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:8f4893f367edf8f3923730a046a36bda, -)
+    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:d397c8020fa4e33527facc866b1a20a7, -)
+    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:32132c18bf4103567994106215344329, -)
+    entity(niiri:ca7d326edc041d49f3a8bd6888a2ad5e,
+        [prov:type = 'nidm_StatisticMap:',
+        prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Statistic Map: pos vs neg" %% xsd:string,
+        nidm_statisticType: = 'stato_TStatistic:',
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
+        nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
+    entity(niiri:a4f6e768a620095f32601b599dfcf4ee,
+        [prov:type = 'nidm_StatisticMap:',
+        nfo:fileName = "spmT_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
+    wasDerivedFrom(niiri:ca7d326edc041d49f3a8bd6888a2ad5e, niiri:a4f6e768a620095f32601b599dfcf4ee, -, -, -)
+    wasGeneratedBy(niiri:ca7d326edc041d49f3a8bd6888a2ad5e, niiri:2831de2cddf960bc84248af0cd98e7e7, -)
+    entity(niiri:b66377f4e2a18ee1d08045e6ec196028,
+        [prov:type = 'nidm_ContrastMap:',
+        prov:location = "Contrast.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "Contrast.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Map: pos vs neg" %% xsd:string,
+        nidm_contrastName: = "pos vs neg" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
+    entity(niiri:d7555057f51e0761d5b6357557846537,
+        [prov:type = 'nidm_ContrastMap:',
+        nfo:fileName = "con_0001.nii" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
+    wasDerivedFrom(niiri:b66377f4e2a18ee1d08045e6ec196028, niiri:d7555057f51e0761d5b6357557846537, -, -, -)
+    wasGeneratedBy(niiri:b66377f4e2a18ee1d08045e6ec196028, niiri:2831de2cddf960bc84248af0cd98e7e7, -)
+    entity(niiri:616d5161e30226dc4d87d86fc9f12ca6,
+        [prov:type = 'nidm_ContrastStandardErrorMap:',
+        prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Contrast Standard Error Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
+    wasGeneratedBy(niiri:616d5161e30226dc4d87d86fc9f12ca6, niiri:2831de2cddf960bc84248af0cd98e7e7, -)
+    entity(niiri:e9c625452832b88935d6c847b635a4c2,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Height Threshold: T=4.000000)" %% xsd:string,
+        prov:value = "4" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:3a225a61c68b3b7a2132f5439a3b7806',
+        nidm_equivalentThreshold: = 'niiri:0665adcee230e9c3db98038317ef01eb'])
+    entity(niiri:3a225a61c68b3b7a2132f5439a3b7806,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "4.3562342453618e-05" %% xsd:float])
+    entity(niiri:0665adcee230e9c3db98038317ef01eb,
+        [prov:type = 'nidm_HeightThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Height Threshold" %% xsd:string,
+        prov:value = "0.9111141889082" %% xsd:float])
+    entity(niiri:7a95c241ad8d0f6c41092f5156ae91fd,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_Statistic:',
+        prov:label = "Extent Threshold: k>=0" %% xsd:string,
+        nidm_clusterSizeInVoxels: = "0" %% xsd:int,
+        nidm_clusterSizeInResels: = "0" %% xsd:float,
+        nidm_equivalentThreshold: = 'niiri:38340c0af4aaac49ecd8bbdeb4c35fdc',
+        nidm_equivalentThreshold: = 'niiri:2ebf8fa32230a6dd48d721260aa95b14'])
+    entity(niiri:38340c0af4aaac49ecd8bbdeb4c35fdc,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'obo_pValueFWER:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:2ebf8fa32230a6dd48d721260aa95b14,
+        [prov:type = 'nidm_ExtentThreshold:',
+        prov:type = 'nidm_PValueUncorrected:',
+        prov:label = "Extent Threshold" %% xsd:string,
+        prov:value = "1" %% xsd:float])
+    entity(niiri:d6573c073b0fd3e892d6d5c2840ea0ff,
+        [prov:type = 'nidm_PeakDefinitionCriteria:',
+        prov:label = "Peak Definition Criteria" %% xsd:string,
+        nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
+        nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
+    entity(niiri:06ba5171d4001c7750aea6e98e50c2fa,
+        [prov:type = 'nidm_ClusterDefinitionCriteria:',
+        prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
+        nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
+    activity(niiri:a6cfbf83b43a688c8c63f74a89dc20ae,
+        [prov:type = 'nidm_Inference:',
+        nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
+        prov:label = "Inference"])
+    wasAssociatedWith(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:7283130bdaae614053b66a993e6bed87, -)
+    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:e9c625452832b88935d6c847b635a4c2, -)
+    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:7a95c241ad8d0f6c41092f5156ae91fd, -)
+    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:ca7d326edc041d49f3a8bd6888a2ad5e, -)
+    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:099512568a9246b3c907bed89316bb8e, -)
+    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:0c1e97eda14902ae1fa46b66fa317472, -)
+    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:d6573c073b0fd3e892d6d5c2840ea0ff, -)
+    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:06ba5171d4001c7750aea6e98e50c2fa, -)
+    entity(niiri:138f6783f353483960178c8bf70ea952,
+        [prov:type = 'nidm_SearchSpaceMaskMap:',
+        prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Search Space Mask Map" %% xsd:string,
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
+        nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
+        nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
+        nidm_searchVolumeInResels: = "2650.12011223711" %% xsd:float,
+        spm_searchVolumeReselsGeometry: = "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]" %% xsd:string,
+        nidm_noiseFWHMInVoxels: = "[4.01704921884936, 4.07618247398105, 4.38831339907177]" %% xsd:string,
+        nidm_noiseFWHMInUnits: = "[8.03409843769872, 8.1523649479621, 8.77662679814353]" %% xsd:string,
+        nidm_randomFieldStationarity: = "true" %% xsd:boolean,
+        nidm_expectedNumberOfVoxelsPerCluster: = "3.88370316592276" %% xsd:float,
+        nidm_expectedNumberOfClusters: = "2.42040275446714" %% xsd:float,
+        nidm_heightCriticalThresholdFWE05: = "5.05094049746367" %% xsd:float,
+        nidm_heightCriticalThresholdFDR05: = "Inf" %% xsd:float,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
+        spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
+        crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
+    wasGeneratedBy(niiri:138f6783f353483960178c8bf70ea952, niiri:a6cfbf83b43a688c8c63f74a89dc20ae, -)
+    entity(niiri:982c4f0c64cd8daea713a5bb9bc8eb76,
+        [prov:type = 'nidm_ExcursionSetMap:',
+        prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string,
+        prov:label = "Excursion Set Map" %% xsd:string,
+        nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
+        nidm_pValue: = "NaN" %% xsd:float,
+        nidm_hasClusterLabelsMap: = 'niiri:535611df3c8befd941831f7da314cec4',
+        nidm_hasMaximumIntensityProjection: = 'niiri:53c77f378e7ddf8eefee3f6f3d0bc941',
+        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
+    entity(niiri:535611df3c8befd941831f7da314cec4,
+        [prov:type = 'nidm_ClusterLabelsMap:',
+        prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
+        nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
+        dct:format = "image/nifti" %% xsd:string])
+    entity(niiri:53c77f378e7ddf8eefee3f6f3d0bc941,
+        [prov:type = 'dctype:Image',
+        prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
+        nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
+        dct:format = "image/png" %% xsd:string])
+    wasGeneratedBy(niiri:982c4f0c64cd8daea713a5bb9bc8eb76, niiri:a6cfbf83b43a688c8c63f74a89dc20ae, -)
+  endBundle
+endDocument

--- a/spmexport/ex_spm_voxelwise_t=4/nidm.provn
+++ b/spmexport/ex_spm_voxelwise_t=4/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:806349bd3ad6f46e7d9750491347fd39,
+  entity(niiri:4c97df89fdb900953287b6ee2d0bf4e4,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:ce2087481eef3055e103b0093848e983,
+  agent(niiri:a08cffbf5401e33768c050f8f5828a54,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:35b73388a8bf62cc251e81b0ce66bca1,
+  activity(niiri:c6b11e6713085858dfaf6132741ca114,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:35b73388a8bf62cc251e81b0ce66bca1, niiri:ce2087481eef3055e103b0093848e983, -)
-  wasGeneratedBy(niiri:806349bd3ad6f46e7d9750491347fd39, niiri:35b73388a8bf62cc251e81b0ce66bca1, 2016-01-11T10:12:28)
-  bundle niiri:806349bd3ad6f46e7d9750491347fd39
+  wasAssociatedWith(niiri:c6b11e6713085858dfaf6132741ca114, niiri:a08cffbf5401e33768c050f8f5828a54, -)
+  wasGeneratedBy(niiri:4c97df89fdb900953287b6ee2d0bf4e4, niiri:c6b11e6713085858dfaf6132741ca114, 2016-01-11T10:34:44)
+  bundle niiri:4c97df89fdb900953287b6ee2d0bf4e4
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:7283130bdaae614053b66a993e6bed87,
+    agent(niiri:9e85c3c113468fdd7321a08d6f0433ec,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:0639cddb4b02210cdc4db993b0fc3874,
+    entity(niiri:c66ef8aa5c4f00b5901391884536d9ff,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:7c6f7eb8aee640b6c0c51daba9b1ef03,
+    entity(niiri:d8fbe9edccebac2906e7cdfaf1e5194e,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:52daeace90e362ef7487f294bf147d54,
+    entity(niiri:a87f74ea074c2617eedbe51685bf8149,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:941e9bbf9c32fd5d3adefb829c4faf73,
+    entity(niiri:b3af73299b71e1b964b104cdf1c99178,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:78be9fd9ec65c96167e098000f81fb4f',
+        dc:description = 'niiri:aa5324eb378411a1f12ca9e8406dba06',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:52daeace90e362ef7487f294bf147d54',
+        nidm_hasDriftModel: = 'niiri:a87f74ea074c2617eedbe51685bf8149',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:78be9fd9ec65c96167e098000f81fb4f,
+    entity(niiri:aa5324eb378411a1f12ca9e8406dba06,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:bce50bde3a0b50f9b261367175337634,
+    entity(niiri:f883eddf86d66045f15be451437fd505,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:6e7bddf230024f1964840b0266c76020,
+    activity(niiri:28550e8b753c726791498099b035ca93,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:6e7bddf230024f1964840b0266c76020, niiri:7283130bdaae614053b66a993e6bed87, -)
-    used(niiri:6e7bddf230024f1964840b0266c76020, niiri:941e9bbf9c32fd5d3adefb829c4faf73, -)
-    used(niiri:6e7bddf230024f1964840b0266c76020, niiri:7c6f7eb8aee640b6c0c51daba9b1ef03, -)
-    used(niiri:6e7bddf230024f1964840b0266c76020, niiri:bce50bde3a0b50f9b261367175337634, -)
-    entity(niiri:0c1e97eda14902ae1fa46b66fa317472,
+    wasAssociatedWith(niiri:28550e8b753c726791498099b035ca93, niiri:9e85c3c113468fdd7321a08d6f0433ec, -)
+    used(niiri:28550e8b753c726791498099b035ca93, niiri:b3af73299b71e1b964b104cdf1c99178, -)
+    used(niiri:28550e8b753c726791498099b035ca93, niiri:d8fbe9edccebac2906e7cdfaf1e5194e, -)
+    used(niiri:28550e8b753c726791498099b035ca93, niiri:f883eddf86d66045f15be451437fd505, -)
+    entity(niiri:aa1c29a1fdf1399681a37fc8a884c2be,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:753e5f49599ebe54312a7accd2ab3d02,
+    entity(niiri:cb009c63e178eb7513ff300b62921d8b,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:0c1e97eda14902ae1fa46b66fa317472, niiri:753e5f49599ebe54312a7accd2ab3d02, -, -, -)
-    wasGeneratedBy(niiri:0c1e97eda14902ae1fa46b66fa317472, niiri:6e7bddf230024f1964840b0266c76020, -)
-    entity(niiri:4e691a10b1fc379276ded79577f2f6a0,
+    wasDerivedFrom(niiri:aa1c29a1fdf1399681a37fc8a884c2be, niiri:cb009c63e178eb7513ff300b62921d8b, -, -, -)
+    wasGeneratedBy(niiri:aa1c29a1fdf1399681a37fc8a884c2be, niiri:28550e8b753c726791498099b035ca93, -)
+    entity(niiri:f36c9efa1d29cf2c16ece1999b83d27f,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:4e691a10b1fc379276ded79577f2f6a0, niiri:6e7bddf230024f1964840b0266c76020, -)
-    entity(niiri:8f4893f367edf8f3923730a046a36bda,
+    wasGeneratedBy(niiri:f36c9efa1d29cf2c16ece1999b83d27f, niiri:28550e8b753c726791498099b035ca93, -)
+    entity(niiri:72efa4876d285bc921fa2e1ff390e862,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874'])
-    entity(niiri:33d8598e2f3352fb20eff97fc152c90f,
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff'])
+    entity(niiri:41f7e8add27779cc7fca4d3a034d6569,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:8f4893f367edf8f3923730a046a36bda, niiri:33d8598e2f3352fb20eff97fc152c90f, -, -, -)
-    wasGeneratedBy(niiri:8f4893f367edf8f3923730a046a36bda, niiri:6e7bddf230024f1964840b0266c76020, -)
-    entity(niiri:d397c8020fa4e33527facc866b1a20a7,
+    wasDerivedFrom(niiri:72efa4876d285bc921fa2e1ff390e862, niiri:41f7e8add27779cc7fca4d3a034d6569, -, -, -)
+    wasGeneratedBy(niiri:72efa4876d285bc921fa2e1ff390e862, niiri:28550e8b753c726791498099b035ca93, -)
+    entity(niiri:2f916c52f15b207fcf0e53698b791216,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874'])
-    entity(niiri:1958601fc5c3f56cb310fc0baabed2be,
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff'])
+    entity(niiri:e3c84d1861d3c7c5eefadd6e2b9f2e5f,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:d397c8020fa4e33527facc866b1a20a7, niiri:1958601fc5c3f56cb310fc0baabed2be, -, -, -)
-    wasGeneratedBy(niiri:d397c8020fa4e33527facc866b1a20a7, niiri:6e7bddf230024f1964840b0266c76020, -)
-    entity(niiri:32132c18bf4103567994106215344329,
+    wasDerivedFrom(niiri:2f916c52f15b207fcf0e53698b791216, niiri:e3c84d1861d3c7c5eefadd6e2b9f2e5f, -, -, -)
+    wasGeneratedBy(niiri:2f916c52f15b207fcf0e53698b791216, niiri:28550e8b753c726791498099b035ca93, -)
+    entity(niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874'])
-    entity(niiri:b5594e8e07cd6eb1e4012d4ee6a28fea,
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff'])
+    entity(niiri:dcaea73602f05b036c9df143c0a7e200,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:32132c18bf4103567994106215344329, niiri:b5594e8e07cd6eb1e4012d4ee6a28fea, -, -, -)
-    wasGeneratedBy(niiri:32132c18bf4103567994106215344329, niiri:6e7bddf230024f1964840b0266c76020, -)
-    entity(niiri:22ad7ded0ac1d711e8a0487cfc836029,
+    wasDerivedFrom(niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d, niiri:dcaea73602f05b036c9df143c0a7e200, -, -, -)
+    wasGeneratedBy(niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d, niiri:28550e8b753c726791498099b035ca93, -)
+    entity(niiri:06e4f88e786fe09809dfe30420188f25,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:8a1a9df782badc0bbaca933d0ac3571f,
+    entity(niiri:00fdfd7ba3a1372b2fbd17a20aa19445,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:22ad7ded0ac1d711e8a0487cfc836029, niiri:8a1a9df782badc0bbaca933d0ac3571f, -, -, -)
-    wasGeneratedBy(niiri:22ad7ded0ac1d711e8a0487cfc836029, niiri:6e7bddf230024f1964840b0266c76020, -)
-    entity(niiri:099512568a9246b3c907bed89316bb8e,
+    wasDerivedFrom(niiri:06e4f88e786fe09809dfe30420188f25, niiri:00fdfd7ba3a1372b2fbd17a20aa19445, -, -, -)
+    wasGeneratedBy(niiri:06e4f88e786fe09809dfe30420188f25, niiri:28550e8b753c726791498099b035ca93, -)
+    entity(niiri:afb00741e29f2942b8bc70b0e38a847b,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:8840e7e42f24e4dae1b15d56a8415d4e,
+    entity(niiri:466df67e27037c9807478d993dcc8246,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:099512568a9246b3c907bed89316bb8e, niiri:8840e7e42f24e4dae1b15d56a8415d4e, -, -, -)
-    wasGeneratedBy(niiri:099512568a9246b3c907bed89316bb8e, niiri:6e7bddf230024f1964840b0266c76020, -)
-    entity(niiri:fc096c306109a662a505b528a003df77,
+    wasDerivedFrom(niiri:afb00741e29f2942b8bc70b0e38a847b, niiri:466df67e27037c9807478d993dcc8246, -, -, -)
+    wasGeneratedBy(niiri:afb00741e29f2942b8bc70b0e38a847b, niiri:28550e8b753c726791498099b035ca93, -)
+    entity(niiri:c2a5865b1a64ede064a33413b821a1fe,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:2831de2cddf960bc84248af0cd98e7e7,
+    activity(niiri:f6527b3ae676ec51392646f86918478a,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:7283130bdaae614053b66a993e6bed87, -)
-    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:0c1e97eda14902ae1fa46b66fa317472, -)
-    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:22ad7ded0ac1d711e8a0487cfc836029, -)
-    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:941e9bbf9c32fd5d3adefb829c4faf73, -)
-    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:fc096c306109a662a505b528a003df77, -)
-    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:8f4893f367edf8f3923730a046a36bda, -)
-    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:d397c8020fa4e33527facc866b1a20a7, -)
-    used(niiri:2831de2cddf960bc84248af0cd98e7e7, niiri:32132c18bf4103567994106215344329, -)
-    entity(niiri:ca7d326edc041d49f3a8bd6888a2ad5e,
+    wasAssociatedWith(niiri:f6527b3ae676ec51392646f86918478a, niiri:9e85c3c113468fdd7321a08d6f0433ec, -)
+    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:aa1c29a1fdf1399681a37fc8a884c2be, -)
+    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:06e4f88e786fe09809dfe30420188f25, -)
+    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:b3af73299b71e1b964b104cdf1c99178, -)
+    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:c2a5865b1a64ede064a33413b821a1fe, -)
+    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:72efa4876d285bc921fa2e1ff390e862, -)
+    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:2f916c52f15b207fcf0e53698b791216, -)
+    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d, -)
+    entity(niiri:32a98391fb64e3b4c085771c0a49fc6f,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:a4f6e768a620095f32601b599dfcf4ee,
+    entity(niiri:ce2d2b79f29ca64888485463e431f288,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:ca7d326edc041d49f3a8bd6888a2ad5e, niiri:a4f6e768a620095f32601b599dfcf4ee, -, -, -)
-    wasGeneratedBy(niiri:ca7d326edc041d49f3a8bd6888a2ad5e, niiri:2831de2cddf960bc84248af0cd98e7e7, -)
-    entity(niiri:b66377f4e2a18ee1d08045e6ec196028,
+    wasDerivedFrom(niiri:32a98391fb64e3b4c085771c0a49fc6f, niiri:ce2d2b79f29ca64888485463e431f288, -, -, -)
+    wasGeneratedBy(niiri:32a98391fb64e3b4c085771c0a49fc6f, niiri:f6527b3ae676ec51392646f86918478a, -)
+    entity(niiri:d52a011528706ad5da1bcebab89ec4b2,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:d7555057f51e0761d5b6357557846537,
+    entity(niiri:24624d7cd6f93e40818435d76154f63c,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:b66377f4e2a18ee1d08045e6ec196028, niiri:d7555057f51e0761d5b6357557846537, -, -, -)
-    wasGeneratedBy(niiri:b66377f4e2a18ee1d08045e6ec196028, niiri:2831de2cddf960bc84248af0cd98e7e7, -)
-    entity(niiri:616d5161e30226dc4d87d86fc9f12ca6,
+    wasDerivedFrom(niiri:d52a011528706ad5da1bcebab89ec4b2, niiri:24624d7cd6f93e40818435d76154f63c, -, -, -)
+    wasGeneratedBy(niiri:d52a011528706ad5da1bcebab89ec4b2, niiri:f6527b3ae676ec51392646f86918478a, -)
+    entity(niiri:05b5e98aee20aefdc7de6d5ada900f65,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:616d5161e30226dc4d87d86fc9f12ca6, niiri:2831de2cddf960bc84248af0cd98e7e7, -)
-    entity(niiri:e9c625452832b88935d6c847b635a4c2,
+    wasGeneratedBy(niiri:05b5e98aee20aefdc7de6d5ada900f65, niiri:f6527b3ae676ec51392646f86918478a, -)
+    entity(niiri:724f6938b9d3c678ce89374d96cd8417,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold: T=4.000000)" %% xsd:string,
         prov:value = "4" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:3a225a61c68b3b7a2132f5439a3b7806',
-        nidm_equivalentThreshold: = 'niiri:0665adcee230e9c3db98038317ef01eb'])
-    entity(niiri:3a225a61c68b3b7a2132f5439a3b7806,
+        nidm_equivalentThreshold: = 'niiri:ac11b497f38fbd2be58f2597ae00ff63',
+        nidm_equivalentThreshold: = 'niiri:1f09035a8e827d457deb1490af42173f'])
+    entity(niiri:ac11b497f38fbd2be58f2597ae00ff63,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.3562342453618e-05" %% xsd:float])
-    entity(niiri:0665adcee230e9c3db98038317ef01eb,
+    entity(niiri:1f09035a8e827d457deb1490af42173f,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.9111141889082" %% xsd:float])
-    entity(niiri:7a95c241ad8d0f6c41092f5156ae91fd,
+    entity(niiri:aa54459b725ec30bcb6e20e9c9ab6de2,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:38340c0af4aaac49ecd8bbdeb4c35fdc',
-        nidm_equivalentThreshold: = 'niiri:2ebf8fa32230a6dd48d721260aa95b14'])
-    entity(niiri:38340c0af4aaac49ecd8bbdeb4c35fdc,
+        nidm_equivalentThreshold: = 'niiri:f27f8d84e42536914e0cd64a4694253a',
+        nidm_equivalentThreshold: = 'niiri:d90df515ec31dcc930a7f6742bba0a9d'])
+    entity(niiri:f27f8d84e42536914e0cd64a4694253a,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:2ebf8fa32230a6dd48d721260aa95b14,
+    entity(niiri:d90df515ec31dcc930a7f6742bba0a9d,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:d6573c073b0fd3e892d6d5c2840ea0ff,
+    entity(niiri:506b45d4a4ab88895094698e0d7c6319,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:06ba5171d4001c7750aea6e98e50c2fa,
+    entity(niiri:9c731ff8e20a1e8750a1f8ec89560ff1,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:a6cfbf83b43a688c8c63f74a89dc20ae,
+    activity(niiri:c087cec5deed4a6989758e633c54ef25,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:7283130bdaae614053b66a993e6bed87, -)
-    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:e9c625452832b88935d6c847b635a4c2, -)
-    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:7a95c241ad8d0f6c41092f5156ae91fd, -)
-    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:ca7d326edc041d49f3a8bd6888a2ad5e, -)
-    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:099512568a9246b3c907bed89316bb8e, -)
-    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:0c1e97eda14902ae1fa46b66fa317472, -)
-    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:d6573c073b0fd3e892d6d5c2840ea0ff, -)
-    used(niiri:a6cfbf83b43a688c8c63f74a89dc20ae, niiri:06ba5171d4001c7750aea6e98e50c2fa, -)
-    entity(niiri:138f6783f353483960178c8bf70ea952,
+    wasAssociatedWith(niiri:c087cec5deed4a6989758e633c54ef25, niiri:9e85c3c113468fdd7321a08d6f0433ec, -)
+    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:724f6938b9d3c678ce89374d96cd8417, -)
+    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:aa54459b725ec30bcb6e20e9c9ab6de2, -)
+    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:32a98391fb64e3b4c085771c0a49fc6f, -)
+    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:afb00741e29f2942b8bc70b0e38a847b, -)
+    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:aa1c29a1fdf1399681a37fc8a884c2be, -)
+    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:506b45d4a4ab88895094698e0d7c6319, -)
+    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:9c731ff8e20a1e8750a1f8ec89560ff1, -)
+    entity(niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:138f6783f353483960178c8bf70ea952, niiri:a6cfbf83b43a688c8c63f74a89dc20ae, -)
-    entity(niiri:982c4f0c64cd8daea713a5bb9bc8eb76,
+    wasGeneratedBy(niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b, niiri:c087cec5deed4a6989758e633c54ef25, -)
+    entity(niiri:6c49fe9342e735959c7bde778b1e58c6,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:535611df3c8befd941831f7da314cec4',
-        nidm_hasMaximumIntensityProjection: = 'niiri:53c77f378e7ddf8eefee3f6f3d0bc941',
-        nidm_inCoordinateSpace: = 'niiri:0639cddb4b02210cdc4db993b0fc3874',
+        nidm_hasClusterLabelsMap: = 'niiri:0d816fc1c460889e384228fa288a25f3',
+        nidm_hasMaximumIntensityProjection: = 'niiri:5b3985681eae5f6d6d353d227056e5fd',
+        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:535611df3c8befd941831f7da314cec4,
+    entity(niiri:0d816fc1c460889e384228fa288a25f3,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:53c77f378e7ddf8eefee3f6f3d0bc941,
+    entity(niiri:5b3985681eae5f6d6d353d227056e5fd,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:982c4f0c64cd8daea713a5bb9bc8eb76, niiri:a6cfbf83b43a688c8c63f74a89dc20ae, -)
+    wasGeneratedBy(niiri:6c49fe9342e735959c7bde778b1e58c6, niiri:c087cec5deed4a6989758e633c54ef25, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_voxelwise_t=4/nidm.provn
+++ b/spmexport/ex_spm_voxelwise_t=4/nidm.provn
@@ -15,22 +15,22 @@ document
   prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
   prefix nidm_NIDMResultsExport <http://purl.org/nidash/nidm#NIDM_0000166>
 
-  entity(niiri:4c97df89fdb900953287b6ee2d0bf4e4,
+  entity(niiri:4440f225ae7d4df86d75399528aed662,
     [prov:type = 'prov:Bundle',
     prov:type = 'nidm_NIDMResults:',
     prov:label = "NIDM-Results",
     nidm_version: = "1.2.0" %% xsd:string])
-  agent(niiri:a08cffbf5401e33768c050f8f5828a54,
+  agent(niiri:85ff3a8f8b5d4deb76f786ea5aa37f75,
     [prov:type = 'nidm_spm_results_nidm:',
     prov:type = 'prov:SoftwareAgent',
     prov:label = "spm_results_nidm" %% xsd:string,
     nidm_softwareVersion: = "12.6646" %% xsd:string])
-  activity(niiri:c6b11e6713085858dfaf6132741ca114,
+  activity(niiri:bed811d0155bdff84fa8cedbad37bf32,
     [prov:type = 'nidm_NIDMResultsExport:',
     prov:label = "NIDM-Results export"])
-  wasAssociatedWith(niiri:c6b11e6713085858dfaf6132741ca114, niiri:a08cffbf5401e33768c050f8f5828a54, -)
-  wasGeneratedBy(niiri:4c97df89fdb900953287b6ee2d0bf4e4, niiri:c6b11e6713085858dfaf6132741ca114, 2016-01-11T10:34:44)
-  bundle niiri:4c97df89fdb900953287b6ee2d0bf4e4
+  wasAssociatedWith(niiri:bed811d0155bdff84fa8cedbad37bf32, niiri:85ff3a8f8b5d4deb76f786ea5aa37f75, -)
+  wasGeneratedBy(niiri:4440f225ae7d4df86d75399528aed662, niiri:bed811d0155bdff84fa8cedbad37bf32, 2016-01-11T10:45:28)
+  bundle niiri:4440f225ae7d4df86d75399528aed662
     prefix nidm_softwareVersion <http://purl.org/nidash/nidm#NIDM_0000122>
     prefix nidm_CoordinateSpace <http://purl.org/nidash/nidm#NIDM_0000016>
     prefix nidm_voxelToWorldMapping <http://purl.org/nidash/nidm#NIDM_0000132>
@@ -119,12 +119,12 @@ document
     prefix nidm_hasMaximumIntensityProjection <http://purl.org/nidash/nidm#NIDM_0000138>
     prefix nidm_ClusterLabelsMap <http://purl.org/nidash/nidm#NIDM_0000008>
 
-    agent(niiri:9e85c3c113468fdd7321a08d6f0433ec,
+    agent(niiri:d18ee3891edc3395269c1f9d3c7a9a1f,
         [prov:type = 'neurolex_SPM:',
         prov:type = 'prov:SoftwareAgent',
         prov:label = "SPM" %% xsd:string,
         nidm_softwareVersion: = "12.6470" %% xsd:string])
-    entity(niiri:c66ef8aa5c4f00b5901391884536d9ff,
+    entity(niiri:27db8bb99e7348823bfb45e6af669a61,
         [prov:type = 'nidm_CoordinateSpace:',
         prov:label = "Coordinate space 1" %% xsd:string,
         nidm_voxelToWorldMapping: = "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]" %% xsd:string,
@@ -133,153 +133,153 @@ document
         nidm_inWorldCoordinateSystem: = 'nidm_MNICoordinateSystem:',
         nidm_numberOfDimensions: = "3" %% xsd:int,
         nidm_dimensionsInVoxels: = "[79,95,79]" %% xsd:string])
-    entity(niiri:d8fbe9edccebac2906e7cdfaf1e5194e,
+    entity(niiri:ae699260d565def6b4bb98f1f770d070,
         [prov:type = 'prov:Collection',
         prov:type = 'nidm_DataScaling:',
         prov:label = "Data" %% xsd:string,
         nidm_grandMeanScaling: = "true" %% xsd:boolean,
         nidm_targetIntensity: = "100" %% xsd:float])
-    entity(niiri:a87f74ea074c2617eedbe51685bf8149,
+    entity(niiri:878b3fc8fd8f74e1aa28390a79f7f730,
         [prov:type = 'spm_DCTDriftModel:',
         prov:label = "SPM's DCT Drift Model",
         spm_SPMsDriftCutoffPeriod: = "128" %% xsd:float])
-    entity(niiri:b3af73299b71e1b964b104cdf1c99178,
+    entity(niiri:fb2347b3655e57a809ca5cd5c53cf87a,
         [prov:type = 'nidm_DesignMatrix:',
         prov:location = "DesignMatrix.csv" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.csv" %% xsd:string,
         dct:format = "text/csv" %% xsd:string,
-        dc:description = 'niiri:aa5324eb378411a1f12ca9e8406dba06',
+        dc:description = 'niiri:0b71661161900ea8c8932e0c1a455bdc',
         prov:label = "Design Matrix" %% xsd:string,
         nidm_regressorNames: = "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]" %% xsd:string,
-        nidm_hasDriftModel: = 'niiri:a87f74ea074c2617eedbe51685bf8149',
+        nidm_hasDriftModel: = 'niiri:878b3fc8fd8f74e1aa28390a79f7f730',
         nidm_hasHRFBasis: = 'spm_SPMsCanonicalHRF:'])
-    entity(niiri:aa5324eb378411a1f12ca9e8406dba06,
+    entity(niiri:0b71661161900ea8c8932e0c1a455bdc,
         [prov:type = 'dctype:Image',
         prov:location = "DesignMatrix.png" %% xsd:anyURI,
         nfo:fileName = "DesignMatrix.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    entity(niiri:f883eddf86d66045f15be451437fd505,
+    entity(niiri:295ad00f3b409060203ec15272073dbb,
         [prov:type = 'nidm_ErrorModel:',
         nidm_hasErrorDistribution: = 'stato_GaussianDistribution:',
         nidm_hasErrorDependence: = 'stato_ToeplitzCovarianceStructure:',
         nidm_dependenceMapWiseDependence: = 'nidm_ConstantParameter:',
         nidm_errorVarianceHomogeneous: = "true" %% xsd:boolean,
         nidm_varianceMapWiseDependence: = 'nidm_IndependentParameter:'])
-    activity(niiri:28550e8b753c726791498099b035ca93,
+    activity(niiri:baf57504feedb2bf8efebb366a0e02f0,
         [prov:type = 'nidm_ModelParametersEstimation:',
         prov:label = "Model parameters estimation",
         nidm_withEstimationMethod: = 'stato_GLS:'])
-    wasAssociatedWith(niiri:28550e8b753c726791498099b035ca93, niiri:9e85c3c113468fdd7321a08d6f0433ec, -)
-    used(niiri:28550e8b753c726791498099b035ca93, niiri:b3af73299b71e1b964b104cdf1c99178, -)
-    used(niiri:28550e8b753c726791498099b035ca93, niiri:d8fbe9edccebac2906e7cdfaf1e5194e, -)
-    used(niiri:28550e8b753c726791498099b035ca93, niiri:f883eddf86d66045f15be451437fd505, -)
-    entity(niiri:aa1c29a1fdf1399681a37fc8a884c2be,
+    wasAssociatedWith(niiri:baf57504feedb2bf8efebb366a0e02f0, niiri:d18ee3891edc3395269c1f9d3c7a9a1f, -)
+    used(niiri:baf57504feedb2bf8efebb366a0e02f0, niiri:fb2347b3655e57a809ca5cd5c53cf87a, -)
+    used(niiri:baf57504feedb2bf8efebb366a0e02f0, niiri:ae699260d565def6b4bb98f1f770d070, -)
+    used(niiri:baf57504feedb2bf8efebb366a0e02f0, niiri:295ad00f3b409060203ec15272073dbb, -)
+    entity(niiri:8b36d7383291227115d2a92ed52e1732,
         [prov:type = 'nidm_MaskMap:',
         prov:location = "Mask.nii.gz" %% xsd:anyURI,
         nidm_isUserDefined: = "false" %% xsd:boolean,
         nfo:fileName = "Mask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Mask" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    entity(niiri:cb009c63e178eb7513ff300b62921d8b,
+    entity(niiri:bb84044832b3e51c5b7474bd540f65fc,
         [prov:type = 'nidm_MaskMap:',
         nfo:fileName = "mask.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5" %% xsd:string])
-    wasDerivedFrom(niiri:aa1c29a1fdf1399681a37fc8a884c2be, niiri:cb009c63e178eb7513ff300b62921d8b, -, -, -)
-    wasGeneratedBy(niiri:aa1c29a1fdf1399681a37fc8a884c2be, niiri:28550e8b753c726791498099b035ca93, -)
-    entity(niiri:f36c9efa1d29cf2c16ece1999b83d27f,
+    wasDerivedFrom(niiri:8b36d7383291227115d2a92ed52e1732, niiri:bb84044832b3e51c5b7474bd540f65fc, -, -, -)
+    wasGeneratedBy(niiri:8b36d7383291227115d2a92ed52e1732, niiri:baf57504feedb2bf8efebb366a0e02f0, -)
+    entity(niiri:7cad2c56857d24b10ced84fc93de78a0,
         [prov:type = 'nidm_GrandMeanMap:',
         prov:location = "GrandMean.nii.gz" %% xsd:anyURI,
         nfo:fileName = "GrandMean.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Grand Mean Map" %% xsd:string,
         nidm_maskedMedian: = "121.744659423828" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         crypto:sha512 = "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273" %% xsd:string])
-    wasGeneratedBy(niiri:f36c9efa1d29cf2c16ece1999b83d27f, niiri:28550e8b753c726791498099b035ca93, -)
-    entity(niiri:72efa4876d285bc921fa2e1ff390e862,
+    wasGeneratedBy(niiri:7cad2c56857d24b10ced84fc93de78a0, niiri:baf57504feedb2bf8efebb366a0e02f0, -)
+    entity(niiri:3e190f12e37b0f96c2a44c488ecd0934,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 1" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff'])
-    entity(niiri:41f7e8add27779cc7fca4d3a034d6569,
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61'])
+    entity(niiri:f7a2420f21f1ab82aab7caa2b1eb113c,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60" %% xsd:string])
-    wasDerivedFrom(niiri:72efa4876d285bc921fa2e1ff390e862, niiri:41f7e8add27779cc7fca4d3a034d6569, -, -, -)
-    wasGeneratedBy(niiri:72efa4876d285bc921fa2e1ff390e862, niiri:28550e8b753c726791498099b035ca93, -)
-    entity(niiri:2f916c52f15b207fcf0e53698b791216,
+    wasDerivedFrom(niiri:3e190f12e37b0f96c2a44c488ecd0934, niiri:f7a2420f21f1ab82aab7caa2b1eb113c, -, -, -)
+    wasGeneratedBy(niiri:3e190f12e37b0f96c2a44c488ecd0934, niiri:baf57504feedb2bf8efebb366a0e02f0, -)
+    entity(niiri:51adc10134a3e0bd713bb50825b3c024,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 2" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff'])
-    entity(niiri:e3c84d1861d3c7c5eefadd6e2b9f2e5f,
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61'])
+    entity(niiri:3b7867d15060ebe3fd326889c6a57e97,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0002.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2" %% xsd:string])
-    wasDerivedFrom(niiri:2f916c52f15b207fcf0e53698b791216, niiri:e3c84d1861d3c7c5eefadd6e2b9f2e5f, -, -, -)
-    wasGeneratedBy(niiri:2f916c52f15b207fcf0e53698b791216, niiri:28550e8b753c726791498099b035ca93, -)
-    entity(niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d,
+    wasDerivedFrom(niiri:51adc10134a3e0bd713bb50825b3c024, niiri:3b7867d15060ebe3fd326889c6a57e97, -, -, -)
+    wasGeneratedBy(niiri:51adc10134a3e0bd713bb50825b3c024, niiri:baf57504feedb2bf8efebb366a0e02f0, -)
+    entity(niiri:7d1a41a2f24c58973cab1afa20e243fc,
         [prov:type = 'nidm_ParameterEstimateMap:',
         prov:label = "Beta Map 3" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff'])
-    entity(niiri:dcaea73602f05b036c9df143c0a7e200,
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61'])
+    entity(niiri:4e3f5daafa9ac0049dcaaeab31b0b477,
         [prov:type = 'nidm_ParameterEstimateMap:',
         nfo:fileName = "beta_0003.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c" %% xsd:string])
-    wasDerivedFrom(niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d, niiri:dcaea73602f05b036c9df143c0a7e200, -, -, -)
-    wasGeneratedBy(niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d, niiri:28550e8b753c726791498099b035ca93, -)
-    entity(niiri:06e4f88e786fe09809dfe30420188f25,
+    wasDerivedFrom(niiri:7d1a41a2f24c58973cab1afa20e243fc, niiri:4e3f5daafa9ac0049dcaaeab31b0b477, -, -, -)
+    wasGeneratedBy(niiri:7d1a41a2f24c58973cab1afa20e243fc, niiri:baf57504feedb2bf8efebb366a0e02f0, -)
+    entity(niiri:39cda3b68e6c6c00e3061abedf7b4907,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         prov:location = "ResidualMeanSquares.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ResidualMeanSquares.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Residual Mean Squares Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         crypto:sha512 = "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca" %% xsd:string])
-    entity(niiri:00fdfd7ba3a1372b2fbd17a20aa19445,
+    entity(niiri:df260d7f560f7838dc091e701d2ad352,
         [prov:type = 'nidm_ResidualMeanSquaresMap:',
         nfo:fileName = "ResMS.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d" %% xsd:string])
-    wasDerivedFrom(niiri:06e4f88e786fe09809dfe30420188f25, niiri:00fdfd7ba3a1372b2fbd17a20aa19445, -, -, -)
-    wasGeneratedBy(niiri:06e4f88e786fe09809dfe30420188f25, niiri:28550e8b753c726791498099b035ca93, -)
-    entity(niiri:afb00741e29f2942b8bc70b0e38a847b,
+    wasDerivedFrom(niiri:39cda3b68e6c6c00e3061abedf7b4907, niiri:df260d7f560f7838dc091e701d2ad352, -, -, -)
+    wasGeneratedBy(niiri:39cda3b68e6c6c00e3061abedf7b4907, niiri:baf57504feedb2bf8efebb366a0e02f0, -)
+    entity(niiri:be23bf0e7b01c4c04185afb0ca818e27,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         prov:location = "ReselsPerVoxel.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ReselsPerVoxel.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Resels per Voxel Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         crypto:sha512 = "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160" %% xsd:string])
-    entity(niiri:466df67e27037c9807478d993dcc8246,
+    entity(niiri:bb0161f7037183a8437956ce98d15129,
         [prov:type = 'nidm_ReselsPerVoxelMap:',
         nfo:fileName = "RPV.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300" %% xsd:string])
-    wasDerivedFrom(niiri:afb00741e29f2942b8bc70b0e38a847b, niiri:466df67e27037c9807478d993dcc8246, -, -, -)
-    wasGeneratedBy(niiri:afb00741e29f2942b8bc70b0e38a847b, niiri:28550e8b753c726791498099b035ca93, -)
-    entity(niiri:c2a5865b1a64ede064a33413b821a1fe,
+    wasDerivedFrom(niiri:be23bf0e7b01c4c04185afb0ca818e27, niiri:bb0161f7037183a8437956ce98d15129, -, -, -)
+    wasGeneratedBy(niiri:be23bf0e7b01c4c04185afb0ca818e27, niiri:baf57504feedb2bf8efebb366a0e02f0, -)
+    entity(niiri:977bcb70c3c7483b68047e4e683981ec,
         [prov:type = 'stato_ContrastWeightMatrix:',
         nidm_statisticType: = 'stato_TStatistic:',
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         prov:label = "Contrast: pos vs neg" %% xsd:string,
         prov:value = "[1, -1, 0]" %% xsd:string])
-    activity(niiri:f6527b3ae676ec51392646f86918478a,
+    activity(niiri:3d7b06b8a653d948635ce92298498589,
         [prov:type = 'nidm_ContrastEstimation:',
         prov:label = "Contrast estimation"])
-    wasAssociatedWith(niiri:f6527b3ae676ec51392646f86918478a, niiri:9e85c3c113468fdd7321a08d6f0433ec, -)
-    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:aa1c29a1fdf1399681a37fc8a884c2be, -)
-    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:06e4f88e786fe09809dfe30420188f25, -)
-    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:b3af73299b71e1b964b104cdf1c99178, -)
-    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:c2a5865b1a64ede064a33413b821a1fe, -)
-    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:72efa4876d285bc921fa2e1ff390e862, -)
-    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:2f916c52f15b207fcf0e53698b791216, -)
-    used(niiri:f6527b3ae676ec51392646f86918478a, niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d, -)
-    entity(niiri:32a98391fb64e3b4c085771c0a49fc6f,
+    wasAssociatedWith(niiri:3d7b06b8a653d948635ce92298498589, niiri:d18ee3891edc3395269c1f9d3c7a9a1f, -)
+    used(niiri:3d7b06b8a653d948635ce92298498589, niiri:8b36d7383291227115d2a92ed52e1732, -)
+    used(niiri:3d7b06b8a653d948635ce92298498589, niiri:39cda3b68e6c6c00e3061abedf7b4907, -)
+    used(niiri:3d7b06b8a653d948635ce92298498589, niiri:fb2347b3655e57a809ca5cd5c53cf87a, -)
+    used(niiri:3d7b06b8a653d948635ce92298498589, niiri:977bcb70c3c7483b68047e4e683981ec, -)
+    used(niiri:3d7b06b8a653d948635ce92298498589, niiri:3e190f12e37b0f96c2a44c488ecd0934, -)
+    used(niiri:3d7b06b8a653d948635ce92298498589, niiri:51adc10134a3e0bd713bb50825b3c024, -)
+    used(niiri:3d7b06b8a653d948635ce92298498589, niiri:7d1a41a2f24c58973cab1afa20e243fc, -)
+    entity(niiri:2c7c74920dd5c59a5c731317458555b9,
         [prov:type = 'nidm_StatisticMap:',
         prov:location = "TStatistic.nii.gz" %% xsd:anyURI,
         nfo:fileName = "TStatistic.nii.gz" %% xsd:string,
@@ -289,103 +289,103 @@ document
         nidm_contrastName: = "pos vs neg" %% xsd:string,
         nidm_errorDegreesOfFreedom: = "214.999999999918" %% xsd:float,
         nidm_effectDegreesOfFreedom: = "1" %% xsd:float,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         crypto:sha512 = "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f" %% xsd:string])
-    entity(niiri:ce2d2b79f29ca64888485463e431f288,
+    entity(niiri:5e6a4a231ef6254f5161fa7516de0995,
         [prov:type = 'nidm_StatisticMap:',
         nfo:fileName = "spmT_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59" %% xsd:string])
-    wasDerivedFrom(niiri:32a98391fb64e3b4c085771c0a49fc6f, niiri:ce2d2b79f29ca64888485463e431f288, -, -, -)
-    wasGeneratedBy(niiri:32a98391fb64e3b4c085771c0a49fc6f, niiri:f6527b3ae676ec51392646f86918478a, -)
-    entity(niiri:d52a011528706ad5da1bcebab89ec4b2,
+    wasDerivedFrom(niiri:2c7c74920dd5c59a5c731317458555b9, niiri:5e6a4a231ef6254f5161fa7516de0995, -, -, -)
+    wasGeneratedBy(niiri:2c7c74920dd5c59a5c731317458555b9, niiri:3d7b06b8a653d948635ce92298498589, -)
+    entity(niiri:21e86dc6306a5ee2e515c4e82f392f82,
         [prov:type = 'nidm_ContrastMap:',
         prov:location = "Contrast.nii.gz" %% xsd:anyURI,
         nfo:fileName = "Contrast.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Map: pos vs neg" %% xsd:string,
         nidm_contrastName: = "pos vs neg" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         crypto:sha512 = "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2" %% xsd:string])
-    entity(niiri:24624d7cd6f93e40818435d76154f63c,
+    entity(niiri:173e2e1a77dd518d0ccc74ebe1cef43b,
         [prov:type = 'nidm_ContrastMap:',
         nfo:fileName = "con_0001.nii" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         crypto:sha512 = "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f" %% xsd:string])
-    wasDerivedFrom(niiri:d52a011528706ad5da1bcebab89ec4b2, niiri:24624d7cd6f93e40818435d76154f63c, -, -, -)
-    wasGeneratedBy(niiri:d52a011528706ad5da1bcebab89ec4b2, niiri:f6527b3ae676ec51392646f86918478a, -)
-    entity(niiri:05b5e98aee20aefdc7de6d5ada900f65,
+    wasDerivedFrom(niiri:21e86dc6306a5ee2e515c4e82f392f82, niiri:173e2e1a77dd518d0ccc74ebe1cef43b, -, -, -)
+    wasGeneratedBy(niiri:21e86dc6306a5ee2e515c4e82f392f82, niiri:3d7b06b8a653d948635ce92298498589, -)
+    entity(niiri:9562ed15778afaf12276671514b93473,
         [prov:type = 'nidm_ContrastStandardErrorMap:',
         prov:location = "ContrastStandardError.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ContrastStandardError.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Contrast Standard Error Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         crypto:sha512 = "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3" %% xsd:string])
-    wasGeneratedBy(niiri:05b5e98aee20aefdc7de6d5ada900f65, niiri:f6527b3ae676ec51392646f86918478a, -)
-    entity(niiri:724f6938b9d3c678ce89374d96cd8417,
+    wasGeneratedBy(niiri:9562ed15778afaf12276671514b93473, niiri:3d7b06b8a653d948635ce92298498589, -)
+    entity(niiri:72f74feeee8cfb1d83a785acd59a4163,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Height Threshold: T=4.000000)" %% xsd:string,
         prov:value = "4" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:ac11b497f38fbd2be58f2597ae00ff63',
-        nidm_equivalentThreshold: = 'niiri:1f09035a8e827d457deb1490af42173f'])
-    entity(niiri:ac11b497f38fbd2be58f2597ae00ff63,
+        nidm_equivalentThreshold: = 'niiri:90bc140bcddbf7cd235182729788522a',
+        nidm_equivalentThreshold: = 'niiri:ff0c0f497e2b4b0a77fcb4475dc3f14f'])
+    entity(niiri:90bc140bcddbf7cd235182729788522a,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "4.3562342453618e-05" %% xsd:float])
-    entity(niiri:1f09035a8e827d457deb1490af42173f,
+    entity(niiri:ff0c0f497e2b4b0a77fcb4475dc3f14f,
         [prov:type = 'nidm_HeightThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Height Threshold" %% xsd:string,
         prov:value = "0.9111141889082" %% xsd:float])
-    entity(niiri:aa54459b725ec30bcb6e20e9c9ab6de2,
+    entity(niiri:ed17f95ad9ec2d065ee1bdf45c3d1239,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_Statistic:',
         prov:label = "Extent Threshold: k>=0" %% xsd:string,
         nidm_clusterSizeInVoxels: = "0" %% xsd:int,
         nidm_clusterSizeInResels: = "0" %% xsd:float,
-        nidm_equivalentThreshold: = 'niiri:f27f8d84e42536914e0cd64a4694253a',
-        nidm_equivalentThreshold: = 'niiri:d90df515ec31dcc930a7f6742bba0a9d'])
-    entity(niiri:f27f8d84e42536914e0cd64a4694253a,
+        nidm_equivalentThreshold: = 'niiri:1ac6b92371ed0612db002a011f2a05be',
+        nidm_equivalentThreshold: = 'niiri:2e8e9f2a0ce37bc6fc89916dd241b0e6'])
+    entity(niiri:1ac6b92371ed0612db002a011f2a05be,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'obo_pValueFWER:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:d90df515ec31dcc930a7f6742bba0a9d,
+    entity(niiri:2e8e9f2a0ce37bc6fc89916dd241b0e6,
         [prov:type = 'nidm_ExtentThreshold:',
         prov:type = 'nidm_PValueUncorrected:',
         prov:label = "Extent Threshold" %% xsd:string,
         prov:value = "1" %% xsd:float])
-    entity(niiri:506b45d4a4ab88895094698e0d7c6319,
+    entity(niiri:4f9e58121ea14e5f4140450763847c72,
         [prov:type = 'nidm_PeakDefinitionCriteria:',
         prov:label = "Peak Definition Criteria" %% xsd:string,
         nidm_maxNumberOfPeaksPerCluster: = "3" %% xsd:int,
         nidm_minDistanceBetweenPeaks: = "8" %% xsd:float])
-    entity(niiri:9c731ff8e20a1e8750a1f8ec89560ff1,
+    entity(niiri:b96348fbb60c39ecab2de2f418567543,
         [prov:type = 'nidm_ClusterDefinitionCriteria:',
         prov:label = "Cluster Connectivity Criterion: 18" %% xsd:string,
         nidm_hasConnectivityCriterion: = 'nidm_voxel18connected:'])
-    activity(niiri:c087cec5deed4a6989758e633c54ef25,
+    activity(niiri:7b4ede27afb30552b24338ab9723138c,
         [prov:type = 'nidm_Inference:',
         nidm_hasAlternativeHypothesis: = 'nidm_OneTailedTest:',
         prov:label = "Inference"])
-    wasAssociatedWith(niiri:c087cec5deed4a6989758e633c54ef25, niiri:9e85c3c113468fdd7321a08d6f0433ec, -)
-    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:724f6938b9d3c678ce89374d96cd8417, -)
-    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:aa54459b725ec30bcb6e20e9c9ab6de2, -)
-    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:32a98391fb64e3b4c085771c0a49fc6f, -)
-    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:afb00741e29f2942b8bc70b0e38a847b, -)
-    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:aa1c29a1fdf1399681a37fc8a884c2be, -)
-    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:506b45d4a4ab88895094698e0d7c6319, -)
-    used(niiri:c087cec5deed4a6989758e633c54ef25, niiri:9c731ff8e20a1e8750a1f8ec89560ff1, -)
-    entity(niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b,
+    wasAssociatedWith(niiri:7b4ede27afb30552b24338ab9723138c, niiri:d18ee3891edc3395269c1f9d3c7a9a1f, -)
+    used(niiri:7b4ede27afb30552b24338ab9723138c, niiri:72f74feeee8cfb1d83a785acd59a4163, -)
+    used(niiri:7b4ede27afb30552b24338ab9723138c, niiri:ed17f95ad9ec2d065ee1bdf45c3d1239, -)
+    used(niiri:7b4ede27afb30552b24338ab9723138c, niiri:2c7c74920dd5c59a5c731317458555b9, -)
+    used(niiri:7b4ede27afb30552b24338ab9723138c, niiri:be23bf0e7b01c4c04185afb0ca818e27, -)
+    used(niiri:7b4ede27afb30552b24338ab9723138c, niiri:8b36d7383291227115d2a92ed52e1732, -)
+    used(niiri:7b4ede27afb30552b24338ab9723138c, niiri:4f9e58121ea14e5f4140450763847c72, -)
+    used(niiri:7b4ede27afb30552b24338ab9723138c, niiri:b96348fbb60c39ecab2de2f418567543, -)
+    entity(niiri:c4f3812d1125547c7f5654c4f111adad,
         [prov:type = 'nidm_SearchSpaceMaskMap:',
         prov:location = "SearchSpaceMask.nii.gz" %% xsd:anyURI,
         nfo:fileName = "SearchSpaceMask.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string,
         prov:label = "Search Space Mask Map" %% xsd:string,
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         nidm_searchVolumeInVoxels: = "205365" %% xsd:int,
         nidm_searchVolumeInUnits: = "1642920" %% xsd:float,
         nidm_reselSizeInVoxels: = "71.8552337008046" %% xsd:float,
@@ -401,8 +401,8 @@ document
         spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: = "Inf" %% xsd:int,
         spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: = "Inf" %% xsd:int,
         crypto:sha512 = "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e" %% xsd:string])
-    wasGeneratedBy(niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b, niiri:c087cec5deed4a6989758e633c54ef25, -)
-    entity(niiri:6c49fe9342e735959c7bde778b1e58c6,
+    wasGeneratedBy(niiri:c4f3812d1125547c7f5654c4f111adad, niiri:7b4ede27afb30552b24338ab9723138c, -)
+    entity(niiri:557de9ff5077e220bd7f5c541c49a757,
         [prov:type = 'nidm_ExcursionSetMap:',
         prov:location = "ExcursionSet.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ExcursionSet.nii.gz" %% xsd:string,
@@ -410,20 +410,20 @@ document
         prov:label = "Excursion Set Map" %% xsd:string,
         nidm_numberOfSupraThresholdClusters: = "0" %% xsd:int,
         nidm_pValue: = "NaN" %% xsd:float,
-        nidm_hasClusterLabelsMap: = 'niiri:0d816fc1c460889e384228fa288a25f3',
-        nidm_hasMaximumIntensityProjection: = 'niiri:5b3985681eae5f6d6d353d227056e5fd',
-        nidm_inCoordinateSpace: = 'niiri:c66ef8aa5c4f00b5901391884536d9ff',
+        nidm_hasClusterLabelsMap: = 'niiri:5fe2d4e54a72b411b90e659e1732901c',
+        nidm_hasMaximumIntensityProjection: = 'niiri:dd9e02bbe1088111472fe54509e41fc0',
+        nidm_inCoordinateSpace: = 'niiri:27db8bb99e7348823bfb45e6af669a61',
         crypto:sha512 = "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640" %% xsd:string])
-    entity(niiri:0d816fc1c460889e384228fa288a25f3,
+    entity(niiri:5fe2d4e54a72b411b90e659e1732901c,
         [prov:type = 'nidm_ClusterLabelsMap:',
         prov:location = "ClusterLabels.nii.gz" %% xsd:anyURI,
         nfo:fileName = "ClusterLabels.nii.gz" %% xsd:string,
         dct:format = "image/nifti" %% xsd:string])
-    entity(niiri:5b3985681eae5f6d6d353d227056e5fd,
+    entity(niiri:dd9e02bbe1088111472fe54509e41fc0,
         [prov:type = 'dctype:Image',
         prov:location = "MaximumIntensityProjection.png" %% xsd:anyURI,
         nfo:fileName = "MaximumIntensityProjection.png" %% xsd:string,
         dct:format = "image/png" %% xsd:string])
-    wasGeneratedBy(niiri:6c49fe9342e735959c7bde778b1e58c6, niiri:c087cec5deed4a6989758e633c54ef25, -)
+    wasGeneratedBy(niiri:557de9ff5077e220bd7f5c541c49a757, niiri:7b4ede27afb30552b24338ab9723138c, -)
   endBundle
 endDocument

--- a/spmexport/ex_spm_voxelwise_t=4/nidm.ttl
+++ b/spmexport/ex_spm_voxelwise_t=4/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:4c97df89fdb900953287b6ee2d0bf4e4
+niiri:4440f225ae7d4df86d75399528aed662
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:a08cffbf5401e33768c050f8f5828a54
+niiri:85ff3a8f8b5d4deb76f786ea5aa37f75
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:c6b11e6713085858dfaf6132741ca114
+niiri:bed811d0155bdff84fa8cedbad37bf32
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:c6b11e6713085858dfaf6132741ca114 prov:wasAssociatedWith niiri:a08cffbf5401e33768c050f8f5828a54 .
+niiri:bed811d0155bdff84fa8cedbad37bf32 prov:wasAssociatedWith niiri:85ff3a8f8b5d4deb76f786ea5aa37f75 .
 
 _:blank5 a prov:Generation .
 
-niiri:4c97df89fdb900953287b6ee2d0bf4e4 prov:qualifiedGeneration _:blank5 .
+niiri:4440f225ae7d4df86d75399528aed662 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:34:44"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:45:28"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:34:44"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:9e85c3c113468fdd7321a08d6f0433ec
+niiri:d18ee3891edc3395269c1f9d3c7a9a1f
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:c66ef8aa5c4f00b5901391884536d9ff
+niiri:27db8bb99e7348823bfb45e6af669a61
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:c66ef8aa5c4f00b5901391884536d9ff
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:d8fbe9edccebac2906e7cdfaf1e5194e
+niiri:ae699260d565def6b4bb98f1f770d070
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:a87f74ea074c2617eedbe51685bf8149
+niiri:878b3fc8fd8f74e1aa28390a79f7f730
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:b3af73299b71e1b964b104cdf1c99178
+niiri:fb2347b3655e57a809ca5cd5c53cf87a
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:aa5324eb378411a1f12ca9e8406dba06 ;
+    dc:description niiri:0b71661161900ea8c8932e0c1a455bdc ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:a87f74ea074c2617eedbe51685bf8149 ;
+    nidm_hasDriftModel: niiri:878b3fc8fd8f74e1aa28390a79f7f730 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:aa5324eb378411a1f12ca9e8406dba06
+niiri:0b71661161900ea8c8932e0c1a455bdc
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:f883eddf86d66045f15be451437fd505
+niiri:295ad00f3b409060203ec15272073dbb
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:f883eddf86d66045f15be451437fd505
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:28550e8b753c726791498099b035ca93
+niiri:baf57504feedb2bf8efebb366a0e02f0
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:28550e8b753c726791498099b035ca93 prov:wasAssociatedWith niiri:9e85c3c113468fdd7321a08d6f0433ec .
+niiri:baf57504feedb2bf8efebb366a0e02f0 prov:wasAssociatedWith niiri:d18ee3891edc3395269c1f9d3c7a9a1f .
 
-niiri:28550e8b753c726791498099b035ca93 prov:used niiri:b3af73299b71e1b964b104cdf1c99178 .
+niiri:baf57504feedb2bf8efebb366a0e02f0 prov:used niiri:fb2347b3655e57a809ca5cd5c53cf87a .
 
-niiri:28550e8b753c726791498099b035ca93 prov:used niiri:d8fbe9edccebac2906e7cdfaf1e5194e .
+niiri:baf57504feedb2bf8efebb366a0e02f0 prov:used niiri:ae699260d565def6b4bb98f1f770d070 .
 
-niiri:28550e8b753c726791498099b035ca93 prov:used niiri:f883eddf86d66045f15be451437fd505 .
+niiri:baf57504feedb2bf8efebb366a0e02f0 prov:used niiri:295ad00f3b409060203ec15272073dbb .
 
-niiri:aa1c29a1fdf1399681a37fc8a884c2be
+niiri:8b36d7383291227115d2a92ed52e1732
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:cb009c63e178eb7513ff300b62921d8b
+niiri:bb84044832b3e51c5b7474bd540f65fc
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:aa1c29a1fdf1399681a37fc8a884c2be prov:wasDerivedFrom niiri:cb009c63e178eb7513ff300b62921d8b .
+niiri:8b36d7383291227115d2a92ed52e1732 prov:wasDerivedFrom niiri:bb84044832b3e51c5b7474bd540f65fc .
 
-niiri:aa1c29a1fdf1399681a37fc8a884c2be prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
+niiri:8b36d7383291227115d2a92ed52e1732 prov:wasGeneratedBy niiri:baf57504feedb2bf8efebb366a0e02f0 .
 
-niiri:f36c9efa1d29cf2c16ece1999b83d27f
+niiri:7cad2c56857d24b10ced84fc93de78a0
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:f36c9efa1d29cf2c16ece1999b83d27f prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
+niiri:7cad2c56857d24b10ced84fc93de78a0 prov:wasGeneratedBy niiri:baf57504feedb2bf8efebb366a0e02f0 .
 
-niiri:72efa4876d285bc921fa2e1ff390e862
+niiri:3e190f12e37b0f96c2a44c488ecd0934
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff .
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 .
 
-niiri:41f7e8add27779cc7fca4d3a034d6569
+niiri:f7a2420f21f1ab82aab7caa2b1eb113c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:72efa4876d285bc921fa2e1ff390e862 prov:wasDerivedFrom niiri:41f7e8add27779cc7fca4d3a034d6569 .
+niiri:3e190f12e37b0f96c2a44c488ecd0934 prov:wasDerivedFrom niiri:f7a2420f21f1ab82aab7caa2b1eb113c .
 
-niiri:72efa4876d285bc921fa2e1ff390e862 prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
+niiri:3e190f12e37b0f96c2a44c488ecd0934 prov:wasGeneratedBy niiri:baf57504feedb2bf8efebb366a0e02f0 .
 
-niiri:2f916c52f15b207fcf0e53698b791216
+niiri:51adc10134a3e0bd713bb50825b3c024
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff .
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 .
 
-niiri:e3c84d1861d3c7c5eefadd6e2b9f2e5f
+niiri:3b7867d15060ebe3fd326889c6a57e97
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:2f916c52f15b207fcf0e53698b791216 prov:wasDerivedFrom niiri:e3c84d1861d3c7c5eefadd6e2b9f2e5f .
+niiri:51adc10134a3e0bd713bb50825b3c024 prov:wasDerivedFrom niiri:3b7867d15060ebe3fd326889c6a57e97 .
 
-niiri:2f916c52f15b207fcf0e53698b791216 prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
+niiri:51adc10134a3e0bd713bb50825b3c024 prov:wasGeneratedBy niiri:baf57504feedb2bf8efebb366a0e02f0 .
 
-niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d
+niiri:7d1a41a2f24c58973cab1afa20e243fc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff .
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 .
 
-niiri:dcaea73602f05b036c9df143c0a7e200
+niiri:4e3f5daafa9ac0049dcaaeab31b0b477
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d prov:wasDerivedFrom niiri:dcaea73602f05b036c9df143c0a7e200 .
+niiri:7d1a41a2f24c58973cab1afa20e243fc prov:wasDerivedFrom niiri:4e3f5daafa9ac0049dcaaeab31b0b477 .
 
-niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
+niiri:7d1a41a2f24c58973cab1afa20e243fc prov:wasGeneratedBy niiri:baf57504feedb2bf8efebb366a0e02f0 .
 
-niiri:06e4f88e786fe09809dfe30420188f25
+niiri:39cda3b68e6c6c00e3061abedf7b4907
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:00fdfd7ba3a1372b2fbd17a20aa19445
+niiri:df260d7f560f7838dc091e701d2ad352
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:06e4f88e786fe09809dfe30420188f25 prov:wasDerivedFrom niiri:00fdfd7ba3a1372b2fbd17a20aa19445 .
+niiri:39cda3b68e6c6c00e3061abedf7b4907 prov:wasDerivedFrom niiri:df260d7f560f7838dc091e701d2ad352 .
 
-niiri:06e4f88e786fe09809dfe30420188f25 prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
+niiri:39cda3b68e6c6c00e3061abedf7b4907 prov:wasGeneratedBy niiri:baf57504feedb2bf8efebb366a0e02f0 .
 
-niiri:afb00741e29f2942b8bc70b0e38a847b
+niiri:be23bf0e7b01c4c04185afb0ca818e27
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:466df67e27037c9807478d993dcc8246
+niiri:bb0161f7037183a8437956ce98d15129
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:afb00741e29f2942b8bc70b0e38a847b prov:wasDerivedFrom niiri:466df67e27037c9807478d993dcc8246 .
+niiri:be23bf0e7b01c4c04185afb0ca818e27 prov:wasDerivedFrom niiri:bb0161f7037183a8437956ce98d15129 .
 
-niiri:afb00741e29f2942b8bc70b0e38a847b prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
+niiri:be23bf0e7b01c4c04185afb0ca818e27 prov:wasGeneratedBy niiri:baf57504feedb2bf8efebb366a0e02f0 .
 
-niiri:c2a5865b1a64ede064a33413b821a1fe
+niiri:977bcb70c3c7483b68047e4e683981ec
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:f6527b3ae676ec51392646f86918478a
+niiri:3d7b06b8a653d948635ce92298498589
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:f6527b3ae676ec51392646f86918478a prov:wasAssociatedWith niiri:9e85c3c113468fdd7321a08d6f0433ec .
+niiri:3d7b06b8a653d948635ce92298498589 prov:wasAssociatedWith niiri:d18ee3891edc3395269c1f9d3c7a9a1f .
 
-niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:aa1c29a1fdf1399681a37fc8a884c2be .
+niiri:3d7b06b8a653d948635ce92298498589 prov:used niiri:8b36d7383291227115d2a92ed52e1732 .
 
-niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:06e4f88e786fe09809dfe30420188f25 .
+niiri:3d7b06b8a653d948635ce92298498589 prov:used niiri:39cda3b68e6c6c00e3061abedf7b4907 .
 
-niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:b3af73299b71e1b964b104cdf1c99178 .
+niiri:3d7b06b8a653d948635ce92298498589 prov:used niiri:fb2347b3655e57a809ca5cd5c53cf87a .
 
-niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:c2a5865b1a64ede064a33413b821a1fe .
+niiri:3d7b06b8a653d948635ce92298498589 prov:used niiri:977bcb70c3c7483b68047e4e683981ec .
 
-niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:72efa4876d285bc921fa2e1ff390e862 .
+niiri:3d7b06b8a653d948635ce92298498589 prov:used niiri:3e190f12e37b0f96c2a44c488ecd0934 .
 
-niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:2f916c52f15b207fcf0e53698b791216 .
+niiri:3d7b06b8a653d948635ce92298498589 prov:used niiri:51adc10134a3e0bd713bb50825b3c024 .
 
-niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d .
+niiri:3d7b06b8a653d948635ce92298498589 prov:used niiri:7d1a41a2f24c58973cab1afa20e243fc .
 
-niiri:32a98391fb64e3b4c085771c0a49fc6f
+niiri:2c7c74920dd5c59a5c731317458555b9
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:32a98391fb64e3b4c085771c0a49fc6f
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:ce2d2b79f29ca64888485463e431f288
+niiri:5e6a4a231ef6254f5161fa7516de0995
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:32a98391fb64e3b4c085771c0a49fc6f prov:wasDerivedFrom niiri:ce2d2b79f29ca64888485463e431f288 .
+niiri:2c7c74920dd5c59a5c731317458555b9 prov:wasDerivedFrom niiri:5e6a4a231ef6254f5161fa7516de0995 .
 
-niiri:32a98391fb64e3b4c085771c0a49fc6f prov:wasGeneratedBy niiri:f6527b3ae676ec51392646f86918478a .
+niiri:2c7c74920dd5c59a5c731317458555b9 prov:wasGeneratedBy niiri:3d7b06b8a653d948635ce92298498589 .
 
-niiri:d52a011528706ad5da1bcebab89ec4b2
+niiri:21e86dc6306a5ee2e515c4e82f392f82
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:24624d7cd6f93e40818435d76154f63c
+niiri:173e2e1a77dd518d0ccc74ebe1cef43b
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:d52a011528706ad5da1bcebab89ec4b2 prov:wasDerivedFrom niiri:24624d7cd6f93e40818435d76154f63c .
+niiri:21e86dc6306a5ee2e515c4e82f392f82 prov:wasDerivedFrom niiri:173e2e1a77dd518d0ccc74ebe1cef43b .
 
-niiri:d52a011528706ad5da1bcebab89ec4b2 prov:wasGeneratedBy niiri:f6527b3ae676ec51392646f86918478a .
+niiri:21e86dc6306a5ee2e515c4e82f392f82 prov:wasGeneratedBy niiri:3d7b06b8a653d948635ce92298498589 .
 
-niiri:05b5e98aee20aefdc7de6d5ada900f65
+niiri:9562ed15778afaf12276671514b93473
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:05b5e98aee20aefdc7de6d5ada900f65 prov:wasGeneratedBy niiri:f6527b3ae676ec51392646f86918478a .
+niiri:9562ed15778afaf12276671514b93473 prov:wasGeneratedBy niiri:3d7b06b8a653d948635ce92298498589 .
 
-niiri:724f6938b9d3c678ce89374d96cd8417
+niiri:72f74feeee8cfb1d83a785acd59a4163
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold: T=4.000000)" ;
     prov:value "4"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:ac11b497f38fbd2be58f2597ae00ff63 ;
-    nidm_equivalentThreshold: niiri:1f09035a8e827d457deb1490af42173f .
+    nidm_equivalentThreshold: niiri:90bc140bcddbf7cd235182729788522a ;
+    nidm_equivalentThreshold: niiri:ff0c0f497e2b4b0a77fcb4475dc3f14f .
 
-niiri:ac11b497f38fbd2be58f2597ae00ff63
+niiri:90bc140bcddbf7cd235182729788522a
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.3562342453618e-05"^^xsd:float .
 
-niiri:1f09035a8e827d457deb1490af42173f
+niiri:ff0c0f497e2b4b0a77fcb4475dc3f14f
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.9111141889082"^^xsd:float .
 
-niiri:aa54459b725ec30bcb6e20e9c9ab6de2
+niiri:ed17f95ad9ec2d065ee1bdf45c3d1239
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:f27f8d84e42536914e0cd64a4694253a ;
-    nidm_equivalentThreshold: niiri:d90df515ec31dcc930a7f6742bba0a9d .
+    nidm_equivalentThreshold: niiri:1ac6b92371ed0612db002a011f2a05be ;
+    nidm_equivalentThreshold: niiri:2e8e9f2a0ce37bc6fc89916dd241b0e6 .
 
-niiri:f27f8d84e42536914e0cd64a4694253a
+niiri:1ac6b92371ed0612db002a011f2a05be
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:d90df515ec31dcc930a7f6742bba0a9d
+niiri:2e8e9f2a0ce37bc6fc89916dd241b0e6
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:506b45d4a4ab88895094698e0d7c6319
+niiri:4f9e58121ea14e5f4140450763847c72
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:9c731ff8e20a1e8750a1f8ec89560ff1
+niiri:b96348fbb60c39ecab2de2f418567543
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:c087cec5deed4a6989758e633c54ef25
+niiri:7b4ede27afb30552b24338ab9723138c
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:c087cec5deed4a6989758e633c54ef25 prov:wasAssociatedWith niiri:9e85c3c113468fdd7321a08d6f0433ec .
+niiri:7b4ede27afb30552b24338ab9723138c prov:wasAssociatedWith niiri:d18ee3891edc3395269c1f9d3c7a9a1f .
 
-niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:724f6938b9d3c678ce89374d96cd8417 .
+niiri:7b4ede27afb30552b24338ab9723138c prov:used niiri:72f74feeee8cfb1d83a785acd59a4163 .
 
-niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:aa54459b725ec30bcb6e20e9c9ab6de2 .
+niiri:7b4ede27afb30552b24338ab9723138c prov:used niiri:ed17f95ad9ec2d065ee1bdf45c3d1239 .
 
-niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:32a98391fb64e3b4c085771c0a49fc6f .
+niiri:7b4ede27afb30552b24338ab9723138c prov:used niiri:2c7c74920dd5c59a5c731317458555b9 .
 
-niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:afb00741e29f2942b8bc70b0e38a847b .
+niiri:7b4ede27afb30552b24338ab9723138c prov:used niiri:be23bf0e7b01c4c04185afb0ca818e27 .
 
-niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:aa1c29a1fdf1399681a37fc8a884c2be .
+niiri:7b4ede27afb30552b24338ab9723138c prov:used niiri:8b36d7383291227115d2a92ed52e1732 .
 
-niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:506b45d4a4ab88895094698e0d7c6319 .
+niiri:7b4ede27afb30552b24338ab9723138c prov:used niiri:4f9e58121ea14e5f4140450763847c72 .
 
-niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:9c731ff8e20a1e8750a1f8ec89560ff1 .
+niiri:7b4ede27afb30552b24338ab9723138c prov:used niiri:b96348fbb60c39ecab2de2f418567543 .
 
-niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b
+niiri:c4f3812d1125547c7f5654c4f111adad
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b prov:wasGeneratedBy niiri:c087cec5deed4a6989758e633c54ef25 .
+niiri:c4f3812d1125547c7f5654c4f111adad prov:wasGeneratedBy niiri:7b4ede27afb30552b24338ab9723138c .
 
-niiri:6c49fe9342e735959c7bde778b1e58c6
+niiri:557de9ff5077e220bd7f5c541c49a757
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:6c49fe9342e735959c7bde778b1e58c6
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:0d816fc1c460889e384228fa288a25f3 ;
-    nidm_hasMaximumIntensityProjection: niiri:5b3985681eae5f6d6d353d227056e5fd ;
-    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
+    nidm_hasClusterLabelsMap: niiri:5fe2d4e54a72b411b90e659e1732901c ;
+    nidm_hasMaximumIntensityProjection: niiri:dd9e02bbe1088111472fe54509e41fc0 ;
+    nidm_inCoordinateSpace: niiri:27db8bb99e7348823bfb45e6af669a61 ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:0d816fc1c460889e384228fa288a25f3
+niiri:5fe2d4e54a72b411b90e659e1732901c
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:5b3985681eae5f6d6d353d227056e5fd
+niiri:dd9e02bbe1088111472fe54509e41fc0
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:6c49fe9342e735959c7bde778b1e58c6 prov:wasGeneratedBy niiri:c087cec5deed4a6989758e633c54ef25 .
+niiri:557de9ff5077e220bd7f5c541c49a757 prov:wasGeneratedBy niiri:7b4ede27afb30552b24338ab9723138c .
 

--- a/spmexport/ex_spm_voxelwise_t=4/nidm.ttl
+++ b/spmexport/ex_spm_voxelwise_t=4/nidm.ttl
@@ -1,0 +1,510 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+niiri:806349bd3ad6f46e7d9750491347fd39
+  a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
+  rdfs:label "NIDM-Results" ;
+  nidm_version: "1.2.0"^^xsd:string .
+
+niiri:ce2087481eef3055e103b0093848e983
+  a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
+  rdfs:label "spm_results_nidm" ;
+  nidm_softwareVersion: "12.6646"^^xsd:string .
+
+niiri:35b73388a8bf62cc251e81b0ce66bca1
+  a prov:Activity, nidm_NIDMResultsExport: ; 
+  rdfs:label "NIDM-Results export" .
+
+niiri:35b73388a8bf62cc251e81b0ce66bca1 prov:wasAssociatedWith niiri:ce2087481eef3055e103b0093848e983 .
+
+_:blank5 a prov:Generation .
+
+niiri:806349bd3ad6f46e7d9750491347fd39 prov:qualifiedGeneration _:blank5 .
+
+_:blank5 prov:atTime "2016-01-11T10:12:28"^^xsd:dateTime .
+
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix stato_ToeplitzCovarianceStructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix stato_GLS: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix stato_GaussianDistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix stato_ContrastWeightMatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix stato_TStatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix obo_Statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix obo_pValueFWER: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_numberOfSupraThresholdClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+
+niiri:7283130bdaae614053b66a993e6bed87
+    a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
+    rdfs:label "SPM" ;
+    nidm_softwareVersion: "12.6470"^^xsd:string .
+
+niiri:0639cddb4b02210cdc4db993b0fc3874
+    a prov:Entity, nidm_CoordinateSpace: ; 
+    rdfs:label "Coordinate space 1" ;
+    nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
+    nidm_voxelUnits: "[\"mm\", \"mm\", \"mm\"]"^^xsd:string ;
+    nidm_voxelSize: "[2, 2, 2]"^^xsd:string ;
+    nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+    nidm_numberOfDimensions: "3"^^xsd:int ;
+    nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
+
+niiri:7c6f7eb8aee640b6c0c51daba9b1ef03
+    a prov:Entity, prov:Collection, nidm_DataScaling: ; 
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:52daeace90e362ef7487f294bf147d54
+    a prov:Entity, spm_DCTDriftModel: ; 
+    rdfs:label "SPM's DCT Drift Model" ;
+    spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:941e9bbf9c32fd5d3adefb829c4faf73
+    a prov:Entity, nidm_DesignMatrix: ; 
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dct:format "text/csv"^^xsd:string ;
+    dc:description niiri:78be9fd9ec65c96167e098000f81fb4f ;
+    rdfs:label "Design Matrix" ;
+    nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasDriftModel: niiri:52daeace90e362ef7487f294bf147d54 ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
+
+niiri:78be9fd9ec65c96167e098000f81fb4f
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+    nfo:fileName "DesignMatrix.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:bce50bde3a0b50f9b261367175337634
+    a prov:Entity, nidm_ErrorModel: ; 
+    nidm_hasErrorDistribution: stato_GaussianDistribution: ;
+    nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
+
+niiri:6e7bddf230024f1964840b0266c76020
+    a prov:Activity, nidm_ModelParametersEstimation: ; 
+    rdfs:label "Model parameters estimation" ;
+    nidm_withEstimationMethod: stato_GLS: .
+
+niiri:6e7bddf230024f1964840b0266c76020 prov:wasAssociatedWith niiri:7283130bdaae614053b66a993e6bed87 .
+
+niiri:6e7bddf230024f1964840b0266c76020 prov:used niiri:941e9bbf9c32fd5d3adefb829c4faf73 .
+
+niiri:6e7bddf230024f1964840b0266c76020 prov:used niiri:7c6f7eb8aee640b6c0c51daba9b1ef03 .
+
+niiri:6e7bddf230024f1964840b0266c76020 prov:used niiri:bce50bde3a0b50f9b261367175337634 .
+
+niiri:0c1e97eda14902ae1fa46b66fa317472
+    a prov:Entity, nidm_MaskMap: ; 
+    prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+    nfo:fileName "Mask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Mask" ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:753e5f49599ebe54312a7accd2ab3d02
+    a prov:Entity, nidm_MaskMap: ; 
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
+
+niiri:0c1e97eda14902ae1fa46b66fa317472 prov:wasDerivedFrom niiri:753e5f49599ebe54312a7accd2ab3d02 .
+
+niiri:0c1e97eda14902ae1fa46b66fa317472 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+
+niiri:4e691a10b1fc379276ded79577f2f6a0
+    a prov:Entity, nidm_GrandMeanMap: ; 
+    prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Grand Mean Map" ;
+    nidm_maskedMedian: "121.744659423828"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
+
+niiri:4e691a10b1fc379276ded79577f2f6a0 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+
+niiri:8f4893f367edf8f3923730a046a36bda
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 .
+
+niiri:33d8598e2f3352fb20eff97fc152c90f
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
+
+niiri:8f4893f367edf8f3923730a046a36bda prov:wasDerivedFrom niiri:33d8598e2f3352fb20eff97fc152c90f .
+
+niiri:8f4893f367edf8f3923730a046a36bda prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+
+niiri:d397c8020fa4e33527facc866b1a20a7
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 .
+
+niiri:1958601fc5c3f56cb310fc0baabed2be
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
+
+niiri:d397c8020fa4e33527facc866b1a20a7 prov:wasDerivedFrom niiri:1958601fc5c3f56cb310fc0baabed2be .
+
+niiri:d397c8020fa4e33527facc866b1a20a7 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+
+niiri:32132c18bf4103567994106215344329
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    rdfs:label "Beta Map 3" ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 .
+
+niiri:b5594e8e07cd6eb1e4012d4ee6a28fea
+    a prov:Entity, nidm_ParameterEstimateMap: ; 
+    nfo:fileName "beta_0003.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
+
+niiri:32132c18bf4103567994106215344329 prov:wasDerivedFrom niiri:b5594e8e07cd6eb1e4012d4ee6a28fea .
+
+niiri:32132c18bf4103567994106215344329 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+
+niiri:22ad7ded0ac1d711e8a0487cfc836029
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Residual Mean Squares Map" ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
+
+niiri:8a1a9df782badc0bbaca933d0ac3571f
+    a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
+
+niiri:22ad7ded0ac1d711e8a0487cfc836029 prov:wasDerivedFrom niiri:8a1a9df782badc0bbaca933d0ac3571f .
+
+niiri:22ad7ded0ac1d711e8a0487cfc836029 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+
+niiri:099512568a9246b3c907bed89316bb8e
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Resels per Voxel Map" ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
+
+niiri:8840e7e42f24e4dae1b15d56a8415d4e
+    a prov:Entity, nidm_ReselsPerVoxelMap: ; 
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
+
+niiri:099512568a9246b3c907bed89316bb8e prov:wasDerivedFrom niiri:8840e7e42f24e4dae1b15d56a8415d4e .
+
+niiri:099512568a9246b3c907bed89316bb8e prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+
+niiri:fc096c306109a662a505b528a003df77
+    a prov:Entity, stato_ContrastWeightMatrix: ; 
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    rdfs:label "Contrast: pos vs neg" ;
+    prov:value "[1, -1, 0]"^^xsd:string .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7
+    a prov:Activity, nidm_ContrastEstimation: ; 
+    rdfs:label "Contrast estimation" .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7 prov:wasAssociatedWith niiri:7283130bdaae614053b66a993e6bed87 .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:0c1e97eda14902ae1fa46b66fa317472 .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:22ad7ded0ac1d711e8a0487cfc836029 .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:941e9bbf9c32fd5d3adefb829c4faf73 .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:fc096c306109a662a505b528a003df77 .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:8f4893f367edf8f3923730a046a36bda .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:d397c8020fa4e33527facc866b1a20a7 .
+
+niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:32132c18bf4103567994106215344329 .
+
+niiri:ca7d326edc041d49f3a8bd6888a2ad5e
+    a prov:Entity, nidm_StatisticMap: ; 
+    prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Statistic Map: pos vs neg" ;
+    nidm_statisticType: stato_TStatistic: ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
+    nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
+
+niiri:a4f6e768a620095f32601b599dfcf4ee
+    a prov:Entity, nidm_StatisticMap: ; 
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
+
+niiri:ca7d326edc041d49f3a8bd6888a2ad5e prov:wasDerivedFrom niiri:a4f6e768a620095f32601b599dfcf4ee .
+
+niiri:ca7d326edc041d49f3a8bd6888a2ad5e prov:wasGeneratedBy niiri:2831de2cddf960bc84248af0cd98e7e7 .
+
+niiri:b66377f4e2a18ee1d08045e6ec196028
+    a prov:Entity, nidm_ContrastMap: ; 
+    prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Map: pos vs neg" ;
+    nidm_contrastName: "pos vs neg"^^xsd:string ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
+
+niiri:d7555057f51e0761d5b6357557846537
+    a prov:Entity, nidm_ContrastMap: ; 
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
+
+niiri:b66377f4e2a18ee1d08045e6ec196028 prov:wasDerivedFrom niiri:d7555057f51e0761d5b6357557846537 .
+
+niiri:b66377f4e2a18ee1d08045e6ec196028 prov:wasGeneratedBy niiri:2831de2cddf960bc84248af0cd98e7e7 .
+
+niiri:616d5161e30226dc4d87d86fc9f12ca6
+    a prov:Entity, nidm_ContrastStandardErrorMap: ; 
+    prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Contrast Standard Error Map" ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
+
+niiri:616d5161e30226dc4d87d86fc9f12ca6 prov:wasGeneratedBy niiri:2831de2cddf960bc84248af0cd98e7e7 .
+
+niiri:e9c625452832b88935d6c847b635a4c2
+    a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
+    rdfs:label "Height Threshold: T=4.000000)" ;
+    prov:value "4"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:3a225a61c68b3b7a2132f5439a3b7806 ;
+    nidm_equivalentThreshold: niiri:0665adcee230e9c3db98038317ef01eb .
+
+niiri:3a225a61c68b3b7a2132f5439a3b7806
+    a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "4.3562342453618e-05"^^xsd:float .
+
+niiri:0665adcee230e9c3db98038317ef01eb
+    a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Height Threshold" ;
+    prov:value "0.9111141889082"^^xsd:float .
+
+niiri:7a95c241ad8d0f6c41092f5156ae91fd
+    a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:38340c0af4aaac49ecd8bbdeb4c35fdc ;
+    nidm_equivalentThreshold: niiri:2ebf8fa32230a6dd48d721260aa95b14 .
+
+niiri:38340c0af4aaac49ecd8bbdeb4c35fdc
+    a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:2ebf8fa32230a6dd48d721260aa95b14
+    a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:d6573c073b0fd3e892d6d5c2840ea0ff
+    a prov:Entity, nidm_PeakDefinitionCriteria: ; 
+    rdfs:label "Peak Definition Criteria" ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
+    nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
+
+niiri:06ba5171d4001c7750aea6e98e50c2fa
+    a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
+    rdfs:label "Cluster Connectivity Criterion: 18" ;
+    nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae
+    a prov:Activity, nidm_Inference: ; 
+    nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    rdfs:label "Inference" .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:wasAssociatedWith niiri:7283130bdaae614053b66a993e6bed87 .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:e9c625452832b88935d6c847b635a4c2 .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:7a95c241ad8d0f6c41092f5156ae91fd .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:ca7d326edc041d49f3a8bd6888a2ad5e .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:099512568a9246b3c907bed89316bb8e .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:0c1e97eda14902ae1fa46b66fa317472 .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:d6573c073b0fd3e892d6d5c2840ea0ff .
+
+niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:06ba5171d4001c7750aea6e98e50c2fa .
+
+niiri:138f6783f353483960178c8bf70ea952
+    a prov:Entity, nidm_SearchSpaceMaskMap: ; 
+    prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Search Space Mask Map" ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
+    nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
+    nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
+    nidm_searchVolumeInResels: "2650.12011223711"^^xsd:float ;
+    spm_searchVolumeReselsGeometry: "[3, 68.5952915380146, 849.440288473186, 2650.12011223711]"^^xsd:string ;
+    nidm_noiseFWHMInVoxels: "[4.01704921884936, 4.07618247398105, 4.38831339907177]"^^xsd:string ;
+    nidm_noiseFWHMInUnits: "[8.03409843769872, 8.1523649479621, 8.77662679814353]"^^xsd:string ;
+    nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+    nidm_expectedNumberOfVoxelsPerCluster: "3.88370316592276"^^xsd:float ;
+    nidm_expectedNumberOfClusters: "2.42040275446714"^^xsd:float ;
+    nidm_heightCriticalThresholdFWE05: "5.05094049746367"^^xsd:float ;
+    nidm_heightCriticalThresholdFDR05: "Inf"^^xsd:float ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFWE05: "Inf"^^xsd:int ;
+    spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
+    crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
+
+niiri:138f6783f353483960178c8bf70ea952 prov:wasGeneratedBy niiri:a6cfbf83b43a688c8c63f74a89dc20ae .
+
+niiri:982c4f0c64cd8daea713a5bb9bc8eb76
+    a prov:Entity, nidm_ExcursionSetMap: ; 
+    prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    rdfs:label "Excursion Set Map" ;
+    nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
+    nidm_pValue: "NaN"^^xsd:float ;
+    nidm_hasClusterLabelsMap: niiri:535611df3c8befd941831f7da314cec4 ;
+    nidm_hasMaximumIntensityProjection: niiri:53c77f378e7ddf8eefee3f6f3d0bc941 ;
+    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
+
+niiri:535611df3c8befd941831f7da314cec4
+    a prov:Entity, nidm_ClusterLabelsMap: ; 
+    prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+    nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string .
+
+niiri:53c77f378e7ddf8eefee3f6f3d0bc941
+    a prov:Entity, dctype:Image ; 
+    prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+    nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+    dct:format "image/png"^^xsd:string .
+
+niiri:982c4f0c64cd8daea713a5bb9bc8eb76 prov:wasGeneratedBy niiri:a6cfbf83b43a688c8c63f74a89dc20ae .
+

--- a/spmexport/ex_spm_voxelwise_t=4/nidm.ttl
+++ b/spmexport/ex_spm_voxelwise_t=4/nidm.ttl
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:806349bd3ad6f46e7d9750491347fd39
+niiri:4c97df89fdb900953287b6ee2d0bf4e4
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.2.0"^^xsd:string .
 
-niiri:ce2087481eef3055e103b0093848e983
+niiri:a08cffbf5401e33768c050f8f5828a54
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
   nidm_softwareVersion: "12.6646"^^xsd:string .
 
-niiri:35b73388a8bf62cc251e81b0ce66bca1
+niiri:c6b11e6713085858dfaf6132741ca114
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:35b73388a8bf62cc251e81b0ce66bca1 prov:wasAssociatedWith niiri:ce2087481eef3055e103b0093848e983 .
+niiri:c6b11e6713085858dfaf6132741ca114 prov:wasAssociatedWith niiri:a08cffbf5401e33768c050f8f5828a54 .
 
 _:blank5 a prov:Generation .
 
-niiri:806349bd3ad6f46e7d9750491347fd39 prov:qualifiedGeneration _:blank5 .
+niiri:4c97df89fdb900953287b6ee2d0bf4e4 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-01-11T10:12:28"^^xsd:dateTime .
+_:blank5 prov:atTime "2016-01-11T10:34:44"^^xsd:dateTime .
 
 @prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
 @prefix neurolex_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
@@ -129,12 +129,12 @@ _:blank5 prov:atTime "2016-01-11T10:12:28"^^xsd:dateTime .
 @prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
 @prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
 
-niiri:7283130bdaae614053b66a993e6bed87
+niiri:9e85c3c113468fdd7321a08d6f0433ec
     a prov:Agent, neurolex_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
     nidm_softwareVersion: "12.6470"^^xsd:string .
 
-niiri:0639cddb4b02210cdc4db993b0fc3874
+niiri:c66ef8aa5c4f00b5901391884536d9ff
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -144,35 +144,35 @@ niiri:0639cddb4b02210cdc4db993b0fc3874
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:7c6f7eb8aee640b6c0c51daba9b1ef03
+niiri:d8fbe9edccebac2906e7cdfaf1e5194e
     a prov:Entity, prov:Collection, nidm_DataScaling: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float .
 
-niiri:52daeace90e362ef7487f294bf147d54
+niiri:a87f74ea074c2617eedbe51685bf8149
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:941e9bbf9c32fd5d3adefb829c4faf73
+niiri:b3af73299b71e1b964b104cdf1c99178
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:78be9fd9ec65c96167e098000f81fb4f ;
+    dc:description niiri:aa5324eb378411a1f12ca9e8406dba06 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) positive feedback\ntask001 co*bf(1)\", \"Sn(1) feedback\ntask002 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:52daeace90e362ef7487f294bf147d54 ;
+    nidm_hasDriftModel: niiri:a87f74ea074c2617eedbe51685bf8149 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:78be9fd9ec65c96167e098000f81fb4f
+niiri:aa5324eb378411a1f12ca9e8406dba06
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:bce50bde3a0b50f9b261367175337634
+niiri:f883eddf86d66045f15be451437fd505
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: stato_GaussianDistribution: ;
     nidm_hasErrorDependence: stato_ToeplitzCovarianceStructure: ;
@@ -180,162 +180,162 @@ niiri:bce50bde3a0b50f9b261367175337634
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:6e7bddf230024f1964840b0266c76020
+niiri:28550e8b753c726791498099b035ca93
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: stato_GLS: .
 
-niiri:6e7bddf230024f1964840b0266c76020 prov:wasAssociatedWith niiri:7283130bdaae614053b66a993e6bed87 .
+niiri:28550e8b753c726791498099b035ca93 prov:wasAssociatedWith niiri:9e85c3c113468fdd7321a08d6f0433ec .
 
-niiri:6e7bddf230024f1964840b0266c76020 prov:used niiri:941e9bbf9c32fd5d3adefb829c4faf73 .
+niiri:28550e8b753c726791498099b035ca93 prov:used niiri:b3af73299b71e1b964b104cdf1c99178 .
 
-niiri:6e7bddf230024f1964840b0266c76020 prov:used niiri:7c6f7eb8aee640b6c0c51daba9b1ef03 .
+niiri:28550e8b753c726791498099b035ca93 prov:used niiri:d8fbe9edccebac2906e7cdfaf1e5194e .
 
-niiri:6e7bddf230024f1964840b0266c76020 prov:used niiri:bce50bde3a0b50f9b261367175337634 .
+niiri:28550e8b753c726791498099b035ca93 prov:used niiri:f883eddf86d66045f15be451437fd505 .
 
-niiri:0c1e97eda14902ae1fa46b66fa317472
+niiri:aa1c29a1fdf1399681a37fc8a884c2be
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:753e5f49599ebe54312a7accd2ab3d02
+niiri:cb009c63e178eb7513ff300b62921d8b
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c0c1a22a1b500e69a07c9ed66a49a4985c4e27c36dd8f8479233f671529496aa97005a46673134ca1315ee7e8704ab8d133677143132a7031d112eadeaf64ba5"^^xsd:string .
 
-niiri:0c1e97eda14902ae1fa46b66fa317472 prov:wasDerivedFrom niiri:753e5f49599ebe54312a7accd2ab3d02 .
+niiri:aa1c29a1fdf1399681a37fc8a884c2be prov:wasDerivedFrom niiri:cb009c63e178eb7513ff300b62921d8b .
 
-niiri:0c1e97eda14902ae1fa46b66fa317472 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+niiri:aa1c29a1fdf1399681a37fc8a884c2be prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
 
-niiri:4e691a10b1fc379276ded79577f2f6a0
+niiri:f36c9efa1d29cf2c16ece1999b83d27f
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "121.744659423828"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     crypto:sha512 "b661142bf9a67026b36139107d0bb5184b078277c9122379a66dd9023787824f16bc37464c790b4cbb72c5dcfeaeeb111c90697aa917ed485ae721dd4d958273"^^xsd:string .
 
-niiri:4e691a10b1fc379276ded79577f2f6a0 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+niiri:f36c9efa1d29cf2c16ece1999b83d27f prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
 
-niiri:8f4893f367edf8f3923730a046a36bda
+niiri:72efa4876d285bc921fa2e1ff390e862
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 1" ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 .
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff .
 
-niiri:33d8598e2f3352fb20eff97fc152c90f
+niiri:41f7e8add27779cc7fca4d3a034d6569
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "88b18c572b2d9d36656073eafa95de25c9c20520f25b1ae6dc147b60e1c00200d7795f69bc959fbc138345b0c327a386a014dad7c9781b0d33c4385a10b64d60"^^xsd:string .
 
-niiri:8f4893f367edf8f3923730a046a36bda prov:wasDerivedFrom niiri:33d8598e2f3352fb20eff97fc152c90f .
+niiri:72efa4876d285bc921fa2e1ff390e862 prov:wasDerivedFrom niiri:41f7e8add27779cc7fca4d3a034d6569 .
 
-niiri:8f4893f367edf8f3923730a046a36bda prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+niiri:72efa4876d285bc921fa2e1ff390e862 prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
 
-niiri:d397c8020fa4e33527facc866b1a20a7
+niiri:2f916c52f15b207fcf0e53698b791216
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 2" ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 .
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff .
 
-niiri:1958601fc5c3f56cb310fc0baabed2be
+niiri:e3c84d1861d3c7c5eefadd6e2b9f2e5f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "30b3cc3a8cc6e613740d7a358a68bd5f089bf7a5e6adc953e1bcd601784f879ee964be8a3b18d237e1d0591db72f0e0a449dce5400f490bf60a6e40221e33ee2"^^xsd:string .
 
-niiri:d397c8020fa4e33527facc866b1a20a7 prov:wasDerivedFrom niiri:1958601fc5c3f56cb310fc0baabed2be .
+niiri:2f916c52f15b207fcf0e53698b791216 prov:wasDerivedFrom niiri:e3c84d1861d3c7c5eefadd6e2b9f2e5f .
 
-niiri:d397c8020fa4e33527facc866b1a20a7 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+niiri:2f916c52f15b207fcf0e53698b791216 prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
 
-niiri:32132c18bf4103567994106215344329
+niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     rdfs:label "Beta Map 3" ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 .
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff .
 
-niiri:b5594e8e07cd6eb1e4012d4ee6a28fea
+niiri:dcaea73602f05b036c9df143c0a7e200
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0d1c5859fbf669cc1a5eb222b3a92d90614236b91b9d1f3a75f6b86ce7bccbf7676cbaee93aeda7fe95778982b7245c2c9b88100e910985c0ccda71a5193272c"^^xsd:string .
 
-niiri:32132c18bf4103567994106215344329 prov:wasDerivedFrom niiri:b5594e8e07cd6eb1e4012d4ee6a28fea .
+niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d prov:wasDerivedFrom niiri:dcaea73602f05b036c9df143c0a7e200 .
 
-niiri:32132c18bf4103567994106215344329 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
 
-niiri:22ad7ded0ac1d711e8a0487cfc836029
+niiri:06e4f88e786fe09809dfe30420188f25
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     crypto:sha512 "5de8b0466dda259c9454bbcf5e37e2259ec020e1140555b371310d652322f838cb2a2a296b755ae4cca3f5806284ea4d70f63231e8a29c868b95d4989f3009ca"^^xsd:string .
 
-niiri:8a1a9df782badc0bbaca933d0ac3571f
+niiri:00fdfd7ba3a1372b2fbd17a20aa19445
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3a74ca792adc28059501eb7e07c44c1d46484b47e8d1c6f3787407b4b753c3a720e369c8dadee0a2404c106d2753af2dc62a0ac13a29805ada9a9abbfc24949d"^^xsd:string .
 
-niiri:22ad7ded0ac1d711e8a0487cfc836029 prov:wasDerivedFrom niiri:8a1a9df782badc0bbaca933d0ac3571f .
+niiri:06e4f88e786fe09809dfe30420188f25 prov:wasDerivedFrom niiri:00fdfd7ba3a1372b2fbd17a20aa19445 .
 
-niiri:22ad7ded0ac1d711e8a0487cfc836029 prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+niiri:06e4f88e786fe09809dfe30420188f25 prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
 
-niiri:099512568a9246b3c907bed89316bb8e
+niiri:afb00741e29f2942b8bc70b0e38a847b
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     crypto:sha512 "e6693f369d2fa58fde6bb78dace1fdc9521df63e568f095ee6db26856a879741791a8c36129499add3e42183cdfd12b7248e0f6dc17498cb171d3531d2214160"^^xsd:string .
 
-niiri:8840e7e42f24e4dae1b15d56a8415d4e
+niiri:466df67e27037c9807478d993dcc8246
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b56fd35a348aee9be010ac31b4609d488cee2d8b5187a90eb8dafa9614d5cfde93da812469684a1bf03fa4ef76069b11f5820ada92bc0ed4630a352716074300"^^xsd:string .
 
-niiri:099512568a9246b3c907bed89316bb8e prov:wasDerivedFrom niiri:8840e7e42f24e4dae1b15d56a8415d4e .
+niiri:afb00741e29f2942b8bc70b0e38a847b prov:wasDerivedFrom niiri:466df67e27037c9807478d993dcc8246 .
 
-niiri:099512568a9246b3c907bed89316bb8e prov:wasGeneratedBy niiri:6e7bddf230024f1964840b0266c76020 .
+niiri:afb00741e29f2942b8bc70b0e38a847b prov:wasGeneratedBy niiri:28550e8b753c726791498099b035ca93 .
 
-niiri:fc096c306109a662a505b528a003df77
+niiri:c2a5865b1a64ede064a33413b821a1fe
     a prov:Entity, stato_ContrastWeightMatrix: ; 
     nidm_statisticType: stato_TStatistic: ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     rdfs:label "Contrast: pos vs neg" ;
     prov:value "[1, -1, 0]"^^xsd:string .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7
+niiri:f6527b3ae676ec51392646f86918478a
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7 prov:wasAssociatedWith niiri:7283130bdaae614053b66a993e6bed87 .
+niiri:f6527b3ae676ec51392646f86918478a prov:wasAssociatedWith niiri:9e85c3c113468fdd7321a08d6f0433ec .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:0c1e97eda14902ae1fa46b66fa317472 .
+niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:aa1c29a1fdf1399681a37fc8a884c2be .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:22ad7ded0ac1d711e8a0487cfc836029 .
+niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:06e4f88e786fe09809dfe30420188f25 .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:941e9bbf9c32fd5d3adefb829c4faf73 .
+niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:b3af73299b71e1b964b104cdf1c99178 .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:fc096c306109a662a505b528a003df77 .
+niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:c2a5865b1a64ede064a33413b821a1fe .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:8f4893f367edf8f3923730a046a36bda .
+niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:72efa4876d285bc921fa2e1ff390e862 .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:d397c8020fa4e33527facc866b1a20a7 .
+niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:2f916c52f15b207fcf0e53698b791216 .
 
-niiri:2831de2cddf960bc84248af0cd98e7e7 prov:used niiri:32132c18bf4103567994106215344329 .
+niiri:f6527b3ae676ec51392646f86918478a prov:used niiri:9d59b9bd7ccc14a2bbc01e334c0cd02d .
 
-niiri:ca7d326edc041d49f3a8bd6888a2ad5e
+niiri:32a98391fb64e3b4c085771c0a49fc6f
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -345,124 +345,124 @@ niiri:ca7d326edc041d49f3a8bd6888a2ad5e
     nidm_contrastName: "pos vs neg"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "214.999999999918"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     crypto:sha512 "36b2d831048359ab4244f94bea8f23b8a741257cf296ff4f6e223022e4310c63f96aa8bb05ef97c69b9f052ef6e19ea7805c8e1c2ccfb93b3f8a54798b176f4f"^^xsd:string .
 
-niiri:a4f6e768a620095f32601b599dfcf4ee
+niiri:ce2d2b79f29ca64888485463e431f288
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d2bf76b00a8aa356a417d1bdb9033c87da4695f69dc134fc737318a6cb517bb263c7f5b14d289c5366cf6c16c5487962571b50b64e9767a6cc7a7969b8656f59"^^xsd:string .
 
-niiri:ca7d326edc041d49f3a8bd6888a2ad5e prov:wasDerivedFrom niiri:a4f6e768a620095f32601b599dfcf4ee .
+niiri:32a98391fb64e3b4c085771c0a49fc6f prov:wasDerivedFrom niiri:ce2d2b79f29ca64888485463e431f288 .
 
-niiri:ca7d326edc041d49f3a8bd6888a2ad5e prov:wasGeneratedBy niiri:2831de2cddf960bc84248af0cd98e7e7 .
+niiri:32a98391fb64e3b4c085771c0a49fc6f prov:wasGeneratedBy niiri:f6527b3ae676ec51392646f86918478a .
 
-niiri:b66377f4e2a18ee1d08045e6ec196028
+niiri:d52a011528706ad5da1bcebab89ec4b2
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: pos vs neg" ;
     nidm_contrastName: "pos vs neg"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     crypto:sha512 "1fd9a38be64c0e4e421908cd51458e9754cb9d0657794cf05d4d0a5acea3305c105657de50866ff7cc493295daf1407987b22a3c7bb42ca27afcd38b16d0bfd2"^^xsd:string .
 
-niiri:d7555057f51e0761d5b6357557846537
+niiri:24624d7cd6f93e40818435d76154f63c
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "952b528e67fdc806bf38c5841674528f02ecef175feea6bbbf7a5dfc0022e6ef213a5c57e128be6901c1537c495c3ef4932ffe160a271446c1e34138827e9c9f"^^xsd:string .
 
-niiri:b66377f4e2a18ee1d08045e6ec196028 prov:wasDerivedFrom niiri:d7555057f51e0761d5b6357557846537 .
+niiri:d52a011528706ad5da1bcebab89ec4b2 prov:wasDerivedFrom niiri:24624d7cd6f93e40818435d76154f63c .
 
-niiri:b66377f4e2a18ee1d08045e6ec196028 prov:wasGeneratedBy niiri:2831de2cddf960bc84248af0cd98e7e7 .
+niiri:d52a011528706ad5da1bcebab89ec4b2 prov:wasGeneratedBy niiri:f6527b3ae676ec51392646f86918478a .
 
-niiri:616d5161e30226dc4d87d86fc9f12ca6
+niiri:05b5e98aee20aefdc7de6d5ada900f65
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     crypto:sha512 "2f90580f98e7a8c8e7fccff73f3fbe9e8b1da7090010e5102961e0a5b330f8d501cddb2db3b390d49348e7c8b2e20e39f324c90225913dc43e7ec86bcae93fb3"^^xsd:string .
 
-niiri:616d5161e30226dc4d87d86fc9f12ca6 prov:wasGeneratedBy niiri:2831de2cddf960bc84248af0cd98e7e7 .
+niiri:05b5e98aee20aefdc7de6d5ada900f65 prov:wasGeneratedBy niiri:f6527b3ae676ec51392646f86918478a .
 
-niiri:e9c625452832b88935d6c847b635a4c2
+niiri:724f6938b9d3c678ce89374d96cd8417
     a prov:Entity, nidm_HeightThreshold:, obo_Statistic: ; 
     rdfs:label "Height Threshold: T=4.000000)" ;
     prov:value "4"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:3a225a61c68b3b7a2132f5439a3b7806 ;
-    nidm_equivalentThreshold: niiri:0665adcee230e9c3db98038317ef01eb .
+    nidm_equivalentThreshold: niiri:ac11b497f38fbd2be58f2597ae00ff63 ;
+    nidm_equivalentThreshold: niiri:1f09035a8e827d457deb1490af42173f .
 
-niiri:3a225a61c68b3b7a2132f5439a3b7806
+niiri:ac11b497f38fbd2be58f2597ae00ff63
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Height Threshold" ;
     prov:value "4.3562342453618e-05"^^xsd:float .
 
-niiri:0665adcee230e9c3db98038317ef01eb
+niiri:1f09035a8e827d457deb1490af42173f
     a prov:Entity, nidm_HeightThreshold:, obo_pValueFWER: ; 
     rdfs:label "Height Threshold" ;
     prov:value "0.9111141889082"^^xsd:float .
 
-niiri:7a95c241ad8d0f6c41092f5156ae91fd
+niiri:aa54459b725ec30bcb6e20e9c9ab6de2
     a prov:Entity, nidm_ExtentThreshold:, obo_Statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:38340c0af4aaac49ecd8bbdeb4c35fdc ;
-    nidm_equivalentThreshold: niiri:2ebf8fa32230a6dd48d721260aa95b14 .
+    nidm_equivalentThreshold: niiri:f27f8d84e42536914e0cd64a4694253a ;
+    nidm_equivalentThreshold: niiri:d90df515ec31dcc930a7f6742bba0a9d .
 
-niiri:38340c0af4aaac49ecd8bbdeb4c35fdc
+niiri:f27f8d84e42536914e0cd64a4694253a
     a prov:Entity, nidm_ExtentThreshold:, obo_pValueFWER: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:2ebf8fa32230a6dd48d721260aa95b14
+niiri:d90df515ec31dcc930a7f6742bba0a9d
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:d6573c073b0fd3e892d6d5c2840ea0ff
+niiri:506b45d4a4ab88895094698e0d7c6319
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:06ba5171d4001c7750aea6e98e50c2fa
+niiri:9c731ff8e20a1e8750a1f8ec89560ff1
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae
+niiri:c087cec5deed4a6989758e633c54ef25
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:wasAssociatedWith niiri:7283130bdaae614053b66a993e6bed87 .
+niiri:c087cec5deed4a6989758e633c54ef25 prov:wasAssociatedWith niiri:9e85c3c113468fdd7321a08d6f0433ec .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:e9c625452832b88935d6c847b635a4c2 .
+niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:724f6938b9d3c678ce89374d96cd8417 .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:7a95c241ad8d0f6c41092f5156ae91fd .
+niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:aa54459b725ec30bcb6e20e9c9ab6de2 .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:ca7d326edc041d49f3a8bd6888a2ad5e .
+niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:32a98391fb64e3b4c085771c0a49fc6f .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:099512568a9246b3c907bed89316bb8e .
+niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:afb00741e29f2942b8bc70b0e38a847b .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:0c1e97eda14902ae1fa46b66fa317472 .
+niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:aa1c29a1fdf1399681a37fc8a884c2be .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:d6573c073b0fd3e892d6d5c2840ea0ff .
+niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:506b45d4a4ab88895094698e0d7c6319 .
 
-niiri:a6cfbf83b43a688c8c63f74a89dc20ae prov:used niiri:06ba5171d4001c7750aea6e98e50c2fa .
+niiri:c087cec5deed4a6989758e633c54ef25 prov:used niiri:9c731ff8e20a1e8750a1f8ec89560ff1 .
 
-niiri:138f6783f353483960178c8bf70ea952
+niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     nidm_searchVolumeInVoxels: "205365"^^xsd:int ;
     nidm_searchVolumeInUnits: "1642920"^^xsd:float ;
     nidm_reselSizeInVoxels: "71.8552337008046"^^xsd:float ;
@@ -479,9 +479,9 @@ niiri:138f6783f353483960178c8bf70ea952
     spm_smallestSupraThresholdClusterSizeInVoxelsFDR05: "Inf"^^xsd:int ;
     crypto:sha512 "805ad0437f8692983d815ca0c6bb8d2a62229ee8cf8888c51bf02988fa40ce867a92df5018cef2504e61071d800cc456b8f48b7970dbb68ae5b48655594cf93e"^^xsd:string .
 
-niiri:138f6783f353483960178c8bf70ea952 prov:wasGeneratedBy niiri:a6cfbf83b43a688c8c63f74a89dc20ae .
+niiri:c727d1f18a55e4df5e7ebf6cd4f58e0b prov:wasGeneratedBy niiri:c087cec5deed4a6989758e633c54ef25 .
 
-niiri:982c4f0c64cd8daea713a5bb9bc8eb76
+niiri:6c49fe9342e735959c7bde778b1e58c6
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -489,22 +489,22 @@ niiri:982c4f0c64cd8daea713a5bb9bc8eb76
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "0"^^xsd:int ;
     nidm_pValue: "NaN"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:535611df3c8befd941831f7da314cec4 ;
-    nidm_hasMaximumIntensityProjection: niiri:53c77f378e7ddf8eefee3f6f3d0bc941 ;
-    nidm_inCoordinateSpace: niiri:0639cddb4b02210cdc4db993b0fc3874 ;
+    nidm_hasClusterLabelsMap: niiri:0d816fc1c460889e384228fa288a25f3 ;
+    nidm_hasMaximumIntensityProjection: niiri:5b3985681eae5f6d6d353d227056e5fd ;
+    nidm_inCoordinateSpace: niiri:c66ef8aa5c4f00b5901391884536d9ff ;
     crypto:sha512 "9a5dadd6a79e39f26ed182737097a9dcd4a2834c11e26ab9a103b16ba7fa617bfea0ef96d313c191e9ff6aec05af86a24164e6c6c811a1c2404b184d59542640"^^xsd:string .
 
-niiri:535611df3c8befd941831f7da314cec4
+niiri:0d816fc1c460889e384228fa288a25f3
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
 
-niiri:53c77f378e7ddf8eefee3f6f3d0bc941
+niiri:5b3985681eae5f6d6d353d227056e5fd
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:982c4f0c64cd8daea713a5bb9bc8eb76 prov:wasGeneratedBy niiri:a6cfbf83b43a688c8c63f74a89dc20ae .
+niiri:6c49fe9342e735959c7bde778b1e58c6 prov:wasGeneratedBy niiri:c087cec5deed4a6989758e633c54ef25 .
 

--- a/spmexport/example001/config.json
+++ b/spmexport/example001/config.json
@@ -1,5 +1,5 @@
 {
     "info": "Tests based on the analysis of single-subject auditory data based on test01_spm_batch.m using SPM12b r5918.",
-    "ground_truth": ["spm/example001/example001_spm_results.ttl"],
+    "ground_truth": ["spm_full_example001/example001_spm_results.ttl"],
     "inclusive": false
 }

--- a/spmexport/ground_truth/HRF_informed_basis/nidm.ttl
+++ b/spmexport/ground_truth/HRF_informed_basis/nidm.ttl
@@ -1,0 +1,23 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix spm_SPMsTemporalDerivative: <http://purl.org/nidash/spm#SPM_0000006> .
+@prefix spm_SPMsDispersionDerivative: <http://purl.org/nidash/spm#SPM_0000003> .
+
+
+niiri:first_level_design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    dct:format "text/csv"^^xsd:string ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
+    nidm_hasHRFBasis: spm_SPMsTemporalDerivative: ;
+    nidm_hasHRFBasis: spm_SPMsDispersionDerivative: .

--- a/spmexport/ground_truth/cluster_k=10/nidm.ttl
+++ b/spmexport/ground_truth/cluster_k=10/nidm.ttl
@@ -1,0 +1,15 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix obo_statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+
+
+niiri:extent_threshold_stat_id a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ;
+    rdfs:label "Extent Threshold: k>=10" ;
+    nidm_clusterSizeInVoxels: "10"^^xsd:int ;
+    nidm_clusterSizeInResels: "0"^^xsd:float .

--- a/spmexport/ground_truth/conjunction/nidm.ttl
+++ b/spmexport/ground_truth/conjunction/nidm.ttl
@@ -1,0 +1,13 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix nidm_ConjunctionInference: <http://purl.org/nidash/nidm#NIDM_0000011> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+
+
+niiri:inference_id a prov:Activity , nidm_ConjunctionInference: ;
+	rdfs:label "Conjunction Inference" ;
+	nidm_hasAlternativeHypothesis: nidm_OneTailedTest: .

--- a/spmexport/ground_truth/contrast_mask/nidm.ttl
+++ b/spmexport/ground_truth/contrast_mask/nidm.ttl
@@ -1,0 +1,14 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+
+@prefix nidm_DisplayMaskMap: <http://purl.org/nidash/nidm#NIDM_0000020> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+
+
+niiri:display_map_id a prov:Entity , nidm_DisplayMaskMap: ;
+	rdfs:label "Display Mask Map" ;
+	dct:format "image/nifti"^^xsd:string .

--- a/spmexport/ground_truth/f_test/nidm.ttl
+++ b/spmexport/ground_truth/f_test/nidm.ttl
@@ -1,0 +1,16 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix obo_contrastweightmatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix obo_fstatistic: <http://purl.obolibrary.org/obo/STATO_0000282> .
+
+
+niiri:contrast_id a prov:Entity , obo_contrastweightmatrix: ;
+	rdfs:label "Contrast: F Contrast Test" ;
+	prov:value "[ [1, 0, 0, 0, 0], [0, 1, 0 ,0 ,0], [0, 0, 1, 0, 0], [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]]"^^xsd:string ;
+	nidm_statisticType: obo_fstatistic: ; 
+	nidm_contrastName: "F Contrast Test"^^xsd:string .

--- a/spmexport/ground_truth/non_sphericity/nidm.ttl
+++ b/spmexport/ground_truth/non_sphericity/nidm.ttl
@@ -1,0 +1,23 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix obo_normaldistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix obo_unstructuredcovariancestructure: <http://purl.obolibrary.org/obo/STATO_0000405> .
+
+
+niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
+    nidm_hasErrorDistribution: obo_normaldistribution: ;
+    nidm_errorVarianceHomogeneous: "false"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
+    nidm_hasErrorDependence: obo_unstructuredcovariancestructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: .

--- a/spmexport/ground_truth/partial_conjunction/nidm.ttl
+++ b/spmexport/ground_truth/partial_conjunction/nidm.ttl
@@ -1,0 +1,15 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix spm_PartialConjunctionInference: <http://purl.org/nidash/spm#SPM_0000005> .
+@prefix spm_partialConjunctionDegree: <http://purl.org/nidash/spm#SPM_0000015> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+
+
+niiri:inference_id a prov:Activity , spm_PartialConjunctionInference: ;
+	rdfs:label "Partial Conjunction Inference" ;
+	nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+	spm_partialConjunctionDegree: "2"^^xsd:int .

--- a/spmexport/ground_truth/spm_full_example001/example001_spm_results.ttl
+++ b/spmexport/ground_truth/spm_full_example001/example001_spm_results.ttl
@@ -1,0 +1,603 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix neurolex: <http://neurolex.org/wiki/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix spm: <http://purl.org/nidash/spm#> .
+@prefix fsl: <http://purl.org/nidash/fsl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix nlx: <http://neurolex.org/wiki/> .
+
+
+@prefix nidm_ClusterDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000007> .
+@prefix nidm_hasConnectivityCriterion: <http://purl.org/nidash/nidm#NIDM_0000099> .
+@prefix nidm_voxel18connected: <http://purl.org/nidash/nidm#NIDM_0000128> .
+@prefix nidm_ClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000008> .
+@prefix nidm_ContrastEstimation: <http://purl.org/nidash/nidm#NIDM_0000001> .
+@prefix nidm_ContrastMap: <http://purl.org/nidash/nidm#NIDM_0000002> .
+@prefix nidm_contrastName: <http://purl.org/nidash/nidm#NIDM_0000085> .
+@prefix nidm_inCoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000104> .
+@prefix nidm_ContrastStandardErrorMap: <http://purl.org/nidash/nidm#NIDM_0000013> .
+@prefix nidm_statisticType: <http://purl.org/nidash/nidm#NIDM_0000123> .
+@prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
+@prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
+@prefix nidm_CoordinateSpace: <http://purl.org/nidash/nidm#NIDM_0000016> .
+@prefix nidm_voxelToWorldMapping: <http://purl.org/nidash/nidm#NIDM_0000132> .
+@prefix nidm_voxelUnits: <http://purl.org/nidash/nidm#NIDM_0000133> .
+@prefix nidm_voxelSize: <http://purl.org/nidash/nidm#NIDM_0000131> .
+@prefix nidm_inWorldCoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000105> .
+@prefix nidm_MNICoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000051> .
+@prefix nidm_numberOfDimensions: <http://purl.org/nidash/nidm#NIDM_0000112> .
+@prefix nidm_dimensionsInVoxels: <http://purl.org/nidash/nidm#NIDM_0000090> .
+@prefix nidm_DataScaling: <http://purl.org/nidash/nidm#NIDM_0000018> .
+@prefix nidm_grandMeanScaling: <http://purl.org/nidash/nidm#NIDM_0000096> .
+@prefix nidm_targetIntensity: <http://purl.org/nidash/nidm#NIDM_0000124> .
+@prefix nidm_ParameterEstimateMap: <http://purl.org/nidash/nidm#NIDM_0000061> .
+@prefix nidm_MaskMap: <http://purl.org/nidash/nidm#NIDM_0000054> .
+@prefix nidm_ResidualMeanSquaresMap: <http://purl.org/nidash/nidm#NIDM_0000066> .
+@prefix nidm_ReselsPerVoxelMap: <http://purl.org/nidash/nidm#NIDM_0000144> .
+@prefix nidm_StatisticMap: <http://purl.org/nidash/nidm#NIDM_0000076> .
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix nidm_ErrorModel: <http://purl.org/nidash/nidm#NIDM_0000023> .
+@prefix nidm_hasErrorDistribution: <http://purl.org/nidash/nidm#NIDM_0000101> .
+@prefix nidm_errorVarianceHomogeneous: <http://purl.org/nidash/nidm#NIDM_0000094> .
+@prefix nidm_varianceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000126> .
+@prefix nidm_IndependentParameter: <http://purl.org/nidash/nidm#NIDM_0000073> .
+@prefix nidm_hasErrorDependence: <http://purl.org/nidash/nidm#NIDM_0000100> .
+@prefix nidm_dependenceMapWiseDependence: <http://purl.org/nidash/nidm#NIDM_0000089> .
+@prefix nidm_ConstantParameter: <http://purl.org/nidash/nidm#NIDM_0000072> .
+@prefix nidm_ExcursionSetMap: <http://purl.org/nidash/nidm#NIDM_0000025> .
+@prefix nidm_hasClusterLabelsMap: <http://purl.org/nidash/nidm#NIDM_0000098> .
+@prefix nidm_hasMaximumIntensityProjection: <http://purl.org/nidash/nidm#NIDM_0000138> .
+@prefix nidm_numberOfSignificantClusters: <http://purl.org/nidash/nidm#NIDM_0000111> .
+@prefix nidm_pValue: <http://purl.org/nidash/nidm#NIDM_0000114> .
+@prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
+@prefix nidm_spm_results_nidm: <http://purl.org/nidash/nidm#NIDM_0000168> .
+@prefix nidm_softwareVersion: <http://purl.org/nidash/nidm#NIDM_0000122> .
+@prefix nidm_ExtentThreshold: <http://purl.org/nidash/nidm#NIDM_0000026> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+@prefix nidm_clusterSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000084> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix nidm_clusterSizeInResels: <http://purl.org/nidash/nidm#NIDM_0000156> .
+@prefix nidm_GrandMeanMap: <http://purl.org/nidash/nidm#NIDM_0000033> .
+@prefix nidm_maskedMedian: <http://purl.org/nidash/nidm#NIDM_0000107> .
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+@prefix nidm_isUserDefined: <http://purl.org/nidash/nidm#NIDM_0000106> .
+@prefix nidm_ModelParametersEstimation: <http://purl.org/nidash/nidm#NIDM_0000056> .
+@prefix nidm_withEstimationMethod: <http://purl.org/nidash/nidm#NIDM_0000134> .
+@prefix nidm_NIDMResults: <http://purl.org/nidash/nidm#NIDM_0000027> .
+@prefix nidm_version: <http://purl.org/nidash/nidm#NIDM_0000127> .
+@prefix nidm_PeakDefinitionCriteria: <http://purl.org/nidash/nidm#NIDM_0000063> .
+@prefix nidm_minDistanceBetweenPeaks: <http://purl.org/nidash/nidm#NIDM_0000109> .
+@prefix nidm_maxNumberOfPeaksPerCluster: <http://purl.org/nidash/nidm#NIDM_0000108> .
+@prefix nidm_Peak: <http://purl.org/nidash/nidm#NIDM_0000062> .
+@prefix nidm_pValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000116> .
+@prefix nidm_equivalentZStatistic: <http://purl.org/nidash/nidm#NIDM_0000092> .
+@prefix nidm_pValueFWER: <http://purl.org/nidash/nidm#NIDM_0000115> .
+@prefix nidm_qValueFDR: <http://purl.org/nidash/nidm#NIDM_0000119> .
+@prefix nidm_SearchSpaceMaskMap: <http://purl.org/nidash/nidm#NIDM_0000068> .
+@prefix nidm_expectedNumberOfVoxelsPerCluster: <http://purl.org/nidash/nidm#NIDM_0000143> .
+@prefix nidm_expectedNumberOfClusters: <http://purl.org/nidash/nidm#NIDM_0000141> .
+@prefix nidm_heightCriticalThresholdFWE05: <http://purl.org/nidash/nidm#NIDM_0000147> .
+@prefix nidm_heightCriticalThresholdFDR05: <http://purl.org/nidash/nidm#NIDM_0000146> .
+@prefix nidm_searchVolumeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000121> .
+@prefix nidm_searchVolumeInUnits: <http://purl.org/nidash/nidm#NIDM_0000136> .
+@prefix nidm_reselSizeInVoxels: <http://purl.org/nidash/nidm#NIDM_0000148> .
+@prefix nidm_searchVolumeInResels: <http://purl.org/nidash/nidm#NIDM_0000149> .
+@prefix nidm_noiseFWHMInVoxels: <http://purl.org/nidash/nidm#NIDM_0000159> .
+@prefix nidm_noiseFWHMInUnits: <http://purl.org/nidash/nidm#NIDM_0000157> .
+@prefix nidm_randomFieldStationarity: <http://purl.org/nidash/nidm#NIDM_0000120> .
+@prefix nidm_effectDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000091> .
+@prefix nidm_errorDegreesOfFreedom: <http://purl.org/nidash/nidm#NIDM_0000093> .
+@prefix nidm_SupraThresholdCluster: <http://purl.org/nidash/nidm#NIDM_0000070> .
+@prefix nidm_clusterLabelId: <http://purl.org/nidash/nidm#NIDM_0000082> .
+@prefix obo_contrastweightmatrix: <http://purl.obolibrary.org/obo/STATO_0000323> .
+@prefix obo_tstatistic: <http://purl.obolibrary.org/obo/STATO_0000176> .
+@prefix obo_normaldistribution: <http://purl.obolibrary.org/obo/STATO_0000227> .
+@prefix obo_Toeplitzcovariancestructure: <http://purl.obolibrary.org/obo/STATO_0000357> .
+@prefix obo_statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+@prefix obo_generalizedleastsquaresestimation: <http://purl.obolibrary.org/obo/STATO_0000372> .
+@prefix obo_FWERadjustedpvalue: <http://purl.obolibrary.org/obo/OBI_0001265> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix spm_DCTDriftModel: <http://purl.org/nidash/spm#SPM_0000002> .
+@prefix spm_SPMsDriftCutoffPeriod: <http://purl.org/nidash/spm#SPM_0000001> .
+@prefix spm_smallestSignificantClusterSizeInVoxelsFWE05: <http://purl.org/nidash/spm#SPM_0000014> .
+@prefix spm_smallestSignificantClusterSizeInVoxelsFDR05: <http://purl.org/nidash/spm#SPM_0000013> .
+@prefix spm_searchVolumeReselsGeometry: <http://purl.org/nidash/spm#SPM_0000010> .
+@prefix nlx_SPM: <http://neurolex.org/wiki/nif-0000-00343> .
+
+
+niiri:cluster_definition_criteria_id a prov:Entity , nidm_ClusterDefinitionCriteria: ;
+	rdfs:label "Cluster Connectivity Criterion: 18" ;
+	nidm_hasConnectivityCriterion: nidm_voxel18connected: .
+
+niiri:cluster_label_map_id a prov:Entity , nidm_ClusterLabelsMap: ;
+	prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
+	nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
+	dct:format "image/nifti"^^xsd:string .
+
+niiri:contrast_estimation_id prov:used niiri:beta_map_id_2 .
+
+niiri:contrast_estimation_id a prov:Activity , nidm_ContrastEstimation: ;
+	rdfs:label "Contrast estimation" ;
+	prov:used niiri:mask_id_1 , niiri:residual_mean_squares_map_id , niiri:design_matrix_id , niiri:contrast_id, niiri:beta_map_id_1 ;
+    prov:wasAssociatedWith niiri:software_id .
+
+niiri:contrast_map_id a prov:Entity , nidm_ContrastMap: ;
+	rdfs:label "Contrast Map: passive listening > rest" ;
+	prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
+	dct:format "image/nifti"^^xsd:string ;
+	nfo:fileName "Contrast.nii.gz"^^xsd:string ;
+	nidm_contrastName: "passive listening > rest"^^xsd:string ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	crypto:sha512 "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2"^^xsd:string ;
+    prov:wasGeneratedBy niiri:contrast_estimation_id .
+
+
+niiri:contrast_standard_error_map_id a prov:Entity , nidm_ContrastStandardErrorMap: ;
+	rdfs:label "Contrast Standard Error Map" ;
+	prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
+	nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
+	dct:format "image/nifti"^^xsd:string ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	crypto:sha512 "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2"^^xsd:string ;
+    prov:wasGeneratedBy niiri:contrast_estimation_id .
+
+niiri:contrast_id a prov:Entity , obo_contrastweightmatrix: ;
+	rdfs:label "Contrast: passive listening > rest" ;
+	prov:value "[1, 0]"^^xsd:string ;
+	nidm_statisticType: obo_tstatistic: ; # obo:'t-statistic'
+	nidm_contrastName: "passive listening > rest"^^xsd:string .
+
+niiri:coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0001" ;
+	nidm_coordinateVector: "[ -60, -25, 11 ]"^^xsd:string .
+
+niiri:coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0002" ;
+	nidm_coordinateVector: "[ -42, -31, 11 ]"^^xsd:string .
+
+niiri:coordinate_0003 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0003" ;
+	nidm_coordinateVector: "[ -66, -31, -1 ]"^^xsd:string .
+
+niiri:coordinate_0004 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0004" ;
+	nidm_coordinateVector: "[ 63, -13, -4 ]"^^xsd:string .
+
+niiri:coordinate_0005 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0005" ;
+	nidm_coordinateVector: "[ 60, -22, 11 ]"^^xsd:string .
+
+niiri:coordinate_0006 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0006" ;
+	nidm_coordinateVector: "[ 57, -40, 5 ]"^^xsd:string .
+
+niiri:coordinate_0007 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0007" ;
+	nidm_coordinateVector: "[ 36, -28, -13 ]"^^xsd:string .
+
+niiri:coordinate_0008 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0008" ;
+	nidm_coordinateVector: "[ -33, -31, -16 ]"^^xsd:string .
+
+niiri:coordinate_0009 a prov:Entity , prov:Location , nidm_Coordinate: ;
+	rdfs:label "Coordinate: 0009" ;
+	nidm_coordinateVector: "[ 45, -40, 32 ]"^^xsd:string .
+
+niiri:coordinate_space_id_1 a prov:Entity , nidm_CoordinateSpace: ;
+	rdfs:label "Coordinate space 1" ;
+	nidm_voxelToWorldMapping: "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]"^^xsd:string ;
+	nidm_voxelUnits: "[ \"mm\", \"mm\", \"mm\" ]"^^xsd:string ;
+	nidm_voxelSize: "[ 3, 3, 3 ]"^^xsd:string ;
+	nidm_inWorldCoordinateSystem: nidm_MNICoordinateSystem: ;
+	nidm_numberOfDimensions: "3"^^xsd:int ;
+	nidm_dimensionsInVoxels: "[ 53, 63, 52 ]"^^xsd:string .
+
+niiri:data_id a prov:Entity , nidm_DataScaling: , prov:Collection ;
+    rdfs:label "Data" ;
+    nidm_grandMeanScaling: "true"^^xsd:boolean ;
+    nidm_targetIntensity: "100"^^xsd:float .
+
+niiri:contrast_map_id_der a prov:Entity , nidm_ContrastMap: ;
+    nfo:fileName "con_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "277dd1da13d391c33c172fb8c71060008cc66e173de6362eb857b0055b41e9bae57911f7ec4b45659905103b1139ebf3da0c2d04cf105bbce0cdc3004b643c22"^^xsd:string .
+
+niiri:contrast_map_id prov:wasDerivedFrom niiri:contrast_map_id_der .
+
+niiri:beta_map_id_2_der a prov:Entity , nidm_ParameterEstimateMap: ;
+    nfo:fileName "beta_0002.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"^^xsd:string .
+
+niiri:beta_map_id_2 prov:wasDerivedFrom niiri:beta_map_id_2_der .
+
+niiri:mask_id_1_der a prov:Entity , nidm_MaskMap: ;
+    nfo:fileName "mask.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11"^^xsd:string .
+
+niiri:mask_id_1 prov:wasDerivedFrom niiri:mask_id_1_der .
+
+niiri:beta_map_id_1_der a prov:Entity , nidm_ParameterEstimateMap: ;
+    nfo:fileName "beta_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"^^xsd:string .
+
+niiri:beta_map_id_1 prov:wasDerivedFrom niiri:beta_map_id_1_der .
+
+niiri:residual_mean_squares_map_id_der a prov:Entity , nidm_ResidualMeanSquaresMap: ;
+    nfo:fileName "ResMS.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "1635e0ae420cac1b5989fbc753b95f504dd957ff2986367fc4cd13ff35c44b4ee60994a9cdcab93a7d247fc5a8decb7578fa4c553b0ac905af8c7041db9b4acd"^^xsd:string .
+
+niiri:residual_mean_squares_map_id prov:wasDerivedFrom niiri:residual_mean_squares_map_id_der .
+
+niiri:resels_per_voxel_map_id_der a prov:Entity , nidm_ReselsPerVoxelMap: ;
+    nfo:fileName "RPV.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d"^^xsd:string .
+
+niiri:resels_per_voxel_map_id prov:wasDerivedFrom niiri:resels_per_voxel_map_id_der .
+
+niiri:statistic_map_id_der a prov:Entity , nidm_StatisticMap: ;
+    nfo:fileName "spmT_0001.nii"^^xsd:string ;
+    dct:format "image/nifti"^^xsd:string ;
+    crypto:sha512 "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825"^^xsd:string .
+
+niiri:statistic_map_id prov:wasDerivedFrom niiri:statistic_map_id_der .
+
+niiri:design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
+    rdfs:label "Design Matrix" ;
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    dct:format "text/csv"^^xsd:string ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    dc:description niiri:design_matrix_png_id ;
+    nidm_regressorNames: "[\"Sn(1) active*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
+    nidm_hasDriftModel: niiri:drift_model_id .
+
+niiri:error_model_id a prov:Entity , nidm_ErrorModel: ;
+    nidm_hasErrorDistribution: obo_normaldistribution: ;
+    nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
+    nidm_varianceMapWiseDependence: nidm_IndependentParameter: ;
+    nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
+    nidm_dependenceMapWiseDependence: nidm_ConstantParameter: .
+
+niiri:excursion_set_map_id a prov:Entity , nidm_ExcursionSetMap: ;
+	rdfs:label "Excursion Set Map" ;
+	prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
+	dct:format "image/nifti"^^xsd:string ;
+	nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
+	nidm_hasClusterLabelsMap: niiri:cluster_label_map_id ;
+	nidm_hasMaximumIntensityProjection: niiri:maximum_intensity_projection_id ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	crypto:sha512 "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652"^^xsd:string ;
+	nidm_numberOfSignificantClusters: "5"^^xsd:int ;
+	nidm_pValue: "2.83510681598e-09"^^xsd:float ;
+	prov:wasGeneratedBy niiri:inference_id .
+
+niiri:export_id a prov:Activity , nidm_NIDMResultsExport: ;
+	rdfs:label "NIDM-Results export" .
+
+niiri:export_id prov:wasAssociatedWith niiri:exporter_id .
+
+niiri:exporter_id a prov:Agent, nidm_spm_results_nidm: , prov:SoftwareAgent ;
+	rdfs:label "spm_results_nidm" ;
+	nidm_softwareVersion: "12b.5858"^^xsd:string .
+
+niiri:extent_threshold_id_2 a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ;
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:extent_threshold_id_3 a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ;
+    rdfs:label "Extent Threshold" ;
+    prov:value "1"^^xsd:float .
+
+niiri:extent_threshold_id a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ;
+    rdfs:label "Extent Threshold: k>=0" ;
+    nidm_clusterSizeInVoxels: "0"^^xsd:int ;
+    nidm_equivalentThreshold: niiri:extent_threshold_id_2 ;
+    nidm_equivalentThreshold: niiri:extent_threshold_id_3 ;
+    nidm_clusterSizeInResels: "0"^^xsd:float .
+
+niiri:grand_mean_map_id a prov:Entity , nidm_GrandMeanMap: ;
+	rdfs:label "Grand Mean Map" ;
+	prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
+	nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
+	dct:format "image/nifti"^^xsd:string ;
+	nidm_maskedMedian: "132.008995056152"^^xsd:float ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	crypto:sha512 "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb"^^xsd:string ;
+    prov:wasGeneratedBy niiri:model_pe_id .
+
+niiri:height_threshold_id_2 a prov:Entity, nidm_HeightThreshold:, obo_statistic: ;
+    rdfs:label "Height Threshold" ;
+    prov:value "4.85241745689539"^^xsd:float .
+
+niiri:height_threshold_id_3 a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ;
+    rdfs:label "Height Threshold" ;
+    prov:value "2.7772578456986e-06"^^xsd:float .
+
+niiri:height_threshold_id a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ;
+    rdfs:label "Height Threshold: p<0.05 (FWE)" ;
+    prov:value "0.0499999999999976"^^xsd:float ;
+    nidm_equivalentThreshold: niiri:height_threshold_id_2 ;
+    nidm_equivalentThreshold: niiri:height_threshold_id_3 .
+
+niiri:maximum_intensity_projection_id a prov:Entity , dctype:Image ;
+	prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
+	nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
+	dct:format "image/png"^^xsd:string .
+
+niiri:design_matrix_png_id a prov:Entity , dctype:Image ;
+	prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
+	nfo:fileName "DesignMatrix.png"^^xsd:string ;
+	dct:format "image/png"^^xsd:string .
+
+niiri:inference_id a prov:Activity , nidm_Inference: ;
+	rdfs:label "Inference" ;
+	nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
+    prov:used niiri:statistic_map_id, niiri:height_threshold_id, niiri:extent_threshold_id, niiri:peak_definition_criteria_id, niiri:cluster_definition_criteria_id, niiri:mask_id_1 ;
+    prov:wasAssociatedWith niiri:software_id .
+
+niiri:contrast_estimation_id prov:used niiri:mask_id_1 .
+niiri:mask_id_1 a prov:Entity , nidm_MaskMap: ;
+	rdfs:label "Mask" ;
+    nidm_isUserDefined: "false"^^xsd:boolean ;
+	prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
+	nfo:fileName "Mask.nii.gz"^^xsd:string ;
+	dct:format "image/nifti"^^xsd:string ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	crypto:sha512 "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875"^^xsd:string ;
+    prov:wasGeneratedBy niiri:model_pe_id .
+
+niiri:model_pe_id prov:used niiri:error_model_id ;
+	a prov:Activity , nidm_ModelParametersEstimation: ;
+	rdfs:label "Model parameters estimation" ;
+	nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: ;
+	prov:used niiri:design_matrix_id ;
+    prov:used niiri:data_id ;
+    prov:used niiri:error_model_id ;
+    prov:wasAssociatedWith niiri:software_id .
+
+niiri:spm_results_id a prov:Entity , prov:Bundle, nidm_NIDMResults: ;
+	rdfs:label "NIDM-Results" ;
+	nidm_version: "1.2.0"^^xsd:string .
+
+_:blank1 a prov:Generation ;
+    prov:activity niiri:export_id .
+niiri:spm_results_id prov:qualifiedGeneration _:blank1 .
+_:blank1 prov:atTime "2014-05-19T10:30:00.000+01:00"^^xsd:dateTime .
+
+niiri:beta_map_id_1 a prov:Entity , nidm_ParameterEstimateMap: ;
+    rdfs:label "Beta Map 1" ;
+    nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+    prov:wasGeneratedBy niiri:model_pe_id .
+
+niiri:beta_map_id_2 a prov:Entity , nidm_ParameterEstimateMap: ;
+    rdfs:label "Beta Map 2" ;
+    nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+    prov:wasGeneratedBy niiri:model_pe_id .
+
+niiri:peak_definition_criteria_id a prov:Entity , nidm_PeakDefinitionCriteria: ;
+	rdfs:label "Peak Definition Criteria" ;
+	nidm_minDistanceBetweenPeaks: "8.0"^^xsd:float ;
+    nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int .
+
+niiri:peak_0001 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0001" ;
+    prov:atLocation niiri:coordinate_0001 ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0001 ;
+    prov:value "17.5207633972168"^^xsd:float ;
+	nidm_pValueFWER: "0"^^xsd:float ;
+	nidm_qValueFDR: "1.19156591713838e-11"^^xsd:float .
+
+niiri:peak_0002 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0002" ;
+    prov:atLocation niiri:coordinate_0002 ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0001 ;
+    prov:value "13.0321407318"^^xsd:float ;
+	nidm_pValueFWER: "0"^^xsd:float ;
+	nidm_qValueFDR: "1.19156591714e-11"^^xsd:float .
+
+niiri:peak_0003 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0003" ;
+    prov:atLocation niiri:coordinate_0003 ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0001 ;
+    prov:value "10.2856016159058"^^xsd:float ;
+	nidm_pValueFWER: "7.69451169446711e-12"^^xsd:float ;
+	nidm_qValueFDR: "6.84121260274992e-10"^^xsd:float .
+
+niiri:peak_0004 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0004" ;
+    prov:atLocation niiri:coordinate_0004 ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0002 ;
+    prov:value "13.5425577163696"^^xsd:float ;
+	nidm_pValueFWER: "0"^^xsd:float ;
+	nidm_qValueFDR: "1.19156591713838e-11"^^xsd:float .
+
+niiri:peak_0005 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0005" ;
+    prov:atLocation niiri:coordinate_0005 ;
+    nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0002 ;
+    prov:value "12.4728717803955"^^xsd:float ;
+	nidm_pValueFWER: "0"^^xsd:float ;
+	nidm_qValueFDR: "1.19156591713838e-11"^^xsd:float .
+
+niiri:peak_0006 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0006" ;
+    prov:atLocation niiri:coordinate_0006 ;
+    nidm_pValueUncorrected: "1.22124532708767e-15"^^xsd:float ;
+    nidm_equivalentZStatistic: "INF"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0002 ;
+    prov:value "9.72103404998779"^^xsd:float ;
+	nidm_pValueFWER: "6.9250605250204e-11"^^xsd:float ;
+	nidm_qValueFDR: "6.52169693024352e-09"^^xsd:float .
+
+niiri:peak_0007 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0007" ;
+    prov:atLocation niiri:coordinate_0007 ;
+    nidm_pValueUncorrected: "2.10478867668229e-09"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.87574033699266"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0003 ;
+    prov:value "6.55745935440063"^^xsd:float ;
+	nidm_pValueFWER: "9.17574302586877e-05"^^xsd:float ;
+	nidm_qValueFDR: "0.00257605396646668"^^xsd:float .
+
+niiri:peak_0008 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0008" ;
+    prov:atLocation niiri:coordinate_0008 ;
+    nidm_pValueUncorrected: "1.0325913235576e-08"^^xsd:float ;
+    nidm_equivalentZStatistic: "5.60645028016544"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0004 ;
+    prov:value "6.19558477401733"^^xsd:float ;
+	nidm_pValueFWER: "0.000382453907303626"^^xsd:float ;
+	nidm_qValueFDR: "0.00949154522981781"^^xsd:float .
+
+niiri:peak_0009 a prov:Entity , nidm_Peak: ;
+    rdfs:label "Peak: 0009" ;
+    prov:atLocation niiri:coordinate_0009 ;
+    nidm_pValueUncorrected: "5.12386299833523e-07"^^xsd:float ;
+    nidm_equivalentZStatistic: "4.88682085490477"^^xsd:float ;
+    prov:wasDerivedFrom niiri:supra_threshold_cluster_0005 ;
+    prov:value "5.27320194244385"^^xsd:float ;
+	nidm_pValueFWER: "0.0119099090973821"^^xsd:float ;
+	nidm_qValueFDR: "0.251554254717758"^^xsd:float .
+
+niiri:residual_mean_squares_map_id a prov:Entity , nidm_ResidualMeanSquaresMap: ;
+	rdfs:label "Residual Mean Squares Map" ;
+	prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
+	nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
+	dct:format "image/nifti"^^xsd:string ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	crypto:sha512 "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b"^^xsd:string ;
+    prov:wasGeneratedBy niiri:model_pe_id .
+
+niiri:drift_model_id a prov:Entity , spm_DCTDriftModel: ;
+	rdfs:label "SPM's DCT Drift Model" ;
+	spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
+
+niiri:inference_id prov:used niiri:resels_per_voxel_map_id .
+
+niiri:resels_per_voxel_map_id a prov:Entity , nidm_ReselsPerVoxelMap: ;
+	rdfs:label "Resels per Voxel Map" ;
+	prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
+	nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
+	dct:format "image/nifti"^^xsd:string ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	crypto:sha512 "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a"^^xsd:string ;
+    prov:wasGeneratedBy niiri:model_pe_id.
+
+niiri:software_id a prov:Agent , nlx_SPM: , prov:SoftwareAgent ;
+	rdfs:label "SPM" ;
+	nidm_softwareVersion: "12.12.1"^^xsd:string .
+
+niiri:search_space_mask_id a prov:Entity , nidm_SearchSpaceMaskMap: ;
+	rdfs:label "Search Space Mask Map" ;
+	prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
+	nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
+	dct:format "image/nifti"^^xsd:string ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	nidm_expectedNumberOfVoxelsPerCluster: "4.02834655908613"^^xsd:float ;
+	nidm_expectedNumberOfClusters: "0.0512932943875478"^^xsd:float ;
+	nidm_heightCriticalThresholdFWE05: "4.85241745689539"^^xsd:float ;
+	nidm_heightCriticalThresholdFDR05: "5.7639536857605"^^xsd:float ;
+	spm_smallestSignificantClusterSizeInVoxelsFWE05: "12"^^xsd:int ;
+	spm_smallestSignificantClusterSizeInVoxelsFDR05: "29"^^xsd:int ;
+	nidm_searchVolumeInVoxels: "69306"^^xsd:int ;
+	nidm_searchVolumeInUnits: "1871262"^^xsd:float ;
+	nidm_reselSizeInVoxels: "132.907586178202"^^xsd:float ;
+	nidm_searchVolumeInResels: "467.07642343881"^^xsd:float ;
+	spm_searchVolumeReselsGeometry: "[7, 42.96312274763, 269.40914815306, 467.07642343881]"^^xsd:string ;
+	nidm_noiseFWHMInVoxels: "[ 5.41278985910694, 5.43638957240286, 4.51666658877481 ]"^^xsd:string ;
+	nidm_noiseFWHMInUnits: "[ 16.2383695773208, 16.3091687172086, 13.5499997663244 ]"^^xsd:string ;
+	nidm_randomFieldStationarity: "true"^^xsd:boolean ;
+	crypto:sha512 "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875"^^xsd:string ;
+	prov:wasGeneratedBy niiri:inference_id .
+
+niiri:statistic_map_id a prov:Entity , nidm_StatisticMap: ;
+	rdfs:label "Statistic Map: passive listening > rest" ;
+	prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
+	nidm_statisticType: obo_tstatistic: ;
+	nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
+	dct:format "image/nifti"^^xsd:string ;
+	nidm_contrastName: "passive listening > rest"^^xsd:string ;
+	nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
+	nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
+	crypto:sha512 "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6"^^xsd:string ;
+	prov:wasGeneratedBy niiri:contrast_estimation_id;
+    nidm_errorDegreesOfFreedom: "84.0"^^xsd:float .
+
+niiri:supra_threshold_cluster_0001 a prov:Entity , nidm_SupraThresholdCluster: ;
+	rdfs:label "Supra-Threshold Cluster: 0001" ;
+	nidm_clusterSizeInVoxels: "839"^^xsd:int ;
+	nidm_clusterLabelId: "1"^^xsd:int ;
+	nidm_clusterSizeInResels: "6.31265696809113"^^xsd:float ;
+	nidm_pValueUncorrected: "3.55896824480477e-19"^^xsd:float ;
+	nidm_pValueFWER: "0"^^xsd:float ;
+	nidm_qValueFDR: "1.77948412240239e-18"^^xsd:float ;
+	prov:wasDerivedFrom niiri:excursion_set_map_id .
+
+niiri:supra_threshold_cluster_0002 a prov:Entity , nidm_SupraThresholdCluster: ;
+	rdfs:label "Supra-Threshold Cluster: 0002" ;
+	nidm_clusterSizeInVoxels: "695"^^xsd:int ;
+	nidm_clusterLabelId: "2"^^xsd:int ;
+	nidm_clusterSizeInResels: "5.22919736927692"^^xsd:float ;
+	nidm_pValueUncorrected: "5.34280282632073e-17"^^xsd:float ;
+	nidm_pValueFWER: "0"^^xsd:float ;
+	nidm_qValueFDR: "1.33570070658018e-16"^^xsd:float ;
+	prov:wasDerivedFrom niiri:excursion_set_map_id .
+
+niiri:supra_threshold_cluster_0003 a prov:Entity , nidm_SupraThresholdCluster: ;
+	rdfs:label "Supra-Threshold Cluster: 0003" ;
+	nidm_clusterSizeInVoxels: "37"^^xsd:int ;
+	nidm_clusterLabelId: "3"^^xsd:int ;
+	nidm_clusterSizeInResels: "0.278388924695318"^^xsd:float ;
+	nidm_pValueUncorrected: "0.00497953247554004"^^xsd:float ;
+	nidm_pValueFWER: "0.000255384009130943"^^xsd:float ;
+	nidm_qValueFDR: "0.00829922079256674"^^xsd:float ;
+	prov:wasDerivedFrom niiri:excursion_set_map_id .
+
+niiri:supra_threshold_cluster_0004 a prov:Entity , nidm_SupraThresholdCluster: ;
+	rdfs:label "Supra-Threshold Cluster: 0004" ;
+	nidm_clusterSizeInVoxels: "29"^^xsd:int ;
+	nidm_clusterLabelId: "4"^^xsd:int ;
+	nidm_clusterSizeInResels: "0.218196724761195"^^xsd:float ;
+	nidm_pValueUncorrected: "0.0110257032104773"^^xsd:float ;
+	nidm_pValueFWER: "0.000565384750377596"^^xsd:float ;
+	nidm_qValueFDR: "0.0137821290130967"^^xsd:float ;
+	prov:wasDerivedFrom niiri:excursion_set_map_id .
+
+niiri:supra_threshold_cluster_0005 a prov:Entity , nidm_SupraThresholdCluster: ;
+	rdfs:label "Supra-Threshold Cluster: 0005" ;
+	nidm_clusterSizeInVoxels: "12"^^xsd:int ;
+	nidm_clusterLabelId: "5"^^xsd:int ;
+	nidm_clusterSizeInResels: "0.0902882999011843"^^xsd:float ;
+	nidm_pValueUncorrected: "0.0818393184514307"^^xsd:float ;
+	nidm_pValueFWER: "0.00418900977248904"^^xsd:float ;
+	nidm_qValueFDR: "0.0818393184514307"^^xsd:float ;
+	prov:wasDerivedFrom niiri:excursion_set_map_id .

--- a/spmexport/ground_truth/t_test/nidm.ttl
+++ b/spmexport/ground_truth/t_test/nidm.ttl
@@ -1,0 +1,12 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+
+@prefix nidm_Inference: <http://purl.org/nidash/nidm#NIDM_0000049> .
+@prefix nidm_hasAlternativeHypothesis: <http://purl.org/nidash/nidm#NIDM_0000097> .
+@prefix nidm_OneTailedTest: <http://purl.org/nidash/nidm#NIDM_0000060> .
+
+
+niiri:inference_id a prov:Activity , nidm_Inference: ;
+	rdfs:label "Inference" ;
+	nidm_hasAlternativeHypothesis: nidm_OneTailedTest: .

--- a/spmexport/ground_truth/temporal_derivative/nidm.ttl
+++ b/spmexport/ground_truth/temporal_derivative/nidm.ttl
@@ -1,0 +1,21 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+
+@prefix nidm_DesignMatrix: <http://purl.org/nidash/nidm#NIDM_0000019> .
+@prefix nidm_regressorNames: <http://purl.org/nidash/nidm#NIDM_0000021> .
+@prefix nidm_hasHRFBasis: <http://purl.org/nidash/nidm#NIDM_0000102> .
+@prefix nidm_hasDriftModel: <http://purl.org/nidash/nidm#NIDM_0000088> .
+@prefix spm_SPMsCanonicalHRF: <http://purl.org/nidash/spm#SPM_0000004> .
+@prefix spm_SPMsTemporalDerivative: <http://purl.org/nidash/spm#SPM_0000006> .
+
+
+niiri:first_level_design_matrix_id a prov:Entity , nidm_DesignMatrix: ;
+    prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
+    dct:format "text/csv"^^xsd:string ;
+    nfo:fileName "DesignMatrix.csv"^^xsd:string ;
+    nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
+    nidm_hasHRFBasis: spm_SPMsTemporalDerivative: .

--- a/spmexport/ground_truth/voxel_FDR_p_05/nidm.ttl
+++ b/spmexport/ground_truth/voxel_FDR_p_05/nidm.ttl
@@ -1,0 +1,12 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix obo_qvalue: <http://purl.obolibrary.org/obo/OBI_0001442> .
+
+
+niiri:height_threshold_fdr_id a prov:Entity, nidm_HeightThreshold:, obo_qvalue: ;
+    rdfs:label "Height Threshold: p<0.05 (FDR-corrected)" ;
+    prov:value "0.05"^^xsd:float .

--- a/spmexport/ground_truth/voxel_FWE_p_05/nidm.ttl
+++ b/spmexport/ground_truth/voxel_FWE_p_05/nidm.ttl
@@ -1,0 +1,13 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_equivalentThreshold: <http://purl.org/nidash/nidm#NIDM_0000161> .
+@prefix obo_FWERadjustedpvalue: <http://purl.obolibrary.org/obo/OBI_0001265> .
+
+
+niiri:height_threshold_fwer_id a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ;
+    rdfs:label "Height Threshold: p<0.05 (FWER-corrected)" ;
+    prov:value "0.05"^^xsd:float .

--- a/spmexport/ground_truth/voxel_t=4/nidm.ttl
+++ b/spmexport/ground_truth/voxel_t=4/nidm.ttl
@@ -1,0 +1,12 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix obo_statistic: <http://purl.obolibrary.org/obo/STATO_0000039> .
+
+
+niiri:height_threshold_stat_id a prov:Entity, nidm_HeightThreshold:, obo_statistic: ;
+    rdfs:label "Height Threshold: T<4" ;
+    prov:value "4"^^xsd:float .

--- a/spmexport/ground_truth/voxel_uncorrected_p_001/nidm.ttl
+++ b/spmexport/ground_truth/voxel_uncorrected_p_001/nidm.ttl
@@ -1,0 +1,12 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix nidm_HeightThreshold: <http://purl.org/nidash/nidm#NIDM_0000034> .
+@prefix nidm_PValueUncorrected: <http://purl.org/nidash/nidm#NIDM_0000160> .
+
+
+niiri:height_threshold_unc_id a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ;
+    rdfs:label "Height Threshold: p<0.001 (uncorrected)" ;
+    prov:value "0.001"^^xsd:float .


### PR DESCRIPTION
This PR update the testing procedure to use test data available at https://github.com/incf-nidash/nidmresults-examples.

As Matlab requires a licence (and is therefore not available on Travis), the nidm exports have to be updated locally (using the `nidm_export_all` function) and pushed before the tests can be run on Travis. 
The procedure to follow to run the test battery is described in the [README.md](https://github.com/incf-nidash/nidm-results_spm/blob/master/README.md).